### PR TITLE
refactor: clear all 128 open SonarCloud code smells

### DIFF
--- a/packages/gateway/src/embedding/create-routing-runtime.test.ts
+++ b/packages/gateway/src/embedding/create-routing-runtime.test.ts
@@ -255,38 +255,38 @@ describe("tryCreateRoutingEmbeddingRuntime — null-return branches", () => {
     }
   });
 
-  test("returns null when ensureSqliteVecForConnection is false (schema >= v6, vec not loaded)", async () => {
-    if (!VEC_AVAILABLE) {
-      return;
-    }
-    const h = makeHarness({ migrateTo: 30, setApiKey: true });
-    h.db.close();
-    const freshDb = new Database(h.db.filename);
-    try {
-      let vecOnFresh = true;
+  test.skipIf(!VEC_AVAILABLE)(
+    "returns null when ensureSqliteVecForConnection is false (schema >= v6, vec not loaded)",
+    async () => {
+      const h = makeHarness({ migrateTo: 30, setApiKey: true });
+      h.db.close();
+      const freshDb = new Database(h.db.filename);
       try {
-        freshDb.query("SELECT vec_version()").get();
-      } catch {
-        vecOnFresh = false;
+        let vecOnFresh = true;
+        try {
+          freshDb.query("SELECT vec_version()").get();
+        } catch {
+          vecOnFresh = false;
+        }
+        if (vecOnFresh) {
+          return;
+        }
+        const factory = await importFactory();
+        const runtime = await factory(freshDb, h.paths, silentLogger, h.toml, h.vault);
+        const stillVec = isVecLoaded(freshDb);
+        if (!stillVec) {
+          expect(runtime).toBeNull();
+        }
+      } finally {
+        freshDb.close();
+        try {
+          rmSync(h.paths.dataDir, { recursive: true, force: true });
+        } catch {
+          /* ignore */
+        }
       }
-      if (vecOnFresh) {
-        return;
-      }
-      const factory = await importFactory();
-      const runtime = await factory(freshDb, h.paths, silentLogger, h.toml, h.vault);
-      const stillVec = isVecLoaded(freshDb);
-      if (!stillVec) {
-        expect(runtime).toBeNull();
-      }
-    } finally {
-      freshDb.close();
-      try {
-        rmSync(h.paths.dataDir, { recursive: true, force: true });
-      } catch {
-        /* ignore */
-      }
-    }
-  });
+    },
+  );
 });
 
 describe.skipIf(!VEC_AVAILABLE)(

--- a/packages/gateway/src/extensions/install-from-local.test.ts
+++ b/packages/gateway/src/extensions/install-from-local.test.ts
@@ -148,30 +148,30 @@ describe("install-from-local", () => {
 });
 
 describe("install-from-local symlink + traversal hardening (G7)", () => {
-  test("rejects extension source that contains a symlink (S7-F5)", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const { symlinkSync, unlinkSync } = await import("node:fs");
-    const { extensionsDir, src, db } = createExtensionInstallFixture(
-      "nimbus-symlink-",
-      "src-symlink",
-    );
-    writeFileSync(
-      join(src, "nimbus.extension.json"),
-      JSON.stringify({ id: "ext.symlink", version: "1.0.0", entry: "dist/index.js" }),
-      "utf8",
-    );
-    writeFileSync(join(src, "dist", "index.js"), "/* legit */\n", "utf8");
+  test.skipIf(process.platform === "win32")(
+    "rejects extension source that contains a symlink (S7-F5)",
+    async () => {
+      const { symlinkSync, unlinkSync } = await import("node:fs");
+      const { extensionsDir, src, db } = createExtensionInstallFixture(
+        "nimbus-symlink-",
+        "src-symlink",
+      );
+      writeFileSync(
+        join(src, "nimbus.extension.json"),
+        JSON.stringify({ id: "ext.symlink", version: "1.0.0", entry: "dist/index.js" }),
+        "utf8",
+      );
+      writeFileSync(join(src, "dist", "index.js"), "/* legit */\n", "utf8");
 
-    const sym = join(src, "dist", "index.js");
-    unlinkSync(sym);
-    symlinkSync("/etc/hostname", sym);
+      const sym = join(src, "dist", "index.js");
+      unlinkSync(sym);
+      symlinkSync("/etc/hostname", sym);
 
-    await expect(
-      installExtensionFromLocalDirectory({ db, extensionsDir, sourcePath: src }),
-    ).rejects.toThrow(/symlink/i);
-  });
+      await expect(
+        installExtensionFromLocalDirectory({ db, extensionsDir, sourcePath: src }),
+      ).rejects.toThrow(/symlink/i);
+    },
+  );
 });
 
 async function writeSignedSource(opts: {
@@ -1235,12 +1235,7 @@ describe("assertSafeExtensionId — missing branch coverage (Tier C-4)", () => {
 // D-candidates noted at bottom for win32 SystemRoot/fallback branches
 // ---------------------------------------------------------------------------
 describe("resolveSystemTarCommand — platform branch (Tier C-5)", () => {
-  test("returns 'tar' on non-win32 platforms", () => {
-    if (process.platform === "win32") {
-      // On Windows CI this branch is unreachable without mutating process.platform —
-      // documented as D-candidate; skip.
-      return;
-    }
+  test.skipIf(process.platform === "win32")("returns 'tar' on non-win32 platforms", () => {
     expect(resolveSystemTarCommand()).toBe("tar");
   });
 });
@@ -1291,32 +1286,30 @@ describe("completeExtensionInstallAfterCopy — error branches (Tier C-6)", () =
 // scanForSymlinks — symlink found path (Tier C-7)
 // ---------------------------------------------------------------------------
 describe("scanForSymlinks — symlink found throws (Tier C-7)", () => {
-  test("directory source with a symlink inside a subdirectory is rejected", async () => {
-    if (process.platform === "win32") {
-      // Symlink creation typically requires elevated privileges on Windows;
-      // this test is D-candidate on win32.
-      return;
-    }
-    const { symlinkSync } = await import("node:fs");
-    const { extensionsDir, src, db } = createExtensionInstallFixture(
-      "nimbus-symlink-subdir-",
-      "src-sym-sub",
-    );
-    const subDir = join(src, "lib");
-    mkdirSync(subDir, { recursive: true });
-    writeFileSync(
-      join(src, "nimbus.extension.json"),
-      JSON.stringify({ id: "ext.symlink.sub", version: "1.0.0", entry: "dist/index.js" }),
-      "utf8",
-    );
-    writeFileSync(join(src, "dist", "index.js"), "/* ok */\n", "utf8");
-    // Create a symlink in a subdirectory (not dist/index.js)
-    symlinkSync("/etc/hostname", join(subDir, "bad.link"));
+  test.skipIf(process.platform === "win32")(
+    "directory source with a symlink inside a subdirectory is rejected",
+    async () => {
+      const { symlinkSync } = await import("node:fs");
+      const { extensionsDir, src, db } = createExtensionInstallFixture(
+        "nimbus-symlink-subdir-",
+        "src-sym-sub",
+      );
+      const subDir = join(src, "lib");
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(src, "nimbus.extension.json"),
+        JSON.stringify({ id: "ext.symlink.sub", version: "1.0.0", entry: "dist/index.js" }),
+        "utf8",
+      );
+      writeFileSync(join(src, "dist", "index.js"), "/* ok */\n", "utf8");
+      // Create a symlink in a subdirectory (not dist/index.js)
+      symlinkSync("/etc/hostname", join(subDir, "bad.link"));
 
-    await expect(
-      installExtensionFromLocalDirectory({ db, extensionsDir, sourcePath: src }),
-    ).rejects.toThrow(/symlink/i);
-  });
+      await expect(
+        installExtensionFromLocalDirectory({ db, extensionsDir, sourcePath: src }),
+      ).rejects.toThrow(/symlink/i);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -2300,63 +2293,60 @@ describe("buildLocalSolverFetcher — registry unavailable for un-pinned dep (Ti
 // and archive symlink (line 238, Linux-only)
 // ---------------------------------------------------------------------------
 describe("checkExtractedEntry — escape and symlink in extracted archive (Tier C-21)", () => {
-  test("extracted archive containing a symlink is rejected (line 238, Linux-only)", async () => {
-    if (process.platform === "win32") {
-      // Symlink creation in tarballs typically requires elevated privileges on Windows.
-      // This test is authoritative on Linux CI; skip on win32.
-      return;
-    }
-
-    // Build a tarball that contains a symlink inside the extracted tree.
-    // We do this by creating the symlink on disk first, then archiving it.
-    const stage = mkdtempSync(join(tmpdir(), "nimbus-sym-arch-"));
-    try {
-      const { symlinkSync } = await import("node:fs");
-      const pkgDir = join(stage, "pkg");
-      mkdirSync(join(pkgDir, "dist"), { recursive: true });
-      writeFileSync(
-        join(pkgDir, "nimbus.extension.json"),
-        JSON.stringify({ id: "symlink.arch.ext", version: "1.0.0", entry: "dist/index.js" }),
-      );
-      writeFileSync(join(pkgDir, "dist", "index.js"), "export {}\n");
-      // Create a symlink inside the archive tree
-      symlinkSync("/etc/hostname", join(pkgDir, "evil.link"));
-
-      const archive = join(stage, "symlink.tgz");
-      const tarBin = resolveSystemTarCommand();
-      const pack = spawnSync(tarBin, ["-czf", archive, "-C", stage, "pkg"], {
-        windowsHide: true,
-      });
-      expect(pack.status).toBe(0);
-
-      const tmp = mkdtempSync(join(tmpdir(), "nimbus-sym-inst-"));
+  test.skipIf(process.platform === "win32")(
+    "extracted archive containing a symlink is rejected (line 238, Linux-only)",
+    async () => {
+      // Build a tarball that contains a symlink inside the extracted tree.
+      // We do this by creating the symlink on disk first, then archiving it.
+      const stage = mkdtempSync(join(tmpdir(), "nimbus-sym-arch-"));
       try {
-        const extensionsDir = join(tmp, "extensions");
-        const db = new Database(":memory:");
-        LocalIndex.ensureSchema(db);
+        const { symlinkSync } = await import("node:fs");
+        const pkgDir = join(stage, "pkg");
+        mkdirSync(join(pkgDir, "dist"), { recursive: true });
+        writeFileSync(
+          join(pkgDir, "nimbus.extension.json"),
+          JSON.stringify({ id: "symlink.arch.ext", version: "1.0.0", entry: "dist/index.js" }),
+        );
+        writeFileSync(join(pkgDir, "dist", "index.js"), "export {}\n");
+        // Create a symlink inside the archive tree
+        symlinkSync("/etc/hostname", join(pkgDir, "evil.link"));
 
-        await expect(
-          installExtensionFromLocalDirectory({
-            db,
-            extensionsDir,
-            sourcePath: archive,
-          }),
-        ).rejects.toThrow(/symlink/i);
+        const archive = join(stage, "symlink.tgz");
+        const tarBin = resolveSystemTarCommand();
+        const pack = spawnSync(tarBin, ["-czf", archive, "-C", stage, "pkg"], {
+          windowsHide: true,
+        });
+        expect(pack.status).toBe(0);
+
+        const tmp = mkdtempSync(join(tmpdir(), "nimbus-sym-inst-"));
+        try {
+          const extensionsDir = join(tmp, "extensions");
+          const db = new Database(":memory:");
+          LocalIndex.ensureSchema(db);
+
+          await expect(
+            installExtensionFromLocalDirectory({
+              db,
+              extensionsDir,
+              sourcePath: archive,
+            }),
+          ).rejects.toThrow(/symlink/i);
+        } finally {
+          try {
+            rmSync(tmp, { recursive: true, force: true });
+          } catch {
+            /* Windows EBUSY */
+          }
+        }
       } finally {
         try {
-          rmSync(tmp, { recursive: true, force: true });
+          rmSync(stage, { recursive: true, force: true });
         } catch {
           /* Windows EBUSY */
         }
       }
-    } finally {
-      try {
-        rmSync(stage, { recursive: true, force: true });
-      } catch {
-        /* Windows EBUSY */
-      }
-    }
-  });
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -2448,36 +2438,34 @@ describe("verifyAndRecordSignature — enforceAirGap omitted defaults to false (
 // test owns the "tar" branch; we skip here so the suite stays cross-platform.
 // ---------------------------------------------------------------------------
 describe("resolveSystemTarCommand — win32 SystemRoot + fallback (Tier C-24)", () => {
-  test("uses SystemRoot/System32/tar.exe when SystemRoot is set; falls back to C:\\Windows", () => {
-    if (process.platform !== "win32") {
-      // Linux/macOS: the win32 branches are unreachable without mutating process.platform.
-      // The Linux-authoritative coverage of these lines is therefore not possible here.
-      return;
-    }
-    const savedRoot = process.env["SystemRoot"];
-    const savedWindir = process.env["windir"];
-    try {
-      // cross-platform-ok: win32 branch assertion path literal
-      process.env["SystemRoot"] = "C:\\WinTest";
-      delete process.env["windir"];
-      expect(resolveSystemTarCommand()).toBe(join("C:\\WinTest", "System32", "tar.exe"));
+  test.skipIf(process.platform !== "win32")(
+    "uses SystemRoot/System32/tar.exe when SystemRoot is set; falls back to C:\\Windows",
+    () => {
+      const savedRoot = process.env["SystemRoot"];
+      const savedWindir = process.env["windir"];
+      try {
+        // cross-platform-ok: win32 branch assertion path literal
+        process.env["SystemRoot"] = "C:\\WinTest";
+        delete process.env["windir"];
+        expect(resolveSystemTarCommand()).toBe(join("C:\\WinTest", "System32", "tar.exe"));
 
-      // Both cleared → hard-coded C:\Windows\System32 fallback.
-      delete process.env["SystemRoot"];
-      delete process.env["windir"];
-      expect(resolveSystemTarCommand()).toBe(join("C:", "Windows", "System32", "tar.exe"));
+        // Both cleared → hard-coded C:\Windows\System32 fallback.
+        delete process.env["SystemRoot"];
+        delete process.env["windir"];
+        expect(resolveSystemTarCommand()).toBe(join("C:", "Windows", "System32", "tar.exe"));
 
-      // windir alone (SystemRoot absent) resolves via the env branch — SystemRoot must be
-      // deleted (not empty) so the `?? process.env["windir"]` coalescing falls through.
-      delete process.env["SystemRoot"];
-      // cross-platform-ok: win32 branch assertion path literal
-      process.env["windir"] = "C:\\WinDirTest";
-      expect(resolveSystemTarCommand()).toBe(join("C:\\WinDirTest", "System32", "tar.exe"));
-    } finally {
-      if (savedRoot === undefined) delete process.env["SystemRoot"];
-      else process.env["SystemRoot"] = savedRoot;
-      if (savedWindir === undefined) delete process.env["windir"];
-      else process.env["windir"] = savedWindir;
-    }
-  });
+        // windir alone (SystemRoot absent) resolves via the env branch — SystemRoot must be
+        // deleted (not empty) so the `?? process.env["windir"]` coalescing falls through.
+        delete process.env["SystemRoot"];
+        // cross-platform-ok: win32 branch assertion path literal
+        process.env["windir"] = "C:\\WinDirTest";
+        expect(resolveSystemTarCommand()).toBe(join("C:\\WinDirTest", "System32", "tar.exe"));
+      } finally {
+        if (savedRoot === undefined) delete process.env["SystemRoot"];
+        else process.env["SystemRoot"] = savedRoot;
+        if (savedWindir === undefined) delete process.env["windir"];
+        else process.env["windir"] = savedWindir;
+      }
+    },
+  );
 });

--- a/packages/gateway/src/index/sqlite-vec-load.test.ts
+++ b/packages/gateway/src/index/sqlite-vec-load.test.ts
@@ -170,16 +170,15 @@ describe("tryLoadSqliteVec — upstream-first chain", () => {
 });
 
 describe("isVecLoaded", () => {
-  test("returns true when vec_version() is queryable (extension already loaded)", () => {
-    if (!upstreamSqliteVecLoadable) {
-      // Can't run this without the extension
-      return;
-    }
-    const db = new Database(":memory:");
-    loadSqliteVec(db);
-    expect(isVecLoaded(db)).toBe(true);
-    db.close();
-  });
+  test.skipIf(!upstreamSqliteVecLoadable)(
+    "returns true when vec_version() is queryable (extension already loaded)",
+    () => {
+      const db = new Database(":memory:");
+      loadSqliteVec(db);
+      expect(isVecLoaded(db)).toBe(true);
+      db.close();
+    },
+  );
 
   test("returns false when vec_version() is not available (extension not loaded)", () => {
     const db = new Database(":memory:");
@@ -238,16 +237,16 @@ describe("ensureSqliteVecForConnection", () => {
     db.close();
   });
 
-  test("returns true when indexedUserVersion >= 6 and vec_version() is already available", () => {
-    if (!upstreamSqliteVecLoadable) {
-      return;
-    }
-    const db = new Database(":memory:");
-    // Pre-load the extension so vec_version() succeeds
-    loadSqliteVec(db);
-    expect(ensureSqliteVecForConnection(db, 6)).toBe(true);
-    db.close();
-  });
+  test.skipIf(!upstreamSqliteVecLoadable)(
+    "returns true when indexedUserVersion >= 6 and vec_version() is already available",
+    () => {
+      const db = new Database(":memory:");
+      // Pre-load the extension so vec_version() succeeds
+      loadSqliteVec(db);
+      expect(ensureSqliteVecForConnection(db, 6)).toBe(true);
+      db.close();
+    },
+  );
 
   test("falls back to tryLoadSqliteVec when indexedUserVersion >= 6 and vec_version() is unavailable", () => {
     // Fresh db without extension — vec_version() will throw → falls to tryLoadSqliteVec

--- a/packages/gateway/src/ipc/clip-rpc.ts
+++ b/packages/gateway/src/ipc/clip-rpc.ts
@@ -6,6 +6,11 @@ import type { PairingWindowController } from "../clips/pairing-window.ts";
 import { buildItemListSql } from "../index/item-list-query.ts";
 import { deleteItemByPrimaryKey } from "../index/item-store.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import {
+  dispatchByMethod,
+  type RpcMethodHandlerMap,
+  type RpcMissOrHit,
+} from "./_lib/dispatch-by-method.ts";
 
 export interface ClipRpcDeps {
   readonly pairing: PairingWindowController;
@@ -30,8 +35,6 @@ export interface ClipListEntry {
   readonly mode: string;
   readonly wordCount: number;
 }
-
-type Outcome = { kind: "hit"; value: unknown } | { kind: "miss" };
 
 function asRecord(p: unknown): Record<string, unknown> {
   return p !== null && typeof p === "object" ? (p as Record<string, unknown>) : {};
@@ -121,62 +124,70 @@ function resolveClipIdsToDelete(db: Database, rec: Record<string, unknown>): str
     : clipIdsByCanonicalUrl(db, canonicalizeUrl(target));
 }
 
-export async function dispatchClipRpc(
+function handleClipPair(params: unknown, deps: ClipRpcDeps): unknown {
+  const rec = asRecord(params);
+  // Random suffix, NOT a memory-only counter: a counter resets to 0 on gateway restart and a
+  // fresh "device-1" would overwrite an existing "device-1" token in the Vault map.
+  const label =
+    typeof rec["label"] === "string" && rec["label"].length > 0
+      ? (rec["label"] as string)
+      : `device-${randomBytes(3).toString("hex")}`;
+  const { code, expiresAtMs } = deps.pairing.open(label);
+  return {
+    code,
+    expiresAtMs,
+    label,
+    ...(deps.httpBaseUrl === undefined ? {} : { gatewayUrl: deps.httpBaseUrl }),
+  };
+}
+
+async function handleClipStatus(_params: unknown, deps: ClipRpcDeps): Promise<unknown> {
+  const devices = await listClipFingerprints(deps.vault);
+  return { devices };
+}
+
+async function handleClipRevoke(params: unknown, deps: ClipRpcDeps): Promise<unknown> {
+  const rec = asRecord(params);
+  const label = typeof rec["label"] === "string" ? (rec["label"] as string) : "";
+  if (label === "") return { revoked: 0 };
+  const revoked = await revokeClipToken(deps.vault, label);
+  return { revoked };
+}
+
+function handleClipList(params: unknown, deps: ClipRpcDeps): unknown {
+  if (deps.db === undefined) return { clips: [] };
+  const rec = asRecord(params);
+  const limit = clampLimit(rec["limit"]);
+  const tag =
+    typeof rec["tag"] === "string" && rec["tag"].length > 0 ? (rec["tag"] as string) : undefined;
+  return { clips: listClips(deps.db, limit, tag) };
+}
+
+function handleClipDelete(params: unknown, deps: ClipRpcDeps): unknown {
+  // Do NOT fail-soft to a false success here: a delete that can't reach the index must not
+  // report "Deleted 0" (which reads as "nothing matched"). Surface it (spec Error handling).
+  if (deps.db === undefined) throw new Error("Clip index unavailable.");
+  const rec = asRecord(params);
+  const ids = resolveClipIdsToDelete(deps.db, rec);
+  if (rec["dryRun"] === true) {
+    return { deleted: 0, matched: ids.length };
+  }
+  for (const id of ids) deleteItemByPrimaryKey(deps.db, id);
+  return { deleted: ids.length, matched: ids.length };
+}
+
+const CLIP_RPC_HANDLERS: RpcMethodHandlerMap<ClipRpcDeps> = {
+  "clip.pair": handleClipPair,
+  "clip.status": handleClipStatus,
+  "clip.revoke": handleClipRevoke,
+  "clip.list": handleClipList,
+  "clip.delete": handleClipDelete,
+};
+
+export function dispatchClipRpc(
   method: string,
   params: unknown,
   deps: ClipRpcDeps,
-): Promise<Outcome> {
-  const rec = asRecord(params);
-  switch (method) {
-    case "clip.pair": {
-      // Random suffix, NOT a memory-only counter: a counter resets to 0 on gateway restart and a
-      // fresh "device-1" would overwrite an existing "device-1" token in the Vault map.
-      const label =
-        typeof rec["label"] === "string" && rec["label"].length > 0
-          ? (rec["label"] as string)
-          : `device-${randomBytes(3).toString("hex")}`;
-      const { code, expiresAtMs } = deps.pairing.open(label);
-      return {
-        kind: "hit",
-        value: {
-          code,
-          expiresAtMs,
-          label,
-          ...(deps.httpBaseUrl === undefined ? {} : { gatewayUrl: deps.httpBaseUrl }),
-        },
-      };
-    }
-    case "clip.status": {
-      const devices = await listClipFingerprints(deps.vault);
-      return { kind: "hit", value: { devices } };
-    }
-    case "clip.revoke": {
-      const label = typeof rec["label"] === "string" ? (rec["label"] as string) : "";
-      if (label === "") return { kind: "hit", value: { revoked: 0 } };
-      const revoked = await revokeClipToken(deps.vault, label);
-      return { kind: "hit", value: { revoked } };
-    }
-    case "clip.list": {
-      if (deps.db === undefined) return { kind: "hit", value: { clips: [] } };
-      const limit = clampLimit(rec["limit"]);
-      const tag =
-        typeof rec["tag"] === "string" && rec["tag"].length > 0
-          ? (rec["tag"] as string)
-          : undefined;
-      return { kind: "hit", value: { clips: listClips(deps.db, limit, tag) } };
-    }
-    case "clip.delete": {
-      // Do NOT fail-soft to a false success here: a delete that can't reach the index must not
-      // report "Deleted 0" (which reads as "nothing matched"). Surface it (spec Error handling).
-      if (deps.db === undefined) throw new Error("Clip index unavailable.");
-      const ids = resolveClipIdsToDelete(deps.db, rec);
-      if (rec["dryRun"] === true) {
-        return { kind: "hit", value: { deleted: 0, matched: ids.length } };
-      }
-      for (const id of ids) deleteItemByPrimaryKey(deps.db, id);
-      return { kind: "hit", value: { deleted: ids.length, matched: ids.length } };
-    }
-    default:
-      return { kind: "miss" };
-  }
+): Promise<RpcMissOrHit> {
+  return dispatchByMethod(method, params, deps, CLIP_RPC_HANDLERS);
 }

--- a/packages/gateway/src/ipc/server/server.test.ts
+++ b/packages/gateway/src/ipc/server/server.test.ts
@@ -99,46 +99,52 @@ describe("createIpcServer — listener startup/shutdown (POSIX unix-socket arm)"
     }
   });
 
-  test("start() binds a unix socket at listenPath; stop() unlinks it", async () => {
-    if (platform() === "win32") return;
-    const server = createIpcServer({
-      listenPath: socketPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    await server.start();
-    expect(existsSync(socketPath)).toBe(true);
-    await server.stop();
-    expect(existsSync(socketPath)).toBe(false);
-  });
+  test.skipIf(platform() === "win32")(
+    "start() binds a unix socket at listenPath; stop() unlinks it",
+    async () => {
+      const server = createIpcServer({
+        listenPath: socketPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      await server.start();
+      expect(existsSync(socketPath)).toBe(true);
+      await server.stop();
+      expect(existsSync(socketPath)).toBe(false);
+    },
+  );
 
-  test("start() removes a stale socket file at listenPath before bind", async () => {
-    if (platform() === "win32") return;
-    writeFileSync(socketPath, "stale");
-    expect(existsSync(socketPath)).toBe(true);
+  test.skipIf(platform() === "win32")(
+    "start() removes a stale socket file at listenPath before bind",
+    async () => {
+      writeFileSync(socketPath, "stale");
+      expect(existsSync(socketPath)).toBe(true);
 
-    const server = createIpcServer({
-      listenPath: socketPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    await server.start();
-    expect(existsSync(socketPath)).toBe(true);
-    await server.stop();
-    expect(existsSync(socketPath)).toBe(false);
-  });
+      const server = createIpcServer({
+        listenPath: socketPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      await server.start();
+      expect(existsSync(socketPath)).toBe(true);
+      await server.stop();
+      expect(existsSync(socketPath)).toBe(false);
+    },
+  );
 
-  test("stop() is idempotent (a second call after cleanup is a no-op)", async () => {
-    if (platform() === "win32") return;
-    const server = createIpcServer({
-      listenPath: socketPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    await server.start();
-    await server.stop();
-    await expect(server.stop()).resolves.toBeUndefined();
-  });
+  test.skipIf(platform() === "win32")(
+    "stop() is idempotent (a second call after cleanup is a no-op)",
+    async () => {
+      const server = createIpcServer({
+        listenPath: socketPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      await server.start();
+      await server.stop();
+      await expect(server.stop()).resolves.toBeUndefined();
+    },
+  );
 });
 
 function testListenPath(): string {
@@ -318,328 +324,347 @@ describe("createIpcServer — RPC dispatch arms", () => {
 
   // ── BRDA line=143 block=7 branch=0 ──────────────────────────────────────────
   // session.* RPC hits tryDispatchSessionRpc → returns before automationRpc chain
-  test("session.list reaches sessionRpc dispatcher (early-return branch)", async () => {
-    if (platform() === "win32") return;
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const store = new SessionMemoryStore({ db, dims: 384, embedText: async () => null });
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-      sessionMemoryStore: store,
-    });
-    await server.start();
-
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({ jsonrpc: "2.0", id: 10, method: "session.list", params: {} })}\n`,
-    );
-    const res = JSON.parse(line) as { result?: unknown; error?: unknown };
-    // Either a hit (sessions envelope) or a method-not-found; what matters is we
-    // got a response (the session-rpc dispatcher was entered).
-    expect(res.result !== undefined || res.error !== undefined).toBe(true);
-  });
-
-  // ── BRDA line=158 block=10 branch=0 ────────────────────────────────────────
-  // diagnostics.* RPC hits tryDispatchDiagnosticsRpc → returns before people/phase4
-  test("diag.snapshot reaches diagnosticsRpc dispatcher (early-return branch)", async () => {
-    if (platform() === "win32") return;
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const localIndex = new LocalIndex(db);
-    const tmpDir2 = mkdtempSync(join(tmpdir(), "nimbus-srv-diag-"));
-    try {
+  test.skipIf(platform() === "win32")(
+    "session.list reaches sessionRpc dispatcher (early-return branch)",
+    async () => {
+      const db = new Database(":memory:");
+      LocalIndex.ensureSchema(db);
+      const store = new SessionMemoryStore({ db, dims: 384, embedText: async () => null });
       server = createIpcServer({
         listenPath,
         vault: createMockVault(),
         version: "0.0.0-test",
-        localIndex,
-        dataDir: tmpDir2,
-        configDir: tmpDir2,
+        sessionMemoryStore: store,
       });
       await server.start();
 
       const line = await exchangeFirstNdjsonLine(
         listenPath,
-        `${JSON.stringify({ jsonrpc: "2.0", id: 11, method: "diag.snapshot", params: {} })}\n`,
+        `${JSON.stringify({ jsonrpc: "2.0", id: 10, method: "session.list", params: {} })}\n`,
       );
       const res = JSON.parse(line) as { result?: unknown; error?: unknown };
-      // The diagnostics dispatcher was entered (either success or typed error).
+      // Either a hit (sessions envelope) or a method-not-found; what matters is we
+      // got a response (the session-rpc dispatcher was entered).
       expect(res.result !== undefined || res.error !== undefined).toBe(true);
-    } finally {
+    },
+  );
+
+  // ── BRDA line=158 block=10 branch=0 ────────────────────────────────────────
+  // diagnostics.* RPC hits tryDispatchDiagnosticsRpc → returns before people/phase4
+  test.skipIf(platform() === "win32")(
+    "diag.snapshot reaches diagnosticsRpc dispatcher (early-return branch)",
+    async () => {
+      const db = new Database(":memory:");
+      LocalIndex.ensureSchema(db);
+      const localIndex = new LocalIndex(db);
+      const tmpDir2 = mkdtempSync(join(tmpdir(), "nimbus-srv-diag-"));
       try {
-        rmSync(tmpDir2, { recursive: true, force: true });
-      } catch {
-        /* best-effort */
+        server = createIpcServer({
+          listenPath,
+          vault: createMockVault(),
+          version: "0.0.0-test",
+          localIndex,
+          dataDir: tmpDir2,
+          configDir: tmpDir2,
+        });
+        await server.start();
+
+        const line = await exchangeFirstNdjsonLine(
+          listenPath,
+          `${JSON.stringify({ jsonrpc: "2.0", id: 11, method: "diag.snapshot", params: {} })}\n`,
+        );
+        const res = JSON.parse(line) as { result?: unknown; error?: unknown };
+        // The diagnostics dispatcher was entered (either success or typed error).
+        expect(res.result !== undefined || res.error !== undefined).toBe(true);
+      } finally {
+        try {
+          rmSync(tmpDir2, { recursive: true, force: true });
+        } catch {
+          /* best-effort */
+        }
       }
-    }
-  });
+    },
+  );
 
   // ── BRDA line=164 block=12 branch=0 ────────────────────────────────────────
   // lan.getStatus is handled by phase4 → triggers phase4RpcSkipped != skip early-return
-  test("lan.getStatus reaches phase4Rpc dispatcher (early-return branch)", async () => {
-    if (platform() === "win32") return;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "lan.getStatus reaches phase4Rpc dispatcher (early-return branch)",
+    async () => {
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({ jsonrpc: "2.0", id: 12, method: "lan.getStatus", params: {} })}\n`,
-    );
-    const res = JSON.parse(line) as { result?: Record<string, unknown>; error?: unknown };
-    expect(res.result).toBeDefined();
-    expect(res.result?.["enabled"]).toBe(false);
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({ jsonrpc: "2.0", id: 12, method: "lan.getStatus", params: {} })}\n`,
+      );
+      const res = JSON.parse(line) as { result?: Record<string, unknown>; error?: unknown };
+      expect(res.result).toBeDefined();
+      expect(res.result?.["enabled"]).toBe(false);
+    },
+  );
 
   // ── BRDA line=166 block=13 branch=1 ────────────────────────────────────────
   // switch case "index.searchRanked"
-  test("index.searchRanked reaches the searchRanked switch arm", async () => {
-    if (platform() === "win32") return;
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const localIndex = new LocalIndex(db);
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-      localIndex,
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "index.searchRanked reaches the searchRanked switch arm",
+    async () => {
+      const db = new Database(":memory:");
+      LocalIndex.ensureSchema(db);
+      const localIndex = new LocalIndex(db);
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+        localIndex,
+      });
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 13,
-        method: "index.searchRanked",
-        params: { name: "test" },
-      })}\n`,
-    );
-    const res = JSON.parse(line) as { result?: unknown; error?: unknown };
-    // Got a response: the searchRanked switch arm was entered.
-    expect(res.result !== undefined || res.error !== undefined).toBe(true);
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 13,
+          method: "index.searchRanked",
+          params: { name: "test" },
+        })}\n`,
+      );
+      const res = JSON.parse(line) as { result?: unknown; error?: unknown };
+      // Got a response: the searchRanked switch arm was entered.
+      expect(res.result !== undefined || res.error !== undefined).toBe(true);
+    },
+  );
 
   // ── BRDA line=166 block=13 branch=5 ────────────────────────────────────────
   // switch case "agent.invoke" — happy path with a handler installed
-  test("agent.invoke reaches the agent.invoke switch arm and returns handler reply", async () => {
-    if (platform() === "win32") return;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    server.setAgentInvokeHandler(async (_ctx) => ({ reply: "invoked-ok" }));
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "agent.invoke reaches the agent.invoke switch arm and returns handler reply",
+    async () => {
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      server.setAgentInvokeHandler(async (_ctx) => ({ reply: "invoked-ok" }));
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 14,
-        method: "agent.invoke",
-        params: { input: "hello" },
-      })}\n`,
-    );
-    const res = JSON.parse(line) as { result?: { reply?: string }; error?: unknown };
-    expect(res.result?.reply).toBe("invoked-ok");
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 14,
+          method: "agent.invoke",
+          params: { input: "hello" },
+        })}\n`,
+      );
+      const res = JSON.parse(line) as { result?: { reply?: string }; error?: unknown };
+      expect(res.result?.reply).toBe("invoked-ok");
+    },
+  );
 
   // ── BRDA line=183 block=14 branch=1 ────────────────────────────────────────
   // engine.getSessionTranscript with localIndex present — no error, proceeds to handler
-  test("engine.getSessionTranscript with localIndex present proceeds past the undefined guard", async () => {
-    if (platform() === "win32") return;
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const localIndex = new LocalIndex(db);
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-      localIndex,
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "engine.getSessionTranscript with localIndex present proceeds past the undefined guard",
+    async () => {
+      const db = new Database(":memory:");
+      LocalIndex.ensureSchema(db);
+      const localIndex = new LocalIndex(db);
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+        localIndex,
+      });
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 15,
-        method: "engine.getSessionTranscript",
-        params: { sessionId: "test-session-id" },
-      })}\n`,
-    );
-    const res = JSON.parse(line) as {
-      result?: unknown;
-      error?: { code: number; message: string };
-    };
-    // With localIndex present the -32603 "requires a configured local index" is NOT thrown.
-    // The handler may return a result or throw a different error (e.g., missing session).
-    if (res.error !== undefined) {
-      expect(res.error.message).not.toContain("local index");
-    } else {
-      expect(res.result).toBeDefined();
-    }
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 15,
+          method: "engine.getSessionTranscript",
+          params: { sessionId: "test-session-id" },
+        })}\n`,
+      );
+      const res = JSON.parse(line) as {
+        result?: unknown;
+        error?: { code: number; message: string };
+      };
+      // With localIndex present the -32603 "requires a configured local index" is NOT thrown.
+      // The handler may return a result or throw a different error (e.g., missing session).
+      if (res.error !== undefined) {
+        expect(res.error.message).not.toContain("local index");
+      } else {
+        expect(res.result).toBeDefined();
+      }
+    },
+  );
 
   // ── BRDA line=125 block=5 branch=1  +  BRDA line=128 block=6 branch=0 ────
   // handleRpc catch: non-RpcMethodError Error — message comes from Error.message
-  test("agent.invoke handler throwing Error yields error response with the Error message", async () => {
-    if (platform() === "win32") return;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    server.setAgentInvokeHandler(async (_ctx) => {
-      throw new Error("handler-error-message");
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "agent.invoke handler throwing Error yields error response with the Error message",
+    async () => {
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      server.setAgentInvokeHandler(async (_ctx) => {
+        throw new Error("handler-error-message");
+      });
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 16,
-        method: "agent.invoke",
-        params: { input: "x" },
-      })}\n`,
-    );
-    const res = JSON.parse(line) as { error?: { code: number; message: string } };
-    expect(res.error).toBeDefined();
-    expect(res.error?.code).toBe(-32603);
-    expect(res.error?.message).toBe("handler-error-message");
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 16,
+          method: "agent.invoke",
+          params: { input: "x" },
+        })}\n`,
+      );
+      const res = JSON.parse(line) as { error?: { code: number; message: string } };
+      expect(res.error).toBeDefined();
+      expect(res.error?.code).toBe(-32603);
+      expect(res.error?.message).toBe("handler-error-message");
+    },
+  );
 
   // ── BRDA line=128 block=6 branch=1 ─────────────────────────────────────────
   // handleRpc catch: thrown value is not an Error → "Internal error" fallback
-  test("agent.invoke handler throwing a non-Error value yields 'Internal error'", async () => {
-    if (platform() === "win32") return;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    // The handler throws a string literal — not an Error instance.
-    server.setAgentInvokeHandler(async (_ctx) => {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
-      throw "non-error-throw" as unknown as Error;
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "agent.invoke handler throwing a non-Error value yields 'Internal error'",
+    async () => {
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      // The handler throws a string literal — not an Error instance.
+      server.setAgentInvokeHandler(async (_ctx) => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "non-error-throw" as unknown as Error;
+      });
+      await server.start();
 
-    const line = await exchangeFirstNdjsonLine(
-      listenPath,
-      `${JSON.stringify({
-        jsonrpc: "2.0",
-        id: 17,
-        method: "agent.invoke",
-        params: { input: "x" },
-      })}\n`,
-    );
-    const res = JSON.parse(line) as { error?: { code: number; message: string } };
-    expect(res.error).toBeDefined();
-    expect(res.error?.code).toBe(-32603);
-    expect(res.error?.message).toBe("Internal error");
-  });
+      const line = await exchangeFirstNdjsonLine(
+        listenPath,
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 17,
+          method: "agent.invoke",
+          params: { input: "x" },
+        })}\n`,
+      );
+      const res = JSON.parse(line) as { error?: { code: number; message: string } };
+      expect(res.error).toBeDefined();
+      expect(res.error?.code).toBe(-32603);
+      expect(res.error?.message).toBe("Internal error");
+    },
+  );
 
   // ── BRDA line=114 block=4 branch=0 ─────────────────────────────────────────
   // handleRpc: notification (no id) → early return without a response
   // We send a notification and then a real request; the first response must be for the request.
-  test("sending a notification (no id) does not produce a response", async () => {
-    if (platform() === "win32") return;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-    });
-    await server.start();
+  test.skipIf(platform() === "win32")(
+    "sending a notification (no id) does not produce a response",
+    async () => {
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+      });
+      await server.start();
 
-    // Write a notification first (no id), then a ping request.
-    // Only the ping response should come back.
-    const twoMessages =
-      `${JSON.stringify({ jsonrpc: "2.0", method: "some.notification", params: {} })}\n` +
-      `${JSON.stringify({ jsonrpc: "2.0", id: 18, method: "gateway.ping", params: {} })}\n`;
+      // Write a notification first (no id), then a ping request.
+      // Only the ping response should come back.
+      const twoMessages =
+        `${JSON.stringify({ jsonrpc: "2.0", method: "some.notification", params: {} })}\n` +
+        `${JSON.stringify({ jsonrpc: "2.0", id: 18, method: "gateway.ping", params: {} })}\n`;
 
-    const line = await exchangeFirstNdjsonLine(listenPath, twoMessages);
-    const res = JSON.parse(line) as { id?: unknown; result?: Record<string, unknown> };
-    // The first (and only) line we receive is the ping reply, not a notification echo.
-    expect(res.id).toBe(18);
-    expect(res.result?.["version"]).toBe("0.0.0-test");
-  });
+      const line = await exchangeFirstNdjsonLine(listenPath, twoMessages);
+      const res = JSON.parse(line) as { id?: unknown; result?: Record<string, unknown> };
+      // The first (and only) line we receive is the ping reply, not a notification echo.
+      expect(res.id).toBe(18);
+      expect(res.result?.["version"]).toBe("0.0.0-test");
+    },
+  );
 
   // ── BRDA line=63 block=1 branch=0 ──────────────────────────────────────────
   // ConsentCoordinatorImpl getWriter lambda: session found → returns the write fn.
   // Triggered by requestConsent() for a connected client.
-  test("consentImpl getWriter finds a connected session and delivers the consent notification", async () => {
-    if (platform() === "win32") return;
-
-    let capturedClientId: string | undefined;
-    server = createIpcServer({
-      listenPath,
-      vault: createMockVault(),
-      version: "0.0.0-test",
-      onClientConnected: (id) => {
-        capturedClientId = id;
-      },
-    });
-    await server.start();
-
-    // Use a helper that keeps the connection open and collects all lines.
-    const notifLines = await new Promise<string[]>((resolve, reject) => {
-      const collected: string[] = [];
-      let buf = "";
-      Bun.connect({
-        unix: listenPath,
-        socket: {
-          open(_socket) {
-            // Connection is now live; capturedClientId is set by onClientConnected.
-          },
-          data(_socket, chunk: Uint8Array) {
-            buf += new TextDecoder().decode(chunk);
-            const parts = buf.split("\n");
-            buf = parts[parts.length - 1] ?? "";
-            for (let i = 0; i < parts.length - 1; i++) {
-              const l = parts[i];
-              if (l !== undefined && l.trim() !== "") collected.push(l);
-            }
-            if (collected.length >= 1) {
-              resolve(collected);
-            }
-          },
-          error(_socket, err) {
-            reject(err);
-          },
+  test.skipIf(platform() === "win32")(
+    "consentImpl getWriter finds a connected session and delivers the consent notification",
+    async () => {
+      let capturedClientId: string | undefined;
+      server = createIpcServer({
+        listenPath,
+        vault: createMockVault(),
+        version: "0.0.0-test",
+        onClientConnected: (id) => {
+          capturedClientId = id;
         },
-      }).catch(reject);
+      });
+      await server.start();
 
-      // Give the open() callback time to fire, then request consent.
-      setTimeout(() => {
-        if (capturedClientId === undefined) {
-          reject(new Error("onClientConnected was not called"));
-          return;
-        }
-        (server as IPCServer).consent
-          .requestConsent(capturedClientId, {
-            requestId: "req-consent-1",
-            prompt: "Allow action?",
-          })
-          .catch(() => {
-            /* consent promise rejection is expected when connection closes */
-          });
-      }, 50);
-    });
+      // Use a helper that keeps the connection open and collects all lines.
+      const notifLines = await new Promise<string[]>((resolve, reject) => {
+        const collected: string[] = [];
+        let buf = "";
+        Bun.connect({
+          unix: listenPath,
+          socket: {
+            open(_socket) {
+              // Connection is now live; capturedClientId is set by onClientConnected.
+            },
+            data(_socket, chunk: Uint8Array) {
+              buf += new TextDecoder().decode(chunk);
+              const parts = buf.split("\n");
+              buf = parts[parts.length - 1] ?? "";
+              for (let i = 0; i < parts.length - 1; i++) {
+                const l = parts[i];
+                if (l !== undefined && l.trim() !== "") collected.push(l);
+              }
+              if (collected.length >= 1) {
+                resolve(collected);
+              }
+            },
+            error(_socket, err) {
+              reject(err);
+            },
+          },
+        }).catch(reject);
 
-    // We should have received the consent.request notification.
-    const parsed = JSON.parse(notifLines[0] ?? "{}") as {
-      method?: string;
-      params?: { requestId?: string };
-    };
-    expect(parsed.method).toBe("consent.request");
-    expect(parsed.params?.requestId).toBe("req-consent-1");
-  });
+        // Give the open() callback time to fire, then request consent.
+        setTimeout(() => {
+          if (capturedClientId === undefined) {
+            reject(new Error("onClientConnected was not called"));
+            return;
+          }
+          (server as IPCServer).consent
+            .requestConsent(capturedClientId, {
+              requestId: "req-consent-1",
+              prompt: "Allow action?",
+            })
+            .catch(() => {
+              /* consent promise rejection is expected when connection closes */
+            });
+        }, 50);
+      });
+
+      // We should have received the consent.request notification.
+      const parsed = JSON.parse(notifLines[0] ?? "{}") as {
+        method?: string;
+        params?: { requestId?: string };
+      };
+      expect(parsed.method).toBe("consent.request");
+      expect(parsed.params?.requestId).toBe("req-consent-1");
+    },
+  );
 });

--- a/packages/gateway/src/ipc/server/socket-listeners.test.ts
+++ b/packages/gateway/src/ipc/server/socket-listeners.test.ts
@@ -127,96 +127,102 @@ describe("startWin32NetServer (cross-platform via unix socket on POSIX)", () => 
     }
   });
 
-  test("starts a net.createServer at the listen path; winSockets starts empty", async () => {
-    if (platform() === "win32") return;
-    const state = makeStubState();
-    const stubSession = makeStubSession(state, () => {});
-    const attach = (_write: SessionWrite): ClientSession => stubSession;
+  test.skipIf(platform() === "win32")(
+    "starts a net.createServer at the listen path; winSockets starts empty",
+    async () => {
+      const state = makeStubState();
+      const stubSession = makeStubSession(state, () => {});
+      const attach = (_write: SessionWrite): ClientSession => stubSession;
 
-    const handle = await startWin32NetServer(socketPath, attach);
-    try {
-      expect(handle.netServer).toBeDefined();
-      expect(handle.netServer.listening).toBe(true);
-      expect(handle.winSockets.size).toBe(0);
-    } finally {
-      await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
-    }
-  });
-
-  test("client connect/write/end/close drives push/endInput/dispose and winSockets cleanup", async () => {
-    if (platform() === "win32") return;
-    const state = makeStubState();
-    let capturedWrite: SessionWrite | null = null;
-    const attach = (write: SessionWrite): ClientSession => {
-      capturedWrite = write;
-      return makeStubSession(state, write);
-    };
-
-    const handle = await startWin32NetServer(socketPath, attach);
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const client = net.connect(socketPath, () => {
-          client.write(Buffer.from([0x41, 0x42, 0x43]));
-          client.end();
-        });
-        client.on("close", () => resolve());
-        client.on("error", reject);
-      });
-
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
-
-      expect(capturedWrite).not.toBeNull();
-
-      expect(state.pushed.length).toBeGreaterThanOrEqual(1);
-      const total = state.pushed.reduce((acc, u) => acc + u.byteLength, 0);
-      expect(total).toBe(3);
-      expect(state.pushed[0]?.[0]).toBe(0x41);
-
-      expect(state.endedInput).toBe(true);
-      expect(state.disposed).toBe(true);
-
-      expect(handle.winSockets.size).toBe(0);
-    } finally {
-      await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
-    }
-  });
-
-  test("socket 'error' handler removes the socket from winSockets and disposes the session", async () => {
-    if (platform() === "win32") return;
-    const state = makeStubState();
-    const stubSession = makeStubSession(state, () => {});
-    const attach = (_write: SessionWrite): ClientSession => stubSession;
-
-    const handle = await startWin32NetServer(socketPath, attach);
-    try {
-      const client = net.connect(socketPath);
-      await new Promise<void>((resolve, reject) => {
-        client.on("connect", () => resolve());
-        client.on("error", reject);
-      });
-
-      await new Promise<void>((resolve) => setTimeout(resolve, 50));
-      expect(handle.winSockets.size).toBe(1);
-
-      const serverSock = Array.from(handle.winSockets)[0];
-      expect(serverSock).toBeDefined();
-      serverSock?.destroy(new Error("forced-error-for-coverage"));
-
-      client.on("error", () => {});
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
-
-      expect(handle.winSockets.size).toBe(0);
-      expect(state.disposed).toBe(true);
-
+      const handle = await startWin32NetServer(socketPath, attach);
       try {
-        client.destroy();
-      } catch {
-        /* best-effort */
+        expect(handle.netServer).toBeDefined();
+        expect(handle.netServer.listening).toBe(true);
+        expect(handle.winSockets.size).toBe(0);
+      } finally {
+        await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
       }
-    } finally {
-      await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
-    }
-  });
+    },
+  );
+
+  test.skipIf(platform() === "win32")(
+    "client connect/write/end/close drives push/endInput/dispose and winSockets cleanup",
+    async () => {
+      const state = makeStubState();
+      let capturedWrite: SessionWrite | null = null;
+      const attach = (write: SessionWrite): ClientSession => {
+        capturedWrite = write;
+        return makeStubSession(state, write);
+      };
+
+      const handle = await startWin32NetServer(socketPath, attach);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const client = net.connect(socketPath, () => {
+            client.write(Buffer.from([0x41, 0x42, 0x43]));
+            client.end();
+          });
+          client.on("close", () => resolve());
+          client.on("error", reject);
+        });
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+        expect(capturedWrite).not.toBeNull();
+
+        expect(state.pushed.length).toBeGreaterThanOrEqual(1);
+        const total = state.pushed.reduce((acc, u) => acc + u.byteLength, 0);
+        expect(total).toBe(3);
+        expect(state.pushed[0]?.[0]).toBe(0x41);
+
+        expect(state.endedInput).toBe(true);
+        expect(state.disposed).toBe(true);
+
+        expect(handle.winSockets.size).toBe(0);
+      } finally {
+        await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
+      }
+    },
+  );
+
+  test.skipIf(platform() === "win32")(
+    "socket 'error' handler removes the socket from winSockets and disposes the session",
+    async () => {
+      const state = makeStubState();
+      const stubSession = makeStubSession(state, () => {});
+      const attach = (_write: SessionWrite): ClientSession => stubSession;
+
+      const handle = await startWin32NetServer(socketPath, attach);
+      try {
+        const client = net.connect(socketPath);
+        await new Promise<void>((resolve, reject) => {
+          client.on("connect", () => resolve());
+          client.on("error", reject);
+        });
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        expect(handle.winSockets.size).toBe(1);
+
+        const serverSock = Array.from(handle.winSockets)[0];
+        expect(serverSock).toBeDefined();
+        serverSock?.destroy(new Error("forced-error-for-coverage"));
+
+        client.on("error", () => {});
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+        expect(handle.winSockets.size).toBe(0);
+        expect(state.disposed).toBe(true);
+
+        try {
+          client.destroy();
+        } catch {
+          /* best-effort */
+        }
+      } finally {
+        await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
+      }
+    },
+  );
 });
 
 describe("startBunUnixListener (POSIX-only)", () => {
@@ -238,39 +244,41 @@ describe("startBunUnixListener (POSIX-only)", () => {
     }
   });
 
-  test("accepts a connection and routes bytes through session.push, then close fires endInput + dispose", async () => {
-    if (platform() === "win32") return;
-    const state = makeStubState();
-    let capturedWrite: SessionWrite | null = null;
-    const attach = (write: SessionWrite): ClientSession => {
-      capturedWrite = write;
-      return makeStubSession(state, write);
-    };
+  test.skipIf(platform() === "win32")(
+    "accepts a connection and routes bytes through session.push, then close fires endInput + dispose",
+    async () => {
+      const state = makeStubState();
+      let capturedWrite: SessionWrite | null = null;
+      const attach = (write: SessionWrite): ClientSession => {
+        capturedWrite = write;
+        return makeStubSession(state, write);
+      };
 
-    const listener = startBunUnixListener(socketPath, attach);
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const client = net.connect(socketPath, () => {
-          client.write(Buffer.from([0x42]));
-          client.end();
-        });
-        client.on("close", () => resolve());
-        client.on("error", reject);
-      });
-
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
-
-      expect(capturedWrite).not.toBeNull();
-      expect(state.pushed.length).toBeGreaterThan(0);
-      expect(state.pushed[0]?.[0]).toBe(0x42);
-      expect(state.endedInput).toBe(true);
-      expect(state.disposed).toBe(true);
-    } finally {
+      const listener = startBunUnixListener(socketPath, attach);
       try {
-        listener.stop();
-      } catch {
-        /* best-effort */
+        await new Promise<void>((resolve, reject) => {
+          const client = net.connect(socketPath, () => {
+            client.write(Buffer.from([0x42]));
+            client.end();
+          });
+          client.on("close", () => resolve());
+          client.on("error", reject);
+        });
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+        expect(capturedWrite).not.toBeNull();
+        expect(state.pushed.length).toBeGreaterThan(0);
+        expect(state.pushed[0]?.[0]).toBe(0x42);
+        expect(state.endedInput).toBe(true);
+        expect(state.disposed).toBe(true);
+      } finally {
+        try {
+          listener.stop();
+        } catch {
+          /* best-effort */
+        }
       }
-    }
-  });
+    },
+  );
 });

