### PR TITLE
fix(gateway): report real version in `nimbus status` + stamp Windows exe metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,13 @@ jobs:
       - name: Build Gateway binary (Windows — with exe metadata)
         if: matrix.target.os == 'windows'
         shell: pwsh
+        env:
+          # Via env (not a ${{ }} run-body expansion) so a crafted tag name can't
+          # inject into the script; then validate the derived 4-part numeric.
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          $winver = "${{ github.ref_name }}".TrimStart("v").Split("-")[0] + ".0"
+          $winver = $env:REF_NAME.TrimStart("v").Split("-")[0] + ".0"
+          if ($winver -notmatch '^[0-9]+(\.[0-9]+){3}$') { throw "unexpected version from ref '$env:REF_NAME': $winver" }
           cd packages/gateway
           bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun `
             --windows-title "Nimbus Gateway" `
@@ -233,8 +238,13 @@ jobs:
       - name: Build CLI binary (Windows — with exe metadata)
         if: matrix.target.os == 'windows'
         shell: pwsh
+        env:
+          # Via env (not a ${{ }} run-body expansion) so a crafted tag name can't
+          # inject into the script; then validate the derived 4-part numeric.
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          $winver = "${{ github.ref_name }}".TrimStart("v").Split("-")[0] + ".0"
+          $winver = $env:REF_NAME.TrimStart("v").Split("-")[0] + ".0"
+          if ($winver -notmatch '^[0-9]+(\.[0-9]+){3}$') { throw "unexpected version from ref '$env:REF_NAME': $winver" }
           cd packages/cli
           bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun `
             --windows-title "Nimbus CLI" `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,28 @@ jobs:
         with:
           verify-lock: "false"
 
-      - name: Build Gateway binary
+      - name: Build Gateway binary (non-Windows)
+        if: matrix.target.os != 'windows'
         run: |
           cd packages/gateway
           bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun
+
+      # Windows PE resources (Details tab: Product name / File version / Company)
+      # are stamped here so the exe reports Nimbus instead of the embedded Bun
+      # runtime's own metadata. --windows-version wants a numeric 4-part
+      # (major.minor.patch.revision); strip any prerelease suffix and pad ".0".
+      - name: Build Gateway binary (Windows — with exe metadata)
+        if: matrix.target.os == 'windows'
+        shell: pwsh
+        run: |
+          $winver = "${{ github.ref_name }}".TrimStart("v").Split("-")[0] + ".0"
+          cd packages/gateway
+          bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun `
+            --windows-title "Nimbus Gateway" `
+            --windows-publisher "Nimbus Contributors" `
+            --windows-version "$winver" `
+            --windows-description "Nimbus Gateway — local-first AI agent framework" `
+            --windows-copyright "Copyright (c) Nimbus Contributors — AGPL-3.0-or-later"
 
       - name: Sign binary (Linux GPG)
         if: matrix.target.os == 'linux'
@@ -203,10 +221,27 @@ jobs:
         with:
           verify-lock: "false"
 
-      - name: Build CLI binary
+      - name: Build CLI binary (non-Windows)
+        if: matrix.target.os != 'windows'
         run: |
           cd packages/cli
           bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun
+
+      # Stamp Windows PE resources so `nimbus.exe` reports Nimbus metadata in the
+      # Details tab rather than the embedded Bun runtime's. See the gateway build
+      # step above for the --windows-version numeric-4-part rationale.
+      - name: Build CLI binary (Windows — with exe metadata)
+        if: matrix.target.os == 'windows'
+        shell: pwsh
+        run: |
+          $winver = "${{ github.ref_name }}".TrimStart("v").Split("-")[0] + ".0"
+          cd packages/cli
+          bun build src/index.ts --compile --outfile ../../dist/${{ matrix.target.artifact }}${{ matrix.target.ext }} --target bun `
+            --windows-title "Nimbus CLI" `
+            --windows-publisher "Nimbus Contributors" `
+            --windows-version "$winver" `
+            --windows-description "Nimbus CLI — local-first AI agent framework" `
+            --windows-copyright "Copyright (c) Nimbus Contributors — AGPL-3.0-or-later"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -11,7 +11,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md",
-      "extra-files": []
+      "extra-files": ["packages/gateway/src/version.ts"]
     }
   }
 }

--- a/packages/gateway/src/version.ts
+++ b/packages/gateway/src/version.ts
@@ -1,1 +1,4 @@
-export const GATEWAY_VERSION = "0.1.0";
+// The value on the next line is kept in lockstep with the released package version by
+// release-please (see `extra-files` in `.release-please-config.json`). Do not edit the
+// version string by hand — the `x-release-please-version` annotation drives it.
+export const GATEWAY_VERSION = "0.21.0"; // x-release-please-version


### PR DESCRIPTION
## Why

Two related version-reporting fixes, both surfaced from a user noticing `nimbus status` reported `0.1.0` while their installed release was much newer, and the Windows `.exe` Details tab showing Bun's version.

### 1. `nimbus status` reported a stale hardcoded version

`GATEWAY_VERSION` in `packages/gateway/src/version.ts` was a hand-maintained constant frozen at `"0.1.0"` since the first GA. `gateway.ping` (and therefore `nimbus status` / `nimbus --version`) echoed it verbatim, so every release reported `0.1.0` regardless of what was actually installed — it had drifted ~20 minor releases.

**Fix:** wire the constant to release-please via the generic updater:
- annotate the line with `x-release-please-version` and register `packages/gateway/src/version.ts` in the config's `extra-files`, so every release rewrites it in lockstep with the package version;
- set the current value to `0.21.0` to clear the existing drift now.

This is cross-platform — it fixes the reported version on Linux/macOS/Windows alike.

### 2. Windows `.exe` Details tab showed Bun's metadata

The gateway/CLI Windows binaries are single-file `bun build --compile` executables that embed the Bun runtime, so Properties → Details showed Bun's Product name / File version.

**Fix:** pass Bun's `--windows-*` metadata flags on the Windows matrix legs of `build-gateway` / `build-cli` (product name, publisher, version, description, copyright). The build step is split into a non-Windows step (unchanged) and a pwsh Windows step so the flags apply only where valid. The version is derived from the release tag, prerelease suffix stripped and padded to the numeric 4-part form Windows requires (e.g. `0.21.1.0`). Publisher/product naming matches the existing WiX installer (`Nimbus Contributors`).

> Linux/macOS need no equivalent: ELF and bare Mach-O have no embedded product-version resource a file manager reads. Version there comes from the package metadata (`.deb`/`.rpm`/`.pkg`, already stamped from the tag) and from `nimbus --version`, which fix #1 corrects.

## Verification

- `version.ts` + config: biome clean, config is valid JSON, `gateway.ping`/dispatcher tests pass. No test asserted the old `"0.1.0"` value.
- Windows flags: compiled a test exe locally on Windows with the exact flags — resulting exe reports `ProductName: Nimbus CLI`, `CompanyName: Nimbus Contributors`, `FileVersion: 0.21.1.0`, description + copyright correct. Version-munging verified for normal and prerelease tags.
- `release.yml` parses as valid YAML.

## Publishing note

The `fix:` commit means release-please will cut a new release (→ `0.21.1`) after this merges, which rewrites `version.ts` to match and — being a fresh tag — builds the Windows binaries with the new metadata. Note the repo currently has a phantom `0.21.0` (manifest/CHANGELOG bumped, but no `v0.21.0` git tag or published assets); the next release should supersede it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)