### PR TITLE
fix(tauri): enable macOSPrivateApi for transparent Quick Query window

### DIFF
--- a/packages/ui/src-tauri/Cargo.toml
+++ b/packages/ui/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.5.6", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10.3", features = ["tray-icon", "image-png"] }
+tauri = { version = "2.10.3", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-global-shortcut = "2"

--- a/packages/ui/src-tauri/tauri.conf.json
+++ b/packages/ui/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
     "security": {
       "csp": null
     },
-    "macOSPrivateApi": false
+    "macOSPrivateApi": true
   },
   "bundle": {
     "active": true,


### PR DESCRIPTION
## Summary
- `transparent()` on `WebviewWindowBuilder` is gated behind the `macos-private-api` Tauri feature on macOS — without it the project fails to compile/clippy on `macos-14` CI.
- Set `macOSPrivateApi: true` in `tauri.conf.json` and add `macos-private-api` to the `tauri` features in `Cargo.toml`.
- Locally verified: `cargo clippy --all-targets --all-features -- -D warnings` passes on Windows (cross-checks all feature flags).

## Test plan
- [x] `cargo clippy` clean locally.
- [ ] CI green on macOS-14 Rust/Tauri job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)