--- a/packages/gateway/src/platform/platform.test.ts
+++ b/packages/gateway/src/platform/platform.test.ts
@@ -111,54 +111,48 @@ describe("Platform Abstraction Layer", () => {
     }
   });
 
-  it("throws PlatformInitError for missing Linux secret-tool (subprocess)", () => {
-    if (platform() !== "linux") {
-      return;
-    }
-    const result = Bun.spawnSync({
-      cmd: ["bun", "run", join(gatewayRoot, "test/fixtures/linux-secret-tool-probe.ts")],
-      cwd: gatewayRoot,
-      env: {
-        ...process.env,
-        PATH: dirname(process.execPath),
-        NIMBUS_LINUX_VAULT_PROBE_STRICT_PATH: "1",
-      },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    expect(result.exitCode).not.toBe(0);
-    const errText = new TextDecoder().decode(result.stderr);
-    expect(errText).toContain("secret-tool not found");
-    expect(errText).toContain("PlatformInitError");
-  });
+  it.skipIf(platform() !== "linux")(
+    "throws PlatformInitError for missing Linux secret-tool (subprocess)",
+    () => {
+      const result = Bun.spawnSync({
+        cmd: ["bun", "run", join(gatewayRoot, "test/fixtures/linux-secret-tool-probe.ts")],
+        cwd: gatewayRoot,
+        env: {
+          ...process.env,
+          PATH: dirname(process.execPath),
+          NIMBUS_LINUX_VAULT_PROBE_STRICT_PATH: "1",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      expect(result.exitCode).not.toBe(0);
+      const errText = new TextDecoder().decode(result.stderr);
+      expect(errText).toContain("secret-tool not found");
+      expect(errText).toContain("PlatformInitError");
+    },
+  );
 
-  it("createWindowsPaths throws PlatformInitError without APPDATA", () => {
-    if (platform() !== "win32") {
-      return;
-    }
-    const prev = processEnvGet("APPDATA");
-    processEnvDelete("APPDATA");
-    try {
-      expect(() => createWindowsPaths()).toThrow(PlatformInitError);
-    } finally {
-      processEnvSet("APPDATA", prev);
-    }
-  });
+  it.skipIf(platform() !== "win32")(
+    "createWindowsPaths throws PlatformInitError without APPDATA",
+    () => {
+      const prev = processEnvGet("APPDATA");
+      processEnvDelete("APPDATA");
+      try {
+        expect(() => createWindowsPaths()).toThrow(PlatformInitError);
+      } finally {
+        processEnvSet("APPDATA", prev);
+      }
+    },
+  );
 });
 
 describe("PlatformPaths factories", () => {
-  it("darwin paths share config and data roots per Q1 plan", () => {
-    if (platform() !== "darwin") {
-      return;
-    }
+  it.skipIf(platform() !== "darwin")("darwin paths share config and data roots per Q1 plan", () => {
     const paths = createDarwinPaths();
     expect(paths.configDir).toBe(paths.dataDir);
   });
 
-  it("linux paths are under XDG-style directories", () => {
-    if (platform() !== "linux") {
-      return;
-    }
+  it.skipIf(platform() !== "linux")("linux paths are under XDG-style directories", () => {
     const paths = createLinuxPaths();
     expect(paths.configDir).toContain("nimbus");
     expect(paths.dataDir).toContain("nimbus");

--- a/packages/gateway/src/tribal/tribal-chat-capture.ts
+++ b/packages/gateway/src/tribal/tribal-chat-capture.ts
@@ -17,13 +17,17 @@ export function parseTribalCaptureCommand(text: string): ParsedTribalCaptureComm
     .replace(/<@[^<>]+>/g, " ")
     .replace(/@\w+/g, " ")
     .trim();
-  // `(\S+)(?:\s+(.*))?` keeps the cluster id and the optional remainder disjoint (separated by
-  // whitespace) rather than letting `\S+` and `.*` compete over the same chars (S8786 backtracking).
-  const m = /^tribal\s+capture\s+(\S+)(?:\s+(.*))?$/i.exec(cleaned);
-  if (m === null) return undefined;
-  const clusterId = m[1] ?? "";
+  // Tokenize on whitespace rather than matching one regex with an optional `(.*)` tail — a single
+  // linear split avoids the super-linear backtracking Sonar flags (S8786). Command shape:
+  // `tribal capture <cluster-id> [--target notion|confluence]`.
+  const tokens = cleaned.split(/\s+/);
+  if (tokens.length < 3) return undefined;
+  if (tokens[0]?.toLowerCase() !== "tribal" || tokens[1]?.toLowerCase() !== "capture") {
+    return undefined;
+  }
+  const clusterId = tokens[2] ?? "";
   if (clusterId === "" || clusterId.startsWith("--")) return undefined;
-  const rest = m[2] ?? "";
+  const rest = tokens.slice(3).join(" ");
   const tm = /--target\s+(notion|confluence)\b/i.exec(rest);
   if (tm !== null) {
     return { clusterId, target: tm[1]?.toLowerCase() as "notion" | "confluence" };

--- a/packages/gateway/src/vault/vault.test.ts
+++ b/packages/gateway/src/vault/vault.test.ts
@@ -106,37 +106,34 @@ describe("MockVault", () => {
 });
 
 describe("DpapiVault (Windows)", () => {
-  test("set, get, delete, listKeys round-trip via DPAPI", async () => {
-    if (process.platform !== "win32") {
-      return;
-    }
-    const root = await mkdtemp(join(tmpdir(), "nimbus-vault-dpapi-"));
-    const paths = dpapiVaultTestPaths(root, String.raw`\\.\pipe\nimbus-vault-test`);
-    const { DpapiVault } = await import("./win32.ts");
-    const v = new DpapiVault(paths);
-    await v.set("svc.token", "round-trip-secret");
-    expect(await v.get("svc.token")).toBe("round-trip-secret");
-    expect(await v.listKeys()).toEqual(["svc.token"]);
-    expect(await v.listKeys("svc.")).toEqual(["svc.token"]);
-    await v.delete("svc.token");
-    expect(await v.get("svc.token")).toBeNull();
-  });
+  test.skipIf(process.platform !== "win32")(
+    "set, get, delete, listKeys round-trip via DPAPI",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "nimbus-vault-dpapi-"));
+      const paths = dpapiVaultTestPaths(root, String.raw`\\.\pipe\nimbus-vault-test`);
+      const { DpapiVault } = await import("./win32.ts");
+      const v = new DpapiVault(paths);
+      await v.set("svc.token", "round-trip-secret");
+      expect(await v.get("svc.token")).toBe("round-trip-secret");
+      expect(await v.listKeys()).toEqual(["svc.token"]);
+      expect(await v.listKeys("svc.")).toEqual(["svc.token"]);
+      await v.delete("svc.token");
+      expect(await v.get("svc.token")).toBeNull();
+    },
+  );
 
-  test("get on missing key returns null without throwing", async () => {
-    if (process.platform !== "win32") {
-      return;
-    }
-    const root = await mkdtemp(join(tmpdir(), "nimbus-vault-dpapi-miss-"));
-    const paths = dpapiVaultTestPaths(root, String.raw`\\.\pipe\nimbus-vault-miss`);
-    const { DpapiVault } = await import("./win32.ts");
-    const v = new DpapiVault(paths);
-    expect(await v.get("missing.key")).toBeNull();
-  });
+  test.skipIf(process.platform !== "win32")(
+    "get on missing key returns null without throwing",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "nimbus-vault-dpapi-miss-"));
+      const paths = dpapiVaultTestPaths(root, String.raw`\\.\pipe\nimbus-vault-miss`);
+      const { DpapiVault } = await import("./win32.ts");
+      const v = new DpapiVault(paths);
+      expect(await v.get("missing.key")).toBeNull();
+    },
+  );
 
-  test("delete on missing key is a no-op", async () => {
-    if (process.platform !== "win32") {
-      return;
-    }
+  test.skipIf(process.platform !== "win32")("delete on missing key is a no-op", async () => {
     const root = await mkdtemp(join(tmpdir(), "nimbus-vault-dpapi-del-"));
     const paths = dpapiVaultTestPaths(root, String.raw`\\.\pipe\nimbus-vault-del`);
     const { DpapiVault } = await import("./win32.ts");
@@ -146,29 +143,29 @@ describe("DpapiVault (Windows)", () => {
 });
 
 describe("DarwinKeychainVault (macOS)", () => {
-  test("set, get, delete, listKeys round-trip via Keychain", async () => {
-    if (process.platform !== "darwin") {
-      return;
-    }
-    const root = await mkdtemp(join(tmpdir(), "nimbus-vault-keychain-"));
-    const paths: PlatformPaths = {
-      configDir: root,
-      dataDir: join(root, "data"),
-      logDir: join(root, "logs"),
-      socketPath: join(root, "nimbus-gateway.sock"),
-      extensionsDir: join(root, "ext"),
-      tempDir: join(root, "tmp"),
-    };
-    const { DarwinKeychainVault } = await import("./darwin.ts");
-    const v = new DarwinKeychainVault(paths);
-    const key = "ci.smoke";
-    await v.set(key, "darwin-round-trip");
-    expect(await v.get(key)).toBe("darwin-round-trip");
-    expect(await v.listKeys()).toContain(key);
-    expect(await v.listKeys("ci.")).toEqual([key]);
-    await v.delete(key);
-    expect(await v.get(key)).toBeNull();
-  });
+  test.skipIf(process.platform !== "darwin")(
+    "set, get, delete, listKeys round-trip via Keychain",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "nimbus-vault-keychain-"));
+      const paths: PlatformPaths = {
+        configDir: root,
+        dataDir: join(root, "data"),
+        logDir: join(root, "logs"),
+        socketPath: join(root, "nimbus-gateway.sock"),
+        extensionsDir: join(root, "ext"),
+        tempDir: join(root, "tmp"),
+      };
+      const { DarwinKeychainVault } = await import("./darwin.ts");
+      const v = new DarwinKeychainVault(paths);
+      const key = "ci.smoke";
+      await v.set(key, "darwin-round-trip");
+      expect(await v.get(key)).toBe("darwin-round-trip");
+      expect(await v.listKeys()).toContain(key);
+      expect(await v.listKeys("ci.")).toEqual([key]);
+      await v.delete(key);
+      expect(await v.get(key)).toBeNull();
+    },
+  );
 });
 
 describe("LinuxSecretToolVault search output parsing", () => {
@@ -202,17 +199,17 @@ attribute.nimbus-key = ci.t_2
 });
 
 describe("LinuxSecretToolVault (Linux)", () => {
-  test("set, get, delete, listKeys round-trip via secret-tool", async () => {
-    if (process.platform !== "linux") {
-      return;
-    }
-    const { LinuxSecretToolVault } = await import("./linux.ts");
-    const v = new LinuxSecretToolVault();
-    const key = `ci.t_${Date.now()}`;
-    await v.set(key, "linux-round-trip");
-    expect(await v.get(key)).toBe("linux-round-trip");
-    expect(await v.listKeys("ci.")).toContain(key);
-    await v.delete(key);
-    expect(await v.get(key)).toBeNull();
-  });
+  test.skipIf(process.platform !== "linux")(
+    "set, get, delete, listKeys round-trip via secret-tool",
+    async () => {
+      const { LinuxSecretToolVault } = await import("./linux.ts");
+      const v = new LinuxSecretToolVault();
+      const key = `ci.t_${Date.now()}`;
+      await v.set(key, "linux-round-trip");
+      expect(await v.get(key)).toBe("linux-round-trip");
+      expect(await v.listKeys("ci.")).toContain(key);
+      await v.delete(key);
+      expect(await v.get(key)).toBeNull();
+    },
+  );
 });

--- a/packages/gateway/test/integration/platform/sandbox/sandbox-helper-strace.test.ts
+++ b/packages/gateway/test/integration/platform/sandbox/sandbox-helper-strace.test.ts
@@ -7,19 +7,19 @@ const helperPath = "./packages/gateway/src-native/sandbox-helper/nimbus-sandbox-
 describe.skipIf(process.platform !== "linux")(
   "nimbus-sandbox-helper host-namespace invariant",
   () => {
-    it("does not call setns or unshare(CLONE_NEWUSER) after the initial unshare(CLONE_NEWNET)", () => {
-      if (!existsSync(helperPath)) {
-        return;
-      }
-      const result = spawnSync(
-        "strace",
-        ["-e", "trace=setns,unshare", helperPath, "--allow", "example.com", "--", "/bin/true"],
-        { encoding: "utf8" },
-      );
-      const unshareLines = (result.stderr.match(/unshare\(/g) || []).length;
-      const setnsLines = (result.stderr.match(/setns\(/g) || []).length;
-      expect(setnsLines).toBe(0);
-      expect(unshareLines).toBe(1);
-    });
+    it.skipIf(!existsSync(helperPath))(
+      "does not call setns or unshare(CLONE_NEWUSER) after the initial unshare(CLONE_NEWNET)",
+      () => {
+        const result = spawnSync(
+          "strace",
+          ["-e", "trace=setns,unshare", helperPath, "--allow", "example.com", "--", "/bin/true"],
+          { encoding: "utf8" },
+        );
+        const unshareLines = (result.stderr.match(/unshare\(/g) || []).length;
+        const setnsLines = (result.stderr.match(/setns\(/g) || []).length;
+        expect(setnsLines).toBe(0);
+        expect(unshareLines).toBe(1);
+      },
+    );
   },
 );

--- a/packages/ui/test/components/PendingUpdates.test.tsx
+++ b/packages/ui/test/components/PendingUpdates.test.tsx
@@ -43,9 +43,7 @@ describe("PendingUpdates", () => {
   it("renders one row per cache entry with version pair + badges", async () => {
     callMock.mockResolvedValue([sample()]);
     render(<PendingUpdates offline={false} />);
-    await waitFor(() =>
-      expect(screen.getByTestId("pending-update-row-com.x.a")).toBeInTheDocument(),
-    );
+    expect(await screen.findByTestId("pending-update-row-com.x.a")).toBeInTheDocument();
     expect(screen.getByText(/X/)).toBeInTheDocument();
     expect(screen.getByText(/1\.0\.0 → 1\.1\.0/)).toBeInTheDocument();
     expect(screen.getByText("stable")).toBeInTheDocument();
@@ -59,7 +57,7 @@ describe("PendingUpdates", () => {
       throw new Error(`unexpected ${method}`);
     });
     render(<PendingUpdates offline={false} />);
-    const btn = await waitFor(() => screen.getByTestId("update-button-com.x.a"));
+    const btn = await screen.findByTestId("update-button-com.x.a");
     await userEvent.click(btn);
     await waitFor(() => {
       const calls = callMock.mock.calls.map((c) => c[0]);
@@ -70,14 +68,14 @@ describe("PendingUpdates", () => {
   it("disables Update + renders needs_sync badge when verification needs sync", async () => {
     callMock.mockResolvedValue([sample({ verificationStatus: "needs_sync" })]);
     render(<PendingUpdates offline={false} />);
-    await waitFor(() => expect(screen.getByTestId("needs-sync-com.x.a")).toBeInTheDocument());
+    expect(await screen.findByTestId("needs-sync-com.x.a")).toBeInTheDocument();
     expect(screen.getByTestId("update-button-com.x.a")).toBeDisabled();
   });
 
   it("disables Update + renders signature_failed badge", async () => {
     callMock.mockResolvedValue([sample({ verificationStatus: "signature_failed" })]);
     render(<PendingUpdates offline={false} />);
-    await waitFor(() => expect(screen.getByTestId("signature-failed-com.x.a")).toBeInTheDocument());
+    expect(await screen.findByTestId("signature-failed-com.x.a")).toBeInTheDocument();
     expect(screen.getByTestId("update-button-com.x.a")).toBeDisabled();
   });
 
@@ -88,7 +86,7 @@ describe("PendingUpdates", () => {
       throw new Error(`unexpected ${method}`);
     });
     render(<PendingUpdates offline={false} />);
-    await waitFor(() => screen.getByTestId("update-button-com.x.a"));
+    await screen.findByTestId("update-button-com.x.a");
     await userEvent.click(screen.getByTestId("update-button-com.x.a"));
     const updateCalls = callMock.mock.calls.filter((c) => c[0] === "extension.update");
     expect(updateCalls).toHaveLength(0);

--- a/packages/ui/test/components/hitl/HitlPopupPage.test.tsx
+++ b/packages/ui/test/components/hitl/HitlPopupPage.test.tsx
@@ -96,7 +96,7 @@ describe("HitlPopupPage", () => {
     consentRespond.mockRejectedValueOnce(new Error("socket closed"));
     render(<HitlPopupPage />);
     fireEvent.click(screen.getByRole("button", { name: /Approve/i }));
-    await waitFor(() => expect(screen.getByText(/socket closed/)).toBeInTheDocument());
+    expect(await screen.findByText(/socket closed/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Approve/i })).toBeEnabled();
   });
 });

--- a/packages/ui/test/components/settings/model/PullDialog.test.tsx
+++ b/packages/ui/test/components/settings/model/PullDialog.test.tsx
@@ -44,7 +44,7 @@ function captureSubscription(): {
 
 async function renderAndStartPull(): Promise<void> {
   render(<PullDialog open onClose={() => {}} />);
-  await waitFor(() => screen.getByLabelText(/model name/i));
+  await screen.findByLabelText(/model name/i);
   await userEvent.type(screen.getByLabelText(/model name/i), "gemma:2b");
   await userEvent.click(screen.getByRole("button", { name: /pull/i }));
   await waitFor(() => expect(llmPullModelMock).toHaveBeenCalledWith("ollama", "gemma:2b"));
@@ -54,14 +54,14 @@ describe("PullDialog", () => {
   it("hides the llama.cpp radio when availability reports it unavailable", async () => {
     llmGetStatusMock.mockResolvedValueOnce({ available: { ollama: true, llamacpp: false } });
     render(<PullDialog open onClose={() => {}} />);
-    await waitFor(() => screen.getByLabelText(/ollama/i));
+    await screen.findByLabelText(/ollama/i);
     expect(screen.queryByLabelText(/llama\.cpp/i)).not.toBeInTheDocument();
   });
 
   it("shows both providers when both are available", async () => {
     llmGetStatusMock.mockResolvedValueOnce({ available: { ollama: true, llamacpp: true } });
     render(<PullDialog open onClose={() => {}} />);
-    await waitFor(() => screen.getByLabelText(/ollama/i));
+    await screen.findByLabelText(/ollama/i);
     expect(screen.getByLabelText(/llama\.cpp/i)).toBeInTheDocument();
   });
 
@@ -92,7 +92,7 @@ describe("PullDialog", () => {
     llmPullModelMock.mockResolvedValueOnce({ pullId: "pull_abc" });
     llmCancelPullMock.mockResolvedValueOnce({ cancelled: true });
     await renderAndStartPull();
-    await waitFor(() => screen.getByRole("button", { name: /cancel pull/i }));
+    await screen.findByRole("button", { name: /cancel pull/i });
     await userEvent.click(screen.getByRole("button", { name: /cancel pull/i }));
     await waitFor(() => expect(llmCancelPullMock).toHaveBeenCalledWith("pull_abc"));
   });
@@ -109,12 +109,12 @@ describe("PullDialog", () => {
       });
       render(<PullDialog open onClose={() => {}} />);
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-      await waitFor(() => screen.getByLabelText(/model name/i));
+      await screen.findByLabelText(/model name/i);
       await user.type(screen.getByLabelText(/model name/i), "gemma:2b");
       await user.click(screen.getByRole("button", { name: /pull/i }));
       await waitFor(() => expect(llmPullModelMock).toHaveBeenCalledWith("ollama", "gemma:2b"));
       vi.advanceTimersByTime(15_000);
-      await waitFor(() => expect(screen.getByText(/connecting…/i)).toBeInTheDocument());
+      expect(await screen.findByText(/connecting…/i)).toBeInTheDocument();
       captured?.({
         method: "llm.pullProgress",
         params: {
@@ -150,10 +150,10 @@ describe("PullDialog", () => {
       });
       llmGetStatusMock.mockResolvedValueOnce({ available: { ollama: true } });
       render(<PullDialog open onClose={() => {}} />);
-      await waitFor(() => screen.getByLabelText(/model name/i));
+      await screen.findByLabelText(/model name/i);
       expect(screen.queryByText(/connecting…/i)).not.toBeInTheDocument();
       vi.advanceTimersByTime(15_000);
-      await waitFor(() => expect(screen.getByText(/connecting…/i)).toBeInTheDocument());
+      expect(await screen.findByText(/connecting…/i)).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/ui/test/pages/Marketplace.test.tsx
+++ b/packages/ui/test/pages/Marketplace.test.tsx
@@ -76,7 +76,7 @@ describe("Marketplace page", () => {
   it("enabled checkbox reflects the extension state", async () => {
     stubExtensionList([EXT_1, EXT_2]);
     renderPage();
-    await waitFor(() => expect(screen.getByText("nimbus-git")).toBeInTheDocument());
+    expect(await screen.findByText("nimbus-git")).toBeInTheDocument();
     expect(screen.getByLabelText("nimbus-git enabled")).toBeChecked();
     expect(screen.getByLabelText("nimbus-slack enabled")).not.toBeChecked();
   });
@@ -95,7 +95,7 @@ describe("Marketplace page", () => {
       throw new Error(`unexpected method: ${method}`);
     });
     renderPage();
-    await waitFor(() => expect(screen.getByLabelText("nimbus-git enabled")).toBeInTheDocument());
+    expect(await screen.findByLabelText("nimbus-git enabled")).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("nimbus-git enabled"));
     expect(extensionDisableMock).toHaveBeenCalledWith("nimbus-git");
   });
@@ -114,7 +114,7 @@ describe("Marketplace page", () => {
       throw new Error(`unexpected method: ${method}`);
     });
     renderPage();
-    await waitFor(() => expect(screen.getByLabelText("nimbus-slack enabled")).toBeInTheDocument());
+    expect(await screen.findByLabelText("nimbus-slack enabled")).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("nimbus-slack enabled"));
     expect(extensionEnableMock).toHaveBeenCalledWith("nimbus-slack");
   });
@@ -132,7 +132,7 @@ describe("Marketplace page", () => {
     });
     vi.spyOn(globalThis, "confirm").mockReturnValue(true);
     renderPage();
-    await waitFor(() => expect(screen.getByText("nimbus-git")).toBeInTheDocument());
+    expect(await screen.findByText("nimbus-git")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /remove extension nimbus-git/i }));
     expect(extensionRemoveMock).toHaveBeenCalledWith("nimbus-git");
   });
@@ -166,13 +166,13 @@ describe("Marketplace page", () => {
   it("shows error state when extension.list fails", async () => {
     callMock.mockRejectedValue(new Error("socket closed"));
     renderPage();
-    await waitFor(() => expect(screen.getByText(/socket closed/)).toBeInTheDocument());
+    expect(await screen.findByText(/socket closed/)).toBeInTheDocument();
   });
 
   it("sandbox badge displays 'Process isolation' for every extension", async () => {
     stubExtensionList([EXT_1, EXT_2]);
     renderPage();
-    await waitFor(() => expect(screen.getByText("nimbus-git")).toBeInTheDocument());
+    expect(await screen.findByText("nimbus-git")).toBeInTheDocument();
     const badges = screen.getAllByTestId("sandbox-badge");
     expect(badges).toHaveLength(2);
     for (const badge of badges) {

--- a/packages/ui/test/pages/OnboardingConnect.test.tsx
+++ b/packages/ui/test/pages/OnboardingConnect.test.tsx
@@ -48,9 +48,7 @@ describe("Onboarding → Connect", () => {
     });
     renderAt();
     fireEvent.click(screen.getByText("GitHub"));
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
-    });
+    fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
     await waitFor(() =>
       expect(callMock).toHaveBeenCalledWith("connector.startAuth", { service: "GitHub" }),
     );
@@ -69,7 +67,7 @@ describe("Onboarding → Connect", () => {
     renderAt();
     fireEvent.click(screen.getByText("GitHub"));
     fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
-    await waitFor(() => expect(screen.getByText("Authenticating…")).toBeTruthy());
+    expect(await screen.findByText("Authenticating…")).toBeTruthy();
     resolveAuth();
   });
 
@@ -81,10 +79,8 @@ describe("Onboarding → Connect", () => {
     });
     renderAt();
     fireEvent.click(screen.getByText("GitHub"));
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
-    });
-    await waitFor(() => expect(screen.getByText("Failed — retry")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
+    expect(await screen.findByText("Failed — retry")).toBeTruthy();
   });
 
   it("navigates to /onboarding/syncing when a connector becomes connected", async () => {
@@ -96,13 +92,14 @@ describe("Onboarding → Connect", () => {
     });
     renderAt();
     fireEvent.click(screen.getByText("GitHub"));
+    fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
+    // advanceTimersByTimeAsync flushes the pending startAuth microtasks first (so onAuth reaches
+    // the setInterval poll registration) and then fires the poll — plain advanceTimersByTime would
+    // run before the interval is even registered, and the navigation would never trigger.
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /authenticate/i }));
+      await vi.advanceTimersByTimeAsync(2100);
     });
-    await act(async () => {
-      vi.advanceTimersByTime(2100);
-    });
-    await waitFor(() => expect(screen.getByText("syncing")).toBeTruthy());
+    expect(await screen.findByText("syncing")).toBeTruthy();
     vi.useRealTimers();
   });
 });

--- a/packages/ui/test/pages/OnboardingSyncing.test.tsx
+++ b/packages/ui/test/pages/OnboardingSyncing.test.tsx
@@ -30,7 +30,7 @@ describe("Onboarding → Syncing", () => {
       throw new Error(`unexpected ${method}`);
     });
     renderAt();
-    await waitFor(() => expect(screen.getByText(/42/)).toBeTruthy());
+    expect(await screen.findByText(/42/)).toBeTruthy();
   });
 
   it("Open Dashboard writes onboarding_completed and navigates", async () => {

--- a/packages/ui/test/pages/QuickQuery.test.tsx
+++ b/packages/ui/test/pages/QuickQuery.test.tsx
@@ -100,7 +100,7 @@ describe("QuickQuery", () => {
       method: "engine.streamDone",
       params: { streamId: "s3", meta: { isLocal: true, modelUsed: "gemma2" } },
     });
-    await waitFor(() => expect(screen.getByText(/local · gemma2/)).toBeTruthy());
+    expect(await screen.findByText(/local · gemma2/)).toBeTruthy();
   });
 
   it("shows remote model label from meta when not local", async () => {
@@ -113,6 +113,6 @@ describe("QuickQuery", () => {
       method: "engine.streamDone",
       params: { streamId: "s4", meta: { isLocal: false, modelUsed: "gpt-4o" } },
     });
-    await waitFor(() => expect(screen.getByText(/gpt-4o/)).toBeTruthy());
+    expect(await screen.findByText(/gpt-4o/)).toBeTruthy();
   });
 });

--- a/packages/ui/test/pages/Watchers.test.tsx
+++ b/packages/ui/test/pages/Watchers.test.tsx
@@ -110,7 +110,7 @@ describe("Watchers page — list", () => {
   it("enabled checkbox reflects the watcher state", async () => {
     stubWatcherList([WATCHER_1, WATCHER_2]);
     renderPage();
-    await waitFor(() => expect(screen.getByText("PR opened")).toBeInTheDocument());
+    expect(await screen.findByText("PR opened")).toBeInTheDocument();
     expect(screen.getByLabelText("PR opened enabled")).toBeChecked();
     expect(screen.getByLabelText("Daily digest enabled")).not.toBeChecked();
   });
@@ -122,7 +122,7 @@ describe("Watchers page — list", () => {
       .mockResolvedValueOnce({ watchers: [WATCHER_1] })
       .mockResolvedValue({ watchers: [{ ...WATCHER_1, enabled: 0 }] });
     renderPage();
-    await waitFor(() => expect(screen.getByLabelText("PR opened enabled")).toBeInTheDocument());
+    expect(await screen.findByLabelText("PR opened enabled")).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("PR opened enabled"));
     expect(watcherPauseMock).toHaveBeenCalledWith("w1");
   });
@@ -134,7 +134,7 @@ describe("Watchers page — list", () => {
       .mockResolvedValueOnce({ watchers: [WATCHER_2] })
       .mockResolvedValue({ watchers: [{ ...WATCHER_2, enabled: 1 }] });
     renderPage();
-    await waitFor(() => expect(screen.getByLabelText("Daily digest enabled")).toBeInTheDocument());
+    expect(await screen.findByLabelText("Daily digest enabled")).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("Daily digest enabled"));
     expect(watcherResumeMock).toHaveBeenCalledWith("w2");
   });
@@ -142,21 +142,21 @@ describe("Watchers page — list", () => {
   it("shows the last-fired timestamp when present", async () => {
     stubWatcherList([WATCHER_1]);
     renderPage();
-    await waitFor(() => expect(screen.getByTestId("last-fired-w1")).toBeInTheDocument());
+    expect(await screen.findByTestId("last-fired-w1")).toBeInTheDocument();
     expect(screen.getByTestId("last-fired-w1").textContent).not.toBe("Never fired");
   });
 
   it("shows 'Never fired' when last_fired_at is null", async () => {
     stubWatcherList([WATCHER_2]);
     renderPage();
-    await waitFor(() => expect(screen.getByTestId("last-fired-w2")).toBeInTheDocument());
+    expect(await screen.findByTestId("last-fired-w2")).toBeInTheDocument();
     expect(screen.getByTestId("last-fired-w2")).toHaveTextContent("Never fired");
   });
 
   it("shows error state when watcher.list fails", async () => {
     callMock.mockRejectedValue(new Error("Gateway timeout"));
     renderPage();
-    await waitFor(() => expect(screen.getByText(/Gateway timeout/)).toBeInTheDocument());
+    expect(await screen.findByText(/Gateway timeout/)).toBeInTheDocument();
   });
 
   it("'New watcher' button is disabled when offline", () => {
@@ -172,7 +172,7 @@ describe("Watchers page — list", () => {
     callMock.mockResolvedValueOnce({ watchers: [WATCHER_1] }).mockResolvedValue({ watchers: [] });
     vi.spyOn(globalThis, "confirm").mockReturnValue(true);
     renderPage();
-    await waitFor(() => expect(screen.getByText("PR opened")).toBeInTheDocument());
+    expect(await screen.findByText("PR opened")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /delete watcher PR opened/i }));
     expect(watcherDeleteMock).toHaveBeenCalledWith("w1");
   });
@@ -183,8 +183,8 @@ async function openDialog() {
   renderPage();
   await waitFor(() => expect(callMock).toHaveBeenCalled());
   await userEvent.click(screen.getByRole("button", { name: /new watcher/i }));
-  await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
-  await waitFor(() => expect(screen.getByLabelText("Graph relation")).toBeInTheDocument());
+  expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  expect(await screen.findByLabelText("Graph relation")).toBeInTheDocument();
 }
 
 describe("Watchers page — graph condition builder", () => {

--- a/packages/ui/test/pages/Workflows.test.tsx
+++ b/packages/ui/test/pages/Workflows.test.tsx
@@ -76,7 +76,7 @@ describe("Workflows page — list", () => {
       .mockResolvedValueOnce({ workflows: [WORKFLOW_1] })
       .mockResolvedValue({ workflows: [WORKFLOW_1] });
     renderPage();
-    await waitFor(() => expect(screen.getByText("Deploy")).toBeInTheDocument());
+    expect(await screen.findByText("Deploy")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /run workflow Deploy/i }));
     expect(workflowRunMock).toHaveBeenCalledWith({ name: "Deploy", dryRun: false });
   });
@@ -88,7 +88,7 @@ describe("Workflows page — list", () => {
       .mockResolvedValueOnce({ workflows: [WORKFLOW_1] })
       .mockResolvedValue({ workflows: [WORKFLOW_1] });
     renderPage();
-    await waitFor(() => expect(screen.getByText("Deploy")).toBeInTheDocument());
+    expect(await screen.findByText("Deploy")).toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("Dry run"));
     await userEvent.click(screen.getByRole("button", { name: /run workflow Deploy/i }));
     expect(workflowRunMock).toHaveBeenCalledWith({ name: "Deploy", dryRun: true });
@@ -102,7 +102,7 @@ describe("Workflows page — list", () => {
       .mockResolvedValue({ workflows: [] });
     vi.spyOn(globalThis, "confirm").mockReturnValue(true);
     renderPage();
-    await waitFor(() => expect(screen.getByText("Deploy")).toBeInTheDocument());
+    expect(await screen.findByText("Deploy")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /delete workflow Deploy/i }));
     expect(workflowDeleteMock).toHaveBeenCalledWith("Deploy");
   });
@@ -110,7 +110,7 @@ describe("Workflows page — list", () => {
   it("shows error state when workflow.list fails", async () => {
     callMock.mockRejectedValue(new Error("connection refused"));
     renderPage();
-    await waitFor(() => expect(screen.getByText(/connection refused/)).toBeInTheDocument());
+    expect(await screen.findByText(/connection refused/)).toBeInTheDocument();
   });
 
   it("'New workflow' button is disabled when offline", () => {
@@ -189,7 +189,7 @@ describe("Workflows page — step-list editor", () => {
   it("edit dialog pre-populates steps from the existing workflow", async () => {
     stubWorkflowList([WORKFLOW_1]);
     renderPage();
-    await waitFor(() => expect(screen.getByText("Deploy")).toBeInTheDocument());
+    expect(await screen.findByText("Deploy")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /edit workflow Deploy/i }));
     expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/packages/ui/test/pages/settings/AuditPanel.test.tsx
+++ b/packages/ui/test/pages/settings/AuditPanel.test.tsx
@@ -97,7 +97,7 @@ describe("AuditPanel", () => {
   it("renders summary and one row per fetched entry", async () => {
     renderAt("/settings/audit");
     await waitFor(() => expect(screen.getAllByTestId("audit-row").length).toBeGreaterThan(0));
-    await waitFor(() => expect(screen.getByText(/Total rows: 3/)).toBeTruthy());
+    expect(await screen.findByText(/Total rows: 3/)).toBeTruthy();
     expect(screen.getByText("3 of 3 rows")).toBeTruthy();
   });
 
@@ -266,7 +266,7 @@ describe("AuditPanel runId deep-link", () => {
 
   test("shows a pruning-semantics banner when runId matches no entries", async () => {
     renderAt("/settings/audit?runId=run-missing");
-    await waitFor(() => expect(screen.getByTestId("audit-runid-banner")).toBeInTheDocument());
+    expect(await screen.findByTestId("audit-runid-banner")).toBeInTheDocument();
     expect(screen.getByTestId("audit-runid-banner").textContent).toMatch(
       /no audit entries found for run run-missing/i,
     );

--- a/packages/ui/test/pages/settings/ConnectorsPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ConnectorsPanel.test.tsx
@@ -85,7 +85,7 @@ describe("ConnectorsPanel", () => {
         enabled: null,
       });
       renderPanel();
-      await waitFor(() => screen.getByLabelText("github interval value"));
+      await screen.findByLabelText("github interval value");
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const input = screen.getByLabelText("github interval value");
       await user.clear(input);
@@ -113,7 +113,7 @@ describe("ConnectorsPanel", () => {
         },
       ]);
       renderPanel();
-      await waitFor(() => screen.getByLabelText("github interval value"));
+      await screen.findByLabelText("github interval value");
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const input = screen.getByLabelText("github interval value");
       const unit = screen.getByLabelText("github interval unit");
@@ -146,7 +146,7 @@ describe("ConnectorsPanel", () => {
       enabled: null,
     });
     renderPanel();
-    await waitFor(() => screen.getByLabelText("github depth"));
+    await screen.findByLabelText("github depth");
     await userEvent.selectOptions(screen.getByLabelText("github depth"), "full");
     await waitFor(() =>
       expect(connectorSetConfigMock).toHaveBeenCalledWith("github", { depth: "full" }),
@@ -170,7 +170,7 @@ describe("ConnectorsPanel", () => {
       enabled: false,
     });
     renderPanel();
-    await waitFor(() => screen.getByLabelText("github enabled"));
+    await screen.findByLabelText("github enabled");
     await userEvent.click(screen.getByLabelText("github enabled"));
     await waitFor(() =>
       expect(connectorSetConfigMock).toHaveBeenCalledWith("github", { enabled: false }),
@@ -192,7 +192,7 @@ describe("ConnectorsPanel", () => {
     });
     stubListStatus([]);
     renderPanel();
-    await waitFor(() => screen.getByLabelText("github enabled"));
+    await screen.findByLabelText("github enabled");
     expect(screen.getByLabelText("github enabled")).toBeDisabled();
     expect(screen.getByLabelText("github depth")).toBeDisabled();
     expect(screen.getByLabelText("github interval value")).toBeDisabled();
@@ -205,7 +205,7 @@ describe("ConnectorsPanel", () => {
         { name: "github", health: "healthy", intervalMs: 120000, depth: "summary", enabled: true },
       ]);
       renderPanel();
-      await waitFor(() => screen.getByLabelText("github interval value"));
+      await screen.findByLabelText("github interval value");
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const input = screen.getByLabelText("github interval value");
       const unit = screen.getByLabelText("github interval unit");
@@ -228,7 +228,7 @@ describe("ConnectorsPanel", () => {
         { name: "github", health: "healthy", intervalMs: 60000, depth: "summary", enabled: true },
       ]);
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /retry/i }));
+    await screen.findByRole("button", { name: /retry/i });
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument(),
@@ -247,7 +247,7 @@ describe("ConnectorsPanel", () => {
       },
     ]);
     renderPanel(["/settings/connectors?highlight=slack"]);
-    await waitFor(() => screen.getByText("slack"));
+    await screen.findByText("slack");
     const row = screen.getByTestId("connector-row-slack");
     expect(row.className).toMatch(/ring-2/);
   });
@@ -270,7 +270,7 @@ describe("ConnectorsPanel — connector.configChanged reconcile", () => {
       return () => {};
     });
     renderPanel();
-    await waitFor(() => screen.getByLabelText("github depth"));
+    await screen.findByLabelText("github depth");
     expect(captured).not.toBeNull();
     captured?.({
       method: "connector.configChanged",

--- a/packages/ui/test/pages/settings/ModelPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ModelPanel.test.tsx
@@ -85,7 +85,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     llmLoadModelMock.mockResolvedValueOnce({ isLoaded: true });
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /load gemma:2b/i }));
+    await screen.findByRole("button", { name: /load gemma:2b/i });
     await userEvent.click(screen.getByRole("button", { name: /load gemma:2b/i }));
     await waitFor(() => expect(llmLoadModelMock).toHaveBeenCalledWith("ollama", "gemma:2b"));
   });
@@ -98,7 +98,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     llmUnloadModelMock.mockResolvedValueOnce({ isLoaded: false });
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /unload gemma:2b/i }));
+    await screen.findByRole("button", { name: /unload gemma:2b/i });
     await userEvent.click(screen.getByRole("button", { name: /unload gemma:2b/i }));
     await waitFor(() => expect(llmUnloadModelMock).toHaveBeenCalledWith("ollama", "gemma:2b"));
   });
@@ -119,7 +119,7 @@ describe("ModelPanel", () => {
       },
     });
     renderPanel();
-    await waitFor(() => screen.getByLabelText("gemma:2b default-for"));
+    await screen.findByLabelText("gemma:2b default-for");
     await userEvent.selectOptions(screen.getByLabelText("gemma:2b default-for"), "reasoning");
     await waitFor(() =>
       expect(llmSetDefaultMock).toHaveBeenCalledWith("reasoning", "ollama", "gemma:2b"),
@@ -131,11 +131,9 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     llmGetStatusMock.mockResolvedValueOnce({ available: { ollama: true, llamacpp: true } });
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     await userEvent.click(screen.getByRole("button", { name: /pull new model/i }));
-    await waitFor(() =>
-      expect(screen.getByRole("dialog", { name: /pull model/i })).toBeInTheDocument(),
-    );
+    expect(await screen.findByRole("dialog", { name: /pull model/i })).toBeInTheDocument();
   });
 
   it("llm.modelLoaded notification patches the row's loaded indicator", async () => {
@@ -145,14 +143,12 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     const sub = captureSubscribe();
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /load gemma:2b/i }));
+    await screen.findByRole("button", { name: /load gemma:2b/i });
     sub.handler?.({
       method: "llm.modelLoaded",
       params: { provider: "ollama", modelName: "gemma:2b" },
     });
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /unload gemma:2b/i })).toBeInTheDocument(),
-    );
+    expect(await screen.findByRole("button", { name: /unload gemma:2b/i })).toBeInTheDocument();
   });
 
   it("surfaces pull progress from a persisted activePullId (re-attach on reload)", async () => {
@@ -186,14 +182,12 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     const sub = captureSubscribe();
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /unload gemma:2b/i }));
+    await screen.findByRole("button", { name: /unload gemma:2b/i });
     sub.handler?.({
       method: "llm.modelUnloaded",
       params: { provider: "ollama", modelName: "gemma:2b" },
     });
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /load gemma:2b/i })).toBeInTheDocument(),
-    );
+    expect(await screen.findByRole("button", { name: /load gemma:2b/i })).toBeInTheDocument();
   });
 
   it("llm.pullProgress notification updates the active pull banner", async () => {
@@ -202,7 +196,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     const sub = captureSubscribe();
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     sub.handler?.({
       method: "llm.pullProgress",
       params: {
@@ -227,7 +221,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     const sub = captureSubscribe();
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     sub.handler?.({ method: "llm.pullCompleted", params: { pullId: "pull_done" } });
     await waitFor(() => expect(llmListModelsMock).toHaveBeenCalledTimes(2));
     expect(useNimbusStore.getState().activePullId).toBeNull();
@@ -239,7 +233,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     const sub = captureSubscribe();
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     sub.handler?.({ method: "llm.pullFailed", params: { pullId: "pull_fail" } });
     await waitFor(() => expect(useNimbusStore.getState().activePullId).toBeNull());
     expect(llmListModelsMock).toHaveBeenCalledTimes(1);
@@ -250,7 +244,7 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     subscribeMock.mockRejectedValueOnce(new Error("subscribe failed"));
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     expect(screen.getByRole("button", { name: /pull new model/i })).toBeInTheDocument();
   });
 
@@ -259,9 +253,9 @@ describe("ModelPanel", () => {
     llmGetRouterStatusMock.mockResolvedValueOnce({ decisions: {} });
     llmGetStatusMock.mockResolvedValueOnce({ available: { ollama: true, llamacpp: false } });
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     await userEvent.click(screen.getByRole("button", { name: /pull new model/i }));
-    await waitFor(() => screen.getByRole("dialog", { name: /pull model/i }));
+    await screen.findByRole("dialog", { name: /pull model/i });
     await userEvent.click(screen.getByRole("button", { name: /close/i }));
     await waitFor(() =>
       expect(screen.queryByRole("dialog", { name: /pull model/i })).not.toBeInTheDocument(),
@@ -276,7 +270,7 @@ describe("ModelPanel", () => {
       installedModels: [{ id: "ollama:gemma:2b", provider: "ollama" }],
     });
     renderPanel();
-    await waitFor(() => screen.getByRole("button", { name: /pull new model/i }));
+    await screen.findByRole("button", { name: /pull new model/i });
     expect(screen.getByRole("button", { name: /pull new model/i })).toBeDisabled();
   });
 });

--- a/packages/ui/test/pages/settings/ProfilesPanel.test.tsx
+++ b/packages/ui/test/pages/settings/ProfilesPanel.test.tsx
@@ -60,12 +60,12 @@ describe("ProfilesPanel", () => {
       });
     profileCreateMock.mockResolvedValueOnce({ name: "scratch" });
     renderPanel();
-    await waitFor(() => screen.getByText("default"));
+    await screen.findByText("default");
     await userEvent.click(screen.getByRole("button", { name: /create…/i }));
     await userEvent.type(screen.getByLabelText(/profile name/i), "scratch");
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
     await waitFor(() => expect(profileCreateMock).toHaveBeenCalledWith("scratch"));
-    await waitFor(() => expect(screen.getByText("scratch")).toBeInTheDocument());
+    expect(await screen.findByText("scratch")).toBeInTheDocument();
   });
 
   it("switch flow calls profileSwitch with the chosen name", async () => {
@@ -75,7 +75,7 @@ describe("ProfilesPanel", () => {
     });
     profileSwitchMock.mockResolvedValueOnce({ active: "work" });
     renderPanel();
-    await waitFor(() => screen.getByText("work"));
+    await screen.findByText("work");
     const switchBtn = screen.getByRole("button", { name: "Switch to work" });
     await userEvent.click(switchBtn);
     await waitFor(() => expect(profileSwitchMock).toHaveBeenCalledWith("work"));
@@ -88,7 +88,7 @@ describe("ProfilesPanel", () => {
     });
     profileDeleteMock.mockResolvedValueOnce({ deleted: "scratch" });
     renderPanel();
-    await waitFor(() => screen.getByText("scratch"));
+    await screen.findByText("scratch");
     await userEvent.click(screen.getByRole("button", { name: "Delete scratch" }));
     const delConfirm = await screen.findByRole("button", { name: "Delete" });
     expect(delConfirm).toBeDisabled();
@@ -104,7 +104,7 @@ describe("ProfilesPanel", () => {
       active: "default",
     });
     renderPanel();
-    await waitFor(() => screen.getByText("default"));
+    await screen.findByText("default");
     useNimbusStore.setState({ connectionState: "disconnected" });
     await waitFor(() => expect(screen.getByRole("button", { name: /create…/i })).toBeDisabled());
   });

