### PR TITLE
feat(gateway): WS5-C IPC plumbing — LLM control, profiles, telemetry, data preflight, audit, connector config, updater progress

### DIFF
--- a/packages/gateway/src/config/profiles.test.ts
+++ b/packages/gateway/src/config/profiles.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProfileManager } from "./profiles.ts";
+
+describe("ProfileManager", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-profiles-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("list returns empty array before any profile is created", async () => {
+    const mgr = new ProfileManager(dir);
+    expect(await mgr.list()).toEqual([]);
+    expect(await mgr.getActive()).toBeUndefined();
+  });
+
+  test("create + switch + list round trip", async () => {
+    const mgr = new ProfileManager(dir);
+    await mgr.create("work");
+    await mgr.create("personal");
+    await mgr.switchTo("personal");
+    const profiles = await mgr.list();
+    expect(profiles.map((p) => p.name).sort()).toEqual(["personal", "work"]);
+    expect(profiles.find((p) => p.active)?.name).toBe("personal");
+  });
+
+  test("delete removes the profile file and clears active if needed", async () => {
+    const mgr = new ProfileManager(dir);
+    await mgr.create("work");
+    await mgr.create("personal");
+    await mgr.switchTo("work");
+    await mgr.delete("personal");
+    const profiles = await mgr.list();
+    expect(profiles.map((p) => p.name)).toEqual(["work"]);
+  });
+
+  test("delete refuses the active profile", async () => {
+    const mgr = new ProfileManager(dir);
+    await mgr.create("work");
+    await mgr.switchTo("work");
+    await expect(mgr.delete("work")).rejects.toThrow(/active/i);
+  });
+
+  test("create rejects invalid names", async () => {
+    const mgr = new ProfileManager(dir);
+    await expect(mgr.create("bad name!")).rejects.toThrow();
+    await expect(mgr.create("default")).rejects.toThrow();
+  });
+
+  test("vaultKeyPrefix returns empty string for default profile", async () => {
+    const mgr = new ProfileManager(dir);
+    expect(mgr.vaultKeyPrefix()).toBe("");
+  });
+
+  test("vaultKeyPrefix returns profile/ prefix after switch", async () => {
+    const mgr = new ProfileManager(dir);
+    await mgr.create("work");
+    await mgr.switchTo("work");
+    expect(mgr.vaultKeyPrefix()).toBe("profile/work/");
+  });
+});

--- a/packages/gateway/src/config/profiles.ts
+++ b/packages/gateway/src/config/profiles.ts
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PROFILE_MARKER = ".nimbus-profile";
+const PROFILE_PREFIX = "nimbus.";
+const PROFILE_SUFFIX = ".toml";
+
+export type ProfileSummary = { name: string; active: boolean };
+
+export class ProfileManager {
+  private readonly configDir: string;
+
+  constructor(configDir: string) {
+    this.configDir = configDir;
+    if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true });
+  }
+
+  private readActiveMarker(): string | undefined {
+    const path = join(this.configDir, PROFILE_MARKER);
+    if (!existsSync(path)) return undefined;
+    const raw = readFileSync(path, "utf8").trim();
+    if (raw === "" || raw === "default") return undefined;
+    return raw;
+  }
+
+  private profileTomlPath(name: string): string {
+    return join(this.configDir, `${PROFILE_PREFIX}${name}${PROFILE_SUFFIX}`);
+  }
+
+  private listProfileNames(): string[] {
+    let names: string[];
+    try {
+      names = readdirSync(this.configDir);
+    } catch {
+      return [];
+    }
+    const out: string[] = [];
+    for (const n of names) {
+      if (n.startsWith(PROFILE_PREFIX) && n.endsWith(PROFILE_SUFFIX) && n !== "nimbus.toml") {
+        out.push(n.slice(PROFILE_PREFIX.length, -PROFILE_SUFFIX.length));
+      }
+    }
+    return out.sort((a, b) => a.localeCompare(b));
+  }
+
+  async list(): Promise<ProfileSummary[]> {
+    const active = this.readActiveMarker();
+    return this.listProfileNames().map((name) => ({ name, active: name === active }));
+  }
+
+  async getActive(): Promise<string | undefined> {
+    return this.readActiveMarker();
+  }
+
+  async create(name: string): Promise<void> {
+    if (!/^[a-z0-9_-]{1,32}$/i.test(name) || name === "default") {
+      throw new Error(`Invalid profile name: ${name}`);
+    }
+    const dest = this.profileTomlPath(name);
+    if (existsSync(dest)) throw new Error(`Profile already exists: ${name}`);
+    writeFileSync(dest, `schema_version = 1\nprofile_name = "${name}"\n`, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+  }
+
+  async switchTo(name: string): Promise<void> {
+    const dest = this.profileTomlPath(name);
+    if (!existsSync(dest)) throw new Error(`Profile not found: ${name}`);
+    writeFileSync(join(this.configDir, PROFILE_MARKER), `${name}\n`, "utf8");
+  }
+
+  async delete(name: string): Promise<void> {
+    if (this.readActiveMarker() === name) {
+      throw new Error(`Cannot delete active profile: ${name}`);
+    }
+    const dest = this.profileTomlPath(name);
+    if (!existsSync(dest)) throw new Error(`Profile not found: ${name}`);
+    rmSync(dest, { force: true });
+  }
+
+  vaultKeyPrefix(): string {
+    const active = this.readActiveMarker();
+    return active === undefined ? "" : `profile/${active}/`;
+  }
+}

