### PR TITLE
ci: migrate release automation from PATs to org GitHub App

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -65,18 +65,23 @@ jobs:
         with:
           verify-lock: "false"
 
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: linux-repo
+          permission-contents: write
+
       # Fail fast with actionable messages if any required secret is missing.
       - name: Require publish + signing secrets
         env:
-          PKG_PAT: ${{ secrets.PACKAGE_MANAGER_PAT }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_SUBKEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
-          if [ -z "${PKG_PAT}" ]; then
-            echo "::error::PACKAGE_MANAGER_PAT is not set. Grant the fine-grained PAT contents:write on nimbus-agent/linux-repo (repo Settings -> Secrets -> Actions)."
-            exit 1
-          fi
           if [ -z "${GPG_PRIVATE_KEY}" ] || [ -z "${GPG_PASSPHRASE}" ]; then
             echo "::error::GPG_SIGNING_SUBKEY and/or GPG_PASSPHRASE are not set. They sign the apt Release + yum repomd (same secrets release.yml already uses)."
             exit 1
@@ -141,7 +146,7 @@ jobs:
 
       - name: Clone the linux-repo Pages repo
         env:
-          GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/nimbus-agent/linux-repo.git" repo
@@ -191,7 +196,7 @@ jobs:
 
       - name: Commit + push to linux-repo
         env:
-          GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -68,15 +68,15 @@ jobs:
       # On the upstream repo a missing secret means releases would silently fail to
       # publish, so we error loudly rather than skip. (Release events don't fire from
       # forks, so this is not a fork-noise concern.)
-      - name: Require PACKAGE_MANAGER_PAT
-        env:
-          PKG_PAT: ${{ secrets.PACKAGE_MANAGER_PAT }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PKG_PAT}" ]; then
-            echo "::error::PACKAGE_MANAGER_PAT is not set. Add a fine-grained PAT with contents:write on nimbus-agent/homebrew-tap + nimbus-agent/scoop-bucket (repo Settings -> Secrets -> Actions)."
-            exit 1
-          fi
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: homebrew-tap,scoop-bucket
+          permission-contents: write
 
       - name: Download SHA256SUMS from the release
         env:
@@ -103,7 +103,7 @@ jobs:
 
       - name: Publish to homebrew-tap
         env:
-          GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
@@ -123,7 +123,7 @@ jobs:
 
       - name: Publish to scoop-bucket
         env:
-          GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,9 @@ jobs:
   release-please:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # Needed when using the default GITHUB_TOKEN (no RELEASE_PLEASE_PAT). Optional PAT keeps
-    # the same scopes off the automatic token if you add secret RELEASE_PLEASE_PAT later.
+    # release-please authenticates with the minted release-bot App token (step below), not
+    # GITHUB_TOKEN; these job-level permissions scope the automatic GITHUB_TOKEN the other
+    # steps (checkout, harden-runner) use.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,8 +24,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.RELEASE_PAT || github.token }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,7 +387,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: release
-    # Keep GITHUB_TOKEN read-only here; GitHub Release API uses RELEASE_PAT (fine-grained: Contents RW).
+    # Keep GITHUB_TOKEN read-only here; GitHub Release API uses a minted release-bot App token (Contents RW).
     # id-token: write is required by anchore/sbom-action to attach an OIDC-signed attestation.
     permissions:
       contents: read
@@ -406,14 +406,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Require release PAT
-        env:
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-        run: |
-          if [ -z "${RELEASE_PAT}" ]; then
-            echo "Missing repository secret RELEASE_PAT (fine-grained PAT: Contents read/write for this repo)." >&2
-            exit 1
-          fi
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus
+          permission-contents: write
 
       - name: Setup Bun and install dependencies (packaging)
         uses: ./.github/actions/setup-nimbus-ci
@@ -617,7 +618,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           files: dist/stage/*
           generate_release_notes: true
           draft: false
@@ -655,6 +656,15 @@ jobs:
       - uses: ./.github/actions/setup-nimbus-ci
         with:
           verify-lock: "false"
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus
+          permission-contents: write
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -675,7 +685,7 @@ jobs:
       - name: Upload latest.json to release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           files: manifest-build/latest.json
 
   alert-on-failure:

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -36,13 +36,22 @@ jobs:
         uses: ./.github/actions/setup-nimbus-ci
         with:
           verify-lock: "false"
+      - name: Mint release-bot token (health probe)
+        id: app-mint
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus,homebrew-tap,scoop-bucket,linux-repo
+          permission-contents: write
+          permission-pull-requests: write
       - name: Run secret-health check
         env:
           GITHUB_TOKEN: ${{ github.token }}
           THRESHOLD_DAYS: ${{ github.event.inputs.threshold_days || '21' }}
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-          RELEASE_PLEASE_PAT: ${{ secrets.RELEASE_PLEASE_PAT }}
-          PACKAGE_MANAGER_PAT: ${{ secrets.PACKAGE_MANAGER_PAT }}
+          APP_MINT_STATUS: ${{ steps.app-mint.outcome }}
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
           NIMBUS_CHECKS_TOKEN: ${{ secrets.NIMBUS_CHECKS_TOKEN }}
           SCORECARD_TOKEN: ${{ secrets.SCORECARD_TOKEN }}

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -250,14 +250,15 @@ controls how far ahead of expiry a certificate is flagged. It checks:
   token (`Mint release-bot token (health probe)` step, `continue-on-error:
   true`) scoped to **all four** installed repos (`Nimbus`, `homebrew-tap`,
   `scoop-bucket`, `linux-repo`) with `Contents: Read and write` +
-  `Pull requests: Read and write` — the same permissions the real release
-  jobs request. Its outcome is passed to the script as `APP_MINT_STATUS`,
+  `Pull requests: Read and write` — a superset of what the individual
+  release jobs request, so a downgrade of either permission on any repo is
+  caught. Its outcome is passed to the script as `APP_MINT_STATUS`,
   which classifies anything other than a clean mint (`failure`, `skipped`, or
   unset) as `dead` so a missing secret, an uninstalled App, or a downgraded
   permission all alert. This deliberately reuses `actions/create-github-app-token`
   rather than reimplementing RS256 JWT signing in the script, and it
   dogfoods the exact mint path the release pipeline depends on.
-- **Two remaining PATs**: `WINGET_PAT`, `NIMBUS_CHECKS_TOKEN` (falls back to
+- **Three remaining PATs**: `WINGET_PAT`, `NIMBUS_CHECKS_TOKEN` (falls back to
   `github.token` when unset), and `SCORECARD_TOKEN` (unset — the Scorecard
   job falls back to `github.token`) — each probed live against the GitHub API
   for basic validity/permissions.

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -11,12 +11,13 @@ Release/publish secrets are scoped to the **`release`** GitHub
 **Settings → Environments → release → Environment secrets**. Everything else is
 a plain repository secret.
 
-> **Token hygiene.** Fine-grained PATs expire (90 days by default). When a
-> release fails with `Bad credentials` from `softprops/action-gh-release`, the
-> `RELEASE_PAT` has expired or been revoked — rotate it (see below) and re-run
-> the failed job. Prefer the **shortest practical expiry** and the **narrowest
-> scope** for every token here; never grant org-wide or `repo`-classic scope
-> when a fine-grained per-repo grant works.
+> **Token hygiene.** The release/publish path now authenticates as the
+> **Nimbus Release Bot** GitHub App for everything it can (see below) — App
+> installation tokens are minted fresh per job and expire in 1 hour, so there
+> is no 90-day clock to watch. `WINGET_PAT` is the one remaining human-owned
+> classic PAT (it must fork an external repo the App cannot reach); prefer the
+> **shortest practical expiry** and the **narrowest scope** for it and for any
+> future token added here.
 
 ---
 
@@ -24,8 +25,8 @@ a plain repository secret.
 
 | Secret | Required for | Type | Used by |
 | --- | --- | --- | --- |
-| `RELEASE_PAT` | Publishing GitHub Releases | Fine-grained PAT — Contents: RW | `release.yml`, `release-please.yml` |
-| `RELEASE_PLEASE_PAT` | release-please PRs (optional) | Fine-grained PAT — Contents + PRs: RW | `release-please.yml` |
+| `RELEASE_BOT_APP_ID` | Minting Nimbus Release Bot tokens | GitHub App ID | `release.yml`, `release-please.yml`, `publish-package-managers.yml`, `publish-linux-repo.yml`, `secret-health.yml` |
+| `RELEASE_BOT_PRIVATE_KEY` | Minting Nimbus Release Bot tokens | GitHub App private key (PEM) | `release.yml`, `release-please.yml`, `publish-package-managers.yml`, `publish-linux-repo.yml`, `secret-health.yml` |
 | `GPG_SIGNING_SUBKEY` | Signing Linux artifacts + `SHA256SUMS` | ASCII-armored GPG private subkey | `release.yml` |
 | `GPG_PASSPHRASE` | Unlocking the GPG subkey | String | `release.yml` |
 | `UPDATER_SIGNING_KEY` | Signing the auto-updater manifest | Ed25519 private key | `release.yml` |
@@ -38,7 +39,6 @@ a plain repository secret.
 | `APPLE_DEVELOPER_ID_INSTALLER` | macOS installer signing identity | Cert common-name | `release.yml` |
 | `APPLE_NOTARY_ID` | Apple notarization | Apple ID e-mail | `release.yml` |
 | `APPLE_NOTARY_PASSWORD` | Apple notarization | App-specific password | `release.yml` |
-| `PACKAGE_MANAGER_PAT` | Homebrew tap + Scoop bucket pushes | Fine-grained PAT — Contents: RW on the two channel repos | `publish-package-managers.yml` |
 | `WINGET_PAT` | winget submission PR | **Classic** PAT — `public_repo` scope | `publish-package-managers.yml` |
 | `VSCE_PAT` | VS Code Marketplace publish | Azure DevOps PAT — Marketplace (Manage) | `publish-vscode.yml` |
 | `OVSX_PAT` | Open VSX publish | Open VSX token | `publish-vscode.yml` |
@@ -50,43 +50,73 @@ a plain repository secret.
 
 `GITHUB_TOKEN` is injected by Actions automatically; it is never set by hand.
 Several optional secrets fall back to `github.token` when unset
-(`NIMBUS_CHECKS_TOKEN`, `RELEASE_PLEASE_PAT`) or simply skip their step
-(`SONAR_TOKEN`).
+(`NIMBUS_CHECKS_TOKEN`) or simply skip their step (`SONAR_TOKEN`).
 
 ---
 
 ## Release & GitHub Release publishing (`release` environment)
 
-### `RELEASE_PAT` — **required to ship a release**
+### Nimbus Release Bot (GitHub App) — **required to ship a release**
 
-Used by the `Create GitHub Release` step (`softprops/action-gh-release`) in
-`release.yml` and as the release-please fallback token. `GITHUB_TOKEN` is kept
-read-only in that job, so the Release API needs this PAT.
+An org-owned **GitHub App** ("Nimbus Release Bot", installed under
+`nimbus-agent`) replaces the three release-scoped PATs this section used to
+document (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`). Every
+job that used to consume one of those PATs now runs a mint step first:
 
-Create it:
+```yaml
+- name: Mint release-bot token
+  id: app-token
+  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+  with:
+    app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+    private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+    owner: nimbus-agent
+    repositories: <only the repos this job writes>
+    permission-contents: write
+    # permission-pull-requests: write   # release-please.yml only
+```
 
-1. <https://github.com/settings/personal-access-tokens/new> → **Fine-grained
-   token**.
-2. **Resource owner:** `nimbus-agent`. **Repository access:** *Only select
-   repositories* → `nimbus-agent/Nimbus`.
-3. **Repository permissions:** **Contents → Read and write**. (That alone is
-   enough to create releases and upload assets.)
-4. Set a short expiry, generate, copy the `github_pat_…` value.
-5. Store as the **`RELEASE_PAT`** environment secret under
-   **Settings → Environments → release**.
+and uses `${{ steps.app-token.outputs.token }}` in place of the retired PAT.
+Each minted token is an **installation access token**: scoped to exactly the
+repos + permissions the `with:` block requests, and it expires in **1 hour**
+— there is no 90-day expiry clock to track, unlike a PAT.
 
-> **Rotation:** when the release job logs
-> `⚠️ Unexpected error fetching GitHub release for tag …: HttpError: Bad
-> credentials`, regenerate this token and re-run the failed
-> `Publish GitHub Release` job. The git tag is created by release-please, so a
-> re-run after rotation publishes against the existing tag.
+- **Two secrets**, both stored as **plain `Nimbus` repository secrets**, not
+  scoped to the `release` environment (`release-please.yml` and
+  `publish-package-managers.yml`/`publish-linux-repo.yml` mint a token
+  without declaring `environment: release`, so an environment-scoped secret
+  would be invisible to them). `create-github-app-token`'s `repositories:`
+  input mints tokens for any *other* installed repo too, so no org-level or
+  per-repo duplicate secrets are needed:
+  - `RELEASE_BOT_APP_ID` — the App's numeric ID.
+  - `RELEASE_BOT_PRIVATE_KEY` — the App's private key, PEM, generated once
+    from the App's settings page.
+- **Installed on exactly four repos** (`nimbus-agent` org, *Only select
+  repositories*): `Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`. A
+  token mint fails for any repo outside this set.
+- **Permissions:** `Contents: Read and write` + `Pull requests: Read and
+  write`. No organization or account permissions, no webhook — the App can
+  push/tag/PR in the four installed repos and nothing else.
+- **Who mints it:** `release-please.yml` (contents + pull-requests: write on
+  `Nimbus`, replacing the old `RELEASE_PLEASE_PAT` `token:` input),
+  `release.yml` (contents: write on `Nimbus`, replacing `RELEASE_PAT` in the
+  `Create GitHub Release` step), `publish-package-managers.yml` (contents:
+  write on `homebrew-tap` + `scoop-bucket`, replacing `PACKAGE_MANAGER_PAT`
+  for the brew/scoop pushes — **`WINGET_PAT` is untouched**, see below), and
+  `publish-linux-repo.yml` (contents: write on `linux-repo`, replacing
+  `PACKAGE_MANAGER_PAT` for the apt/yum repo + Pages push).
+  `secret-health.yml` also mints a token (scoped to all four repos) purely as
+  a weekly health probe — see
+  [Release-health monitor](#release-health-monitor) below.
 
-### `RELEASE_PLEASE_PAT` — optional
-
-Lets release-please open its release PR with a PAT instead of `GITHUB_TOKEN`
-(so the PR can trigger downstream workflows). Fine-grained, `nimbus-agent/Nimbus`
-only, **Contents: RW + Pull requests: RW**. Falls back to `RELEASE_PAT`, then
-`github.token`, when unset.
+> **Rotation:** an App private key doesn't expire on a schedule the way a PAT
+> does, but if it's ever compromised or you want to rotate it proactively:
+> generate a **new** private key from the App's settings page
+> (<https://github.com/organizations/nimbus-agent/settings/apps> → Nimbus
+> Release Bot → Generate a private key), replace the
+> **`RELEASE_BOT_PRIVATE_KEY`** repo secret with the new PEM, then revoke the
+> old key from the same page. No `RELEASE_BOT_APP_ID` change is needed — the
+> App ID is stable across key rotations.
 
 ### `GPG_SIGNING_SUBKEY` + `GPG_PASSPHRASE` — required for Linux signing
 
@@ -128,18 +158,24 @@ Seven secrets feed the per-arch `.pkg` build/sign/notarize step:
 
 ## Package-manager channels (`publish-package-managers.yml`)
 
-### `PACKAGE_MANAGER_PAT` — Homebrew tap + Scoop bucket
+### Homebrew tap + Scoop bucket — Nimbus Release Bot
 
 Pushes the updated formula/manifest to `nimbus-agent/homebrew-tap` and
-`nimbus-agent/scoop-bucket`. **Fine-grained** PAT, resource owner
-`nimbus-agent`, **both** channel repos selected, **Contents: Read and write**.
+`nimbus-agent/scoop-bucket`. Both repos are installed targets of the Nimbus
+Release Bot App (see above); the job mints a token scoped to both with
+`Contents: Read and write` and uses it in place of the retired
+`PACKAGE_MANAGER_PAT`.
 
-### `WINGET_PAT` — winget submission
+### `WINGET_PAT` — winget submission — **stays a classic PAT, on purpose**
 
-`wingetcreate` must **fork** `microsoft/winget-pkgs`, push to the fork, and open
-a cross-repo PR — which a fine-grained PAT cannot do. This one must be a
-**classic** PAT with the **`public_repo`** scope
-(<https://github.com/settings/tokens/new>).
+`wingetcreate` must **fork `microsoft/winget-pkgs`** (owned by Microsoft, not
+`nimbus-agent`), push to that fork, and open a cross-repo PR against it. A
+GitHub App installed on the `nimbus-agent` org can only mint tokens for repos
+*inside* that org's installation — it has no way to authenticate against an
+external org's repo or fork it. So this one credential cannot be migrated to
+the App and remains a **classic** PAT with the **`public_repo`** scope
+(<https://github.com/settings/tokens/new>). This is a deliberate, documented
+exception, not an oversight.
 
 ---
 
@@ -184,11 +220,18 @@ no `NPM_TOKEN` involved, here or there.
 
 After rotating or adding a secret, re-run the affected workflow from the Actions
 tab (**Re-run failed jobs** for a failed release). For the release path
-specifically, the `Require release PAT` / `Require PACKAGE_MANAGER_PAT` /
-`Require WINGET_PAT` guard steps fail fast with an actionable message when a
-required secret is missing, so a green guard step confirms the secret is at
-least present (it does not prove the token is unexpired — a valid-but-expired
-token still passes the guard and fails later at the API call).
+specifically:
+
+- The **`Mint release-bot token`** step itself is the guard for
+  `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` — it fails fast if either
+  secret is missing, the App isn't installed on the target repo, or the
+  requested permission exceeds what the App grants, so there's no separate
+  "Require …" step to check.
+- The **`Require WINGET_PAT`** guard step still fails fast with an actionable
+  message when that secret is missing, so a green guard step confirms the
+  PAT is at least present (it does not prove the token is unexpired — a
+  valid-but-expired token still passes the guard and fails later at the
+  API call).
 
 ---
 
@@ -203,21 +246,33 @@ Runs on a **weekly cron** (`0 9 * * 1`, Mondays 09:00 UTC) and is also
 `workflow_dispatch`-able with a `threshold_days` input (default `21`) that
 controls how far ahead of expiry a certificate is flagged. It checks:
 
-- **Six PATs**: `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`,
-  `WINGET_PAT`, `NIMBUS_CHECKS_TOKEN`, `SCORECARD_TOKEN` — each probed live
-  against the GitHub API for basic validity/permissions.
+- **Nimbus Release Bot App-health check**: the workflow itself mints an App
+  token (`Mint release-bot token (health probe)` step, `continue-on-error:
+  true`) scoped to **all four** installed repos (`Nimbus`, `homebrew-tap`,
+  `scoop-bucket`, `linux-repo`) with `Contents: Read and write` +
+  `Pull requests: Read and write` — the same permissions the real release
+  jobs request. Its outcome is passed to the script as `APP_MINT_STATUS`,
+  which classifies anything other than a clean mint (`failure`, `skipped`, or
+  unset) as `dead` so a missing secret, an uninstalled App, or a downgraded
+  permission all alert. This deliberately reuses `actions/create-github-app-token`
+  rather than reimplementing RS256 JWT signing in the script, and it
+  dogfoods the exact mint path the release pipeline depends on.
+- **Two remaining PATs**: `WINGET_PAT`, `NIMBUS_CHECKS_TOKEN` (falls back to
+  `github.token` when unset), and `SCORECARD_TOKEN` (unset — the Scorecard
+  job falls back to `github.token`) — each probed live against the GitHub API
+  for basic validity/permissions.
 - **Three certificate/signing-credential pairs**: the GPG signing subkey
   (`GPG_SIGNING_SUBKEY` + `GPG_PASSPHRASE`), the Windows code-signing cert
   (`WINDOWS_CERT_PFX_BASE64` + `WINDOWS_CERT_PASSWORD`), and the Apple
   Developer ID cert (`APPLE_CERT_P12_BASE64` + `APPLE_CERT_PASSWORD`) —
   decoded and checked for upcoming expiry against `threshold_days`.
 
-> **Caveat — PAT dead/alive is not the same as PAT correct.** A live probe
-> only proves the token authenticates and has *some* permission; it does not
-> exercise the exact scope combination a release run needs (e.g. `RELEASE_PAT`
-> passing the health probe still says nothing about whether it retains
-> `Contents: Read and write` on this specific repo). Treat a green run as
-> "not yet expired," not as a release dry-run.
+> **Caveat — a green probe is not the same as "the real job will work."** A
+> live probe only proves the credential authenticates and has *some*
+> permission; the App-health check narrows this gap by minting with the same
+> repo set + permissions the release jobs use, but it still doesn't run the
+> actual publish steps. Treat a green run as "not yet broken," not as a
+> release dry-run.
 
 Findings are filed as a single, de-duped **`release-health`** GitHub issue
 (opened or updated in place per run, not re-created every week) — see
@@ -252,3 +307,63 @@ Local dry-run aliases: `bun run release:verify-assets` and
 `bun run release:secret-health` (see `package.json`) let you exercise either
 script by hand with the right env vars set locally, without waiting for the
 scheduled/tag-triggered workflow.
+
+---
+
+## GitHub App setup + migration runbook
+
+The four release/publish workflows and the secret-health monitor already
+contain the mint steps and reference `RELEASE_BOT_APP_ID` /
+`RELEASE_BOT_PRIVATE_KEY` — that part ships in code. What code **cannot** do
+is create the App itself or grant it org-admin-gated access; the following
+steps are **human-only**, done once, by someone with `nimbus-agent`
+org-admin rights:
+
+1. **Create the App.** `nimbus-agent` org → Settings → Developer settings →
+   GitHub Apps → New GitHub App. Name it **Nimbus Release Bot**.
+2. **Set repository permissions:** `Contents: Read and write` and
+   `Pull requests: Read and write`. Grant **no** organization or account
+   permissions, and **no** webhook — the App only needs to push commits/tags
+   and open PRs in the repos it's installed on.
+3. **Install the App** on `nimbus-agent`, *Only select repositories* →
+   `Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`. These are exactly
+   the four repos the release/publish pipeline writes to.
+4. **Generate a private key** from the App's settings page, then add it and
+   the App ID as two **plain repository secrets** on `Nimbus` (not
+   environment-scoped — see the note above):
+   - `RELEASE_BOT_APP_ID`
+   - `RELEASE_BOT_PRIVATE_KEY` (the full PEM block)
+5. **Allow-list the mint action.** `Nimbus` requires SHA-pinned third-party
+   actions, so add
+   `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1`
+   (`v3.2.0`) to the org's (or repo's) allowed-actions list, or the mint step
+   fails closed with an "action not allowed" error before ever reaching the
+   App.
+6. **Grant the App push access on protected branches, if any.**
+   `homebrew-tap`, `scoop-bucket`, and `linux-repo` all receive direct
+   `git push`es from the publish workflows (not PRs). If any of those repos'
+   default branches has branch protection that requires PRs or restricts
+   which actors can push, add the Nimbus Release Bot App to that branch's
+   bypass/allowlist. `Nimbus` itself needs no change here — release-please
+   opens a PR and `release.yml` only pushes a tag, neither of which is a
+   protected-branch commit.
+7. **Confirm Actions are enabled** on all four target repos so that an
+   App-token-pushed tag actually triggers `release.yml`. This matters because
+   App-minted tokens (unlike the default `github.token`) *do* trigger
+   downstream workflow runs on push — that's part of why the App is used for
+   release-please in the first place — but it only works if Actions isn't
+   disabled on the receiving repo. Validate this live on the first real
+   release after cutover.
+8. **After the first green release, delete the three retired PAT secrets** —
+   `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`. Do this only
+   once a full release has gone out end-to-end on the App wiring; keeping the
+   PATs around until then is a deliberate break-glass window — if the App
+   wiring has a problem, reverting the wiring PR falls back to a pipeline
+   that still has working PATs, with no secret to re-create under time
+   pressure.
+
+**Optional, deferred:** setting the publish jobs' git author identity to the
+bot (`<app-id>+<app-slug>[bot]@users.noreply.github.com`) is cosmetic —
+commits pushed with an App token show as **Unverified** either way (the same
+as today's PAT-pushed commits), and the App's slug isn't known until step 1
+is done. Not required for the migration to be complete.

--- a/docs/superpowers/plans/2026-07-19-github-app-migration-review.md
+++ b/docs/superpowers/plans/2026-07-19-github-app-migration-review.md
@@ -1,0 +1,46 @@
+# Implementation Plan Review — GitHub App Migration
+
+**Date:** 2026-07-19
+**Target:** [2026-07-19-github-app-migration.md](./2026-07-19-github-app-migration.md)
+
+## Open Questions & Suggestions
+
+### 1. Scoping Pull Requests Permission in the Secret-Health Monitor
+
+* **Problem:** In Task 5 Step 1, the `secret-health.yml` mint step is configured with:
+
+  ```yaml
+  repositories: Nimbus, homebrew-tap, scoop-bucket, linux-repo
+  permission-contents: write
+  ```
+
+  However, the `release-please.yml` workflow requires both `contents: write` and `pull-requests: write`. If the organization administrator accidentally revokes or downgrades the App's `pull-requests` permission while keeping `contents: write` intact, the monitor's token minting check will succeed (status `success`), but the actual release-please workflow will fail.
+* **Suggestion:** Configure the health check mint step to request both permissions to verify complete functional health:
+
+  ```yaml
+  permission-contents: write
+  permission-pull-requests: write
+  ```
+
+### 2. Handling Missing Secrets / Skipped Minting in the Monitor
+
+* **Problem:** In Task 5 Step 3, the `classifyAppMint` helper maps `"success"` to `"ok"`, `"failure"` to `"dead"`, and anything else to `"indeterminate"`.
+  If the repository secrets (`RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`) are deleted or missing, the `create-github-app-token` action step may be skipped by the runner (or fail depending on configuration). If it is skipped, the step outcome might be `"skipped"`, which maps to `"indeterminate"` under this classification. An `"indeterminate"` status does not trigger a hard failure, which could allow a completely unconfigured/missing App credential to go unnoticed without raising a critical alert.
+* **Suggestion:** Map `"skipped"` or undefined outcomes explicitly to `"dead"` or a status that triggers a warning/failure, ensuring that missing/unset secrets trigger a notification to the maintainers.
+
+### 3. Git Author Config for Bot Commits
+
+* **Problem:** In Tasks 3 and 4, the workflows clone external repos (`homebrew-tap`, `scoop-bucket`, `linux-repo`) and push changes. The existing workflows configure git author info (email and username) for local commits. When migrating from PATs (where commits appear under the PAT owner's account) to the GitHub App, pushing commits without adjusting the git author config will still work, but attribution might be inconsistent.
+* **Suggestion:** When the App token is used for commits/pushes, update the git config step in those jobs to use the official GitHub App bot user details:
+  * **User Name:** `nimbus-release-bot[bot]`
+  * **User Email:** `[app-id]+nimbus-release-bot[bot]@users.noreply.github.com` (or the default `github-actions[bot] <github-actions[bot]@users.noreply.github.com>`).
+
+### 4. Verification of Pinned Action SHA
+
+* **Problem:** The plan leaves the action SHA as a placeholder `<APP_TOKEN_SHA>` to be resolved dynamically during execution.
+* **Suggestion:** Resolve the SHA of `actions/create-github-app-token@v2` (e.g. `v2.1.0` or latest stable) using the `gh` command or looking it up, and hardcode it directly in the implementation plan to make the steps fully deterministic for the runner.
+
+## Alignment with Invariants
+
+* **No Plaintext Secrets (I12/I18):** Using the GitHub App private key via Actions Secrets aligns perfectly with our security standards.
+* **Staged Deletion / Rollback Gate:** The plan's emphasis on staging the PAT secret deletion as a manual post-release step ensures a safe rollback path if any unseen edge case arises.

--- a/docs/superpowers/plans/2026-07-19-github-app-migration.md
+++ b/docs/superpowers/plans/2026-07-19-github-app-migration.md
@@ -10,13 +10,7 @@
 
 ## Global Constraints
 
-- **Resolve + reuse one pinned SHA** for `actions/create-github-app-token` across every workflow (the org requires SHA-pinned third-party actions; `audit:action-sha-pins` gates it). Resolve the latest `v2` SHA once:
-
-  ```bash
-  gh api repos/actions/create-github-app-token/git/matching-refs/tags/v2 --jq '.[-1].object.sha'
-  ```
-
-  Use that 40-hex SHA as `<APP_TOKEN_SHA>` in every mint step below, with a `# vX.Y.Z` trailing comment.
+- **Pinned action (hardcoded, resolved 2026-07-19):** every mint step pins `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0` (latest stable; `audit:action-sha-pins` gates the pin). This exact SHA is used in all mint steps below. It must also be added to the org's allowed-actions list (runbook step).
 - **The mint step is least-privilege:** `owner: nimbus-agent`, `repositories:` = only that job's repos, `permission-contents: write` (add `permission-pull-requests: write` ONLY for `release-please.yml`).
 - **Do NOT delete the PAT secrets in this PR.** `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT` deletion is a post-first-green-release runbook step (break-glass window). `WINGET_PAT` is never touched.
 - **Sequencing (documented, not code):** the wiring is static and committable now, but the workflows only *run* green once the human runbook is done (App created + installed + `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` secrets added + the action allow-listed org-side). The PR must not merge before that.
@@ -26,7 +20,7 @@
   ```yaml
   - name: Mint release-bot token
     id: app-token
-    uses: actions/create-github-app-token@<APP_TOKEN_SHA> # vX.Y.Z
+    uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
     with:
       app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
       private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -45,11 +39,9 @@
 
 **Steps:**
 
-- [ ] **Step 1: Resolve the pinned SHA** (Global Constraints command) and record it for reuse in all tasks.
+- [ ] **Step 1: Insert the mint step** into the `release-please` job, before the `googleapis/release-please-action@…` step (line ~27). Use the canonical mint step (pinned SHA from Global Constraints) with `repositories: Nimbus` and add `permission-pull-requests: write` (this job opens PRs).
 
-- [ ] **Step 2: Insert the mint step** into the `release-please` job, before the `googleapis/release-please-action@…` step (line ~27). Use the canonical mint step with `repositories: Nimbus` and add `permission-pull-requests: write` (this job opens PRs).
-
-- [ ] **Step 3: Swap the action token.** Line 31:
+- [ ] **Step 2: Swap the action token.** Line 31:
 
   ```yaml
   # before
@@ -58,9 +50,9 @@
           token: ${{ steps.app-token.outputs.token }}
   ```
 
-- [ ] **Step 4: Verify.** `bun -e "import{parse}from'yaml';parse(await Bun.file('.github/workflows/release-please.yml').text());console.log('valid')"` → valid; `bun run audit:action-sha-pins` → OK.
+- [ ] **Step 3: Verify.** `bun -e "import{parse}from'yaml';parse(await Bun.file('.github/workflows/release-please.yml').text());console.log('valid')"` → valid; `bun run audit:action-sha-pins` → OK.
 
-- [ ] **Step 5: Commit.** `git add .github/workflows/release-please.yml && git commit -m "ci(app-migration): mint release-bot token in release-please"`
+- [ ] **Step 4: Commit.** `git add .github/workflows/release-please.yml && git commit -m "ci(app-migration): mint release-bot token in release-please"`
 
 ---
 
@@ -142,13 +134,13 @@
 
 **Steps:**
 
-- [ ] **Step 1: `secret-health.yml` — add the scoped App-mint step.** Before the "Run secret-health check" step, add the canonical mint step with `id: app-mint`, `continue-on-error: true`, `repositories:` = all four target repos (`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`), `permission-contents: write`. Then add to the check step's `env:` `APP_MINT_STATUS: ${{ steps.app-mint.outcome }}` (`success`/`failure`). Remove the `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT` env lines (43-45) — those probes are retired.
+- [ ] **Step 1: `secret-health.yml` — add the scoped App-mint step.** Before the "Run secret-health check" step, add the canonical mint step with `id: app-mint`, `continue-on-error: true`, `repositories:` = all four target repos (`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`), and BOTH `permission-contents: write` **and `permission-pull-requests: write`** — so it verifies the full permission set the pipeline needs (a PRs-permission downgrade that would break `release-please` is caught too; design-review #1). Then add to the check step's `env:` `APP_MINT_STATUS: ${{ steps.app-mint.outcome }}` (`success`/`failure`). Remove the `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT` env lines (43-45) — those probes are retired.
 
-- [ ] **Step 2: Write the failing test** in `check-secret-health.test.ts`: given a health row list containing an `App` row derived from `APP_MINT_STATUS`, assert `summarize` marks `hardFailure` when the App row is `dead` and healthy when `ok`. Add a `classifyAppMint("success"|"failure")` pure helper test: `success → "ok"`, `failure → "dead"`, anything else → `"indeterminate"`.
+- [ ] **Step 2: Write the failing test** in `check-secret-health.test.ts`: given a health row list containing an `App` row derived from `APP_MINT_STATUS`, assert `summarize` marks `hardFailure` when the App row is `dead` and healthy when `ok`. Add a `classifyAppMint(outcome)` pure helper test: `success → "ok"`; **any non-success outcome (`failure`, `skipped`, empty/undefined) → `"dead"`** — fail-closed, so a missing App secret or a skipped mint step alerts rather than silently passing (design-review #2).
 
 - [ ] **Step 2b: Run it** → FAIL (`classifyAppMint` not defined).
 
-- [ ] **Step 3: Implement.** In `check-secret-health.ts`: (a) delete the three PAT entries (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) from the `pats` table in `import.meta.main`, keeping `WINGET_PAT`; (b) add `export function classifyAppMint(outcome: string): PatStatus { return outcome === "success" ? "ok" : outcome === "failure" ? "dead" : "indeterminate"; }`; (c) in `import.meta.main`, read `process.env["APP_MINT_STATUS"]` and push a `HealthRow { name: "RELEASE_BOT_APP", kind: "pat", status: classifyAppMint(...), detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo" }` (treat an unset value as `indeterminate` → reported, not fatal). The App row flows through the existing `summarize` (a `dead` App → hardFailure → red + `release-health` issue).
+- [ ] **Step 3: Implement.** In `check-secret-health.ts`: (a) delete the three PAT entries (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) from the `pats` table in `import.meta.main`, keeping `WINGET_PAT`; (b) add `export function classifyAppMint(outcome: string): PatStatus { return outcome === "success" ? "ok" : "dead"; }` (fail-closed — any non-success outcome, incl. unset/`skipped`, is `dead`); (c) in `import.meta.main`, read `process.env["APP_MINT_STATUS"] ?? ""` and push a `HealthRow { name: "RELEASE_BOT_APP", kind: "pat", status: classifyAppMint(...), detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo" }`. The App row flows through the existing `summarize` (a `dead` App → hardFailure → red + `release-health` issue).
 
 - [ ] **Step 4: Run tests** → `bun test scripts/release/check-secret-health.test.ts` GREEN; then `bun test scripts/release/` all green.
 
@@ -190,3 +182,17 @@
 
 - The design's "release-please auto-create fix" is scoped as *attempt + validate on the next real release* — there is no code task that can prove it pre-merge, so it is a documented post-merge observation, and the manual tag step stays in `ci-secrets.md` until a release proves it auto-creates.
 - No `NIMBUS_CHECKS_TOKEN` / `SCORECARD_TOKEN` work — already deleted / unset.
+- **Bot git-author attribution (design-review #3) is deferred, not built.** The publish jobs' existing git author config already works; changing it to the App bot identity (`<app-id>+<app-slug>[bot]@users.noreply.github.com`) is cosmetic attribution only, the commits are Unverified either way (design-review #5), and the `<app-slug>` isn't known until the App is created. Recorded as an **optional** post-creation runbook item, not a task.
+
+## Plan-review dispositions (2026-07-19)
+
+Review: [2026-07-19-github-app-migration-review.md](./2026-07-19-github-app-migration-review.md).
+
+| # | Point | Disposition |
+| --- | --- | --- |
+| 1 | Monitor mint should also request `pull-requests: write` (a PRs downgrade would break release-please but pass a contents-only check) | **Fixed** — Task 5 Step 1 mint requests contents **and** pull-requests write. |
+| 2 | `skipped`/undefined outcome maps to non-alerting `indeterminate` — a missing App secret could go unnoticed | **Fixed** — `classifyAppMint` is fail-closed: `success → ok`, everything else (`failure`/`skipped`/empty) → `dead` (alerts). |
+| 3 | Set git author to the App bot identity for commit attribution | **Deferred** — cosmetic only; commits are Unverified regardless (design-review #5), and the bot slug isn't known until the App exists. Recorded as an optional post-creation runbook item. |
+| 4 | Hardcode the pinned action SHA instead of a placeholder | **Fixed** — pinned `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0` (resolved 2026-07-19) throughout. |
+
+Invariant-alignment section confirmed the security posture (key in Actions secrets, staged deletion / rollback gate). No action.

--- a/docs/superpowers/plans/2026-07-19-github-app-migration.md
+++ b/docs/superpowers/plans/2026-07-19-github-app-migration.md
@@ -1,0 +1,192 @@
+# GitHub App Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the three org-scoped human PATs (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) in the release/publish pipeline with per-job, least-privilege, 1-hour tokens minted by one org-owned GitHub App ("Nimbus Release Bot").
+
+**Architecture:** Each job that consumed a PAT gains an `actions/create-github-app-token` mint step scoped to only the repos + permissions it needs, then uses `steps.app-token.outputs.token`. `WINGET_PAT` stays (external repo). The secret-health monitor retires the three PAT probes and gains an App-mint health check. Big-bang wiring; PAT-secret deletion is staged to a post-release runbook step.
+
+**Tech Stack:** GitHub Actions, `actions/create-github-app-token` (SHA-pinned), Bun/TS (the monitor script), `googleapis/release-please-action@v5`.
+
+## Global Constraints
+
+- **Resolve + reuse one pinned SHA** for `actions/create-github-app-token` across every workflow (the org requires SHA-pinned third-party actions; `audit:action-sha-pins` gates it). Resolve the latest `v2` SHA once:
+
+  ```bash
+  gh api repos/actions/create-github-app-token/git/matching-refs/tags/v2 --jq '.[-1].object.sha'
+  ```
+
+  Use that 40-hex SHA as `<APP_TOKEN_SHA>` in every mint step below, with a `# vX.Y.Z` trailing comment.
+- **The mint step is least-privilege:** `owner: nimbus-agent`, `repositories:` = only that job's repos, `permission-contents: write` (add `permission-pull-requests: write` ONLY for `release-please.yml`).
+- **Do NOT delete the PAT secrets in this PR.** `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT` deletion is a post-first-green-release runbook step (break-glass window). `WINGET_PAT` is never touched.
+- **Sequencing (documented, not code):** the wiring is static and committable now, but the workflows only *run* green once the human runbook is done (App created + installed + `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` secrets added + the action allow-listed org-side). The PR must not merge before that.
+- No new runtime dependency. Docs stay markdownlint-clean (`bun run lint:markdown`). Third-party actions SHA-pinned.
+- The canonical mint step (fill `<APP_TOKEN_SHA>` + the per-job `repositories`):
+
+  ```yaml
+  - name: Mint release-bot token
+    id: app-token
+    uses: actions/create-github-app-token@<APP_TOKEN_SHA> # vX.Y.Z
+    with:
+      app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+      private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+      owner: nimbus-agent
+      repositories: <comma-or-newline repo list for this job>
+      permission-contents: write
+  ```
+
+---
+
+### Task 1: `release-please.yml` — mint + token swap
+
+**Files:**
+
+- Modify: `.github/workflows/release-please.yml`
+
+**Steps:**
+
+- [ ] **Step 1: Resolve the pinned SHA** (Global Constraints command) and record it for reuse in all tasks.
+
+- [ ] **Step 2: Insert the mint step** into the `release-please` job, before the `googleapis/release-please-action@…` step (line ~27). Use the canonical mint step with `repositories: Nimbus` and add `permission-pull-requests: write` (this job opens PRs).
+
+- [ ] **Step 3: Swap the action token.** Line 31:
+
+  ```yaml
+  # before
+          token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.RELEASE_PAT || github.token }}
+  # after
+          token: ${{ steps.app-token.outputs.token }}
+  ```
+
+- [ ] **Step 4: Verify.** `bun -e "import{parse}from'yaml';parse(await Bun.file('.github/workflows/release-please.yml').text());console.log('valid')"` → valid; `bun run audit:action-sha-pins` → OK.
+
+- [ ] **Step 5: Commit.** `git add .github/workflows/release-please.yml && git commit -m "ci(app-migration): mint release-bot token in release-please"`
+
+---
+
+### Task 2: `release.yml` — mint (2 jobs) + `RELEASE_PAT` swaps
+
+`RELEASE_PAT` appears in two jobs: `publish-release` (the "Require release PAT" guard at ~411-414, and the `action-gh-release` token at line 620) and `update-manifest` (token at line 678). Each job mints its own token.
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+
+**Steps:**
+
+- [ ] **Step 1: `publish-release` job — replace the guard with the mint step.** Replace the entire "Require release PAT" step (the `env: RELEASE_PAT:` + the `if [ -z … ]` guard, ~lines 410-415) with the canonical mint step (`repositories: Nimbus`, `permission-contents: write`, `id: app-token`). The mint step itself fails loudly if the App secrets are missing, so it subsumes the guard.
+
+- [ ] **Step 2: `publish-release` — swap the release token.** Line 620: `token: ${{ secrets.RELEASE_PAT }}` → `token: ${{ steps.app-token.outputs.token }}`.
+
+- [ ] **Step 3: `update-manifest` job — add a mint step.** Insert the canonical mint step (`repositories: Nimbus`, `permission-contents: write`, `id: app-token`) as the job's first step after checkout/setup, before the `action-gh-release` step at ~668.
+
+- [ ] **Step 4: `update-manifest` — swap the token.** Line 678: `token: ${{ secrets.RELEASE_PAT }}` → `token: ${{ steps.app-token.outputs.token }}`.
+
+- [ ] **Step 5: Update the stale comment** at line 390 ("GitHub Release API uses RELEASE_PAT") to reference the minted App token.
+
+- [ ] **Step 6: Verify.** YAML parse valid; `bun run audit:action-sha-pins` → OK.
+
+- [ ] **Step 7: Commit.** `git add .github/workflows/release.yml && git commit -m "ci(app-migration): mint release-bot token in release.yml (publish + manifest)"`
+
+---
+
+### Task 3: `publish-package-managers.yml` — mint + `PACKAGE_MANAGER_PAT` swaps (keep `WINGET_PAT`)
+
+**Files:**
+
+- Modify: `.github/workflows/publish-package-managers.yml`
+
+**Steps:**
+
+- [ ] **Step 1: Replace the "Require PACKAGE_MANAGER_PAT" guard** (~lines 71-77) with the canonical mint step: `repositories:` = `homebrew-tap` + `scoop-bucket`, `permission-contents: write`, `id: app-token`.
+
+- [ ] **Step 2: Swap the two channel-push tokens.** Lines 106 and 126: `GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}` → `GH_TOKEN: ${{ steps.app-token.outputs.token }}` (the `git clone https://x-access-token:${GH_TOKEN}@…` lines for `homebrew-tap` and `scoop-bucket` are unchanged — they just consume `GH_TOKEN`).
+
+- [ ] **Step 3: Leave `WINGET_PAT` fully intact** (the winget job forks `microsoft/winget-pkgs`, external — the App cannot mint for it).
+
+- [ ] **Step 4: Verify.** YAML parse valid; `audit:action-sha-pins` OK; confirm `WINGET_PAT` still referenced (grep) and `PACKAGE_MANAGER_PAT` no longer referenced.
+
+- [ ] **Step 5: Commit.** `git add .github/workflows/publish-package-managers.yml && git commit -m "ci(app-migration): mint release-bot token for brew/scoop; keep winget PAT"`
+
+---
+
+### Task 4: `publish-linux-repo.yml` — mint + `PACKAGE_MANAGER_PAT` swaps
+
+**Files:**
+
+- Modify: `.github/workflows/publish-linux-repo.yml`
+
+**Steps:**
+
+- [ ] **Step 1: Replace the "Require PACKAGE_MANAGER_PAT" guard** (~lines 71-77) with the canonical mint step: `repositories: linux-repo`, `permission-contents: write`, `id: app-token`.
+
+- [ ] **Step 2: Swap the push tokens.** Lines 144 and 194: `GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_PAT }}` → `GH_TOKEN: ${{ steps.app-token.outputs.token }}` (the clone + `git push` to `linux-repo` are unchanged — branch-served Pages, contents:write suffices).
+
+- [ ] **Step 3: Verify.** YAML parse valid; `audit:action-sha-pins` OK; `PACKAGE_MANAGER_PAT` no longer referenced.
+
+- [ ] **Step 4: Commit.** `git add .github/workflows/publish-linux-repo.yml && git commit -m "ci(app-migration): mint release-bot token for linux-repo"`
+
+---
+
+### Task 5: Secret-health monitor — retire 3 PAT probes, add App-mint health check
+
+**Files:**
+
+- Modify: `.github/workflows/secret-health.yml`
+- Modify: `scripts/release/check-secret-health.ts`
+- Modify: `scripts/release/check-secret-health.test.ts`
+
+**Interfaces:**
+
+- Consumes: the existing `PatStrategy` / `HealthRow` / `summarize` in `check-secret-health.ts`.
+
+**Steps:**
+
+- [ ] **Step 1: `secret-health.yml` — add the scoped App-mint step.** Before the "Run secret-health check" step, add the canonical mint step with `id: app-mint`, `continue-on-error: true`, `repositories:` = all four target repos (`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`), `permission-contents: write`. Then add to the check step's `env:` `APP_MINT_STATUS: ${{ steps.app-mint.outcome }}` (`success`/`failure`). Remove the `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT` env lines (43-45) — those probes are retired.
+
+- [ ] **Step 2: Write the failing test** in `check-secret-health.test.ts`: given a health row list containing an `App` row derived from `APP_MINT_STATUS`, assert `summarize` marks `hardFailure` when the App row is `dead` and healthy when `ok`. Add a `classifyAppMint("success"|"failure")` pure helper test: `success → "ok"`, `failure → "dead"`, anything else → `"indeterminate"`.
+
+- [ ] **Step 2b: Run it** → FAIL (`classifyAppMint` not defined).
+
+- [ ] **Step 3: Implement.** In `check-secret-health.ts`: (a) delete the three PAT entries (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) from the `pats` table in `import.meta.main`, keeping `WINGET_PAT`; (b) add `export function classifyAppMint(outcome: string): PatStatus { return outcome === "success" ? "ok" : outcome === "failure" ? "dead" : "indeterminate"; }`; (c) in `import.meta.main`, read `process.env["APP_MINT_STATUS"]` and push a `HealthRow { name: "RELEASE_BOT_APP", kind: "pat", status: classifyAppMint(...), detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo" }` (treat an unset value as `indeterminate` → reported, not fatal). The App row flows through the existing `summarize` (a `dead` App → hardFailure → red + `release-health` issue).
+
+- [ ] **Step 4: Run tests** → `bun test scripts/release/check-secret-health.test.ts` GREEN; then `bun test scripts/release/` all green.
+
+- [ ] **Step 5: Verify workflow.** YAML parse valid; `audit:action-sha-pins` OK; `bunx biome check scripts/release/` clean.
+
+- [ ] **Step 6: Commit.** `git add .github/workflows/secret-health.yml scripts/release/check-secret-health.ts scripts/release/check-secret-health.test.ts && git commit -m "ci(app-migration): monitor App health via scoped mint; retire 3 PAT probes"`
+
+---
+
+### Task 6: Docs — `ci-secrets.md` + runbook
+
+**Files:**
+
+- Modify: `docs/ci-secrets.md`
+
+**Steps:**
+
+- [ ] **Step 1: Replace the three PAT rows** (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) in the quick-reference table + their detail sections with a single **Nimbus Release Bot (GitHub App)** entry: what it is (App ID + private key → per-job 1-hour tokens), the two secrets (`RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`), the four installed repos, and key rotation (regenerate the App private key + update the secret; no 90-day expiry).
+
+- [ ] **Step 2: Keep `WINGET_PAT`** documented with an explicit note on *why* it stays (external `microsoft/winget-pkgs` fork — the org App can't mint for it).
+
+- [ ] **Step 3: Add the "GitHub App setup + migration runbook"** section (the six human-only steps from the design: create App → permissions → install on 4 repos → add 2 secrets → allow-list the action org-side → branch-protection push access → confirm Actions-enabled → delete the 3 PAT secrets after the first green release).
+
+- [ ] **Step 4: Verify.** `bun run audit:doc-refs` → OK; `bun run lint:markdown` → 0 errors.
+
+- [ ] **Step 5: Commit.** `git add docs/ci-secrets.md && git commit -m "docs(app-migration): document the release-bot App, winget exception, and setup runbook"`
+
+---
+
+## Self-Review
+
+**Spec coverage:** App + per-job least-privilege minting → Tasks 1-4 (+ Global Constraints mint step). WINGET_PAT untouched → Task 3 step 3. Secret-health App-mint (scoped to 4 repos, via the action, no crypto) → Task 5. Branch-protection + Actions-enabled + trigger validation + staged PAT deletion → Task 6 runbook + Global Constraints. release-please auto-create (attempt) → Task 1 wires the App token; validation is a post-merge live check (documented, not a task). ci-secrets.md rewrite → Task 6.
+
+**Placeholder scan:** `<APP_TOKEN_SHA>` and per-job `repositories` lists are resolved in Task 1 Step 1 / stated per task — environment values, not logic gaps. No TBD/TODO.
+
+**Type consistency:** `classifyAppMint` returns `PatStatus` (defined in check-secret-health.ts); the App `HealthRow` uses the existing `HealthRow` shape and flows through the existing `summarize`.
+
+## Deviations / notes
+
+- The design's "release-please auto-create fix" is scoped as *attempt + validate on the next real release* — there is no code task that can prove it pre-merge, so it is a documented post-merge observation, and the manual tag step stays in `ci-secrets.md` until a release proves it auto-creates.
+- No `NIMBUS_CHECKS_TOKEN` / `SCORECARD_TOKEN` work — already deleted / unset.

--- a/docs/superpowers/specs/2026-07-19-github-app-migration-design-review.md
+++ b/docs/superpowers/specs/2026-07-19-github-app-migration-design-review.md
@@ -1,0 +1,46 @@
+# Design Review — GitHub App Migration
+
+**Date:** 2026-07-19
+**Target:** [2026-07-19-github-app-migration-design.md](./2026-07-19-github-app-migration-design.md)
+
+## Open Questions & Suggestions
+
+### 1. Verification Logic for App Installation & Scopes in `check-secret-health.ts`
+
+* **Problem:** In the PAT era, the health check validated scope existence via headers. In the App-token era, minting a token using the App ID and Private Key proves that the credentials are valid, but it does not guarantee that the App is still *installed* on all the target repositories (`homebrew-tap`, `scoop-bucket`, `linux-repo`), or that the installation still has the correct permissions (e.g., someone could modify the App's permissions in the organization settings).
+* **Suggestion:**
+  * In the updated `check-secret-health.ts`, don't just assert a successful mint of a generic token.
+  * Explicitly attempt to mint a token requesting access to each of the target repositories (e.g., specifying `repositories: ["Nimbus", "homebrew-tap", "scoop-bucket", "linux-repo"]`).
+  * If the API returns an error for any of the repositories (e.g., due to the App being uninstalled or permission downgraded), report it as a health failure for that specific target.
+
+### 2. Implementation of Token Minting in the Bun Script
+
+* **Problem:** To mint an installation token programmatically in the secret health check script (`check-secret-health.ts`), the script must construct and sign a JWT using the RS256 algorithm with the PEM private key.
+* **Suggestion:**
+  * Avoid adding heavy dependencies like `jsonwebtoken` or `@octokit/auth-app` if possible.
+  * Utilize Bun's native Web Crypto API (`crypto.subtle`) or Node's `crypto` module to import the private key and sign the RS256 JWT natively.
+  * Clearly document the cryptographic utility helper that does this to keep the script lightweight.
+
+### 3. Branch Protection Rule Bypasses for the App
+
+* **Problem:** If `main` or the release branches on `Nimbus`, `homebrew-tap`, `scoop-bucket`, or `linux-repo` have branch protection rules (e.g., requiring pull requests, requiring status checks, or restricting pushes to specific actors), direct pushes from the GitHub Actions workflow using the App token will fail.
+* **Suggestion:**
+  * Add a step to the **Human-only steps (runbook)** to update the branch protection rules for the target repositories, allowing the "Nimbus Release Bot" App to bypass pull request requirements or push restrictions where necessary.
+
+### 4. Downstream Workflow Triggers and Action Permissions
+
+* **Problem:** Pushing commits or tags with a GitHub App token triggers downstream workflows, which is the desired behavior for triggering `release.yml` on a tag push. However, some repositories restrict Actions permissions (e.g., "Allow all actions and reusable workflows" vs "Allow select actions").
+* **Suggestion:**
+  * Ensure the target repositories have action permissions enabled so that commits/tags pushed by the App actually trigger the workflows as expected.
+  * Verify if `Pages` or `Deployments` permissions are needed for the `publish-linux-repo.yml` workflow, as Page deployments sometimes require additional `pages: write` / `id-token: write` scopes.
+
+### 5. GPG/Commit Signing for App Commits
+
+* **Problem:** When the App pushes commits to repositories (such as update commits to `homebrew-tap` or `scoop-bucket`), GitHub will show them as unverified unless they are signed.
+* **Suggestion:**
+  * GitHub Apps can sign commits using GitHub's web-flow signing key if the commits are made via the GitHub API. However, if using standard `git push`, we may want to either document that these automated commits will appear unsigned, or configure a signing subkey for the bot. Given the complexity, documenting that App-pushed commits are unsigned (or verifying if GitHub's automatic App-attribution signature is applied) is recommended.
+
+## Alignment with Invariants
+
+* **Credentials Handling (Non-Negotiable 3):** The migration away from personal tokens to short-lived App tokens significantly improves security. The private key `RELEASE_BOT_PRIVATE_KEY` remains safely stored in the `Nimbus` repo Actions secrets and is never exposed in logs or scripts.
+* **HITL Consent (Non-Negotiable 2 / I2):** The App token is strictly confined to CI/CD workflows and is used to automate publication after the owner has already run the release process. It does not bypass any local execution gates or user consent mechanisms on the client.

--- a/docs/superpowers/specs/2026-07-19-github-app-migration-design.md
+++ b/docs/superpowers/specs/2026-07-19-github-app-migration-design.md
@@ -24,11 +24,12 @@ A GitHub App installed on the `nimbus-agent` org can mint tokens for repos **ins
 - **`NIMBUS_CHECKS_TOKEN`** — already deleted (falls back to `github.token`).
 - **npm trusted publishing / keyless signing** — sub-project #3.
 - **Rolling the App out to the other satellite repos, rotation calendar, org push-protection** — sub-project #4. This sub-project installs the App only on the repos the current release pipeline touches.
+- **Bot commit signing** — App-pushed commits to the channel repos appear **Unverified**, exactly as today's `PACKAGE_MANAGER_PAT`-pushed commits do (not a regression); giving the bot a signing key is out of scope (design-review #5).
 
 ## The App
 
 - **Name:** Nimbus Release Bot (org-owned, under `nimbus-agent`).
-- **Repository permissions:** `Contents: Read and write` (create releases + tags, push to the channel repos) and `Pull requests: Read and write` (release-please PRs). No organization or account permissions.
+- **Repository permissions:** `Contents: Read and write` (create releases + tags, push to the channel repos) and `Pull requests: Read and write` (release-please PRs). No organization or account permissions. **No `Pages` permission is needed** (design-review #4): `publish-linux-repo` updates GitHub Pages by `git push`-ing to the branch `linux-repo` serves from (contents:write), not via the Pages deploy API — verified against the workflow (clone → commit → push, Jekyll disabled).
 - **Installed on:** `nimbus-agent`, *Only select repositories* → **`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`**.
 - **Credentials:** two secrets on the `Nimbus` repo — `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` (PEM). The Actions workflows run in `Nimbus`, and `create-github-app-token` mints cross-repo tokens for any installed repo via its `repositories:` input, so repo-scoped secrets on `Nimbus` are sufficient (no org secrets needed).
 
@@ -77,7 +78,7 @@ An App token *should* let `googleapis/release-please-action@v5` create the GitHu
 `scripts/release/check-secret-health.ts` + `secret-health.yml` are updated to match the new credential reality:
 
 - **Remove** the `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT` PAT probes (those secrets are being retired).
-- **Add** an App-health check: mint a token via the App (App ID + private key) and assert success — a failed mint (bad/rotated key, App uninstalled) reports `dead` → red + `release-health` issue, exactly as the PAT probes did. This is the App-era equivalent of the expiry probe.
+- **Add** an App-health check that mints a token **scoped to all four target repos** (`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`) with `contents: write` — so it catches not just a bad/rotated key but also the App being uninstalled from a repo or having its permissions downgraded (design-review #1). The mint is performed by the same `actions/create-github-app-token` action the pipeline uses, run in `secret-health.yml` with `continue-on-error: true`; its success/failure is passed into `check-secret-health.ts` via an env flag (`APP_MINT_STATUS=ok|failed`), which reports `dead` → red + `release-health` issue on failure. This deliberately avoids re-implementing RS256 JWT signing in the script — design-review #2 suggested native `node:crypto`; using the action instead needs no crypto at all **and** dogfoods the exact mint path the release pipeline depends on.
 - **Keep** the `WINGET_PAT` probe (still a live PAT) and the cert decoders.
 - **Fix a pre-existing gap** the release-health PR shipped: the `PACKAGE_MANAGER_PAT` `repo-write` check listed only `homebrew-tap` + `scoop-bucket` and **missed `linux-repo`**. That check is superseded by the App-health check here, so the gap is closed by removal — but the design records it so the plan does not silently reintroduce it.
 
@@ -97,7 +98,9 @@ These require org-admin rights and cannot be automated from CI:
 3. Install the App on `nimbus-agent`, selected repos: `Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`.
 4. Generate a private key; add `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` as `Nimbus` repo Actions secrets.
 5. Add `actions/create-github-app-token@<sha>` to the org's allowed-actions list (the repo requires SHA-pinned third-party actions).
-6. After the first green release: delete the three retired PAT secrets.
+6. Confirm the App can push to the channel repos' default branches (design-review #3): `homebrew-tap`, `scoop-bucket`, and `linux-repo` receive direct `git push`es from the publish workflows, so if any has branch protection requiring PRs or restricting push actors, add the App to its bypass/allowlist. `Nimbus` needs no change — release-please uses a PR and `release.yml` pushes a tag, not a protected-branch commit.
+7. Confirm Actions are enabled on the target repos so an App-token-pushed tag triggers `release.yml` (App tokens trigger downstream workflows, unlike `github.token`; validated live on the first release — design-review #4).
+8. After the first green release: delete the three retired PAT secrets.
 
 Everything else — the four workflow edits, the monitor + script changes, and the docs — is automated in the PR.
 
@@ -110,3 +113,17 @@ Everything else — the four workflow edits, the monitor + script changes, and t
 - `.github/workflows/secret-health.yml` + `scripts/release/check-secret-health.ts` (+ `.test.ts`) (edit: retire 3 PAT probes, add App-mint health check)
 - `docs/ci-secrets.md` (edit: replace the 3 PAT rows with the App; document App setup + key rotation + the winget exception)
 - Allowed-actions config for `actions/create-github-app-token` (SHA-pinned)
+
+## Design-review dispositions (2026-07-19)
+
+Review: [2026-07-19-github-app-migration-design-review.md](./2026-07-19-github-app-migration-design-review.md).
+
+| # | Point | Disposition |
+| --- | --- | --- |
+| 1 | Health check must verify installation + scopes, not just a generic mint | **Fixed** — the App-health check mints a token scoped to all four target repos with `contents: write`, catching uninstall/permission-downgrade. |
+| 2 | RS256 JWT minting without heavy deps | **Fixed (cleaner path)** — the mint is done by the `actions/create-github-app-token` action in `secret-health.yml` (`continue-on-error`), fed into the script via an env flag; no crypto re-implemented, and it dogfoods the real mint path. The review's native-`node:crypto` suggestion was considered but the action is simpler + more faithful. |
+| 3 | Branch-protection could block App pushes | **Fixed** — added a runbook step to allow the App to push to the channel repos' default branches. |
+| 4 | Pages/Deployments perms + downstream triggers | **Fixed** — verified `publish-linux-repo` uses branch-served Pages (git push), so `contents: write` suffices (no `pages: write`); added a runbook step to confirm Actions-enabled + first-release trigger validation. |
+| 5 | App commits show Unverified | **Fixed (documented)** — recorded as a non-regression (PAT pushes are already unverified) and a non-goal; bot commit-signing is deferred. |
+
+Invariant-alignment section of the review confirmed the security improvement (short-lived tokens, key stays in Actions secrets) and that the App is CI-confined (no HITL/local-gate bypass). No action.

--- a/docs/superpowers/specs/2026-07-19-github-app-migration-design.md
+++ b/docs/superpowers/specs/2026-07-19-github-app-migration-design.md
@@ -1,0 +1,112 @@
+# GitHub App Migration — Design
+
+> **Status:** Design — approved in brainstorm (2026-07-19); ready for implementation plan.
+> **Sub-project 2 of 4** in the org secrets-management program. Sub-project 1 (release-health verification + secret-health monitor) shipped in #768. The remaining sub-projects are #3 (npm OIDC + keyless signing) and #4 (rotation calendar + env/push-protection hardening).
+
+## Problem
+
+The release + publish pipeline authenticates with a sprawl of **human-owned fine-grained PATs** that expire (≤90 days), break when the owner rotates or leaves, and — as the phantom releases v0.17–v0.21 proved — fail *silently*. Sub-project 1 added a monitor that *watches* these PATs; this sub-project *retires* the ones it can, replacing them with a single org-owned GitHub App that issues short-lived (1-hour) installation tokens per job.
+
+A GitHub App installed on the `nimbus-agent` org can mint tokens for repos **inside that org** only. That cleanly covers three PATs; two others cannot or need not be migrated (see Non-goals).
+
+## Goals
+
+- Retire the three org-scoped fine-grained PATs — `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT` — replacing them with one org-owned App ("Nimbus Release Bot").
+- Mint **per-job, least-privilege, 1-hour** tokens (`actions/create-github-app-token`), scoped to exactly the repos + permissions each job needs.
+- Remove the recurring silent-expiry failure class for those three credentials (an App private key does not expire on a 90-day clock).
+- **Attempt** to fix release-please auto-creating the release + tag (removing today's manual `git tag` + `autorelease: tagged` step) — see the honest caveat below.
+- Keep the release path safe throughout: big-bang wiring cutover, but the PAT secrets are deleted only *after* the first green release (break-glass window).
+
+## Non-goals
+
+- **`WINGET_PAT` stays a classic PAT.** `publish-package-managers.yml` forks and opens a PR against **`microsoft/winget-pkgs`** (an external repo); an App installed on `nimbus-agent` cannot mint tokens for it. Documented as a deliberate exception.
+- **`SCORECARD_TOKEN`** is not migrated — the monitor showed it unset (the OSSF Scorecard job falls back to `github.token`); there is nothing to replace.
+- **`NIMBUS_CHECKS_TOKEN`** — already deleted (falls back to `github.token`).
+- **npm trusted publishing / keyless signing** — sub-project #3.
+- **Rolling the App out to the other satellite repos, rotation calendar, org push-protection** — sub-project #4. This sub-project installs the App only on the repos the current release pipeline touches.
+
+## The App
+
+- **Name:** Nimbus Release Bot (org-owned, under `nimbus-agent`).
+- **Repository permissions:** `Contents: Read and write` (create releases + tags, push to the channel repos) and `Pull requests: Read and write` (release-please PRs). No organization or account permissions.
+- **Installed on:** `nimbus-agent`, *Only select repositories* → **`Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`**.
+- **Credentials:** two secrets on the `Nimbus` repo — `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` (PEM). The Actions workflows run in `Nimbus`, and `create-github-app-token` mints cross-repo tokens for any installed repo via its `repositories:` input, so repo-scoped secrets on `Nimbus` are sufficient (no org secrets needed).
+
+## Approach: per-job least-privilege minting
+
+Each job that currently consumes one of the three PATs gains a token-mint step:
+
+```yaml
+- name: Mint release-bot token
+  id: app-token
+  uses: actions/create-github-app-token@<pinned-sha>  # add to allowed actions + SHA-pin
+  with:
+    app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+    private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+    owner: nimbus-agent
+    repositories: <only the repos this job writes>
+    permission-contents: write        # down-scope to just what the job needs
+    # permission-pull-requests: write # only where PRs are created (release-please)
+```
+
+Downstream steps then use `${{ steps.app-token.outputs.token }}` in place of the PAT. Each token is scoped to the narrowest repo set + permission the job needs, and expires in 1 hour — a far smaller blast radius than a broad, long-lived PAT.
+
+## Per-workflow wiring
+
+| Workflow | Job token scope | Replaces |
+| --- | --- | --- |
+| `release-please.yml` | `Nimbus` — contents + pull-requests: write | `RELEASE_PLEASE_PAT` (the `token:` input to `release-please-action`) |
+| `release.yml` | `Nimbus` — contents: write | `RELEASE_PAT` (the `action-gh-release` step + the "Require release PAT" guard) |
+| `publish-package-managers.yml` | `homebrew-tap`, `scoop-bucket` — contents: write | `PACKAGE_MANAGER_PAT` (brew/scoop pushes). **`WINGET_PAT` untouched.** |
+| `publish-linux-repo.yml` | `linux-repo` — contents: write | `PACKAGE_MANAGER_PAT` (apt/yum repo + Pages push) |
+
+`GPG_SIGNING_SUBKEY` / `GPG_PASSPHRASE` / `UPDATER_SIGNING_KEY` / Windows + Apple signing secrets are **unchanged** — they are signing keys, not GitHub API tokens, and out of scope.
+
+## release-please auto-create — honest caveat
+
+An App token *should* let `googleapis/release-please-action@v5` create the GitHub Release + tag on release-PR merge: App tokens can create releases, and unlike `github.token` their tag-push **does** trigger downstream workflows (so `release.yml` would fire automatically).
+
+**However:** `RELEASE_PLEASE_PAT` is currently set and healthy, yet release-please still did **not** auto-create v0.23.0 (it stayed `autorelease: pending`, requiring the manual tag). So the token may not be the sole cause. This design therefore scopes the auto-create fix as **attempt + validate on the next release**, not a guarantee:
+
+- Wire the App token into `release-please.yml` and observe whether the next release auto-creates.
+- If it does — remove the manual step from `ci-secrets.md`.
+- If it does not — the manual `git tag` + `autorelease: tagged` step **remains the documented fallback**, and the root cause (config vs. token vs. org setting) is diagnosed as separate follow-up work. The PAT retirement stands on its own regardless.
+
+## Secret-health monitor update
+
+`scripts/release/check-secret-health.ts` + `secret-health.yml` are updated to match the new credential reality:
+
+- **Remove** the `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT` PAT probes (those secrets are being retired).
+- **Add** an App-health check: mint a token via the App (App ID + private key) and assert success — a failed mint (bad/rotated key, App uninstalled) reports `dead` → red + `release-health` issue, exactly as the PAT probes did. This is the App-era equivalent of the expiry probe.
+- **Keep** the `WINGET_PAT` probe (still a live PAT) and the cert decoders.
+- **Fix a pre-existing gap** the release-health PR shipped: the `PACKAGE_MANAGER_PAT` `repo-write` check listed only `homebrew-tap` + `scoop-bucket` and **missed `linux-repo`**. That check is superseded by the App-health check here, so the gap is closed by removal — but the design records it so the plan does not silently reintroduce it.
+
+## Migration and rollback
+
+- **Big-bang wiring** in one PR: all four workflows gain the mint step and switch to the App token; the monitor + `ci-secrets.md` are updated in the same PR.
+- **Staged secret deletion:** the PR does **not** delete `RELEASE_PAT` / `RELEASE_PLEASE_PAT` / `PACKAGE_MANAGER_PAT`. They are deleted as a **final step only after the first green release** proves the App wiring works end-to-end. This preserves a break-glass window.
+- **Rollback:** revert the wiring PR — the PATs still exist (deletion is staged), so the pipeline returns to its prior working state with one revert.
+- **Pre-flight:** a `workflow_dispatch`-able check (or the updated monitor) mints a token and verifies it can read the target repos before the first real release relies on it.
+
+## Human-only steps (runbook, delivered with the PR)
+
+These require org-admin rights and cannot be automated from CI:
+
+1. Create the GitHub App under `nimbus-agent` org settings (Developer settings → GitHub Apps → New).
+2. Set repository permissions: Contents R/W, Pull requests R/W. No org/account permissions. No webhook.
+3. Install the App on `nimbus-agent`, selected repos: `Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`.
+4. Generate a private key; add `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` as `Nimbus` repo Actions secrets.
+5. Add `actions/create-github-app-token@<sha>` to the org's allowed-actions list (the repo requires SHA-pinned third-party actions).
+6. After the first green release: delete the three retired PAT secrets.
+
+Everything else — the four workflow edits, the monitor + script changes, and the docs — is automated in the PR.
+
+## Files
+
+- `.github/workflows/release.yml` (edit: mint step + swap `RELEASE_PAT`)
+- `.github/workflows/release-please.yml` (edit: mint step + swap the `token:` input)
+- `.github/workflows/publish-package-managers.yml` (edit: mint step + swap `PACKAGE_MANAGER_PAT`; leave `WINGET_PAT`)
+- `.github/workflows/publish-linux-repo.yml` (edit: mint step + swap `PACKAGE_MANAGER_PAT`)
+- `.github/workflows/secret-health.yml` + `scripts/release/check-secret-health.ts` (+ `.test.ts`) (edit: retire 3 PAT probes, add App-mint health check)
+- `docs/ci-secrets.md` (edit: replace the 3 PAT rows with the App; document App setup + key rotation + the winget exception)
+- Allowed-actions config for `actions/create-github-app-token` (SHA-pinned)

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  classifyAppMint,
   classifyPatProbe,
   evaluateCertExpiry,
   type PatStrategy,
@@ -29,6 +30,21 @@ describe("classifyPatProbe", () => {
     expect(classifyPatProbe(s, { status: 200, scopes: null })).toBe("ok");
     expect(classifyPatProbe(s, { status: 401, scopes: null })).toBe("dead");
     expect(classifyPatProbe(s, { status: 403, scopes: null })).toBe("indeterminate");
+  });
+});
+
+describe("classifyAppMint", () => {
+  test("success outcome → ok", () => {
+    expect(classifyAppMint("success")).toBe("ok");
+  });
+  test("failure outcome → dead", () => {
+    expect(classifyAppMint("failure")).toBe("dead");
+  });
+  test("skipped outcome → dead (fail-closed: a skipped mint step alerts)", () => {
+    expect(classifyAppMint("skipped")).toBe("dead");
+  });
+  test("empty/unset outcome → dead (fail-closed: missing App secret alerts)", () => {
+    expect(classifyAppMint("")).toBe("dead");
   });
 });
 
@@ -75,6 +91,29 @@ describe("summarize", () => {
     const r = summarize([{ name: "X", kind: "pat", status: "ok", detail: "" }]);
     expect(r.hasHardFailure).toBe(false);
     expect(r.hasWarning).toBe(false);
+  });
+  test("dead RELEASE_BOT_APP row (from classifyAppMint) → hard failure", () => {
+    const r = summarize([
+      {
+        name: "RELEASE_BOT_APP",
+        kind: "pat",
+        status: classifyAppMint("failure"),
+        detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
+      },
+    ]);
+    expect(r.hasHardFailure).toBe(true);
+    expect(r.table).toContain("RELEASE_BOT_APP");
+  });
+  test("ok RELEASE_BOT_APP row (from classifyAppMint) → not a hard failure", () => {
+    const r = summarize([
+      {
+        name: "RELEASE_BOT_APP",
+        kind: "pat",
+        status: classifyAppMint("success"),
+        detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
+      },
+    ]);
+    expect(r.hasHardFailure).toBe(false);
   });
 });
 
@@ -264,6 +303,64 @@ describe("runSecretHealth (orchestration)", () => {
     });
     expect(result.hardFailure).toBe(true);
     expect(api.calls.createIssue.length).toBe(1);
+  });
+
+  test("extraRows: a dead App-mint row (classifyAppMint) opens the issue and returns hardFailure:true, even with otherwise-healthy pats/certs", async () => {
+    const api = createFakeApi({
+      probeResults: { "good-token": { status: 200, scopes: null } },
+    });
+    const result = await runSecretHealth({
+      api,
+      now: new Date("2026-07-18T00:00:00Z"),
+      thresholdDays: 21,
+      pats: [
+        {
+          env: "WINGET_PAT",
+          token: "good-token",
+          strategy: { kind: "alive" } as PatStrategy,
+        },
+      ],
+      certs: [],
+      extraRows: [
+        {
+          name: "RELEASE_BOT_APP",
+          kind: "pat",
+          status: classifyAppMint("skipped"),
+          detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
+        },
+      ],
+    });
+    expect(result.hardFailure).toBe(true);
+    expect(api.calls.createIssue.length).toBe(1);
+  });
+
+  test("extraRows: an ok App-mint row does not trigger a hard failure", async () => {
+    const api = createFakeApi({
+      probeResults: { "good-token": { status: 200, scopes: null } },
+    });
+    const result = await runSecretHealth({
+      api,
+      now: new Date("2026-07-18T00:00:00Z"),
+      thresholdDays: 21,
+      pats: [
+        {
+          env: "WINGET_PAT",
+          token: "good-token",
+          strategy: { kind: "alive" } as PatStrategy,
+        },
+      ],
+      certs: [],
+      extraRows: [
+        {
+          name: "RELEASE_BOT_APP",
+          kind: "pat",
+          status: classifyAppMint("success"),
+          detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
+        },
+      ],
+    });
+    expect(result.hardFailure).toBe(false);
+    expect(api.calls.createIssue.length).toBe(0);
   });
 
   test("repo-write: a repo perms-lookup error object → indeterminate, NOT a hard failure (T6)", async () => {

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -26,6 +26,17 @@ export function classifyPatProbe(
   return "ok";
 }
 
+/**
+ * The release-bot GitHub App health probe: a scoped-mint step (`actions/create-github-app-token`)
+ * runs before this check, and its `steps.<id>.outcome` is passed in via `APP_MINT_STATUS`.
+ * Fail-closed — only an explicit "success" outcome is "ok"; any other outcome (`failure`,
+ * `skipped`, unset/empty) is "dead", so a missing App secret or a skipped mint step alerts
+ * rather than silently passing.
+ */
+export function classifyAppMint(outcome: string): PatStatus {
+  return outcome === "success" ? "ok" : "dead";
+}
+
 /** Guard against malformed/localized binary output — an unparseable date must be indeterminate, never a false "ok" (plan-review #2). */
 export function safeParseDate(dateStr: string): Date | null {
   const d = new Date(dateStr.trim());
@@ -88,8 +99,10 @@ export async function runSecretHealth(deps: {
     present: boolean;
     decode: CertDecoder;
   }[];
+  /** Pre-classified rows (e.g. the App-mint health probe) merged in alongside the PAT/cert rows. */
+  extraRows?: readonly HealthRow[];
 }): Promise<{ hardFailure: boolean }> {
-  const rows: HealthRow[] = [];
+  const rows: HealthRow[] = [...(deps.extraRows ?? [])];
   for (const p of deps.pats) {
     if (!p.token) {
       rows.push({ name: p.env, kind: "pat", status: "not-configured", detail: "unset" });
@@ -308,24 +321,6 @@ if (import.meta.main) {
   const thresholdDays = Number.isFinite(rawThreshold) && rawThreshold >= 0 ? rawThreshold : 21;
   const pats: readonly { env: string; token: string | undefined; strategy: PatStrategy }[] = [
     {
-      env: "RELEASE_PAT",
-      token: process.env["RELEASE_PAT"],
-      strategy: { kind: "repo-write", targetRepos: [repo] } as PatStrategy,
-    },
-    {
-      env: "RELEASE_PLEASE_PAT",
-      token: process.env["RELEASE_PLEASE_PAT"],
-      strategy: { kind: "repo-write", targetRepos: [repo] } as PatStrategy,
-    },
-    {
-      env: "PACKAGE_MANAGER_PAT",
-      token: process.env["PACKAGE_MANAGER_PAT"],
-      strategy: {
-        kind: "repo-write",
-        targetRepos: ["nimbus-agent/homebrew-tap", "nimbus-agent/scoop-bucket"],
-      } as PatStrategy,
-    },
-    {
       env: "WINGET_PAT",
       token: process.env["WINGET_PAT"],
       strategy: { kind: "scopes", required: "public_repo" } as PatStrategy,
@@ -364,12 +359,19 @@ if (import.meta.main) {
       decode: decodePkcs12Expiry,
     },
   ];
+  const appMintRow: HealthRow = {
+    name: "RELEASE_BOT_APP",
+    kind: "pat",
+    status: classifyAppMint(process.env["APP_MINT_STATUS"] ?? ""),
+    detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
+  };
   const { hardFailure } = await runSecretHealth({
     api: createGitHubApi({ token, repo }),
     now: new Date(),
     thresholdDays,
     pats,
     certs,
+    extraRows: [appMintRow],
   });
   process.exit(hardFailure ? 1 : 0);
 }


### PR DESCRIPTION
## What

Migrates the org's CI release automation off three long-lived Personal Access Tokens (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`) onto a single org-owned **GitHub App** ("Nimbus Release Bot") that mints per-job, 1-hour, least-privilege installation tokens via `actions/create-github-app-token` (SHA-pinned `@bcd2ba49…` v3.2.0).

`WINGET_PAT` intentionally **stays** a classic PAT — it targets the external `microsoft/winget-pkgs` fork, which the org App cannot be installed on.

## Why

- No more 1-year-lived, broadly-scoped PATs sitting in org secrets (the root cause of the v0.17–v0.21 phantom-release outage was an expired `RELEASE_PAT`).
- Tokens are minted per job, scoped to exactly the repos + permissions that job needs, and expire in an hour.
- The secret-health monitor now probes the App's mint path directly with a **superset** of the permissions the individual release jobs request, so a permission downgrade on any repo is caught before a release needs it.

## Changes (6 tasks, subagent-driven + reviewed)

| Workflow | Mint scope | Perms |
| --- | --- | --- |
| `release-please.yml` | `Nimbus` | contents + PRs: write |
| `release.yml` (publish-release + update-manifest) | `Nimbus` | contents: write |
| `publish-package-managers.yml` | `homebrew-tap`, `scoop-bucket` | contents: write |
| `publish-linux-repo.yml` | `linux-repo` | contents: write |
| `secret-health.yml` | all 4 repos | contents + PRs: write (superset health probe) |

- `scripts/release/check-secret-health.ts` — retired the 3 PAT probes; added a fail-closed `classifyAppMint` (`success → ok`, else `dead`) fed from `steps.app-mint.outcome`; `RELEASE_BOT_APP` health row via new `extraRows` param. Tests updated.
- `docs/ci-secrets.md` — replaced the 3 PAT rows with the App entry; kept `WINGET_PAT` + rationale; added the setup/migration runbook (below).

## ⚠️ DO NOT MERGE until the App exists

This is a big-bang cutover. The mint steps reference `secrets.RELEASE_BOT_APP_ID` / `secrets.RELEASE_BOT_PRIVATE_KEY`, which do not exist yet. **Human-only setup must land first**, or the next release's mint step fails (loudly, by design — but the release won't ship):

1. Create a GitHub App **"Nimbus Release Bot"** under the `nimbus-agent` org.
   - Permissions: **Contents: Read & write**, **Pull requests: Read & write**. No Pages perm (Pages is branch-served via `git push`).
2. Install it on: `Nimbus`, `homebrew-tap`, `scoop-bucket`, `linux-repo`.
3. Generate a private key; add org (or repo) secrets `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY`.
4. Org **Settings → Actions → allowed actions**: ensure `actions/create-github-app-token@*` is permitted (SHA-pinned here).
5. Merge this PR.
6. Cut one release and confirm it ships assets green (asset-verify gate passes).
7. **Only then** delete `RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT` from org secrets (staged post-first-green-release — **not in this PR**).

Full runbook is in `docs/ci-secrets.md`.

## Deferred (non-blocking, post-App-live)

`release-please.yml` job-level `permissions: contents/pull-requests: write` now govern only the automatic `GITHUB_TOKEN`, which the job no longer uses for writes (release-please-action uses the minted App token). These could tighten to `contents: read`. Deferred pending live confirmation the action never falls back to `GITHUB_TOKEN`; the current superset is safe.

## Verification

`bun test scripts/release/` 89/89 · biome clean · all 5 workflows valid YAML · `audit:action-sha-pins` OK · `lint:markdown` 0 · `audit:doc-refs` OK · 0 leftover retired-PAT references across workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