--- a/packages/ui/test/pages/settings/TelemetryPanel.test.tsx
+++ b/packages/ui/test/pages/settings/TelemetryPanel.test.tsx
@@ -52,7 +52,7 @@ describe("TelemetryPanel", () => {
   it("renders counter cards when enabled", async () => {
     telemetryGetStatusMock.mockResolvedValueOnce(ENABLED_PAYLOAD);
     render(<TelemetryPanel />);
-    await waitFor(() => expect(screen.getByText(/query p95/i)).toBeInTheDocument());
+    expect(await screen.findByText(/query p95/i)).toBeInTheDocument();
     expect(screen.getByText("14")).toBeInTheDocument();
   });
 
@@ -62,7 +62,7 @@ describe("TelemetryPanel", () => {
       .mockResolvedValueOnce({ enabled: false });
     telemetrySetEnabledMock.mockResolvedValueOnce({ enabled: false });
     render(<TelemetryPanel />);
-    await waitFor(() => screen.getByText(/query p95/i));
+    await screen.findByText(/query p95/i);
     await userEvent.click(screen.getByRole("switch", { name: /telemetry/i }));
     await waitFor(() => expect(telemetrySetEnabledMock).toHaveBeenCalledWith(false));
     await waitFor(() =>
@@ -76,7 +76,7 @@ describe("TelemetryPanel", () => {
   it("expander shows the raw JSON payload when opened", async () => {
     telemetryGetStatusMock.mockResolvedValueOnce(ENABLED_PAYLOAD);
     render(<TelemetryPanel />);
-    await waitFor(() => screen.getByText(/query p95/i));
+    await screen.findByText(/query p95/i);
     await userEvent.click(screen.getByRole("button", { name: /view payload sample/i }));
     expect(screen.getByTestId("telemetry-payload-json")).toHaveTextContent("preview-not-persisted");
   });
@@ -84,7 +84,7 @@ describe("TelemetryPanel", () => {
   it("toggle is disabled when connectionState is disconnected", async () => {
     telemetryGetStatusMock.mockResolvedValueOnce({ enabled: false });
     render(<TelemetryPanel />);
-    await waitFor(() => screen.getByRole("switch", { name: /telemetry/i }));
+    await screen.findByRole("switch", { name: /telemetry/i });
     useNimbusStore.setState({ connectionState: "disconnected" });
     await waitFor(() => expect(screen.getByRole("switch", { name: /telemetry/i })).toBeDisabled());
   });

--- a/packages/ui/test/pages/settings/UpdatesPanel.test.tsx
+++ b/packages/ui/test/pages/settings/UpdatesPanel.test.tsx
@@ -52,7 +52,7 @@ afterEach(() => {
 describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", () => {
   it("renders current version once status loads", async () => {
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByText("0.1.0")).toBeTruthy());
+    expect(await screen.findByText("0.1.0")).toBeTruthy();
   });
 
   it("Check now success with no update keeps state idle", async () => {
@@ -62,7 +62,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
       updateAvailable: false,
     });
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByRole("button", { name: "Check now" })).toBeTruthy());
+    expect(await screen.findByRole("button", { name: "Check now" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Check now" }));
     await waitFor(() => expect(useNimbusStore.getState().updaterUiState).toBe("idle"));
     expect(useNimbusStore.getState().updaterCheck?.updateAvailable).toBe(false);
@@ -89,7 +89,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
     });
     updaterApplyUpdateMock.mockResolvedValueOnce({ jobId: "x" });
     render(<UpdatesPanel />);
-    await waitFor(() => screen.getByRole("button", { name: /Apply 0.2.0/ }));
+    await screen.findByRole("button", { name: /Apply 0.2.0/ });
     fireEvent.click(screen.getByRole("button", { name: /Apply 0.2.0/ }));
     await waitFor(() => expect(useNimbusStore.getState().updaterUiState).toBe("applying"));
     expect(updaterApplyUpdateMock).toHaveBeenCalledTimes(1);
@@ -104,7 +104,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
     });
     updaterRollbackMock.mockResolvedValueOnce({ ok: true });
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByText(/previous install failed/)).toBeTruthy());
+    expect(await screen.findByText(/previous install failed/)).toBeTruthy();
     const rollback = screen.getByRole("button", { name: "Rollback" });
     fireEvent.click(rollback);
     await waitFor(() => expect(updaterRollbackMock).toHaveBeenCalledTimes(1));
@@ -113,7 +113,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
   it("Disconnected state disables Check now", async () => {
     useNimbusStore.setState({ connectionState: "disconnected" });
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByText("0.1.0")).toBeTruthy());
+    expect(await screen.findByText("0.1.0")).toBeTruthy();
     expect((screen.getByRole("button", { name: "Check now" }) as HTMLButtonElement).disabled).toBe(
       true,
     );
@@ -122,9 +122,9 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
   it("Check now error shows fetch error and resets state to idle", async () => {
     updaterCheckNowMock.mockRejectedValueOnce(new Error("network timeout"));
     render(<UpdatesPanel />);
-    await waitFor(() => screen.getByRole("button", { name: "Check now" }));
+    await screen.findByRole("button", { name: "Check now" });
     fireEvent.click(screen.getByRole("button", { name: "Check now" }));
-    await waitFor(() => expect(screen.getByText(/network timeout/)).toBeTruthy());
+    expect(await screen.findByText(/network timeout/)).toBeTruthy();
     expect(useNimbusStore.getState().updaterUiState).toBe("idle");
   });
 
@@ -135,7 +135,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
     });
     updaterApplyUpdateMock.mockRejectedValueOnce(new Error("installer failed"));
     render(<UpdatesPanel />);
-    await waitFor(() => screen.getByRole("button", { name: /Apply 0.2.0/ }));
+    await screen.findByRole("button", { name: /Apply 0.2.0/ });
     fireEvent.click(screen.getByRole("button", { name: /Apply 0.2.0/ }));
     await waitFor(() => expect(useNimbusStore.getState().updaterUiState).toBe("failed"));
     expect(screen.getByText(/installer failed/)).toBeTruthy();
@@ -150,7 +150,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
     });
     updaterRollbackMock.mockRejectedValueOnce(new Error("rollback rpc failed"));
     render(<UpdatesPanel />);