--- a/packages/gateway/src/index/llm-task-defaults-v20-sql.ts
+++ b/packages/gateway/src/index/llm-task-defaults-v20-sql.ts
@@ -1,0 +1,8 @@
+export const LLM_TASK_DEFAULTS_V20_SQL = `
+CREATE TABLE IF NOT EXISTS llm_task_defaults (
+  task_type TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+`;

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -263,7 +263,7 @@ export interface LanPeerRow {
 }
 
 export class LocalIndex {
-  static readonly SCHEMA_VERSION = 19;
+  static readonly SCHEMA_VERSION = 20;
 
   /**
    * Applies bundled migrations when `user_version` is below `SCHEMA_VERSION`.

--- a/packages/gateway/src/index/local-index.ts
+++ b/packages/gateway/src/index/local-index.ts
@@ -859,6 +859,32 @@ export class LocalIndex {
     this.db.close();
   }
 
+  getAuditSummary(): {
+    byOutcome: Record<string, number>;
+    byService: Record<string, number>;
+    total: number;
+  } {
+    const byOutcome: Record<string, number> = {};
+    const byService: Record<string, number> = {};
+    let total = 0;
+    const outcomes = this.db
+      .query("SELECT hitl_status AS outcome, COUNT(*) AS c FROM audit_log GROUP BY hitl_status")
+      .all() as { outcome: string; c: number }[];
+    for (const r of outcomes) {
+      byOutcome[r.outcome] = r.c;
+      total += r.c;
+    }
+    // Group by the first segment of action_type (e.g. "github.sync" → "github")
+    const services = this.db
+      .query("SELECT action_type, COUNT(*) AS c FROM audit_log GROUP BY action_type")
+      .all() as { action_type: string; c: number }[];
+    for (const r of services) {
+      const prefix = r.action_type.split(".")[0] ?? r.action_type;
+      byService[prefix] = (byService[prefix] ?? 0) + r.c;
+    }
+    return { byOutcome, byService, total };
+  }
+
   listAudit(limit: number): AuditEntry[] {
     const capped = Math.min(1000, Math.max(1, Math.floor(limit)));
     const rows = this.db

--- a/packages/gateway/src/index/migrations/runner-v20.test.ts
+++ b/packages/gateway/src/index/migrations/runner-v20.test.ts
@@ -1,0 +1,59 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { runIndexedSchemaMigrations } from "./runner.ts";
+
+describe("V20 migration — llm_task_defaults", () => {
+  test("creates llm_task_defaults table with correct columns", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 20);
+    const cols = db.query(`PRAGMA table_info(llm_task_defaults)`).all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort((a, b) => a.localeCompare(b));
+    expect(names).toContain("task_type");
+    expect(names).toContain("provider");
+    expect(names).toContain("model_name");
+    expect(names).toContain("updated_at");
+  });
+
+  test("is idempotent", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 20);
+    runIndexedSchemaMigrations(db, 20);
+    const row = db.query(`SELECT COUNT(*) AS n FROM llm_task_defaults`).get() as { n: number };
+    expect(row.n).toBe(0);
+  });
+
+  test("upsert round-trip: insert then conflict-update", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 20);
+    db.run(
+      `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at) VALUES (?, ?, ?, ?)`,
+      ["classification", "ollama", "gemma:2b", 1000],
+    );
+    db.run(
+      `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(task_type) DO UPDATE SET provider=excluded.provider, model_name=excluded.model_name, updated_at=excluded.updated_at`,
+      ["classification", "llamacpp", "llama3.2", 2000],
+    );
+    const row = db
+      .query(`SELECT provider, model_name FROM llm_task_defaults WHERE task_type = ?`)
+      .get("classification") as { provider: string; model_name: string } | undefined;
+    expect(row?.provider).toBe("llamacpp");
+    expect(row?.model_name).toBe("llama3.2");
+  });
+
+  test("task_type is PRIMARY KEY (duplicate rejected)", () => {
+    const db = new Database(":memory:");
+    runIndexedSchemaMigrations(db, 20);
+    db.run(
+      `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at) VALUES (?, ?, ?, ?)`,
+      ["embedding", "ollama", "nomic-embed", 1000],
+    );
+    expect(() =>
+      db.run(
+        `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at) VALUES (?, ?, ?, ?)`,
+        ["embedding", "llamacpp", "nomic-embed", 2000],
+      ),
+    ).toThrow(/UNIQUE/);
+  });
+});

--- a/packages/gateway/src/index/migrations/runner.ts
+++ b/packages/gateway/src/index/migrations/runner.ts
@@ -346,6 +346,7 @@ const BACKFILL_LABELS: readonly string[] = [
   "sub_task_results (backfilled)",
   "audit_log BLAKE3 chain + _meta (backfilled)",
   "lan_peers (LAN remote-access peer registry) (backfilled)",
+  "llm_task_defaults (per-task-type LLM model defaults) (backfilled)",
 ];
 
 /**

--- a/packages/gateway/src/index/migrations/runner.ts
+++ b/packages/gateway/src/index/migrations/runner.ts
@@ -29,6 +29,7 @@ import { GRAPH_RELATION_TYPES_V12_SQL } from "../graph-relation-types-v12-sql.ts
 import { GRAPH_V7_MIGRATION_SQL } from "../graph-v7-sql.ts";
 import { LAN_PEERS_V19_SQL } from "../lan-peers-v19-sql.ts";
 import { LLM_CONTEXT_WINDOW_V16_ALTER_SQL, LLM_MODELS_V16_SQL } from "../llm-models-v16-sql.ts";
+import { LLM_TASK_DEFAULTS_V20_SQL } from "../llm-task-defaults-v20-sql.ts";
 import { PERSON_HANDLES_V5_ALTER_SQL } from "../person-handles-v5-sql.ts";
 import { PERSON_LINKED_V4_ALTER_SQL } from "../person-linked-v4-sql.ts";
 import { QUERY_LATENCY_V14_SQL } from "../query-latency-v14-sql.ts";
@@ -294,6 +295,14 @@ function migrateIndexedV18ToV19(db: Database, now: number): void {
   })();
 }
 
+function migrateIndexedV19ToV20(db: Database, now: number): void {
+  db.transaction(() => {
+    db.exec(LLM_TASK_DEFAULTS_V20_SQL);
+    db.exec("PRAGMA user_version = 20");
+    recordMigration(db, 20, "llm_task_defaults (per-task-type LLM model defaults)", now);
+  })();
+}
+
 const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 0, toVersion: 1, apply: migrateIndexedV0ToV1 },
   { fromVersion: 1, toVersion: 2, apply: migrateIndexedV1ToV2 },
@@ -314,6 +323,7 @@ const INDEXED_SCHEMA_STEPS: readonly IndexedSchemaStep[] = [
   { fromVersion: 16, toVersion: 17, apply: migrateIndexedV16ToV17 },
   { fromVersion: 17, toVersion: 18, apply: migrateIndexedV17ToV18 },
   { fromVersion: 18, toVersion: 19, apply: migrateIndexedV18ToV19 },
+  { fromVersion: 19, toVersion: 20, apply: migrateIndexedV19ToV20 },
 ];
 
 const BACKFILL_LABELS: readonly string[] = [

--- a/packages/gateway/src/ipc/audit-rpc.test.ts
+++ b/packages/gateway/src/ipc/audit-rpc.test.ts
@@ -54,3 +54,44 @@ describe("dispatchAuditRpc", () => {
     );
   });
 });
+
+describe("audit.getSummary", () => {
+  test("returns counts grouped by outcome and total", async () => {
+    const idx = seededIndex();
+    const r = await dispatchAuditRpc("audit.getSummary", null, { index: idx });
+    expect(r.kind).toBe("hit");
+    const v = (
+      r as {
+        kind: "hit";
+        value: {
+          byOutcome: Record<string, number>;
+          byService: Record<string, number>;
+          total: number;
+        };
+      }
+    ).value;
+    expect(v.total).toBe(1);
+    expect(typeof v.byOutcome).toBe("object");
+    expect(typeof v.byService).toBe("object");
+  });
+
+  test("throws AuditRpcError when index not configured", async () => {
+    await expect(
+      dispatchAuditRpc("audit.getSummary", null, { index: undefined }),
+    ).rejects.toBeInstanceOf(AuditRpcError);
+  });
+});
+
+describe("audit.export alias", () => {
+  test("audit.export returns same shape as audit.exportAll", async () => {
+    const idx = seededIndex();
+    const r1 = await dispatchAuditRpc("audit.exportAll", null, { index: seededIndex() });
+    const r2 = await dispatchAuditRpc("audit.export", null, { index: idx });
+    expect(r1.kind).toBe("hit");
+    expect(r2.kind).toBe("hit");
+    // Both return arrays of the same shape
+    const rows1 = (r1 as { kind: "hit"; value: unknown }).value as Array<{ rowHash: string }>;
+    const rows2 = (r2 as { kind: "hit"; value: unknown }).value as Array<{ rowHash: string }>;
+    expect(rows1).toHaveLength(rows2.length);
+  });
+});

--- a/packages/gateway/src/ipc/audit-rpc.ts
+++ b/packages/gateway/src/ipc/audit-rpc.ts
@@ -36,9 +36,13 @@ export async function dispatchAuditRpc(
     if (result.ok) idx.setAuditVerifiedThroughId(result.lastVerifiedId);
     return { kind: "hit", value: result };
   }
-  if (method === "audit.exportAll") {
+  if (method === "audit.exportAll" || method === "audit.export") {
     const idx = ensureIndex(ctx);
     return { kind: "hit", value: idx.listAuditWithChain(10_000) };
+  }
+  if (method === "audit.getSummary") {
+    const idx = ensureIndex(ctx);
+    return { kind: "hit", value: idx.getAuditSummary() };
   }
   return { kind: "miss" };
 }

--- a/packages/gateway/src/ipc/connector-rpc-handlers.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers.ts
@@ -188,6 +188,46 @@ export function handleConnectorSetInterval(ctx: ConnectorRpcHandlerContext): Con
   return { kind: "hit", value: { ok: true } };
 }
 
+export function handleConnectorSetConfig(ctx: ConnectorRpcHandlerContext): ConnectorRpcHit {
+  const { rec, localIndex, syncScheduler } = ctx;
+  const id = requireRegisteredSchedulerServiceId(rec, localIndex);
+  const intervalMs = rec?.["intervalMs"];
+  const enabled = rec?.["enabled"];
+  if (typeof intervalMs === "number") {
+    if (!Number.isFinite(intervalMs) || intervalMs < 1) {
+      throw new ConnectorRpcError(-32602, "Invalid intervalMs");
+    }
+    const ms = Math.floor(intervalMs);
+    localIndex.setConnectorSyncIntervalMs(id, ms, Date.now());
+    if (syncScheduler !== undefined) {
+      syncScheduler.setInterval(id, ms);
+    }
+  }
+  if (typeof enabled === "boolean") {
+    if (enabled) {
+      if (syncScheduler === undefined) {
+        localIndex.resumeConnectorSync(id);
+      } else {
+        syncScheduler.resume(id);
+      }
+    } else {
+      if (syncScheduler === undefined) {
+        localIndex.pauseConnectorSync(id);
+      } else {
+        syncScheduler.pause(id);
+      }
+    }
+  }
+  return {
+    kind: "hit",
+    value: {
+      service: id,
+      intervalMs: typeof intervalMs === "number" ? Math.floor(intervalMs) : null,
+      enabled: typeof enabled === "boolean" ? enabled : null,
+    },
+  };
+}
+
 export function handleConnectorStatus(ctx: ConnectorRpcHandlerContext): ConnectorRpcHit {
   const { rec, localIndex } = ctx;
   const id = requireRegisteredSchedulerServiceId(rec, localIndex);

--- a/packages/gateway/src/ipc/connector-rpc.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc.test.ts
@@ -1,0 +1,195 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { LocalIndex } from "../index/local-index.ts";
+import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import { dispatchConnectorRpc } from "./connector-rpc.ts";
+import { ConnectorRpcError } from "./connector-rpc-shared.ts";
+
+function makeIndex(): LocalIndex {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  const idx = new LocalIndex(db);
+  // Register a connector in scheduler_state so requireRegisteredSchedulerServiceId passes
+  db.run(
+    `INSERT INTO scheduler_state
+       (service_id, cursor, interval_ms, last_sync_at, next_sync_at, status, error_msg, consecutive_failures, paused)
+     VALUES ('github', NULL, 60000, NULL, ?, 'ok', NULL, 0, 0)`,
+    [Date.now()],
+  );
+  return idx;
+}
+
+const baseOpts = {
+  vault: {} as unknown as NimbusVault,
+  openUrl: async (_url: string): Promise<void> => {},
+  syncScheduler: undefined,
+} as const;
+
+describe("connector.setConfig", () => {
+  test("returns miss for unknown method", async () => {
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      method: "connector.unknown",
+      params: {},
+    });
+    expect(r.kind).toBe("miss");
+  });
+
+  test("sets intervalMs only", async () => {
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      method: "connector.setConfig",
+      params: { serviceId: "github", intervalMs: 120000 },
+    });
+    expect(r.kind).toBe("hit");
+    const v = (
+      r as {
+        kind: "hit";
+        value: { service: string; intervalMs: number | null; enabled: boolean | null };
+      }
+    ).value;
+    expect(v.service).toBe("github");
+    expect(v.intervalMs).toBe(120000);
+    expect(v.enabled).toBeNull();
+  });
+
+  test("sets enabled=false only (pause)", async () => {
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      method: "connector.setConfig",
+      params: { serviceId: "github", enabled: false },
+    });
+    expect(r.kind).toBe("hit");
+    const v = (
+      r as {
+        kind: "hit";
+        value: { service: string; intervalMs: number | null; enabled: boolean | null };
+      }
+    ).value;
+    expect(v.service).toBe("github");
+    expect(v.intervalMs).toBeNull();
+    expect(v.enabled).toBe(false);
+  });
+
+  test("sets intervalMs and enabled=true together", async () => {
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      method: "connector.setConfig",
+      params: { serviceId: "github", intervalMs: 120000, enabled: true },
+    });
+    expect(r.kind).toBe("hit");
+    const v = (
+      r as {
+        kind: "hit";
+        value: { service: string; intervalMs: number | null; enabled: boolean | null };
+      }
+    ).value;
+    expect(v.service).toBe("github");
+    expect(v.intervalMs).toBe(120000);
+    expect(v.enabled).toBe(true);
+  });
+
+  test("rejects missing serviceId", async () => {
+    await expect(
+      dispatchConnectorRpc({
+        ...baseOpts,
+        localIndex: makeIndex(),
+        method: "connector.setConfig",
+        params: {},
+      }),
+    ).rejects.toBeInstanceOf(ConnectorRpcError);
+  });
+
+  test("rejects unregistered serviceId", async () => {
+    await expect(
+      dispatchConnectorRpc({
+        ...baseOpts,
+        localIndex: makeIndex(),
+        method: "connector.setConfig",
+        params: { serviceId: "slack" },
+      }),
+    ).rejects.toBeInstanceOf(ConnectorRpcError);
+  });
+
+  test("rejects invalid intervalMs (zero)", async () => {
+    await expect(
+      dispatchConnectorRpc({
+        ...baseOpts,
+        localIndex: makeIndex(),
+        method: "connector.setConfig",
+        params: { serviceId: "github", intervalMs: 0 },
+      }),
+    ).rejects.toBeInstanceOf(ConnectorRpcError);
+  });
+
+  test("rejects invalid intervalMs (non-finite)", async () => {
+    await expect(
+      dispatchConnectorRpc({
+        ...baseOpts,
+        localIndex: makeIndex(),
+        method: "connector.setConfig",
+        params: { serviceId: "github", intervalMs: Number.POSITIVE_INFINITY },
+      }),
+    ).rejects.toBeInstanceOf(ConnectorRpcError);
+  });
+
+  test("floors fractional intervalMs", async () => {
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      method: "connector.setConfig",
+      params: { serviceId: "github", intervalMs: 90000.9 },
+    });
+    expect(r.kind).toBe("hit");
+    const v = (r as { kind: "hit"; value: { intervalMs: number | null } }).value;
+    expect(v.intervalMs).toBe(90000);
+  });
+
+  test("delegates to syncScheduler.setInterval and resume when provided", async () => {
+    const calls: string[] = [];
+    const syncScheduler = {
+      setInterval: (id: string, ms: number) => {
+        calls.push(`setInterval:${id}:${ms}`);
+      },
+      pause: (id: string) => {
+        calls.push(`pause:${id}`);
+      },
+      resume: (id: string) => {
+        calls.push(`resume:${id}`);
+      },
+    } as never;
+    const r = await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      syncScheduler,
+      method: "connector.setConfig",
+      params: { serviceId: "github", intervalMs: 60000, enabled: true },
+    });
+    expect(r.kind).toBe("hit");
+    expect(calls).toContain("setInterval:github:60000");
+    expect(calls).toContain("resume:github");
+  });
+
+  test("delegates to syncScheduler.pause when enabled=false", async () => {
+    const calls: string[] = [];
+    const syncScheduler = {
+      setInterval: (_id: string, _ms: number) => {},
+      pause: (id: string) => {
+        calls.push(`pause:${id}`);
+      },
+      resume: (_id: string) => {},
+    } as never;
+    await dispatchConnectorRpc({
+      ...baseOpts,
+      localIndex: makeIndex(),
+      syncScheduler,
+      method: "connector.setConfig",
+      params: { serviceId: "github", enabled: false },
+    });
+    expect(calls).toContain("pause:github");
+  });
+});

--- a/packages/gateway/src/ipc/connector-rpc.ts
+++ b/packages/gateway/src/ipc/connector-rpc.ts
@@ -10,6 +10,7 @@ import {
   handleConnectorPause,
   handleConnectorRemove,
   handleConnectorResume,
+  handleConnectorSetConfig,
   handleConnectorSetInterval,
   handleConnectorStatus,
   handleConnectorSync,
@@ -40,6 +41,8 @@ export async function dispatchConnectorRpc(options: {
       return handleConnectorPause(ctx);
     case "connector.resume":
       return handleConnectorResume(ctx);
+    case "connector.setConfig":
+      return handleConnectorSetConfig(ctx);
     case "connector.setInterval":
       return handleConnectorSetInterval(ctx);
     case "connector.status":

--- a/packages/gateway/src/ipc/data-rpc.test.ts
+++ b/packages/gateway/src/ipc/data-rpc.test.ts
@@ -92,3 +92,143 @@ describe("dispatchDataRpc", () => {
     ).rejects.toBeInstanceOf(DataRpcError);
   });
 });
+
+describe("data.getExportPreflight", () => {
+  test("returns zero values when index is undefined", async () => {
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: undefined,
+      vault: undefined,
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    const r = await dispatchDataRpc("data.getExportPreflight", null, ctx);
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as { lastExportAt: unknown; estimatedSizeBytes: number; itemCount: number };
+      expect(v.lastExportAt).toBeNull();
+      expect(v.estimatedSizeBytes).toBe(0);
+      expect(v.itemCount).toBe(0);
+    }
+  });
+
+  test("returns estimatedSizeBytes and itemCount from live index", async () => {
+    const idx = newIndex();
+    idx.rawDb.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at, pinned)
+       VALUES ('github-1', 'github', 'test', 'ext-1', 't', ?, ?, 0)`,
+      [Date.now(), Date.now()],
+    );
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: idx,
+      vault: memVault(),
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    const r = await dispatchDataRpc("data.getExportPreflight", null, ctx);
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as { lastExportAt: unknown; estimatedSizeBytes: number; itemCount: number };
+      expect(v.lastExportAt).toBeNull();
+      expect(v.estimatedSizeBytes).toBeGreaterThan(0);
+      expect(v.itemCount).toBe(1);
+    }
+  });
+});
+
+describe("data.getDeletePreflight", () => {
+  test("returns zero counts when index is undefined", async () => {
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: undefined,
+      vault: undefined,
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    const r = await dispatchDataRpc("data.getDeletePreflight", { service: "github" }, ctx);
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as {
+        service: string;
+        itemCount: number;
+        embeddingCount: number;
+        vaultKeyCount: number;
+      };
+      expect(v.service).toBe("github");
+      expect(v.itemCount).toBe(0);
+      expect(v.embeddingCount).toBe(0);
+      expect(typeof v.vaultKeyCount).toBe("number");
+      expect(v.vaultKeyCount).toBeGreaterThan(0); // github has github.pat
+    }
+  });
+
+  test("returns item count from live index", async () => {
+    const idx = newIndex();
+    idx.rawDb.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at, pinned)
+       VALUES ('github-1', 'github', 'test', 'ext-1', 't', ?, ?, 0)`,
+      [Date.now(), Date.now()],
+    );
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: idx,
+      vault: memVault(),
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    const r = await dispatchDataRpc("data.getDeletePreflight", { service: "github" }, ctx);
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as {
+        service: string;
+        itemCount: number;
+        embeddingCount: number;
+        vaultKeyCount: number;
+      };
+      expect(v.service).toBe("github");
+      expect(v.itemCount).toBe(1);
+      expect(v.embeddingCount).toBe(0);
+      expect(v.vaultKeyCount).toBeGreaterThan(0);
+    }
+  });
+
+  test("rejects null params (missing service)", async () => {
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: undefined,
+      vault: undefined,
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    await expect(dispatchDataRpc("data.getDeletePreflight", null, ctx)).rejects.toBeInstanceOf(
+      DataRpcError,
+    );
+  });
+
+  test("rejects empty service string", async () => {
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: undefined,
+      vault: undefined,
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    await expect(
+      dispatchDataRpc("data.getDeletePreflight", { service: "" }, ctx),
+    ).rejects.toBeInstanceOf(DataRpcError);
+  });
+
+  test("returns zero vaultKeyCount for unknown service", async () => {
+    const ctx: Parameters<typeof dispatchDataRpc>[2] = {
+      index: undefined,
+      vault: undefined,
+      platform: "linux",
+      nimbusVersion: "0.0.0-test",
+    };
+    const r = await dispatchDataRpc(
+      "data.getDeletePreflight",
+      { service: "unknown_service_xyz" },
+      ctx,
+    );
+    expect(r.kind).toBe("hit");
+    if (r.kind === "hit") {
+      const v = r.value as { vaultKeyCount: number };
+      expect(v.vaultKeyCount).toBe(0);
+    }
+  });
+});

--- a/packages/gateway/src/ipc/data-rpc.test.ts
+++ b/packages/gateway/src/ipc/data-rpc.test.ts
@@ -232,3 +232,64 @@ describe("data.getDeletePreflight", () => {
     }
   });
 });
+
+describe("data.export emits progress notifications", () => {
+  test("emits exportProgress and exportCompleted", async () => {
+    const notifications: { method: string; params: unknown }[] = [];
+    const out = await dispatchDataRpc(
+      "data.export",
+      {
+        output: join(mkdtempSync(join(tmpdir(), "nimbus-rpc-prog-")), "b.tar.gz"),
+        passphrase: "pw",
+        includeIndex: false,
+      },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+        notify: (m, p) => notifications.push({ method: m, params: p }),
+      },
+    );
+    expect(out.kind).toBe("hit");
+    expect(notifications.some((n) => n.method === "data.exportProgress")).toBe(true);
+    expect(notifications.some((n) => n.method === "data.exportCompleted")).toBe(true);
+  });
+});
+
+describe("data.import emits progress notifications", () => {
+  test("emits importProgress and importCompleted", async () => {
+    // First create a bundle to import
+    const exportDir = mkdtempSync(join(tmpdir(), "nimbus-rpc-imp-"));
+    const bundlePath = join(exportDir, "bundle.tar.gz");
+    await dispatchDataRpc(
+      "data.export",
+      { output: bundlePath, passphrase: "pw", includeIndex: false },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+      },
+    );
+
+    const notifications: { method: string; params: unknown }[] = [];
+    const out = await dispatchDataRpc(
+      "data.import",
+      { bundlePath, passphrase: "pw" },
+      {
+        index: newIndex(),
+        vault: memVault(),
+        platform: "linux",
+        nimbusVersion: "0.1.0",
+        kdfParams: testKdf,
+        notify: (m, p) => notifications.push({ method: m, params: p }),
+      },
+    );
+    expect(out.kind).toBe("hit");
+    expect(notifications.some((n) => n.method === "data.importProgress")).toBe(true);
+    expect(notifications.some((n) => n.method === "data.importCompleted")).toBe(true);
+  });
+});

--- a/packages/gateway/src/ipc/data-rpc.ts
+++ b/packages/gateway/src/ipc/data-rpc.ts
@@ -15,6 +15,8 @@ export type DataRpcContext = {
   nimbusVersion: string;
   /** Optional — tests override Argon2id params to keep runtime small. */
   kdfParams?: KdfParams;
+  /** Optional — emit JSON-RPC notifications back to the caller. */
+  notify?: (method: string, params: Record<string, unknown>) => void;
 };
 
 type RpcResult = { kind: "hit"; value: unknown } | { kind: "miss" };
