### PR TITLE
feat(cli): add `nimbus --version` / `-v` / `version`

### DIFF
--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -45,6 +45,7 @@ Usage:
   nimbus repl [--session]  Interactive agent loop (TTY)
   nimbus run <file>        Save + run workflow from JSON/YAML file
   nimbus scaffold extension <id>  Minimal extension folder + manifest
+  nimbus version            Show the installed Nimbus version (also: --version, -v)
   nimbus help               Show this message
 
 Environment (optional):

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,6 +61,7 @@ import {
 } from "./commands/index.ts";
 import { createCliFileLogger } from "./lib/cli-logger.ts";
 import { getCliPlatformPaths } from "./paths.ts";
+import { NIMBUS_VERSION } from "./version.ts";
 
 const rawArgv = process.argv.slice(2);
 const isInteractiveShell = process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -132,8 +133,13 @@ const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler>> = {
 };
 
 const HELP_ALIASES = new Set(["help", "--help", "-h"]);
+const VERSION_ALIASES = new Set(["--version", "-v", "version"]);
 
 async function dispatchCommand(command: string, args: string[]): Promise<void> {
+  if (VERSION_ALIASES.has(command)) {
+    console.log(NIMBUS_VERSION);
+    return;
+  }
   if (HELP_ALIASES.has(command)) {
     printHelp();
     return;

--- a/packages/cli/src/version.test.ts
+++ b/packages/cli/src/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { NIMBUS_VERSION } from "./version.ts";
+
+describe("NIMBUS_VERSION", () => {
+  it("is a non-empty semver-shaped string", () => {
+    expect(NIMBUS_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("matches the monorepo root package.json version (release-please source of truth)", () => {
+    const rootPkgPath = join(import.meta.dir, "..", "..", "..", "package.json");
+    const rootVersion = JSON.parse(readFileSync(rootPkgPath, "utf8")).version as string;
+    expect(NIMBUS_VERSION).toBe(rootVersion);
+  });
+});

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the CLI's reported version: the monorepo root
+// package.json, which release-please bumps on every release (the per-package
+// package.json files are intentionally left at 0.1.0). Bun inlines this JSON
+// import into the compiled `nimbus` binary at build time, so `nimbus --version`
+// reports the released version with no runtime file access.
+import rootPkg from "../../../package.json";
+
+export const NIMBUS_VERSION: string = rootPkg.version;


### PR DESCRIPTION
## Why

Diagnosing why `nimbus clip pair` printed the help menu on a Windows install, the root cause was a **stale binary** (pre-v0.18.0, before the `clip` command existed) — and the CLI had **no way to report its own version**, so there was no quick way to confirm that. `nimbus --version` closes that gap.

## What

Adds `--version`, `-v`, and bareword `version`, all printing just the release version string (e.g. `0.20.0`):

- **`version.ts`** — single source of truth: imports the monorepo **root** `package.json` version (the one release-please bumps; per-package files stay at `0.1.0`). Bun inlines the JSON at `--compile` time, so the shipped binary needs no runtime file access.
- **`index.ts`** — `VERSION_ALIASES` handled in `dispatchCommand`, before the unknown-command → help fallback.
- **`help.ts`** — documents `nimbus version`.
- **`version.test.ts`** — asserts semver shape + exact match against root `package.json`.

## Verification

- `bun test packages/cli/src/version.test.ts` → 2 pass
- `biome check` on the 4 files → clean
- `tsc --noEmit` (cli) → clean
- Compiled a standalone binary and ran `--version` from an unrelated cwd → prints the version (confirms build-time inlining, no runtime file access)

```
$ nimbus --version → 0.20.0
$ nimbus version   → 0.20.0
$ nimbus -v        → 0.20.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nimbus version`, `--version`, and `-v` commands to display the installed Nimbus version.
  * Updated CLI help text to document the new version options.

* **Tests**
  * Added validation to ensure the reported version is present, correctly formatted, and matches the release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->