### PR TITLE
docs: clean up leftover packages/sdk references (poly-repo consistency)

### DIFF
--- a/.claude/commands/nimbus-architecture.md
+++ b/.claude/commands/nimbus-architecture.md
@@ -182,7 +182,7 @@ Full walkthrough: `docs/contributors/extension-author-walkthrough.md`
 | New Tauri UI page | `packages/ui/src/pages/<Name>.tsx` |
 | New TUI pane | `packages/cli/src/tui/<Name>.tsx` |
 | New LLM provider | `packages/gateway/src/llm/<name>-provider.ts` |
-| SDK export for extension authors | `packages/sdk/src/` |
+| SDK export for extension authors | _(standalone repo)_ [nimbus-agent/nimbus-sdk](https://github.com/nimbus-agent/nimbus-sdk) — published as `@nimbus-dev/sdk` |
 
 ---
 

--- a/.claude/commands/nimbus-file-map.md
+++ b/.claude/commands/nimbus-file-map.md
@@ -48,7 +48,7 @@ Curated pointer index. Source of truth is the working tree — verify a path wit
 | `packages/gateway/src/connectors/lazy-mesh/wrap-server-spec.ts` | `wrapServerSpec(spec, manifest, cwd)` — I15 wiring entrypoint |
 | `packages/gateway/src/connectors/lazy-mesh/first-party-manifests.ts` | `FIRST_PARTY_MANIFESTS` — per-connector sandbox manifests |
 | `packages/gateway/src-native/sandbox-helper/main.c` | Privileged C helper — `cap_net_admin+ep` via setcap; setns/unshare-killer |
-| `packages/sdk/src/testing/sandbox-contract.ts` | `runSandboxContractTests(manifestPath)` — SDK API for connector authors |
+| _(standalone repo)_ `nimbus-sdk/src/testing/sandbox-contract.ts` | `runSandboxContractTests(manifestPath)` — [nimbus-agent/nimbus-sdk](https://github.com/nimbus-agent/nimbus-sdk), published as `@nimbus-dev/sdk` — SDK API for connector authors |
 | `docs/sandbox.md` | Operator-facing reference; `#platform-asymmetry` + `#windows-platform-status` |
 
 ## Extensions — Dependency Resolution
@@ -236,8 +236,8 @@ Everything else follows the standard triple. These break from it in a way worth 
 
 | File | Purpose |
 |---|---|
-| `packages/sdk/src/index.ts` | `@nimbus-dev/sdk` public API |
 | `packages/gateway/src/clips/*` | Gateway web-clip surface — `PairingWindowController` (I30) + `clip-token-store.ts`; ingest via `POST /v1/clips` (the browser extension itself is the standalone repo below) |
+| _(standalone repo)_ | `@nimbus-dev/sdk` — [nimbus-agent/nimbus-sdk](https://github.com/nimbus-agent/nimbus-sdk) (npm, MIT) — extension-authoring contract; `mcp-connectors/*` consume the published package |
 | _(standalone repo)_ | `@nimbus-dev/client` — [nimbus-agent/nimbus-client](https://github.com/nimbus-agent/nimbus-client) (npm, MIT) — `NimbusClient`, `MockClient`; `packages/cli` and the VS Code extension consume the published package |
 | _(standalone repo)_ | VS Code extension — [nimbus-agent/nimbus-vscode](https://github.com/nimbus-agent/nimbus-vscode) (Marketplace + Open VSX) |
 | _(standalone repo)_ | Web clipper — [nimbus-agent/nimbus-web-clipper](https://github.com/nimbus-agent/nimbus-web-clipper) (Chrome + Firefox MV3) |

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -30,19 +30,12 @@ module.exports = {
       to: { path: "^packages/gateway/src" },
     },
     {
-      name: "sdk-no-import-core",
-      severity: "error",
-      comment: "SDK is MIT and must not import any AGPL package.",
-      from: { path: "^packages/sdk/src" },
-      to: { path: "^packages/(gateway|cli|ui|client|mcp-connectors)/" },
-    },
-    {
       name: "mcp-connectors-only-import-sdk",
       severity: "error",
       comment: "First-party MCP connectors depend only on @nimbus-dev/sdk.",
       from: { path: "^packages/mcp-connectors/[^/]+/src" },
       to: {
-        path: "^packages/(gateway|cli|ui|client)/",
+        path: "^packages/(gateway|cli|ui)/",
       },
     },
 

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ Found a vulnerability? See [SECURITY.md](./.github/SECURITY.md).
 
 ## License
 
-Dual-licensed by design: **AGPL-3.0** for the gateway, CLI, and MCP connectors; **MIT** for the `@nimbus-dev/sdk` and `@nimbus-dev/client` packages so extensions and integrations stay unencumbered.
+Dual-licensed by design: **AGPL-3.0** for the gateway, CLI, and MCP connectors; **MIT** for the separately-published [`@nimbus-dev/sdk`](https://github.com/nimbus-agent/nimbus-sdk) and [`@nimbus-dev/client`](https://github.com/nimbus-agent/nimbus-client) npm packages so extensions and integrations stay unencumbered.

--- a/docs/contributors/coverage.md
+++ b/docs/contributors/coverage.md
@@ -8,7 +8,6 @@ Phase 0 covers the bun-tested packages only:
 
 - `packages/gateway`
 - `packages/cli`
-- `packages/sdk`
 - `packages/mcp-connectors/*`
 
 UI (`packages/ui`) uses Vitest, which emits its own `coverage/lcov.info`. That file is not yet merged into the gate's input; the existing Vitest `>=80% lines / >=75% branches` thresholds keep that surface honest. A future phase can extend the floor to UI by merging the Vitest lcov into `coverage/lcov.info` before the gate runs.

--- a/docs/sonar-local.md
+++ b/docs/sonar-local.md
@@ -112,7 +112,7 @@ For reproducing a full scan before pushing (e.g. when CI is unavailable, or to d
 3. Generate coverage so the scanner finds an `lcov.info`:
 
    ```bash
-   bun test packages/gateway packages/cli packages/sdk packages/mcp-connectors scripts \
+   bun test packages/gateway packages/cli packages/mcp-connectors scripts \
      --coverage --coverage-reporter=lcov
    cd packages/ui && bunx vitest run --coverage && cd -
    sed -i 's|^SF:src/|SF:packages/ui/src/|' packages/ui/coverage/lcov.info

--- a/docs/sonar-local.md
+++ b/docs/sonar-local.md
@@ -27,7 +27,7 @@ The scan runs inside the reusable [`_test-suite.yml`](../.github/workflows/_test
 
 Coverage is fed in from two sources, both produced earlier in the same job:
 
-- `coverage/lcov.info` — written by `bun test --coverage --coverage-reporter=lcov` for `gateway`, `cli`, `sdk`, `client`, `mcp-connectors`, and `scripts`.
+- `coverage/lcov.info` — written by `bun test --coverage --coverage-reporter=lcov` for `gateway`, `cli`, `mcp-connectors`, and `scripts`.
 - `packages/ui/coverage/lcov.info` — written by `bunx vitest run --coverage`. The job rewrites `SF:src/` → `SF:packages/ui/src/` so SonarCloud resolves paths from the repo root rather than the UI sub-project root.
 
 `sonar.qualitygate.wait=true` in [`sonar-project.properties`](../sonar-project.properties) forces the scanner to wait for the Compute Engine task and gate verdict to be computed before the job moves on. The scan-upload step itself is `continue-on-error: true` (a scanner network/infra failure should be a rerun, not a hard block); the **`SonarQube quality gate (enforced)`** step that follows is what actually fails the build. It reads the analysis the scan produced, queries the `api/qualitygates/project_status` Web API, and:

--- a/knip.json
+++ b/knip.json
@@ -24,10 +24,6 @@
       "entry": ["src/**/*.test.{ts,tsx}", "test/**/*.test.{ts,tsx}"],
       "project": "src/**/*.{ts,tsx}"
     },
-    "packages/sdk": {
-      "entry": ["src/**/*.test.ts"],
-      "project": "src/**/*.ts"
-    },
     "packages/mcp-connectors/*": {
       "entry": ["src/server.ts", "src/**/*.test.ts"],
       "project": "src/**/*.ts"

--- a/packages/docs/src/content/docs/getting-started.mdx
+++ b/packages/docs/src/content/docs/getting-started.mdx
@@ -67,7 +67,6 @@ nimbus ask "what is in my Drive?"
 | `packages/gateway` | The Gateway — JSON-RPC IPC, agent runtime, MCP mesh, Vault, local SQLite index. |
 | `packages/cli` | The `nimbus` command — thin client, talks to the Gateway over the local socket. |
 | `packages/ui` | The Tauri 2.0 desktop app (Rust shell + React renderer). |
-| `packages/sdk` | `@nimbus-dev/sdk` — interfaces and contract tests for first-party and community connectors. |
 | `packages/mcp-connectors/*` | First-party MCP servers (Google Drive, Gmail, GitHub, Slack, Linear, etc.). |
 
 The Gateway never imports from the CLI or UI; clients communicate with the


### PR DESCRIPTION
Follow-up to the client extraction (#758). Removes the last stale `packages/sdk` references left behind when the SDK was extracted, so the monorepo docs/config consistently reflect that **both** `@nimbus-dev/sdk` and `@nimbus-dev/client` are external published packages.

- Skill docs (`nimbus-architecture`, `nimbus-file-map`) point at the standalone repos instead of deleted `packages/sdk/src` files
- `docs/contributors/coverage.md`, `docs/sonar-local.md`, docs-site `getting-started.mdx` — drop `packages/sdk` from package lists
- `README.md` — reword so sdk/client read as external npm packages
- `knip.json` — drop the dead `packages/sdk` workspace entry
- `.dependency-cruiser.cjs` — remove the `sdk-no-import-core` rule + `client` alternation (neither package is in the tree)

Verified: `audit:doc-refs` (603 refs), `audit:boundaries` (dependency-cruiser, 0 violations), biome lint, `audit:status-drift` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated architecture and file-map guidance to point SDK users to the standalone `@nimbus-dev/sdk` location.
  - Adjusted contributor/getting-started docs to remove legacy monorepo SDK references.
  - Refreshed README license wording to use linked package references.

- **Chores**
  - Tightened allowed SDK import targets for MCP connectors.
  - Updated coverage and local analysis to exclude `packages/sdk`.
  - Removed the SDK from workspace/coverage gate configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->