-    await waitFor(() => screen.getByRole("button", { name: "Rollback" }));
+    await screen.findByRole("button", { name: "Rollback" });
     fireEvent.click(screen.getByRole("button", { name: "Rollback" }));
     await waitFor(() => expect(useNimbusStore.getState().updaterUiState).toBe("failed"));
     expect(screen.getByText(/rollback rpc failed/)).toBeTruthy();
@@ -162,7 +162,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
       updaterFailure: { reason: "signature_invalid" },
     });
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByText(/signature invalid/i)).toBeTruthy());
+    expect(await screen.findByText(/signature invalid/i)).toBeTruthy();
   });
 
   it("shows hash_mismatch failure message when uiState is failed", async () => {
@@ -171,7 +171,7 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
       updaterFailure: { reason: "hash_mismatch" },
     });
     render(<UpdatesPanel />);
-    await waitFor(() => expect(screen.getByText(/hash mismatch/i)).toBeTruthy());
+    expect(await screen.findByText(/hash mismatch/i)).toBeTruthy();
   });
 
   it("shows generic rolled-back message for unknown failure reason", async () => {
@@ -180,8 +180,6 @@ describe("UpdatesPanel (slimmed; subscriptions live in UpdaterRestartChrome)", (
       updaterFailure: { reason: "unknown_reason" },
     });
     render(<UpdatesPanel />);
-    await waitFor(() =>
-      expect(screen.getByText(/Update rolled back: unknown_reason/)).toBeTruthy(),
-    );
+    expect(await screen.findByText(/Update rolled back: unknown_reason/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## What

Clears **all 128 open SonarCloud code smells** on the board. The quality gate was already green (0 bugs, 0 vulnerabilities, 0 hotspots to review, coverage 94.3%, duplication 0.2%); this drives the smell count to zero. 126 of the 128 are mechanical test-file cleanups; only 2 touch production source.

| Rule | Count | Fix |
|---|---|---|
| S9020 | 88 | UI/RTL `waitFor` + `getBy*` (element appearance) → awaited `findBy*` |
| S8968 | 35 | gateway tests skipping via `if (cond) return;` → `test.skipIf(cond)` / `it.skipIf(cond)` |
| S8980 | 3 | removed redundant `act()` wrappers around `fireEvent` |
| S3776 | 1 | `ipc/clip-rpc.ts` `dispatchClipRpc` cognitive complexity 21 → ~1, via the existing `dispatchByMethod` handler-map helper |
| S8786 | 1 | `tribal/tribal-chat-capture.ts` ReDoS-prone regex (`(\S+)(?:\s+(.*))?`) → linear whitespace tokenize + a simple `--target` regex |

## Notes

- Both source refactors are **behavior-preserving** and covered by their existing suites (clip-rpc 31 tests, tribal-chat-capture tests all pass).
- A handful of Sonar-adjacent `waitFor`s that assert `toHaveTextContent`/state on an **already-mounted** element were deliberately left as-is — `findBy*` retries on element existence only, so converting them would assert stale content and break the test. None were in the flagged 128.
- OnboardingConnect's fake-timer navigation test: removing the `act()` around the click required switching the timer advance to `vi.advanceTimersByTimeAsync` so the poll interval registers before the timer fires.

## Verification (local)

- Full UI Vitest: **74 files / 506 tests, 0 fail**
- All changed gateway suites: **138 pass / 26 platform-skip, 0 fail**
- `tsc --noEmit`: **exit 0** for both `packages/ui` and `packages/gateway`
- `biome check`: clean (84 files)
- static invariant audit (`check-nimbus-invariants.ts`): **exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined clip RPC request dispatching while preserving existing validation and behavior.
  * Simplified tribal capture command parsing.

* **Tests**
  * Improved asynchronous UI test reliability with direct async queries.
  * Standardized platform- and environment-specific test skipping.
  * Preserved existing coverage and behavioral assertions across gateway, UI, and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->