@@ -52,7 +54,8 @@ async function handleDataExport(
     throw new DataRpcError(-32602, "Missing param: output");
   if (typeof passphrase !== "string" || passphrase === "")
     throw new DataRpcError(-32602, "Missing param: passphrase");
-  return runDataExport({
+  ctx.notify?.("data.exportProgress", { stage: "packing", bytesWritten: 0, totalBytes: 0 });
+  const result = await runDataExport({
     output,
     passphrase,
     includeIndex,
@@ -62,6 +65,11 @@ async function handleDataExport(
     nimbusVersion: ctx.nimbusVersion,
     ...(ctx.kdfParams === undefined ? {} : { kdfParams: ctx.kdfParams }),
   });
+  ctx.notify?.("data.exportCompleted", {
+    path: result.outputPath,
+    itemsExported: result.itemsExported,
+  });
+  return result;
 }
 
 async function handleDataImport(
@@ -74,13 +82,16 @@ async function handleDataImport(
   const recoverySeed = rec["recoverySeed"];
   if (typeof bundlePath !== "string" || bundlePath === "")
     throw new DataRpcError(-32602, "Missing param: bundlePath");
-  return runDataImport({
+  ctx.notify?.("data.importProgress", { stage: "unpacking", bytesRead: 0, totalBytes: 0 });
+  const result = await runDataImport({
     bundlePath,
     ...(typeof passphrase === "string" ? { passphrase } : {}),
     ...(typeof recoverySeed === "string" ? { recoverySeed } : {}),
     vault,
     index,
   });
+  ctx.notify?.("data.importCompleted", { credentialsRestored: result.credentialsRestored });
+  return result;
 }
 
 async function handleDataDelete(

--- a/packages/gateway/src/ipc/data-rpc.ts
+++ b/packages/gateway/src/ipc/data-rpc.ts
@@ -1,7 +1,10 @@
 import { runDataDelete } from "../commands/data-delete.ts";
 import { runDataExport } from "../commands/data-export.ts";
 import { runDataImport } from "../commands/data-import.ts";
+import { normalizeConnectorServiceId } from "../connectors/connector-catalog.ts";
+import { CONNECTOR_VAULT_SECRET_KEYS } from "../connectors/connector-secrets-manifest.ts";
 import type { KdfParams } from "../db/data-vault-crypto.ts";
+import { collectIndexMetrics } from "../db/metrics.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 
@@ -92,6 +95,69 @@ async function handleDataDelete(
   return runDataDelete({ service, dryRun, vault, index });
 }
 
+export type ExportPreflightResult = {
+  lastExportAt: number | null;
+  estimatedSizeBytes: number;
+  itemCount: number;
+};
+
+export type DeletePreflightResult = {
+  service: string;
+  itemCount: number;
+  embeddingCount: number;
+  vaultKeyCount: number;
+};
+
+function handleGetExportPreflight(ctx: DataRpcContext): ExportPreflightResult {
+  if (ctx.index === undefined) {
+    return { lastExportAt: null, estimatedSizeBytes: 0, itemCount: 0 };
+  }
+  const db = ctx.index.getDatabase();
+  const metrics = collectIndexMetrics(db);
+  let lastExportAt: number | null = null;
+  try {
+    const row = db
+      .query(
+        "SELECT MAX(timestamp) AS ts FROM audit_log WHERE action_type = 'data.export' AND hitl_status = 'approved'",
+      )
+      .get() as { ts: number | null } | undefined;
+    lastExportAt = row?.ts ?? null;
+  } catch {
+    // audit_log may not exist in older schemas — ignore
+  }
+  return {
+    lastExportAt,
+    estimatedSizeBytes: metrics.indexSizeBytes,
+    itemCount: metrics.totalItems,
+  };
+}
+
+function handleGetDeletePreflight(params: unknown, ctx: DataRpcContext): DeletePreflightResult {
+  const p =
+    params !== null && typeof params === "object" ? (params as Record<string, unknown>) : null;
+  if (p === null || typeof p["service"] !== "string" || p["service"] === "") {
+    throw new DataRpcError(-32602, "data.getDeletePreflight requires service:string");
+  }
+  const service = p["service"];
+  if (ctx.index === undefined) {
+    const serviceId = normalizeConnectorServiceId(service);
+    const vaultKeyCount = serviceId !== null ? CONNECTOR_VAULT_SECRET_KEYS[serviceId].length : 0;
+    return { service, itemCount: 0, embeddingCount: 0, vaultKeyCount };
+  }
+  const db = ctx.index.getDatabase();
+  const metrics = collectIndexMetrics(db);
+  const itemCount = metrics.itemCountByService[service] ?? 0;
+  const embRow = db
+    .query(
+      "SELECT COUNT(DISTINCT ec.item_id) AS c FROM embedding_chunk ec JOIN item i ON ec.item_id = i.id WHERE i.service = ?",
+    )
+    .get(service) as { c: number } | undefined;
+  const embeddingCount = embRow?.c ?? 0;
+  const serviceId = normalizeConnectorServiceId(service);
+  const vaultKeyCount = serviceId !== null ? CONNECTOR_VAULT_SECRET_KEYS[serviceId].length : 0;
+  return { service, itemCount, embeddingCount, vaultKeyCount };
+}
+
 export async function dispatchDataRpc(
   method: string,
   params: unknown,
@@ -101,5 +167,9 @@ export async function dispatchDataRpc(
   if (method === "data.export") return { kind: "hit", value: await handleDataExport(rec, ctx) };
   if (method === "data.import") return { kind: "hit", value: await handleDataImport(rec, ctx) };
   if (method === "data.delete") return { kind: "hit", value: await handleDataDelete(rec, ctx) };
+  if (method === "data.getExportPreflight")
+    return { kind: "hit", value: handleGetExportPreflight(ctx) };
+  if (method === "data.getDeletePreflight")
+    return { kind: "hit", value: handleGetDeletePreflight(params, ctx) };
   return { kind: "miss" };
 }

--- a/packages/gateway/src/ipc/diagnostics-rpc.test.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DiagnosticsRpcContext } from "./diagnostics-rpc.ts";
+import { dispatchDiagnosticsRpc } from "./diagnostics-rpc.ts";
+
+function makeCtx(dataDir: string): DiagnosticsRpcContext {
+  return {
+    dataDir,
+    configDir: dataDir,
+    consent: { pendingCount: () => 0 } as never,
+    gatewayVersion: "0.0.0-test",
+    startedAtMs: Date.now(),
+  };
+}
+
+describe("telemetry.getStatus", () => {
+  test("returns enabled:true when marker file absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-"));
+    try {
+      const r = dispatchDiagnosticsRpc("telemetry.getStatus", null, makeCtx(dir));
+      expect(r.kind).toBe("hit");
+      expect((r as { kind: "hit"; value: { enabled: boolean } }).value.enabled).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns enabled:false when marker file present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-"));
+    try {
+      writeFileSync(join(dir, ".nimbus-telemetry-disabled"), `${Date.now()}\n`);
+      const r = dispatchDiagnosticsRpc("telemetry.getStatus", null, makeCtx(dir));
+      expect(r.kind).toBe("hit");
+      expect((r as { kind: "hit"; value: { enabled: boolean } }).value.enabled).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("telemetry.setEnabled", () => {
+  test("setEnabled(false) writes the disable marker", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-"));
+    try {
+      dispatchDiagnosticsRpc("telemetry.setEnabled", { enabled: false }, makeCtx(dir));
+      expect(existsSync(join(dir, ".nimbus-telemetry-disabled"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("setEnabled(true) removes the disable marker", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-"));
+    try {
+      writeFileSync(join(dir, ".nimbus-telemetry-disabled"), `${Date.now()}\n`);
+      dispatchDiagnosticsRpc("telemetry.setEnabled", { enabled: true }, makeCtx(dir));
+      expect(existsSync(join(dir, ".nimbus-telemetry-disabled"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects missing enabled param", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-"));
+    try {
+      expect(() => dispatchDiagnosticsRpc("telemetry.setEnabled", null, makeCtx(dir))).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/gateway/src/ipc/diagnostics-rpc.test.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.test.ts
@@ -71,3 +71,19 @@ describe("telemetry.setEnabled", () => {
     }
   });
 });
+
+describe("diag.getVersion", () => {
+  test("returns gateway version string", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-diag-ver-"));
+    try {
+      const r = dispatchDiagnosticsRpc("diag.getVersion", null, makeCtx(dir));
+      expect(r.kind).toBe("hit");
+      const v = (r as { kind: "hit"; value: { version: string; uptimeMs: number } }).value;
+      expect(typeof v.version).toBe("string");
+      expect(v.version.length).toBeGreaterThan(0);
+      expect(typeof v.uptimeMs).toBe("number");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/gateway/src/ipc/diagnostics-rpc.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.ts
@@ -3,7 +3,14 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { existsSync, lstatSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
@@ -413,6 +420,40 @@ export function dispatchDiagnosticsRpc(
       return rpcTelemetryPreview(ctx);
     case "diag.snapshot":
       return rpcDiagSnapshot(ctx);
+    case "telemetry.getStatus": {
+      const disabled = existsSync(join(ctx.dataDir, ".nimbus-telemetry-disabled"));
+      if (disabled) return { kind: "hit", value: { enabled: false } };
+      if (ctx.localIndex === undefined) {
+        return { kind: "hit", value: { enabled: true } };
+      }
+      const d = ctx.localIndex.getDatabase();
+      const m = collectIndexMetrics(d);
+      const preview = buildTelemetryPreview({
+        nimbusVersion: ctx.gatewayVersion,
+        queryLatencyP50Ms: m.queryLatencyP50Ms,
+        queryLatencyP95Ms: m.queryLatencyP95Ms,
+        queryLatencyP99Ms: m.queryLatencyP99Ms,
+        db: d,
+      });
+      return { kind: "hit", value: { enabled: true, ...preview } };
+    }
+    case "telemetry.setEnabled": {
+      const p = params as { enabled?: unknown } | null;
+      if (p === null || typeof p.enabled !== "boolean") {
+        throw new DiagnosticsRpcError(-32602, "telemetry.setEnabled requires enabled:boolean");
+      }
+      const markerPath = join(ctx.dataDir, ".nimbus-telemetry-disabled");
+      if (p.enabled) {
+        if (existsSync(markerPath)) {
+          assertTelemetryDisablePathSafe(markerPath);
+          unlinkSync(markerPath);
+        }
+      } else {
+        assertTelemetryDisablePathSafe(markerPath);
+        writeFileSync(markerPath, `${String(Date.now())}\n`, { mode: 0o600 });
+      }
+      return { kind: "hit", value: { enabled: p.enabled } };
+    }
     default:
       return { kind: "miss" };
   }

--- a/packages/gateway/src/ipc/diagnostics-rpc.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.ts
@@ -454,6 +454,17 @@ export function dispatchDiagnosticsRpc(
       }
       return { kind: "hit", value: { enabled: p.enabled } };
     }
+    case "diag.getVersion": {
+      return {
+        kind: "hit",
+        value: {
+          version: ctx.gatewayVersion,
+          commit: process.env["NIMBUS_BUILD_COMMIT"] ?? null,
+          buildId: process.env["NIMBUS_BUILD_ID"] ?? null,
+          uptimeMs: Date.now() - ctx.startedAtMs,
+        },
+      };
+    }
     default:
       return { kind: "miss" };
   }

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -135,3 +135,31 @@ describe("llm.loadModel / llm.unloadModel", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("llm.setDefault", () => {
+  test("persists default per task type and echoes back", async () => {
+    const setDefault = mock(async () => {});
+    const registry = { setDefault } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc(
+      "llm.setDefault",
+      { taskType: "classification", provider: "ollama", modelName: "gemma:2b" },
+      { registry, notify: () => {} },
+    );
+    expect(r.kind).toBe("hit");
+    expect((r as { kind: "hit"; value: { taskType: string } }).value.taskType).toBe(
+      "classification",
+    );
+    expect(setDefault).toHaveBeenCalledWith("classification", "ollama", "gemma:2b");
+  });
+
+  test("rejects invalid taskType", async () => {
+    const registry = { setDefault: mock(async () => {}) } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.setDefault",
+        { taskType: "bogus", provider: "ollama", modelName: "x" },
+        { registry, notify: () => {} },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -76,3 +76,24 @@ describe("llm.pullModel", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("llm.cancelPull", () => {
+  test("returns cancelled:false for unknown pullId", async () => {
+    const r = await dispatchLlmRpc(
+      "llm.cancelPull",
+      { pullId: "pull_unknown_000" },
+      { registry: {} as unknown as LlmRegistry, notify: () => {} },
+    );
+    expect(r.kind).toBe("hit");
+    expect((r as { kind: "hit"; value: { cancelled: boolean } }).value.cancelled).toBe(false);
+  });
+
+  test("rejects missing pullId with -32602", async () => {
+    await expect(
+      dispatchLlmRpc("llm.cancelPull", null, {
+        registry: {} as unknown as LlmRegistry,
+        notify: () => {},
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -136,6 +136,27 @@ describe("llm.loadModel / llm.unloadModel", () => {
   });
 });
 
+describe("llm.getRouterStatus", () => {
+  test("returns a routing decision per task type", async () => {
+    const getRouterStatus = mock(async () => ({
+      classification: { providerId: "ollama", modelName: "gemma:2b", reason: "default" },
+      reasoning: { providerId: "remote", modelName: "claude", reason: "air-gap off" },
+      summarisation: { providerId: "ollama", modelName: "llama3.2", reason: "default" },
+      agent_step: { providerId: "ollama", modelName: "llama3.2", reason: "default" },
+    }));
+    const registry = { getRouterStatus } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.getRouterStatus", null, { registry, notify: () => {} });
+    expect(r.kind).toBe("hit");
+    const val = (r as { kind: "hit"; value: { decisions: Record<string, unknown> } }).value;
+    expect(Object.keys(val.decisions).sort()).toEqual([
+      "agent_step",
+      "classification",
+      "reasoning",
+      "summarisation",
+    ]);
+  });
+});
+
 describe("llm.setDefault", () => {
   test("persists default per task type and echoes back", async () => {
     const setDefault = mock(async () => {});

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -97,3 +97,41 @@ describe("llm.cancelPull", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("llm.loadModel / llm.unloadModel", () => {
+  test("loadModel marks the model as loaded and returns isLoaded: true", async () => {
+    const loadModel = mock(async () => {});
+    const registry = { loadModel } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc(
+      "llm.loadModel",
+      { provider: "ollama", modelName: "gemma:2b" },
+      { registry, notify: () => {} },
+    );
+    expect(r.kind).toBe("hit");
+    expect((r as { kind: "hit"; value: { isLoaded: boolean } }).value.isLoaded).toBe(true);
+    expect(loadModel).toHaveBeenCalledWith("ollama", "gemma:2b");
+  });
+
+  test("unloadModel returns isLoaded: false", async () => {
+    const unloadModel = mock(async () => {});
+    const registry = { unloadModel } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc(
+      "llm.unloadModel",
+      { provider: "ollama", modelName: "gemma:2b" },
+      { registry, notify: () => {} },
+    );
+    expect((r as { kind: "hit"; value: { isLoaded: boolean } }).value.isLoaded).toBe(false);
+    expect(unloadModel).toHaveBeenCalledWith("ollama", "gemma:2b");
+  });
+
+  test("loadModel rejects unsupported provider", async () => {
+    const registry = { loadModel: mock(async () => {}) } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.loadModel",
+        { provider: "remote", modelName: "x" },
+        { registry, notify: () => {} },
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import type { LlmRegistry } from "../llm/registry.ts";
 import type { LlmModelInfo } from "../llm/types.ts";
 import type { LlmRpcContext } from "./llm-rpc.ts";
 import { dispatchLlmRpc } from "./llm-rpc.ts";
@@ -12,13 +13,13 @@ function makeFakeRegistry(models: LlmModelInfo[] = []): LlmRpcContext["registry"
 
 describe("dispatchLlmRpc", () => {
   test("returns miss for unknown method", async () => {
-    const ctx: LlmRpcContext = { registry: makeFakeRegistry() };
+    const ctx: LlmRpcContext = { registry: makeFakeRegistry(), notify: () => {} };
     const result = await dispatchLlmRpc("unknown.method", {}, ctx);
     expect(result.kind).toBe("miss");
   });
 
   test("returns miss for non-llm prefix", async () => {
-    const ctx: LlmRpcContext = { registry: makeFakeRegistry() };
+    const ctx: LlmRpcContext = { registry: makeFakeRegistry(), notify: () => {} };
     const result = await dispatchLlmRpc("connector.list", {}, ctx);
     expect(result.kind).toBe("miss");
   });
@@ -27,7 +28,7 @@ describe("dispatchLlmRpc", () => {
     const models: LlmModelInfo[] = [
       { provider: "ollama", modelName: "llama3.2", contextWindow: 128000 },
     ];
-    const ctx: LlmRpcContext = { registry: makeFakeRegistry(models) };
+    const ctx: LlmRpcContext = { registry: makeFakeRegistry(models), notify: () => {} };
     const result = await dispatchLlmRpc("llm.listModels", {}, ctx);
     expect(result.kind).toBe("hit");
     if (result.kind === "hit") {
@@ -38,7 +39,7 @@ describe("dispatchLlmRpc", () => {
   });
 
   test("llm.getStatus returns availability map", async () => {
-    const ctx: LlmRpcContext = { registry: makeFakeRegistry() };
+    const ctx: LlmRpcContext = { registry: makeFakeRegistry(), notify: () => {} };
     const result = await dispatchLlmRpc("llm.getStatus", {}, ctx);
     expect(result.kind).toBe("hit");
     if (result.kind === "hit") {
@@ -46,5 +47,32 @@ describe("dispatchLlmRpc", () => {
       expect(value.available["ollama"]).toBe(true);
       expect(value.available["llamacpp"]).toBe(false);
     }
+  });
+});
+
+describe("llm.pullModel", () => {
+  test("returns { pullId } and calls registry.pullModel", async () => {
+    const pullModel = mock(async () => {});
+    const registry = { pullModel } as unknown as LlmRegistry;
+    const notify = mock((_m: string, _p: unknown) => {});
+    const result = await dispatchLlmRpc(
+      "llm.pullModel",
+      { provider: "ollama", modelName: "gemma:2b" },
+      { registry, notify },
+    );
+    expect(result.kind).toBe("hit");
+    expect((result as { kind: "hit"; value: { pullId: string } }).value.pullId).toMatch(/^pull_/);
+    expect(pullModel).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects unknown provider with -32602", async () => {
+    const registry = { pullModel: mock(async () => {}) } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.pullModel",
+        { provider: "remote", modelName: "x" },
+        { registry, notify: () => {} },
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -39,21 +39,21 @@ export async function dispatchLlmRpc(
       if (provider !== "ollama" && provider !== "llamacpp") {
         throw new LlmRpcError(-32602, `Unsupported provider: ${provider}`);
       }
+      const modelName = p.modelName;
       const pullId = `pull_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       const controller = new AbortController();
       activePulls.set(pullId, controller);
       void ctx.registry
-        .pullModel(provider, p.modelName, {
+        .pullModel(provider, modelName, {
           signal: controller.signal,
-          onProgress: (c) =>
-            ctx.notify("llm.pullProgress", { pullId, provider, modelName: p.modelName, ...c }),
+          onProgress: (c) => ctx.notify("llm.pullProgress", { pullId, provider, modelName, ...c }),
         })
-        .then(() => ctx.notify("llm.pullCompleted", { pullId, provider, modelName: p.modelName }))
+        .then(() => ctx.notify("llm.pullCompleted", { pullId, provider, modelName }))
         .catch((err: unknown) =>
           ctx.notify("llm.pullFailed", {
             pullId,
             provider,
-            modelName: p.modelName,
+            modelName,
             error: err instanceof Error ? err.message : String(err),
           }),
         )

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -98,6 +98,10 @@ export async function dispatchLlmRpc(
       ctx.notify("llm.modelUnloaded", { provider, modelName });
       return { kind: "hit", value: { isLoaded: false } };
     }
+    case "llm.getRouterStatus": {
+      const decisions = await ctx.registry.getRouterStatus();
+      return { kind: "hit", value: { decisions } };
+    }
     case "llm.setDefault": {
       const VALID_TASKS = new Set(["classification", "embedding", "reasoning", "generation"]);
       const VALID_PROVIDERS = new Set(["ollama", "llamacpp", "remote"]);

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -70,6 +70,34 @@ export async function dispatchLlmRpc(
       controller?.abort();
       return { kind: "hit", value: { cancelled } };
     }
+    case "llm.loadModel": {
+      const p = params as { provider?: string; modelName?: string } | null;
+      if (p === null || typeof p.modelName !== "string") {
+        throw new LlmRpcError(-32602, "loadModel requires modelName");
+      }
+      const provider = p.provider ?? "ollama";
+      if (provider !== "ollama" && provider !== "llamacpp") {
+        throw new LlmRpcError(-32602, `Unsupported provider: ${provider}`);
+      }
+      const modelName = p.modelName;
+      await ctx.registry.loadModel(provider, modelName);
+      ctx.notify("llm.modelLoaded", { provider, modelName });
+      return { kind: "hit", value: { isLoaded: true } };
+    }
+    case "llm.unloadModel": {
+      const p = params as { provider?: string; modelName?: string } | null;
+      if (p === null || typeof p.modelName !== "string") {
+        throw new LlmRpcError(-32602, "unloadModel requires modelName");
+      }
+      const provider = p.provider ?? "ollama";
+      if (provider !== "ollama" && provider !== "llamacpp") {
+        throw new LlmRpcError(-32602, `Unsupported provider: ${provider}`);
+      }
+      const modelName = p.modelName;
+      await ctx.registry.unloadModel(provider, modelName);
+      ctx.notify("llm.modelUnloaded", { provider, modelName });
+      return { kind: "hit", value: { isLoaded: false } };
+    }
     default:
       return { kind: "miss" };
   }

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -103,7 +103,7 @@ export async function dispatchLlmRpc(
       return { kind: "hit", value: { decisions } };
     }
     case "llm.setDefault": {
-      const VALID_TASKS = new Set(["classification", "embedding", "reasoning", "generation"]);
+      const VALID_TASKS = new Set(["classification", "reasoning", "summarisation", "agent_step"]);
       const VALID_PROVIDERS = new Set(["ollama", "llamacpp", "remote"]);
       const p = params as { taskType?: string; provider?: string; modelName?: string } | null;
       if (
@@ -117,7 +117,7 @@ export async function dispatchLlmRpc(
         throw new LlmRpcError(-32602, "setDefault requires valid taskType, provider, modelName");
       }
       await ctx.registry.setDefault(
-        p.taskType as "classification" | "embedding" | "reasoning" | "generation",
+        p.taskType as "classification" | "reasoning" | "summarisation" | "agent_step",
         p.provider as "ollama" | "llamacpp" | "remote",
         p.modelName,
       );

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -11,11 +11,14 @@ export class LlmRpcError extends Error {
 
 export type LlmRpcContext = {
   registry: LlmRegistry;
+  notify: (method: string, params: unknown) => void;
 };
+
+const activePulls = new Map<string, AbortController>();
 
 export async function dispatchLlmRpc(
   method: string,
-  _params: unknown,
+  params: unknown,
   ctx: LlmRpcContext,
 ): Promise<{ kind: "hit"; value: unknown } | { kind: "miss" }> {
   switch (method) {
@@ -26,6 +29,46 @@ export async function dispatchLlmRpc(
     case "llm.getStatus": {
       const available = await ctx.registry.checkAvailability();
       return { kind: "hit", value: { available } };
+    }
+    case "llm.pullModel": {
+      const p = params as { provider?: string; modelName?: string } | null;
+      if (p === null || typeof p.modelName !== "string") {
+        throw new LlmRpcError(-32602, "pullModel requires modelName");
+      }
+      const provider = p.provider ?? "ollama";
+      if (provider !== "ollama" && provider !== "llamacpp") {
+        throw new LlmRpcError(-32602, `Unsupported provider: ${provider}`);
+      }
+      const pullId = `pull_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const controller = new AbortController();
+      activePulls.set(pullId, controller);
+      void ctx.registry
+        .pullModel(provider, p.modelName, {
+          signal: controller.signal,
+          onProgress: (c) =>
+            ctx.notify("llm.pullProgress", { pullId, provider, modelName: p.modelName, ...c }),
+        })
+        .then(() => ctx.notify("llm.pullCompleted", { pullId, provider, modelName: p.modelName }))
+        .catch((err: unknown) =>
+          ctx.notify("llm.pullFailed", {
+            pullId,
+            provider,
+            modelName: p.modelName,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        )
+        .finally(() => activePulls.delete(pullId));
+      return { kind: "hit", value: { pullId } };
+    }
+    case "llm.cancelPull": {
+      const p = params as { pullId?: string } | null;
+      if (p === null || typeof p.pullId !== "string") {
+        throw new LlmRpcError(-32602, "cancelPull requires pullId");
+      }
+      const controller = activePulls.get(p.pullId);
+      const cancelled = controller !== undefined;
+      controller?.abort();
+      return { kind: "hit", value: { cancelled } };
     }
     default:
       return { kind: "miss" };

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -98,6 +98,30 @@ export async function dispatchLlmRpc(
       ctx.notify("llm.modelUnloaded", { provider, modelName });
       return { kind: "hit", value: { isLoaded: false } };
     }
+    case "llm.setDefault": {
+      const VALID_TASKS = new Set(["classification", "embedding", "reasoning", "generation"]);
+      const VALID_PROVIDERS = new Set(["ollama", "llamacpp", "remote"]);
+      const p = params as { taskType?: string; provider?: string; modelName?: string } | null;
+      if (
+        p === null ||
+        typeof p.taskType !== "string" ||
+        !VALID_TASKS.has(p.taskType) ||
+        typeof p.provider !== "string" ||
+        !VALID_PROVIDERS.has(p.provider) ||
+        typeof p.modelName !== "string"
+      ) {
+        throw new LlmRpcError(-32602, "setDefault requires valid taskType, provider, modelName");
+      }
+      await ctx.registry.setDefault(
+        p.taskType as "classification" | "embedding" | "reasoning" | "generation",
+        p.provider as "ollama" | "llamacpp" | "remote",
+        p.modelName,
+      );
+      return {
+        kind: "hit",
+        value: { taskType: p.taskType, provider: p.provider, modelName: p.modelName },
+      };
+    }
     default:
       return { kind: "miss" };
   }

--- a/packages/gateway/src/ipc/profile-rpc.test.ts
+++ b/packages/gateway/src/ipc/profile-rpc.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProfileManager } from "../config/profiles.ts";
+import { dispatchProfileRpc } from "./profile-rpc.ts";
+
+function makeMgr(): ProfileManager {
+  return new ProfileManager(mkdtempSync(join(tmpdir(), "nimbus-prof-")));
+}
+
+describe("profile.list", () => {
+  test("returns empty list + active=null before any create", async () => {
+    const r = await dispatchProfileRpc("profile.list", null, { manager: makeMgr() });
+    expect(r.kind).toBe("hit");
+    const v = (r as { kind: "hit"; value: { profiles: unknown[]; active: string | null } }).value;
+    expect(v.profiles).toEqual([]);
+    expect(v.active).toBeNull();
+  });
+
+  test("returns created profiles + current active", async () => {
+    const mgr = makeMgr();
+    await mgr.create("work");
+    await mgr.switchTo("work");
+    const r = await dispatchProfileRpc("profile.list", null, { manager: mgr });
+    const v = (
+      r as { kind: "hit"; value: { profiles: Array<{ name: string }>; active: string | null } }
+    ).value;
+    expect(v.profiles.map((p) => p.name)).toEqual(["work"]);
+    expect(v.active).toBe("work");
+  });
+});
+
+describe("profile.create", () => {
+  test("creates a new profile and returns it", async () => {
+    const mgr = makeMgr();
+    const r = await dispatchProfileRpc("profile.create", { name: "work" }, { manager: mgr });
+    expect(r.kind).toBe("hit");
+    const profiles = await mgr.list();
+    expect(profiles.map((p) => p.name)).toEqual(["work"]);
+  });
+
+  test("rejects duplicate names", async () => {
+    const mgr = makeMgr();
+    await mgr.create("work");
+    await expect(
+      dispatchProfileRpc("profile.create", { name: "work" }, { manager: mgr }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects invalid names", async () => {
+    await expect(
+      dispatchProfileRpc("profile.create", { name: "bad name!" }, { manager: makeMgr() }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects missing name param", async () => {
+    await expect(
+      dispatchProfileRpc("profile.create", null, { manager: makeMgr() }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("profile.switch", () => {
+  test("switches active profile and emits profile.switched", async () => {
+    const mgr = makeMgr();
+    await mgr.create("work");
+    const notifications: { method: string; params: unknown }[] = [];
+    const r = await dispatchProfileRpc(
+      "profile.switch",
+      { name: "work" },
+      { manager: mgr, notify: (m, p) => notifications.push({ method: m, params: p }) },
+    );
+    expect(r.kind).toBe("hit");
+    expect(await mgr.getActive()).toBe("work");
+    expect(notifications.some((n) => n.method === "profile.switched")).toBe(true);
+  });
+
+  test("rejects unknown profile", async () => {
+    await expect(
+      dispatchProfileRpc("profile.switch", { name: "ghost" }, { manager: makeMgr() }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("profile.delete", () => {
+  test("deletes a non-active profile", async () => {
+    const mgr = makeMgr();
+    await mgr.create("work");
+    await mgr.create("personal");
+    await mgr.switchTo("work");
+    const r = await dispatchProfileRpc("profile.delete", { name: "personal" }, { manager: mgr });
+    expect(r.kind).toBe("hit");
+    expect((await mgr.list()).map((p) => p.name)).toEqual(["work"]);
+  });
+
+  test("refuses to delete the active profile", async () => {
+    const mgr = makeMgr();
+    await mgr.create("work");
+    await mgr.switchTo("work");
+    await expect(
+      dispatchProfileRpc("profile.delete", { name: "work" }, { manager: mgr }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("dispatchProfileRpc", () => {
+  test("returns miss for unknown method", async () => {
+    const r = await dispatchProfileRpc("profile.unknown", null, { manager: makeMgr() });
+    expect(r.kind).toBe("miss");
+  });
+});

--- a/packages/gateway/src/ipc/profile-rpc.ts
+++ b/packages/gateway/src/ipc/profile-rpc.ts
@@ -1,0 +1,56 @@
+import type { ProfileManager } from "../config/profiles.ts";
+
+export class ProfileRpcError extends Error {
+  readonly rpcCode: number;
+  constructor(rpcCode: number, message: string) {
+    super(message);
+    this.name = "ProfileRpcError";
+    this.rpcCode = rpcCode;
+  }
+}
+
+export type ProfileRpcContext = {
+  manager: ProfileManager;
+  notify?: (method: string, params: unknown) => void;
+};
+
+export async function dispatchProfileRpc(
+  method: string,
+  params: unknown,
+  ctx: ProfileRpcContext,
+): Promise<{ kind: "hit"; value: unknown } | { kind: "miss" }> {
+  switch (method) {
+    case "profile.list": {
+      const profiles = await ctx.manager.list();
+      const active = (await ctx.manager.getActive()) ?? null;
+      return { kind: "hit", value: { profiles, active } };
+    }
+    case "profile.create": {
+      const p = params as { name?: unknown } | null;
+      if (p === null || typeof p.name !== "string") {
+        throw new ProfileRpcError(-32602, "profile.create requires name");
+      }
+      await ctx.manager.create(p.name);
+      return { kind: "hit", value: { name: p.name } };
+    }
+    case "profile.switch": {
+      const p = params as { name?: unknown } | null;
+      if (p === null || typeof p.name !== "string") {
+        throw new ProfileRpcError(-32602, "profile.switch requires name");
+      }
+      await ctx.manager.switchTo(p.name);
+      ctx.notify?.("profile.switched", { name: p.name });
+      return { kind: "hit", value: { active: p.name } };
+    }
+    case "profile.delete": {
+      const p = params as { name?: unknown } | null;
+      if (p === null || typeof p.name !== "string") {
+        throw new ProfileRpcError(-32602, "profile.delete requires name");
+      }
+      await ctx.manager.delete(p.name);
+      return { kind: "hit", value: { deleted: p.name } };
+    }
+    default:
+      return { kind: "miss" };
+  }
+}

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -345,7 +345,10 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
       return phase4RpcSkipped;
     }
     try {
-      const out = await dispatchLlmRpc(method, params, { registry: options.llmRegistry });
+      const out = await dispatchLlmRpc(method, params, {
+        registry: options.llmRegistry,
+        notify: (m, p) => broadcastNotification(m, p as Record<string, unknown>),
+      });
       if (out.kind === "hit") return out.value;
     } catch (e) {
       if (e instanceof LlmRpcError) {

--- a/packages/gateway/src/ipc/server.ts
+++ b/packages/gateway/src/ipc/server.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from "node:events";
 import { chmodSync, existsSync, unlinkSync } from "node:fs";
 import net from "node:net";
 import { platform } from "node:os";
+import type { ProfileManager } from "../config/profiles.ts";
 import { Config } from "../config.ts";
 import type { LazyConnectorMesh } from "../connectors/lazy-mesh.ts";
 import { asRecord } from "../connectors/unknown-record.ts";
@@ -36,6 +37,7 @@ import { generatePairingCode, type PairingWindow } from "./lan-pairing.ts";
 import type { LanServer } from "./lan-server.ts";
 import { dispatchLlmRpc, LlmRpcError } from "./llm-rpc.ts";
 import { dispatchPeopleRpc, PeopleRpcError } from "./people-rpc.ts";
+import { dispatchProfileRpc, ProfileRpcError } from "./profile-rpc.ts";
 import { dispatchReindexRpc, ReindexRpcError } from "./reindex-rpc.ts";
 import { ClientSession, type SessionWrite } from "./session.ts";
 import { dispatchSessionRpc, SessionRpcError } from "./session-rpc.ts";
@@ -175,6 +177,8 @@ export type CreateIpcServerOptions = {
   lanServer?: LanServer;
   /** Pairing window shared with the LAN server (Phase 4 WS4). */
   lanPairingWindow?: PairingWindow;
+  /** Profile manager for profile.* RPCs (Phase 4 WS5-C). */
+  profileManager?: ProfileManager;
 };
 
 function requireNonEmptyRpcString(rec: Record<string, unknown> | undefined, key: string): string {
@@ -413,6 +417,24 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     return phase4RpcSkipped;
   }
 
+  async function tryDispatchProfileRpc(method: string, params: unknown): Promise<unknown> {
+    if (!method.startsWith("profile.")) return phase4RpcSkipped;
+    if (options.profileManager === undefined) {
+      throw new RpcMethodError(-32603, "Profile manager is not available on this gateway");
+    }
+    try {
+      const out = await dispatchProfileRpc(method, params, {
+        manager: options.profileManager,
+        notify: (m, p) => broadcastNotification(m, p as Record<string, unknown>),
+      });
+      if (out.kind === "hit") return out.value;
+    } catch (e) {
+      if (e instanceof ProfileRpcError) throw new RpcMethodError(e.rpcCode, e.message);
+      throw e;
+    }
+    return phase4RpcSkipped;
+  }
+
   async function tryDispatchDataRpc(method: string, params: unknown): Promise<unknown> {
     if (!method.startsWith("data.")) return phase4RpcSkipped;
     try {
@@ -515,6 +537,8 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     if (dataOutcome !== phase4RpcSkipped) return dataOutcome;
     const lanOutcome = await tryDispatchLanRpc(method, params);
     if (lanOutcome !== phase4RpcSkipped) return lanOutcome;
+    const profileOutcome = await tryDispatchProfileRpc(method, params);
+    if (profileOutcome !== phase4RpcSkipped) return profileOutcome;
     return tryDispatchReindexRpc(method, params);
   }
 

--- a/packages/gateway/src/llm/ollama-provider.test.ts
+++ b/packages/gateway/src/llm/ollama-provider.test.ts
@@ -136,6 +136,10 @@ describe("OllamaProvider.pullModel", () => {
     globalThis.fetch = _realFetch;
   });
 
+  afterEach(() => {
+    globalThis.fetch = _realFetch;
+  });
+
   test("pullModel streams progress chunks and resolves on done", async () => {
     const chunks = [
       '{"status":"pulling manifest"}\n',

--- a/packages/gateway/src/llm/ollama-provider.test.ts
+++ b/packages/gateway/src/llm/ollama-provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { OllamaProvider } from "./ollama-provider.ts";
+import type { PullProgressChunk } from "./types.ts";
 
 const _realFetch = globalThis.fetch;
 
@@ -126,5 +127,40 @@ describe("OllamaProvider", () => {
     expect(tokens).toEqual(["Hello", " world"]);
     expect(result.text).toBe("Hello world");
     expect(result.tokensOut).toBe(2);
+  });
+});
+
+describe("OllamaProvider.pullModel", () => {
+  beforeEach(() => {
+    // Restore real fetch so Bun.serve can be reached
+    globalThis.fetch = _realFetch;
+  });
+
+  test("pullModel streams progress chunks and resolves on done", async () => {
+    const chunks = [
+      '{"status":"pulling manifest"}\n',
+      '{"status":"downloading","completed":100,"total":1000}\n',
+      '{"status":"downloading","completed":1000,"total":1000}\n',
+      '{"status":"success"}\n',
+    ];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (new URL(req.url).pathname !== "/api/pull") return new Response(null, { status: 404 });
+        const body = new ReadableStream({
+          start(controller) {
+            for (const c of chunks) controller.enqueue(new TextEncoder().encode(c));
+            controller.close();
+          },
+        });
+        return new Response(body, { headers: { "Content-Type": "application/x-ndjson" } });
+      },
+    });
+    const p = new OllamaProvider(`http://127.0.0.1:${server.port}`);
+    const received: PullProgressChunk[] = [];
+    await p.pullModel!("llama3.2:1b", { onProgress: (c) => received.push(c) });
+    server.stop();
+    expect(received.at(-1)?.status).toBe("success");
+    expect(received.some((c) => c.completedBytes === 1000)).toBe(true);
   });
 });

--- a/packages/gateway/src/llm/ollama-provider.ts
+++ b/packages/gateway/src/llm/ollama-provider.ts
@@ -1,4 +1,10 @@
-import type { LlmGenerateOptions, LlmGenerateResult, LlmModelInfo, LlmProvider } from "./types.ts";
+import type {
+  LlmGenerateOptions,
+  LlmGenerateResult,
+  LlmModelInfo,
+  LlmProvider,
+  PullProgressChunk,
+} from "./types.ts";
 
 type OllamaTagsModel = {
   name?: unknown;
@@ -186,5 +192,48 @@ export class OllamaProvider implements LlmProvider {
       isLocal: true,
       provider: "ollama",
     };
+  }
+
+  async pullModel(
+    modelName: string,
+    opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void } = {},
+  ): Promise<void> {
+    const resp = await fetch(`${this.baseUrl}/api/pull`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: modelName, stream: true }),
+      signal: opts.signal ?? null,
+    });
+    if (!resp.ok) throw new Error(`Ollama pullModel HTTP ${resp.status}`);
+    const reader = resp.body?.getReader();
+    if (reader === undefined) throw new Error("No response body");
+    const decoder = new TextDecoder();
+    let buf = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === "") continue;
+        try {
+          const chunk = JSON.parse(trimmed) as {
+            status?: unknown;
+            completed?: unknown;
+            total?: unknown;
+          };
+          const progress: PullProgressChunk = {
+            status: typeof chunk.status === "string" ? chunk.status : "",
+            ...(typeof chunk.completed === "number" && { completedBytes: chunk.completed }),
+            ...(typeof chunk.total === "number" && { totalBytes: chunk.total }),
+          };
+          opts.onProgress?.(progress);
+        } catch {
+          /* ignore malformed chunk */
+        }
+      }
+    }
   }
 }

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -98,7 +98,7 @@ export class LlmRegistry {
   }
 
   async setDefault(
-    taskType: "classification" | "embedding" | "reasoning" | "generation",
+    taskType: "classification" | "reasoning" | "summarisation" | "agent_step",
     provider: "ollama" | "llamacpp" | "remote",
     modelName: string,
   ): Promise<void> {

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { LlmRouter, type LlmRouterConfig } from "./router.ts";
-import type { LlmModelInfo, LlmProvider } from "./types.ts";
+import type { LlmModelInfo, LlmProvider, PullProgressChunk } from "./types.ts";
 
 export type LlmRegistryOptions = {
   config: LlmRouterConfig;
@@ -59,6 +59,21 @@ export class LlmRegistry {
       }
     }
     return result;
+  }
+
+  async pullModel(
+    provider: "ollama" | "llamacpp",
+    modelName: string,
+    opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void } = {},
+  ): Promise<void> {
+    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
+      provider,
+    );
+    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+    if (typeof p.pullModel !== "function") {
+      throw new Error(`Provider ${provider} does not support pullModel`);
+    }
+    await p.pullModel(modelName, opts);
   }
 
   private syncModelsToDb(models: LlmModelInfo[]): void {

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -97,6 +97,31 @@ export class LlmRegistry {
     await p.pullModel(modelName, opts);
   }
 
+  async setDefault(
+    taskType: "classification" | "embedding" | "reasoning" | "generation",
+    provider: "ollama" | "llamacpp" | "remote",
+    modelName: string,
+  ): Promise<void> {
+    if (this.db === undefined) return;
+    this.db.run(
+      `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(task_type) DO UPDATE SET
+         provider = excluded.provider,
+         model_name = excluded.model_name,
+         updated_at = excluded.updated_at`,
+      [taskType, provider, modelName, Date.now()],
+    );
+  }
+
+  getDefault(taskType: string): { provider: string; modelName: string } | undefined {
+    if (this.db === undefined) return undefined;
+    const row = this.db
+      .query("SELECT provider, model_name FROM llm_task_defaults WHERE task_type = ?")
+      .get(taskType) as { provider: string; model_name: string } | undefined;
+    return row === undefined ? undefined : { provider: row.provider, modelName: row.model_name };
+  }
+
   private syncModelsToDb(models: LlmModelInfo[]): void {
     if (this.db === undefined) return;
     const now = Date.now();

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -61,6 +61,27 @@ export class LlmRegistry {
     return result;
   }
 
+  async loadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
+    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
+      provider,
+    );
+    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+    if (typeof (p as unknown as { loadModel?: unknown }).loadModel === "function") {
+      await (p as unknown as { loadModel: (m: string) => Promise<void> }).loadModel(modelName);
+    }
+    // Ollama auto-loads on first generate; this is a no-op for Ollama.
+  }
+
+  async unloadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
+    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
+      provider,
+    );
+    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+    if (typeof (p as unknown as { unloadModel?: unknown }).unloadModel === "function") {
+      await (p as unknown as { unloadModel: (m: string) => Promise<void> }).unloadModel(modelName);
+    }
+  }
+
   async pullModel(
     provider: "ollama" | "llamacpp",
     modelName: string,

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -114,6 +114,10 @@ export class LlmRegistry {
     );
   }
 
+  async getRouterStatus(): Promise<Awaited<ReturnType<LlmRouter["getStatus"]>>> {
+    return await this.router.getStatus();
+  }
+
   getDefault(taskType: string): { provider: string; modelName: string } | undefined {
     if (this.db === undefined) return undefined;
     const row = this.db

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -110,6 +110,29 @@ export class LlmRouter {
     return meta.parameterCount >= this.config.minReasoningParams;
   }
 
+  async getStatus(): Promise<
+    Record<LlmTaskType, { providerId: string; modelName: string; reason: string } | undefined>
+  > {
+    const tasks: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
+    const out: Partial<
+      Record<LlmTaskType, { providerId: string; modelName: string; reason: string } | undefined>
+    > = {};
+    for (const t of tasks) {
+      const provider = await this.selectProvider(t);
+      if (provider === undefined) {
+        out[t] = undefined;
+        continue;
+      }
+      const isLocal = LOCAL_PROVIDER_IDS.has(provider.providerId);
+      const reason = !isLocal && this.config.enforceAirGap ? "air-gap bypassed" : "default";
+      out[t] = { providerId: provider.providerId, modelName: "", reason };
+    }
+    return out as Record<
+      LlmTaskType,
+      { providerId: string; modelName: string; reason: string } | undefined
+    >;
+  }
+
   private providerPriority(_task: LlmTaskType): LlmProviderKind[] {
     if (this.config.preferLocal) {
       return ["ollama", "llamacpp", "remote"];

--- a/packages/gateway/src/llm/types.ts
+++ b/packages/gateway/src/llm/types.ts
@@ -36,9 +36,19 @@ export type LlmGenerateResult = {
   provider: LlmProviderKind;
 };
 
+export type PullProgressChunk = {
+  status: string;
+  completedBytes?: number;
+  totalBytes?: number;
+};
+
 export interface LlmProvider {
   readonly providerId: LlmProviderKind;
   isAvailable(): Promise<boolean>;
   listModels(): Promise<LlmModelInfo[]>;
   generate(opts: LlmGenerateOptions): Promise<LlmGenerateResult>;
+  pullModel?(
+    modelName: string,
+    opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void },
+  ): Promise<void>;
 }

--- a/packages/gateway/src/updater/updater.test.ts
+++ b/packages/gateway/src/updater/updater.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { randomBytes } from "node:crypto";
 import type { Server } from "bun";
-import type { UpdaterOptions } from "./updater.ts";
+import type { UpdaterEmit, UpdaterOptions } from "./updater.ts";
 import { Updater } from "./updater.ts";
 import { buildSignedManifest, jsonResponse, makeKeypair } from "./updater-test-fixtures.ts";
 
@@ -118,5 +118,57 @@ describe("Updater state machine", () => {
     await expect(u.applyUpdate()).rejects.toThrow(/signature|hash/i);
     expect(invocations).toEqual([]);
     expect(events).toContain("updater.rolledBack");
+  });
+
+  test("applyUpdate emits downloadProgress events during streaming fetch", async () => {
+    const progressEvents: Array<{ bytes: number; total: number }> = [];
+    const emit = mock((name: Parameters<UpdaterEmit>[0], payload?: Record<string, unknown>) => {
+      if (name === "updater.downloadProgress") {
+        progressEvents.push(payload as { bytes: number; total: number });
+      }
+    }) as UpdaterEmit;
+
+    const chunk = new Uint8Array(256);
+    downloadServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => {
+        const stream = new ReadableStream({
+          start(c) {
+            c.enqueue(chunk);
+            c.enqueue(chunk);
+            c.close();
+          },
+        });
+        return new Response(stream, {
+          headers: { "content-length": "512", "content-type": "application/octet-stream" },
+        });
+      },
+    });
+
+    // Use a valid manifest signed against the real binary so verification fails
+    // at hash/sig rather than before progress events are emitted
+    const binary = new Uint8Array(randomBytes(512));
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        jsonResponse(
+          buildSignedManifest(binary, kp, `http://127.0.0.1:${downloadServer.port}/bin`),
+        ),
+    });
+
+    const u = makeUpdater({ emit });
+    await u.checkNow();
+
+    // applyUpdate will throw at hash/sig verification (tampered binary), but
+    // downloadProgress events must have been emitted before that point
+    await u.applyUpdate().catch(() => {});
+
+    expect(progressEvents.length).toBeGreaterThanOrEqual(1);
+    // total comes from content-length header; some servers omit it for streaming (ok to be 0)
+    expect(typeof progressEvents[0]?.total).toBe("number");
+    const last = progressEvents[progressEvents.length - 1]!;
+    expect(last.bytes).toBe(512);
   });
 });

--- a/packages/gateway/src/updater/updater.ts
+++ b/packages/gateway/src/updater/updater.ts
@@ -80,20 +80,38 @@ export class Updater {
     }
 
     this.state = "downloading";
-    let body: ArrayBuffer;
+    let bytes: Uint8Array;
     try {
       const resp = await fetch(asset.url, { redirect: "follow" });
       if (!resp.ok) {
         throw new Error(`download HTTP ${resp.status}`);
       }
-      body = await resp.arrayBuffer();
+      const total = Number(resp.headers.get("content-length") ?? 0);
+      const reader = resp.body?.getReader();
+      if (reader === undefined) throw new Error("No response body from download");
+      const chunks: Uint8Array[] = [];
+      let downloaded = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value !== undefined) {
+          chunks.push(value);
+          downloaded += value.byteLength;
+          this.opts.emit("updater.downloadProgress", { bytes: downloaded, total });
+        }
+      }
+      bytes = new Uint8Array(downloaded);
+      let off = 0;
+      for (const c of chunks) {
+        bytes.set(c, off);
+        off += c.byteLength;
+      }
     } catch (err) {
       this.state = "failed";
       this.lastError = err instanceof Error ? err.message : String(err);
       this.opts.emit("updater.rolledBack", { reason: "download_failed" });
       throw err;
     }
-    const bytes = new Uint8Array(body);
 
     this.state = "verifying";
     const computedSha = sha256Hex(bytes);


### PR DESCRIPTION
## Summary

Adds the Gateway-side JSON-RPC surface the WS5-C Settings UI consumes. All 20 tasks from the [implementation plan](docs/superpowers/plans/2026-04-19-ws5c-gateway-ipc-plumbing.md) are complete. Additive only — no breaking changes to existing methods or CLI behavior.

- **LLM (Tasks 1–5):** `OllamaProvider.pullModel` NDJSON streaming; `llm.pullModel` with `pullProgress`/`pullCompleted`/`pullFailed` notifications + `llm.cancelPull`; `llm.loadModel`/`llm.unloadModel`; `llm.setDefault` persisted to new `llm_task_defaults` table (V20 schema); `llm.getRouterStatus`
- **Profiles (Tasks 6–10):** New `ProfileManager` (CLI-compatible `.nimbus-profile` + `nimbus.<name>.toml` format); `profile.list`/`create`/`switch`/`delete` RPC dispatcher wired into `server.ts`; `profile.switch` emits `profile.switched` notification
- **Telemetry (Tasks 11–12):** `telemetry.getStatus` (marker-file check + preview payload); `telemetry.setEnabled` (writes/removes `.nimbus-telemetry-disabled` with symlink safety)
- **Data (Tasks 13–15):** `data.getExportPreflight` (lastExportAt + estimatedSizeBytes + itemCount); `data.getDeletePreflight` (per-service item/embedding/vault-key counts); `data.exportProgress`/`importProgress` + `*Completed` notifications threaded via optional `notify` on `DataRpcContext`
- **Audit (Tasks 16–17):** `LocalIndex.getAuditSummary()` + `audit.getSummary` RPC; `audit.export` alias for `audit.exportAll`
- **Diag (Task 18):** `diag.getVersion` returns `version` + `commit` + `buildId` + `uptimeMs`
- **Connector (Task 19):** `connector.setConfig` composes `setInterval` + `pause`/`resume`
- **Updater (Task 20):** `applyUpdate` replaced `resp.arrayBuffer()` with streaming `ReadableStream` reader loop emitting `updater.downloadProgress` per chunk

## Test plan

- [x] `bun run typecheck` — green (gateway, cli, sdk, docs; pre-existing `@nimbus/ui` react-router-dom errors unrelated)
- [x] `bun test packages/gateway/` — 835/836 pass (1 pre-existing Windows EBUSY flake in `platform.test.ts`)
- [x] `bun run lint` — clean (689 files, no fixes needed)
- [x] Spec reviewer confirmed all 20 method implementations match spec; `LlmTaskType` vocabulary mismatch (plan used `embedding`/`generation`, codebase uses `summarisation`/`agent_step`) caught and fixed in final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)