### PR TITLE
npm supply-chain assurance: weekly provenance monitoring + credential-absence guard

### DIFF
--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -47,6 +47,32 @@ jobs:
           repositories: Nimbus,homebrew-tap,scoop-bucket,linux-repo
           permission-contents: write
           permission-pull-requests: write
+      - name: Resolve latest published versions
+        id: versions
+        run: |
+          set -euo pipefail
+          echo "sdk=$(npm view @nimbus-dev/sdk version)" >> "$GITHUB_OUTPUT"
+          echo "client=$(npm view @nimbus-dev/client version)" >> "$GITHUB_OUTPUT"
+
+      - name: Probe @nimbus-dev/sdk provenance
+        id: sdk-provenance
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
+        with:
+          package: "@nimbus-dev/sdk"
+          version: ${{ steps.versions.outputs.sdk }}
+          expected-repo: nimbus-agent/nimbus-sdk
+          expected-workflow: .github/workflows/release.yml
+          severity: monitor
+
+      - name: Probe @nimbus-dev/client provenance
+        id: client-provenance
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
+        with:
+          package: "@nimbus-dev/client"
+          version: ${{ steps.versions.outputs.client }}
+          expected-repo: nimbus-agent/nimbus-client
+          expected-workflow: .github/workflows/release.yml
+          severity: monitor
       - name: Run secret-health check
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -61,4 +87,7 @@ jobs:
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          SDK_PROVENANCE_STATUS: ${{ steps.sdk-provenance.outputs.status }}
+          CLIENT_PROVENANCE_STATUS: ${{ steps.client-provenance.outputs.status }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun scripts/release/check-secret-health.ts

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Resolve latest published versions
         id: versions
         # Same reasoning as `app-mint` above: a registry hiccup here must
-        # degrade into a classified row (via the empty-version -> empty-status
-        # -> `indeterminate` path below), not abort the whole weekly job and
-        # silence PAT/cert monitoring too.
+        # degrade into a classified row, not abort the whole weekly job and
+        # silence PAT/cert monitoring too. The degradation only works because
+        # each probe below carries an `if:` guard against an empty version —
+        # without it an empty version is reported as missing-provenance (hard),
+        # not indeterminate. See the comment on the sdk probe.
         continue-on-error: true
         run: |
           set -euo pipefail
@@ -79,8 +81,18 @@ jobs:
           printf 'sdk=%s\n' "$sdk_version" >> "$GITHUB_OUTPUT"
           printf 'client=%s\n' "$client_version" >> "$GITHUB_OUTPUT"
 
+      # Skip rather than probe an empty version. If the resolution step above
+      # failed, `continue-on-error` leaves this output empty, and the action
+      # would request `.../@nimbus-dev/sdk@` — which the registry answers 404.
+      # `fetch-attestations` treats a 404 that survives the full backoff as
+      # `absent`, and `decide()` maps `absent` to `missing-provenance`, a HARD
+      # failure. An npm outage would therefore file an issue claiming the
+      # published package lost its provenance: the exact false alarm this
+      # design exists to avoid. Skipping leaves the status empty, which
+      # `classifyProvenanceOutcome` maps to `indeterminate` (warn).
       - name: Probe @nimbus-dev/sdk provenance
         id: sdk-provenance
+        if: steps.versions.outputs.sdk != ''
         continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
@@ -90,8 +102,11 @@ jobs:
           expected-workflow: .github/workflows/release.yml
           severity: monitor
 
+      # Same guard as the sdk probe above — see that comment for why an empty
+      # version would otherwise be reported as missing-provenance (hard).
       - name: Probe @nimbus-dev/client provenance
         id: client-provenance
+        if: steps.versions.outputs.client != ''
         continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -49,13 +49,39 @@ jobs:
           permission-pull-requests: write
       - name: Resolve latest published versions
         id: versions
+        # Same reasoning as `app-mint` above: a registry hiccup here must
+        # degrade into a classified row (via the empty-version -> empty-status
+        # -> `indeterminate` path below), not abort the whole weekly job and
+        # silence PAT/cert monitoring too.
+        continue-on-error: true
         run: |
           set -euo pipefail
-          echo "sdk=$(npm view @nimbus-dev/sdk version)" >> "$GITHUB_OUTPUT"
-          echo "client=$(npm view @nimbus-dev/client version)" >> "$GITHUB_OUTPUT"
+          # `set -euo pipefail` does NOT catch a failing command substitution
+          # used as an argument: `echo "sdk=$(npm view …)"` still returns 0
+          # because that's echo's own exit status, so a failed `npm view`
+          # silently wrote a literal "sdk=" to $GITHUB_OUTPUT — which the
+          # provenance probe below would then run against an empty version.
+          # Assigning to a variable first fixes this: the assignment's exit
+          # status IS the command substitution's, so `set -e` actually trips.
+          # The explicit empty-check is a second line of defense, and writing
+          # with `printf` (rather than embedding another command substitution
+          # in the echo line) avoids reintroducing the same hazard.
+          sdk_version="$(npm view @nimbus-dev/sdk version)"
+          if [ -z "$sdk_version" ]; then
+            echo "::error::npm view @nimbus-dev/sdk version returned an empty version" >&2
+            exit 1
+          fi
+          client_version="$(npm view @nimbus-dev/client version)"
+          if [ -z "$client_version" ]; then
+            echo "::error::npm view @nimbus-dev/client version returned an empty version" >&2
+            exit 1
+          fi
+          printf 'sdk=%s\n' "$sdk_version" >> "$GITHUB_OUTPUT"
+          printf 'client=%s\n' "$client_version" >> "$GITHUB_OUTPUT"
 
       - name: Probe @nimbus-dev/sdk provenance
         id: sdk-provenance
+        continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/sdk"
@@ -66,6 +92,7 @@ jobs:
 
       - name: Probe @nimbus-dev/client provenance
         id: client-provenance
+        continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/client"

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -57,28 +57,27 @@ jobs:
         # not indeterminate. See the comment on the sdk probe.
         continue-on-error: true
         run: |
-          set -euo pipefail
-          # `set -euo pipefail` does NOT catch a failing command substitution
-          # used as an argument: `echo "sdk=$(npm view …)"` still returns 0
-          # because that's echo's own exit status, so a failed `npm view`
-          # silently wrote a literal "sdk=" to $GITHUB_OUTPUT — which the
-          # provenance probe below would then run against an empty version.
-          # Assigning to a variable first fixes this: the assignment's exit
-          # status IS the command substitution's, so `set -e` actually trips.
-          # The explicit empty-check is a second line of defense, and writing
-          # with `printf` (rather than embedding another command substitution
-          # in the echo line) avoids reintroducing the same hazard.
-          sdk_version="$(npm view @nimbus-dev/sdk version)"
+          set -uo pipefail
+          # Each package's version is resolved AND written to $GITHUB_OUTPUT
+          # independently, before moving on to the next package. `set -e` is
+          # deliberately NOT used here: an earlier version aborted the whole
+          # step (via `exit 1`) as soon as ONE package's `npm view` failed or
+          # returned empty, which ran before EITHER package's output was
+          # written — so a client-only registry hiccup also blanked the sdk
+          # version and skipped the sdk probe too, even though sdk resolved
+          # fine. Redirecting stderr and falling back to an empty string on
+          # failure (`|| true`) means a failing `npm view` for one package
+          # can never prevent the other's printf from running.
+          sdk_version="$(npm view @nimbus-dev/sdk version 2>/dev/null || true)"
           if [ -z "$sdk_version" ]; then
-            echo "::error::npm view @nimbus-dev/sdk version returned an empty version" >&2
-            exit 1
-          fi
-          client_version="$(npm view @nimbus-dev/client version)"
-          if [ -z "$client_version" ]; then
-            echo "::error::npm view @nimbus-dev/client version returned an empty version" >&2
-            exit 1
+            echo "::warning::npm view @nimbus-dev/sdk version returned no version" >&2
           fi
           printf 'sdk=%s\n' "$sdk_version" >> "$GITHUB_OUTPUT"
+
+          client_version="$(npm view @nimbus-dev/client version 2>/dev/null || true)"
+          if [ -z "$client_version" ]; then
+            echo "::warning::npm view @nimbus-dev/client version returned no version" >&2
+          fi
           printf 'client=%s\n' "$client_version" >> "$GITHUB_OUTPUT"
 
       # Skip rather than probe an empty version. If the resolution step above
@@ -129,7 +128,11 @@ jobs:
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          SDK_VERSION: ${{ steps.versions.outputs.sdk }}
+          CLIENT_VERSION: ${{ steps.versions.outputs.client }}
           SDK_PROVENANCE_STATUS: ${{ steps.sdk-provenance.outputs.status }}
+          SDK_PROVENANCE_DETAIL: ${{ steps.sdk-provenance.outputs.detail }}
           CLIENT_PROVENANCE_STATUS: ${{ steps.client-provenance.outputs.status }}
+          CLIENT_PROVENANCE_DETAIL: ${{ steps.client-provenance.outputs.detail }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun scripts/release/check-secret-health.ts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,33 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-20 — npm supply-chain assurance: provenance monitoring + `NPM_TOKEN` absence guard.**
+  The weekly `secret-health.yml` job now carries three new rows alongside the existing App-health/
+  PAT/cert checks: two npm provenance probes (`@nimbus-dev/sdk`, `@nimbus-dev/client`), each resolved
+  to its latest published version and checked via the org's `verify-npm-provenance` composite action
+  in monitor mode (confirms the publish attestation + SLSA provenance predicate are present and name
+  the expected source repo/workflow), and an `NPM_TOKEN` absence guard that hard-fails if the deleted
+  secret (revoked 2026-07-19) is ever re-created — publishing is meant to be OIDC-only. New
+  `ProvenanceStatus`/`AbsenceStatus` classifiers (`classifyProvenanceOutcome`, fail-closed to
+  `indeterminate` on any unset/unrecognised value; `classifySecretAbsence`) feed the existing
+  de-duped issue filer. The `source-mismatch`/`missing-provenance` alert rows now carry the action's
+  own `detail` output plus the resolved version (`composeProvenanceDetail`), so an alert names what
+  actually happened instead of a static placeholder. Each package's version is now resolved and
+  written to `$GITHUB_OUTPUT` independently, so one package's registry hiccup no longer blanks the
+  other's probe too. `docs/ci-secrets.md` documents the new rows, the branched remediation per row
+  kind (rotate vs. unpublish/deprecate vs. delete-the-secret — "rotate" does not apply to a
+  provenance or absence row), and corrects two overclaims: the 2FA-required/no-tokens npm setting
+  blocks token-based publishing, not human publishing (an interactive maintainer with an OTP can
+  still publish by hand), and the `nimbus-vscode` weekly PAT-liveness probe is not yet live — it
+  ships as that repo's own `secret-health.yml`, landing in
+  [PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), open as of 2026-07-20, not yet
+  merged. Two accompanying but separate PRs add the release-time provenance gate to the npm
+  satellites' own release workflows — `nimbus-sdk`
+  [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12) and `nimbus-client`
+  [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) — both also open as of 2026-07-20, not
+  yet merged; this entry covers only the monorepo-side monitoring that lands with this branch. No
+  migration, no new invariant.
+
 - **2026-07-19 — docs: Phase 6 closed out; the Sequencing Spine is now the live build order.** A
   status-drift sweep across the roadmap and its mirror surfaces. `docs/roadmap.md` moves **Phase 6 —
   Team** out of `## Active` into `## Shipped` and gives `## Active` a new **Spine S1 — Local Brain**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,15 +25,18 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   kind (rotate vs. unpublish/deprecate vs. delete-the-secret — "rotate" does not apply to a
   provenance or absence row), and corrects two overclaims: the 2FA-required/no-tokens npm setting
   blocks token-based publishing, not human publishing (an interactive maintainer with an OTP can
-  still publish by hand), and the `nimbus-vscode` weekly PAT-liveness probe is not yet live — it
-  ships as that repo's own `secret-health.yml`, landing in
-  [PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), open as of 2026-07-20, not yet
-  merged. Two accompanying but separate PRs add the release-time provenance gate to the npm
-  satellites' own release workflows — `nimbus-sdk`
-  [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12) and `nimbus-client`
-  [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) — both also open as of 2026-07-20, not
-  yet merged; this entry covers only the monorepo-side monitoring that lands with this branch. No
-  migration, no new invariant.
+  still publish by hand). Three accompanying PRs merged the same day in the satellite repos:
+  `nimbus-vscode` [#35](https://github.com/nimbus-agent/nimbus-vscode/pull/35) adds that repo's own
+  `secret-health.yml` weekly PAT-liveness probe (the secrets stay where they are — copying them here
+  to centralise monitoring would spread credentials to save a workflow file) plus a `.vsix` build
+  provenance attestation, and `nimbus-sdk` [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12)
+  and `nimbus-client` [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) add the release-time
+  gate to their own release workflows: a pre-publish preflight asserting OIDC is available and npm
+  meets the 11.5.1 floor, then two post-publish checks — the just-published version is installed from
+  the registry into a clean tree so `npm audit signatures` verifies *that* tarball (run in the repo
+  root it would audit the project's own dependencies, which never include the package just shipped),
+  and the provenance is asserted to name the expected repo, workflow and commit. No migration, no new
+  invariant.
 
 - **2026-07-19 — docs: Phase 6 closed out; the Sequencing Spine is now the live build order.** A
   status-drift sweep across the roadmap and its mirror surfaces. `docs/roadmap.md` moves **Phase 6 —

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -207,8 +207,12 @@ publishing and carry two attestations: the npm publish attestation and a
 SLSA provenance predicate naming the source repo, workflow, and commit.
 
 Publishing access on both packages is set to **require two-factor
-authentication and disallow tokens**, so OIDC is the only path that can
-publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
+authentication and disallow tokens**, so no automation or token-based publish
+is possible — CI's only path to publish is OIDC, and a leaked token cannot
+publish either. This does **not** mean only OIDC can publish, full stop: an
+interactive maintainer authenticating with a One-Time Password can still
+publish by hand from their own machine — the setting removes token-based
+publishing, not human publishing. `NPM_TOKEN` was revoked and deleted on
 2026-07-19; the weekly secret-health run asserts it stays absent.
 
 Verify a published version yourself:
@@ -240,7 +244,11 @@ wrong source.
 | `VSCE_PAT` | `nimbus-vscode` | @AsafGolombek | Azure DevOps PAT. ⚠️ **Global ADO PATs are decommissioned 2026-12-01** and cannot be regenerated since 2026-03-15. Marketplace trusted publishing is unshipped (microsoft/vsmarketplace#1422). |
 | `OVSX_PAT` | `nimbus-vscode` | @AsafGolombek | Open VSX token. No OIDC path exists (eclipse-openvsx/openvsx#1534); rotation is the only mitigation. |
 
-Both are probed weekly for liveness by `nimbus-vscode`'s own `secret-health.yml`.
+Both will be probed weekly for liveness by `nimbus-vscode`'s own
+`secret-health.yml` — landing as
+[PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), open as of
+2026-07-20, not yet merged. Until it merges, neither PAT is under any
+automated liveness check.
 
 ---
 
@@ -309,6 +317,17 @@ controls how far ahead of expiry a certificate is flagged. It checks:
   (`WINDOWS_CERT_PFX_BASE64` + `WINDOWS_CERT_PASSWORD`), and the Apple
   Developer ID cert (`APPLE_CERT_P12_BASE64` + `APPLE_CERT_PASSWORD`) —
   decoded and checked for upcoming expiry against `threshold_days`.
+- **Two npm provenance probes**: `@nimbus-dev/sdk` and `@nimbus-dev/client`,
+  each resolved to its latest published version and checked via the
+  `verify-npm-provenance` composite action in monitor mode — confirming the
+  publish attestation + SLSA provenance predicate are present and name the
+  expected source repo/workflow. A version-resolution failure for either
+  package degrades that package's row to `indeterminate` rather than aborting
+  the job or blanking the other package's probe (see the `versions` step
+  comment in the workflow).
+- **The `NPM_TOKEN` absence guard**: asserts the secret stays unset (revoked
+  and deleted 2026-07-19) in this repo's env — a returned value is `present`,
+  a hard failure, since publishing is meant to be OIDC-only.
 
 > **Caveat — a green probe is not the same as "the real job will work."** A
 > live probe only proves the credential authenticates and has *some*
@@ -321,10 +340,23 @@ Findings are filed as a single, de-duped **`release-health`** GitHub issue
 (opened or updated in place per run, not re-created every week) — see
 `scripts/release/open-health-issue.ts`.
 
-**Responding to an alert:** rotate the flagged secret using the per-secret
-runbook earlier in this document, confirm the new value is stored under the
-correct scope (repo secret vs. the `release` environment), then close the
-`release-health` issue (or just re-run `secret-health.yml` via
+**Responding to an alert** — the fix depends on which kind of row fired,
+"rotate" is only correct for the first:
+
+- **A `dead`/`insufficient`/`expiring`/`expired` PAT or cert row** (App-health,
+  the three PATs, the three cert pairs): rotate the flagged secret using the
+  per-secret runbook earlier in this document, confirm the new value is
+  stored under the correct scope (repo secret vs. the `release` environment).
+- **A `missing-provenance` or `source-mismatch` provenance row**: this is not
+  a credential problem, so there is nothing to rotate. Either unpublish the
+  affected version within npm's 72-hour unpublish window, or once that window
+  has passed, deprecate it (`npm deprecate <pkg>@<version> "<reason>"`) and
+  publish a corrected version with OIDC provenance intact.
+- **An `NPM_TOKEN=present` row**: someone re-created the secret. Delete it
+  (repo Settings → Secrets and variables → Actions) — do not rotate it;
+  publishing is meant to be OIDC-only and the secret should not exist at all.
+
+Then close the `release-health` issue (or just re-run `secret-health.yml` via
 `workflow_dispatch` — a clean run auto-resolves it on the next scheduled
 pass).
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -225,9 +225,13 @@ curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0"
   | jq -r '.attestations[].predicateType'  # expect both predicates
 ```
 
-The release workflows gate on this automatically: a pre-publish preflight
-asserts OIDC is available and npm meets the 11.5.1 floor, and a post-publish
-step fails the release if provenance is missing or names the wrong source.
+This gate is landing in the two satellite release workflows as Task C1
+(`nimbus-sdk` [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12),
+`nimbus-client` [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) —
+both open as of 2026-07-20, not yet merged): once merged, a pre-publish
+preflight will assert OIDC is available and npm meets the 11.5.1 floor, and a
+post-publish step will fail the release if provenance is missing or names the
+wrong source.
 
 ### Publish PATs that cannot yet be retired
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -200,6 +200,38 @@ monorepo — both were extracted to their own standalone repos
 and each publishes to npm via release-please + an OIDC trusted publisher —
 no `NPM_TOKEN` involved, here or there.
 
+### npm provenance verification
+
+Both `@nimbus-dev/sdk` and `@nimbus-dev/client` publish via OIDC trusted
+publishing and carry two attestations: the npm publish attestation and a
+SLSA provenance predicate naming the source repo, workflow, and commit.
+
+Publishing access on both packages is set to **require two-factor
+authentication and disallow tokens**, so OIDC is the only path that can
+publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
+2026-07-19; the weekly secret-health run asserts it stays absent.
+
+Verify a published version yourself:
+
+```bash
+npm audit signatures                       # registry signature verification
+curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0" \
+  | jq -r '.attestations[].predicateType'  # expect both predicates
+```
+
+The release workflows gate on this automatically: a pre-publish preflight
+asserts OIDC is available and npm meets the 11.5.1 floor, and a post-publish
+step fails the release if provenance is missing or names the wrong source.
+
+### Publish PATs that cannot yet be retired
+
+| Secret | Repo | Owner | Notes |
+| --- | --- | --- | --- |
+| `VSCE_PAT` | `nimbus-vscode` | @AsafGolombek | Azure DevOps PAT. ⚠️ **Global ADO PATs are decommissioned 2026-12-01** and cannot be regenerated since 2026-03-15. Marketplace trusted publishing is unshipped (microsoft/vsmarketplace#1422). |
+| `OVSX_PAT` | `nimbus-vscode` | @AsafGolombek | Open VSX token. No OIDC path exists (eclipse-openvsx/openvsx#1534); rotation is the only mitigation. |
+
+Both are probed weekly for liveness by `nimbus-vscode`'s own `secret-health.yml`.
+
 ---
 
 ## CI quality, coverage & supply-chain (mostly optional)

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -229,13 +229,14 @@ curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0"
   | jq -r '.attestations[].predicateType'  # expect both predicates
 ```
 
-This gate is landing in the two satellite release workflows as Task C1
+This gate is live in both satellite release workflows as of 2026-07-20
 (`nimbus-sdk` [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12),
-`nimbus-client` [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) —
-both open as of 2026-07-20, not yet merged): once merged, a pre-publish
-preflight will assert OIDC is available and npm meets the 11.5.1 floor, and a
-post-publish step will fail the release if provenance is missing or names the
-wrong source.
+`nimbus-client` [#5](https://github.com/nimbus-agent/nimbus-client/pull/5)): a
+pre-publish preflight asserts OIDC is available and npm meets the 11.5.1 floor,
+and two post-publish steps fail the release if the published tarball's registry
+signature does not verify, or if provenance is missing or names the wrong
+source. Neither has executed against a real publish yet — the next release of
+either package is the first live exercise.
 
 ### Publish PATs that cannot yet be retired
 
@@ -244,11 +245,13 @@ wrong source.
 | `VSCE_PAT` | `nimbus-vscode` | @AsafGolombek | Azure DevOps PAT. ⚠️ **Global ADO PATs are decommissioned 2026-12-01** and cannot be regenerated since 2026-03-15. Marketplace trusted publishing is unshipped (microsoft/vsmarketplace#1422). |
 | `OVSX_PAT` | `nimbus-vscode` | @AsafGolombek | Open VSX token. No OIDC path exists (eclipse-openvsx/openvsx#1534); rotation is the only mitigation. |
 
-Both will be probed weekly for liveness by `nimbus-vscode`'s own
-`secret-health.yml` — landing as
-[PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), open as of
-2026-07-20, not yet merged. Until it merges, neither PAT is under any
-automated liveness check.
+Both are probed weekly for liveness by `nimbus-vscode`'s own `secret-health.yml`
+([PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), merged
+2026-07-20), which runs Mondays 09:00 UTC and files a labelled issue when either
+PAT reports `dead` (rotate it) or `not-configured` (provision it — do not rotate
+a credential that does not exist). The secrets stay in `nimbus-vscode`; copying
+them here to centralise monitoring would spread credentials to save a workflow
+file.
 
 ---
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -214,7 +214,13 @@ publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
 Verify a published version yourself:
 
 ```bash
+# `npm audit signatures` audits the tree it runs in, so install the package
+# under test into a clean directory first — running it inside a checkout would
+# audit that project's dependencies instead of the published tarball.
+tmp="$(mktemp -d)" && cd "$tmp" && npm init -y >/dev/null
+npm install @nimbus-dev/sdk@1.3.0 --no-audit --no-fund
 npm audit signatures                       # registry signature verification
+
 curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0" \
   | jq -r '.attestations[].predicateType'  # expect both predicates
 ```

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance-review.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance-review.md
@@ -1,0 +1,111 @@
+# Review: npm Supply-Chain Assurance Implementation Plan
+
+This review evaluates the implementation plan defined in [2026-07-19-npm-supply-chain-assurance.md](./2026-07-19-npm-supply-chain-assurance.md) against the design goals, safety constraints, and potential edge cases.
+
+---
+
+## Open Questions & Suggestions
+
+### 1. Handling Transient JSON Parsing Errors in Fetcher (Task A2)
+
+* **Observation:** In `fetch-attestations.js`, if `res.status === 200` but `await res.json()` throws a parsing error (e.g., due to a truncated response body, CDN packet loss, or an HTML proxy error page returning 200), the function immediately returns `{ outcome: "error", ... }` without retrying.
+* **Risk:** A transient error mid-stream on a large response could cause a release gate to fail immediately instead of retrying.
+* **Suggestion:** Catch the JSON parsing error *inside* the retry loop and treat it as a transient error (updating `lastDetail = "JSON parsing error"` and letting the loop continue) rather than returning immediately.
+
+  ```js
+  // Current:
+  try {
+    return { outcome: "body", body: await res.json(), detail: "200" };
+  } catch {
+    return { outcome: "error", detail: "200 with unparseable JSON body" };
+  }
+
+  // Suggested:
+  try {
+    const body = await res.json();
+    return { outcome: "body", body, detail: "200" };
+  } catch {
+    lastDetail = "200 with unparseable JSON body";
+    continue;
+  }
+  ```
+
+### 2. Version Pinning for CLI Tools in `probe-publish-token` (Task A4)
+
+* **Observation:** The `probe-publish-token` action uses `npx --yes @vscode/vsce` and `npx --yes ovsx`. By default, omitting a version specifier pulls the `@latest` tag from npm.
+* **Risk:**
+  1. A malicious package release or supply-chain compromise of `@vscode/vsce` or `ovsx` on the public registry could lead to code execution in our runners.
+  2. Unannounced breaking changes in the CLI tools' command flags (specifically `verify-pat`) could cause the health check to break.
+* **Suggestion:** Pin these tools to a specific major version (e.g., `npx --yes @vscode/vsce@^3.0.0` or `npx --yes ovsx@^0.9.0`) to ensure reliability and minimize supply-chain risk.
+
+### 3. Registry/Network Failures During Token Probing (Task A4)
+
+* **Observation:** The `probe-publish-token` script uses `set +e` and evaluates the exit code of the `vsce`/`ovsx` verify command. If the command fails for *any* reason (including npm registry downtime, a network timeout, or an API rate limit from the marketplace), `code` will be non-zero, resulting in `status=dead`.
+* **Risk:** The weekly monitor workflow will interpret a transient network/registry failure as a revoked/expired token and file a false-alarm critical issue.
+* **Suggestion:** Consider whether the script can parse the error or check if it's a CLI execution error versus a 401/Unauthorized token error. Alternatively, document in the runbook that a `dead` alert should first be cross-checked against registry/marketplace status pages.
+
+### 4. Portability of `sort -V` in Preflight Check (Task C1)
+
+* **Observation:** The preflight check uses `sort -V` to perform a semantic version comparison:
+
+  ```bash
+  if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -n1)" != "$need" ]; then
+  ```
+
+* **Verification:** `sort -V` is a GNU coreutils extension. It is guaranteed to be available on Ubuntu/Debian runners (e.g., `ubuntu-24.04`).
+* **Caution:** If the satellite workflows are ever run on macOS runners (which use BSD `sort` by default, where `-V` is not supported unless `gsort` is installed), this step will fail.
+* **Suggestion:** Since the satellites (`nimbus-sdk`, `nimbus-client`) currently build on Ubuntu runners, `sort -V` is safe. However, adding a comment indicating this Ubuntu dependency is recommended to prevent future migration issues to macOS runners.
+
+### 5. `GITHUB_OUTPUT` Deprecation and Node APIs
+
+* **Observation:** In `main.js` (Task A3), output variables are written using `appendFileSync(process.env["GITHUB_OUTPUT"], ...)`.
+* **Safety:** Ensure `process.env["GITHUB_OUTPUT"]` is defined before appending, which the current implementation handles via `if (out)`. This is robust and prevents failures when running the script locally or in tests where the variable is not set.
+
+---
+
+## Resolutions
+
+Recorded 2026-07-19 against plan revision 2. Four findings accepted (two of them hardened beyond the suggestion); one required no change.
+
+### 1. Retry on unparseable JSON — **ACCEPTED**
+
+Correct: a 200 carrying an HTML proxy error page or a truncated body is transient, and returning immediately would fail a release on one bad CDN edge response. The parse failure now sets `lastDetail` and continues the loop, exactly as suggested.
+
+Two tests were added rather than one, because the fix has two observable behaviours worth pinning: that a persistently-bad body **retries the full schedule** before reporting `error` (asserting the call count, not just the outcome), and that a single bad response **followed by a good one succeeds**. The existing "never a false absent" assertion is preserved — `lastDetail` is not the 404 sentinel, so the outcome stays `error` rather than degrading to `absent`.
+
+### 2. Version pinning for the vendor CLIs — **ACCEPTED, and tightened**
+
+The right call, and it matters more than the review states: this action passes a **live publish credential** into whatever `npx` resolves. Unpinned third-party code inside a credential's trust boundary would undercut the premise of a supply-chain program.
+
+For that reason the suggested `^` ranges were **not** used — a caret range still floats to the newest match and provides no protection against a malicious release. Pins are **exact**: `@vscode/vsce@3.9.2` and `ovsx@1.0.2` (current versions, checked against the registry today). The verification step in Task A4 now checks the pinned versions rather than `@latest`, and explicitly instructs the implementer not to float the pin if a newer version has shipped — bumping is a deliberate, reviewed change.
+
+Accepted trade-off, recorded so it is not a surprise later: these pins live in a shell command, not a manifest, so Dependabot will not bump them. They will go stale. That is preferable to a floating dependency holding a publish token, and PAT-adjacent maintenance belongs on sub-project 4's rotation calendar.
+
+### 3. Network failure misreported as a dead token — **ACCEPTED; this was a real defect I introduced**
+
+Not merely a refinement. The design specified a three-way classification (`ok` / `dead` / `indeterminate`), and `indeterminate` was silently lost when the probe switched from hand-rolled HTTP to the vendor `verify-pat` CLIs — exit codes flattened three states into two. The review caught a genuine regression against the spec.
+
+The consequence was worse than a missed signal: a weekly job filing a **critical revocation alert** every time the marketplace had a blip would train the operator to ignore the alarm, defeating the monitor's entire purpose.
+
+Fixed on both sides, since fixing only the action would have achieved nothing:
+
+* **Action:** on a non-zero exit, probe a public unauthenticated endpoint (`marketplace.visualstudio.com` / `open-vsx.org/api/-/search`). Reachable → `dead` (the service genuinely rejected the token). Unreachable → `indeterminate`.
+* **Consumer:** `nimbus-vscode`'s workflow now mirrors the monorepo's warn/hard split — only `dead` files an issue and fails; `indeterminate` emits a `::warning::` and exits 0.
+
+The runbook cross-check the review suggested is also included, in the issue body and in Task D1's interpretation table.
+
+### 4. `sort -V` portability — **ACCEPTED as documentation**
+
+The review's own verification is right: `sort -V` is a GNU coreutils extension, guaranteed on `ubuntu-24.04`, which is where both satellites run. No functional change was warranted. A comment now records the Ubuntu dependency and names the remedy (`gsort` or a Node one-liner) should the job ever move to a macOS runner — the failure would otherwise be baffling at migration time.
+
+### 5. `GITHUB_OUTPUT` guard — **NO CHANGE REQUIRED**
+
+Not a finding; the review confirms the existing `if (out)` guard is correct. It is what lets `main.js` run in the Task A3 Step 6 local smoke test, where `GITHUB_OUTPUT` is unset. Left as is.
+
+### Scope note
+
+Findings 1 and 3 both moved a failure mode from *false-negative* to *inconclusive*. That is the correct direction for this system: a monitor that cries wolf is worse than one that occasionally says "I don't know", because only the second preserves the operator's trust in the alert.
+
+## Conclusion
+
+The plan is extremely thorough, aligns perfectly with the security invariants (especially **Non-Negotiable 3** regarding credentials isolation and non-disclosure), and leverages the proven monitoring patterns already established in the codebase. Implementing the above refinements will further harden the assurance mechanism against transient network/registry noise.

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -1238,8 +1238,18 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
           printf 'sdk=%s\n' "$sdk_version" >> "$GITHUB_OUTPUT"
           printf 'client=%s\n' "$client_version" >> "$GITHUB_OUTPUT"
 
+      # Skip rather than probe an empty version. If the resolution step above
+      # failed, `continue-on-error` leaves this output empty, and the action
+      # would request `.../@nimbus-dev/sdk@` — which the registry answers 404.
+      # `fetch-attestations` treats a 404 that survives the full backoff as
+      # `absent`, and `decide()` maps `absent` to `missing-provenance`, a HARD
+      # failure. An npm outage would therefore file an issue claiming the
+      # published package lost its provenance: the exact false alarm this
+      # design exists to avoid. Skipping leaves the status empty, which
+      # `classifyProvenanceOutcome` maps to `indeterminate` (warn).
       - name: Probe @nimbus-dev/sdk provenance
         id: sdk-provenance
+        if: steps.versions.outputs.sdk != ''
         continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
@@ -1249,8 +1259,11 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
           expected-workflow: .github/workflows/release.yml
           severity: monitor
 
+      # Same guard as the sdk probe above — see that comment for why an empty
+      # version would otherwise be reported as missing-provenance (hard).
       - name: Probe @nimbus-dev/client provenance
         id: client-provenance
+        if: steps.versions.outputs.client != ''
         continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -436,20 +436,26 @@ test("404 then 200 succeeds without exhausting the schedule", async () => {
 });
 
 test("5xx exhausts retries and reports error, not absent", async () => {
+  let calls = 0;
   const r = await fetchAttestations("@x/y", "1.0.0", {
-    fetchFn: async () => new Response("", { status: 503 }),
+    fetchFn: async () => { calls += 1; return new Response("", { status: 503 }); },
     sleep: noSleep,
   });
   assert.equal(r.outcome, "error");
   assert.match(r.detail, /503/);
+  // Assert the RETRY, not just the outcome: a branch that returned immediately
+  // would still satisfy the outcome check while breaking the module's purpose.
+  assert.equal(calls, BACKOFF_MS.length + 1, "5xx is retryable; must exhaust the schedule");
 });
 
 test("network throw is error, never absent", async () => {
+  let calls = 0;
   const r = await fetchAttestations("@x/y", "1.0.0", {
-    fetchFn: async () => { throw new Error("ECONNRESET"); },
+    fetchFn: async () => { calls += 1; throw new Error("ECONNRESET"); },
     sleep: noSleep,
   });
   assert.equal(r.outcome, "error");
+  assert.equal(calls, BACKOFF_MS.length + 1, "network errors are transient; must exhaust the schedule");
 });
 
 test("invalid JSON body retries, then reports error — never a false absent", async () => {

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -703,7 +703,11 @@ if (process.env["NODE_ENV"] !== "test" && process.argv[1]?.endsWith("main.js")) 
   if (out) appendFileSync(out, `status=${status}\ndetail=${detail}\n`);
   console.log(`npm provenance: ${pkg}@${version} -> ${status} (${detail})`);
   if (status !== "ok" && severity === "gate") console.log(runbook(pkg, version, status, detail));
-  process.exit(exitCodeFor(status, severity));
+  // Assign exitCode; do NOT call process.exit(). exit() tears the process down
+  // while undici's keep-alive sockets from fetch() are still open, which trips a
+  // libuv assertion (observed: exit 127 on a SUCCESSFUL verification) and can
+  // truncate buffered stdout, silently dropping the GITHUB_OUTPUT write.
+  process.exitCode = exitCodeFor(status, severity);
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -20,7 +20,7 @@
 - **npm floor for trusted publishing:** `11.5.1`.
 - **Fail closed.** Any unrecognised shape maps to `indeterminate`, never a false `ok`.
 - **Branch/commit rules:** work on `dev/asafgolombek/<topic>` branches; never commit to `main`. Monorepo work happens in a git worktree under `.claude/worktrees/`.
-- **`<ACTIONS_SHA>`** appears in Tasks B2, C1, and D1. It is the 40-character commit SHA of `nimbus-agent/.github` `main` **after Task A3's PR is merged**. Resolve it once with `gh api repos/nimbus-agent/.github/commits/main --jq '.sha'` and substitute the literal value everywhere. A tag or branch ref will fail the org's SHA-pinning requirement.
+- **`5fb42792fa88287048fd24f704183b9a9b807a67`** appears in Tasks B2, C1, and D1. It is the 40-character commit SHA of `nimbus-agent/.github` `main` **after Task A3's PR is merged**. Resolve it once with `gh api repos/nimbus-agent/.github/commits/main --jq '.sha'` and substitute the literal value everywhere. A tag or branch ref will fail the org's SHA-pinning requirement.
 
 ## Scope of Verification — read before Task A1
 
@@ -1186,7 +1186,7 @@ and tested for emptiness only, since GITHUB_TOKEN cannot list repo secrets."
 gh api repos/nimbus-agent/.github/commits/main --jq '.sha'
 ```
 
-Record this value; it is `<ACTIONS_SHA>` below. Task A3's PR must be merged first.
+Record this value; it is `5fb42792fa88287048fd24f704183b9a9b807a67` below. Task A3's PR must be merged first.
 
 - [ ] **Step 2: Add the version-resolution and provenance probe steps**
 
@@ -1202,7 +1202,7 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
 
       - name: Probe @nimbus-dev/sdk provenance
         id: sdk-provenance
-        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/sdk"
           version: ${{ steps.versions.outputs.sdk }}
@@ -1212,7 +1212,7 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
 
       - name: Probe @nimbus-dev/client provenance
         id: client-provenance
-        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/client"
           version: ${{ steps.versions.outputs.client }}
@@ -1315,7 +1315,7 @@ cannot be retired, including the 2026-12-01 ADO decommission deadline."
 
 **Interfaces:**
 
-- Consumes: `verify-npm-provenance` at `<ACTIONS_SHA>` (Task A3).
+- Consumes: `verify-npm-provenance` at `5fb42792fa88287048fd24f704183b9a9b807a67` (Task A3).
 
 **Per-repo values** — do not mix these up:
 
@@ -1374,7 +1374,7 @@ Insert immediately **after** the "Publish to npm with provenance" step:
         run: npm audit signatures
 
       - name: Verify provenance names this repo, workflow and commit
-        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/sdk"
           version: ${{ steps.published.outputs.version }}
@@ -1451,7 +1451,7 @@ Use the `nimbus-client` row from the table above. Do not copy the `nimbus-sdk` v
 
 **Interfaces:**
 
-- Consumes: `probe-publish-token` at `<ACTIONS_SHA>` (Task A4).
+- Consumes: `probe-publish-token` at `5fb42792fa88287048fd24f704183b9a9b807a67` (Task A4).
 
 - [ ] **Step 1: Create the health workflow**
 
@@ -1487,7 +1487,7 @@ jobs:
 
       - name: Probe VSCE_PAT
         id: vsce
-        uses: nimbus-agent/.github/actions/probe-publish-token@<ACTIONS_SHA>
+        uses: nimbus-agent/.github/actions/probe-publish-token@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           tool: vsce
           namespace: nimbus-agent
@@ -1496,7 +1496,7 @@ jobs:
 
       - name: Probe OVSX_PAT
         id: ovsx
-        uses: nimbus-agent/.github/actions/probe-publish-token@<ACTIONS_SHA>
+        uses: nimbus-agent/.github/actions/probe-publish-token@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           tool: ovsx
           namespace: nimbus-agent

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -443,12 +443,29 @@ test("network throw is error, never absent", async () => {
   assert.equal(r.outcome, "error");
 });
 
-test("invalid JSON body is error, never a false absent", async () => {
+test("invalid JSON body retries, then reports error — never a false absent", async () => {
+  let calls = 0;
   const r = await fetchAttestations("@x/y", "1.0.0", {
-    fetchFn: async () => new Response("<html>502</html>", { status: 200 }),
+    fetchFn: async () => { calls += 1; return new Response("<html>502</html>", { status: 200 }); },
     sleep: noSleep,
   });
   assert.equal(r.outcome, "error");
+  assert.equal(calls, BACKOFF_MS.length + 1, "a proxy error page is transient — must retry");
+});
+
+test("transient bad body then good body succeeds", async () => {
+  let calls = 0;
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response("<html>502</html>", { status: 200 })
+        : new Response(JSON.stringify({ attestations: [1] }), { status: 200 });
+    },
+    sleep: noSleep,
+  });
+  assert.equal(r.outcome, "body");
+  assert.equal(calls, 2);
 });
 ```
 
@@ -504,7 +521,11 @@ export async function fetchAttestations(pkg, version, deps) {
         try {
           return { outcome: "body", body: await res.json(), detail: "200" };
         } catch {
-          return { outcome: "error", detail: "200 with unparseable JSON body" };
+          // A 200 carrying unparseable bytes is transient, not authoritative:
+          // a CDN/proxy error page or a truncated body both look like this.
+          // Retry rather than failing a release on one bad edge response.
+          lastDetail = "200 with unparseable JSON body";
+          continue;
         }
       }
       if (res.status === 404) {
@@ -780,9 +801,14 @@ gh pr create --repo nimbus-agent/.github --fill
 **Interfaces:**
 
 - Consumes: nothing.
-- Produces: action inputs `tool` (`vsce`|`ovsx`), `namespace`; output `status` (`ok`|`dead`); token supplied by the caller as the `PUBLISH_TOKEN` env var.
+- Produces: action inputs `tool` (`vsce`|`ovsx`), `namespace`; output `status` (`ok`|`dead`|`indeterminate`); token supplied by the caller as the `PUBLISH_TOKEN` env var.
 
 **Design note:** both CLIs ship a first-class `verify-pat` command and both read the token from the environment (`VSCE_PAT` / `OVSX_PAT`). Using them means our own code never handles the token at all — the non-disclosure contract is satisfied structurally rather than by careful coding. Do not hand-roll an HTTP probe here.
+
+**Two hazards this task must handle — do not simplify them away:**
+
+1. **A non-zero exit does not mean the token is dead.** Registry downtime, a network timeout, or marketplace rate-limiting all produce a non-zero exit. Treating those as `dead` would file a false critical alert claiming a working credential is revoked — worse than silence, because it trains the operator to ignore the alarm. The probe therefore distinguishes "the service said no" from "we could not reach the service" by checking a public unauthenticated endpoint after a failure, and reports `indeterminate` when the service is unreachable.
+2. **The token is handed to whatever `npx` resolves.** `npx --yes <pkg>` with no version pulls `@latest` — so a compromised release of `@vscode/vsce` or `ovsx` would receive a live publish credential. Pin **exact** versions, not ranges: a `^` range still resolves to the newest match and provides no protection here. This is a supply-chain program; running unpinned third-party code with a credential in scope would undercut its own premise.
 
 - [ ] **Step 1: Create the action**
 
@@ -805,7 +831,7 @@ inputs:
 
 outputs:
   status:
-    description: "ok | dead"
+    description: "ok | dead | indeterminate"
     value: ${{ steps.probe.outputs.status }}
 
 runs:
@@ -817,6 +843,11 @@ runs:
       # It is exported into the vendor CLI's expected env var and never echoed.
       # Output is discarded wholesale: error messages from these CLIs can echo
       # request context, and this runs in a public repository's logs.
+      #
+      # CLI versions are pinned EXACTLY, not by range: this hands a live publish
+      # credential to the resolved package, so `@latest` (or a `^` range, which
+      # still floats) would put a third-party release in the credential's trust
+      # boundary. Bumping these is a deliberate, reviewed change.
       run: |
         set +e
         if [ -z "${PUBLISH_TOKEN}" ]; then
@@ -825,17 +856,33 @@ runs:
           exit 0
         fi
         if [ "${TOOL}" = "vsce" ]; then
-          VSCE_PAT="${PUBLISH_TOKEN}" npx --yes @vscode/vsce verify-pat "${NAMESPACE}" >/dev/null 2>&1
+          VSCE_PAT="${PUBLISH_TOKEN}" npx --yes @vscode/vsce@3.9.2 verify-pat "${NAMESPACE}" >/dev/null 2>&1
+          code=$?
+          reach_url="https://marketplace.visualstudio.com/"
         else
-          OVSX_PAT="${PUBLISH_TOKEN}" npx --yes ovsx verify-pat "${NAMESPACE}" >/dev/null 2>&1
+          OVSX_PAT="${PUBLISH_TOKEN}" npx --yes ovsx@1.0.2 verify-pat "${NAMESPACE}" >/dev/null 2>&1
+          code=$?
+          reach_url="https://open-vsx.org/api/-/search?size=1"
         fi
-        code=$?
+
         if [ $code -eq 0 ]; then
           echo "status=ok" >> "$GITHUB_OUTPUT"
-        else
-          echo "status=dead" >> "$GITHUB_OUTPUT"
+          echo "probe ${TOOL} (${NAMESPACE}): ok"
+          exit 0
         fi
-        echo "probe ${TOOL} (${NAMESPACE}): exit=${code}"
+
+        # A non-zero exit alone does NOT mean the token is revoked — registry
+        # downtime, a timeout or rate-limiting look identical. Only call it dead
+        # if the service is actually reachable; otherwise report indeterminate
+        # so the caller warns instead of raising a false revocation alarm.
+        http="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$reach_url" 2>/dev/null)"
+        if [ "$http" = "200" ]; then
+          echo "status=dead" >> "$GITHUB_OUTPUT"
+          echo "probe ${TOOL} (${NAMESPACE}): failed (exit=${code}) and service reachable -> dead"
+        else
+          echo "status=indeterminate" >> "$GITHUB_OUTPUT"
+          echo "probe ${TOOL} (${NAMESPACE}): failed (exit=${code}) and service unreachable (http=${http}) -> indeterminate"
+        fi
         exit 0
       env:
         TOOL: ${{ inputs.tool }}
@@ -844,12 +891,16 @@ runs:
 
 - [ ] **Step 2: Verify `verify-pat` exists in both CLIs before relying on it**
 
+Check the **exact pinned versions**, not `@latest` — those are what will run.
+
 ```bash
-npx --yes @vscode/vsce --help 2>&1 | grep -i "verify-pat"
-npx --yes ovsx --help 2>&1 | grep -i "verify-pat"
+npx --yes @vscode/vsce@3.9.2 --help 2>&1 | grep -i "verify-pat"
+npx --yes ovsx@1.0.2 --help 2>&1 | grep -i "verify-pat"
 ```
 
 Expected: both print a `verify-pat` line.
+
+If a newer version has since shipped, that is fine — do **not** float the pin to pick it up. Bump the pinned version deliberately, re-run this check, and note it in the commit.
 
 **If either does not:** stop and report. Do not substitute an invented HTTP endpoint — re-check the CLI's current docs and adjust the command, then continue.
 
@@ -1273,6 +1324,10 @@ In `.github/workflows/release.yml`, insert immediately **before** the "Publish t
           fi
           have="$(npm --version)"
           need="11.5.1"
+          # `sort -V` is a GNU coreutils extension. Both satellites run on
+          # ubuntu-24.04, where it is guaranteed. If this job is ever moved to a
+          # macOS runner, BSD sort has no -V and this comparison breaks — switch
+          # to `gsort` or a Node one-liner at that point.
           if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -n1)" != "$need" ]; then
             echo "::error::npm $have is below the $need floor required for OIDC trusted publishing."
             exit 1
@@ -1433,16 +1488,30 @@ jobs:
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
           echo "| VSCE_PAT | ${VSCE_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| OVSX_PAT | ${OVSX_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${VSCE_STATUS}" != "ok" ] || [ "${OVSX_STATUS}" != "ok" ]; then
+
+          # Mirror the monorepo's warn/hard split. Only `dead` is a hard failure —
+          # `indeterminate` means we could not reach the service, which is NOT
+          # evidence the token is revoked. Filing a revocation alert on a network
+          # blip trains the operator to ignore the alarm.
+          hard=""
+          [ "${VSCE_STATUS}" = "dead" ] && hard="yes"
+          [ "${OVSX_STATUS}" = "dead" ] && hard="yes"
+
+          if [ -n "$hard" ]; then
             title="🔑 Publish credential health alert"
             existing="$(gh issue list --state open --search "$title" --json number --jq '.[0].number // empty')"
-            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. A dead token blocks the next extension release. See docs/ci-secrets.md in the Nimbus monorepo."
+            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. A dead token blocks the next extension release. Cross-check the marketplace status page before rotating — see docs/ci-secrets.md in the Nimbus monorepo."
             if [ -n "$existing" ]; then
               gh issue comment "$existing" --body "$body"
             else
               gh issue create --title "$title" --body "$body"
             fi
             exit 1
+          fi
+
+          if [ "${VSCE_STATUS}" != "ok" ] || [ "${OVSX_STATUS}" != "ok" ]; then
+            echo "::warning::probe inconclusive (VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}) — service unreachable, not a revocation signal"
+            exit 0
           fi
           echo "both publish credentials healthy"
 ```
@@ -1510,7 +1579,13 @@ sleep 60
 gh run list --workflow secret-health.yml --repo nimbus-agent/nimbus-vscode --limit 1
 ```
 
-Expected: a completed run. **Read the step summary**: both credentials should report `ok`. If either reports `dead`, that is a real finding — the token is already expired and the next release would have failed. Report it rather than adjusting the probe to pass.
+Expected: a completed run. **Read the step summary** and interpret it precisely:
+
+| Reported | Meaning | Action |
+| --- | --- | --- |
+| `ok` | Token valid | Nothing |
+| `dead` | Service reachable and rejected the token | **A real finding** — the token is already expired and the next release would have failed. Report it; do not adjust the probe to pass. |
+| `indeterminate` | Service unreachable — no signal either way | Re-run once. If it persists, check the marketplace status page before concluding anything about the token. |
 
 - [ ] **Step 6: File the deadline issue**
 

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- **No new runtime dependencies.** Action code uses only Node 20 built-ins (`node:test`, `node:assert`, global `fetch`, `Buffer`). Sub-project 1's precedent: no new dep.
+- **No new runtime dependencies.** Node action code uses only Node 20 built-ins (`node:test`, `node:assert`, global `fetch`, `Buffer`) — no `package.json`, no install step. Sub-project 1's precedent: no new dep. This governs code we author; it does not forbid Task A4 invoking the vendor `vsce`/`ovsx` CLIs via `npx` at an exact pin, which is a deliberate, documented choice.
 - **Secrets never touch argv.** Tokens flow only through the child process environment. Applies to every probe.
 - **Never log a token, request header, or raw response body.** Log only a derived classification and an HTTP status or exit code. Error paths must be scrubbed — client libraries embed request headers in thrown errors.
 - **SHA-pin every action reference.** The org sets `sha_pinning_required: true`. Use `uses: nimbus-agent/.github/actions/<name>@<full-40-char-sha>`.
@@ -549,7 +549,7 @@ export async function fetchAttestations(pkg, version, deps) {
 
 Run: `node --test actions/verify-npm-provenance/test/`
 
-Expected: PASS — 20 tests total across both files, 0 failures
+Expected: PASS — 21 tests total across both files, 0 failures
 
 - [ ] **Step 5: Commit**
 
@@ -696,7 +696,7 @@ if (process.env["NODE_ENV"] !== "test" && process.argv[1]?.endsWith("main.js")) 
 
 Run: `node --test actions/verify-npm-provenance/test/`
 
-Expected: PASS — 25 tests total, 0 failures
+Expected: PASS — 26 tests total, 0 failures
 
 - [ ] **Step 5: Create the action interface**
 
@@ -1680,7 +1680,7 @@ Follow the connector-docs convention: log the delivery in `docs/CHANGELOG.md`, n
 
 Do not report this plan complete until all of the following hold:
 
-- [ ] `node --test actions/**/test/` passes in `nimbus-agent/.github` (25 tests)
+- [ ] `node --test actions/**/test/` passes in `nimbus-agent/.github` (26 tests)
 - [ ] `bun test scripts/release/check-secret-health.test.ts` passes in the monorepo
 - [ ] `bun run preflight:fast` passes in the monorepo worktree
 - [ ] The live smoke test in Task A3 Step 6 returns `ok` / exit 0 for the real package **and** exit 1 for the wrong-repo case

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -1564,6 +1564,14 @@ on:
 permissions:
   contents: read
 
+# Fix (PR #35 review, finding 5): a manual workflow_dispatch overlapping the
+# Monday cron can race the label-scoped dedup lookup in the Report step below
+# and file two alert issues for the same incident. Serialize instead of
+# canceling — a probe in flight should finish, not be dropped.
+concurrency:
+  group: secret-health
+  cancel-in-progress: false
+
 jobs:
   check:
     name: Probe publish credentials
@@ -1597,7 +1605,11 @@ jobs:
         env:
           PUBLISH_TOKEN: ${{ secrets.OVSX_PAT }}
 
+      # Fix (finding 4): `if: always()` so an infra-level failure upstream (a
+      # bad action ref, a network blip resolving the action) still reports,
+      # rather than silently skipping the whole alerting path.
       - name: Report
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
           VSCE_STATUS: ${{ steps.vsce.outputs.status }}
@@ -1609,33 +1621,67 @@ jobs:
           echo "| VSCE_PAT | ${VSCE_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| OVSX_PAT | ${OVSX_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
 
-          # Mirror the monorepo's warn/hard split. Only `dead` is a hard failure —
-          # `indeterminate` means we could not reach the service, which is NOT
-          # evidence the token is revoked. Filing a revocation alert on a network
-          # blip trains the operator to ignore the alarm.
           # Both tokens are REQUIRED to publish this extension, so `dead` and
           # `not-configured` are both hard failures here — but they are reported
           # distinctly, because "revoked" and "never provisioned" need different
-          # remedies. `indeterminate` means we could not reach the service, which
-          # is NOT evidence about the token; it only warns.
+          # remedies (rotate vs. provision). `indeterminate` means we could not
+          # reach the service, which is NOT evidence the token is revoked —
+          # filing a revocation alert on a network blip trains the operator to
+          # ignore the alarm, so it only warns.
+          #
+          # Fix (finding 3): the mapping is explicit and default-hard. The old
+          # code branched on "anything that isn't ok" for the warn path, so an
+          # empty status, a renamed action output, an `id:` typo, or an
+          # incompatible action-ref bump would fall through to the warn branch
+          # and print a confident, false "service unreachable" explanation for
+          # a shape that was never indeterminate. Now only the literal
+          # `indeterminate` value warns; every other non-ok value — including
+          # anything unrecognised, via `*)` — is hard.
           hard=""
+          indeterminate=""
           for s in "${VSCE_STATUS}" "${OVSX_STATUS}"; do
-            case "$s" in dead|not-configured) hard="yes" ;; esac
+            case "$s" in
+              ok) ;;
+              indeterminate) indeterminate="yes" ;;
+              dead|not-configured) hard="yes" ;;
+              *) hard="yes" ;;
+            esac
           done
 
           if [ -n "$hard" ]; then
             title="🔑 Publish credential health alert"
-            existing="$(gh issue list --state open --search "$title" --json number --jq '.[0].number // empty')"
-            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. \`dead\` = the marketplace rejected a configured token (rotate it); \`not-configured\` = the secret is missing entirely (provision it — do NOT rotate). Either blocks the next extension release. Cross-check the marketplace status page first — see docs/ci-secrets.md in the Nimbus monorepo."
+            label="publish-credential-health"
+            # Fix (finding 1, CRITICAL): this workflow has no actions/checkout
+            # step (deliberately — the job only probes secrets and files/
+            # comments an issue, so `contents: read` has no other purpose
+            # otherwise). Without a checkout there is no `.git` remote for `gh`
+            # to resolve a repo from, and `gh` does not read
+            # `GITHUB_REPOSITORY` — it reads `GH_REPO`, which Actions does not
+            # set. Every gh call below is explicit about its target repo via
+            # `--repo`, which is cheaper than adding a checkout just to give
+            # `gh` a working directory.
+            #
+            # Fix (finding 2, IMPORTANT): dedup is label-scoped, not a text
+            # search. `gh issue list --search` is a fuzzy full-text match over
+            # title AND body — any unrelated open issue that happens to score
+            # on "publish"/"credential"/"health" would win `.[0]` and the real
+            # alert would be posted as a comment on the wrong issue and never
+            # created as its own issue. `gh issue create --label` fails if the
+            # label doesn't exist, so create it first (idempotent via
+            # --force) so the workflow is self-sufficient on a fresh repo.
+            gh label create "$label" --repo "$GITHUB_REPOSITORY" --color "B60205" \
+              --description "Publish credential rotation/provisioning alerts (secret-health.yml)" --force
+            existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$label" --json number --jq '.[0].number // empty')"
+            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. \`dead\` = the marketplace rejected a configured token (rotate it); \`not-configured\` = the secret is missing entirely (provision it — do NOT rotate); any other value is an unrecognised probe result and should be treated as equally urgent until diagnosed. Either blocks the next extension release. Cross-check the marketplace status page first — see docs/ci-secrets.md in the Nimbus monorepo."
             if [ -n "$existing" ]; then
-              gh issue comment "$existing" --body "$body"
+              gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
             else
-              gh issue create --title "$title" --body "$body"
+              gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --label "$label"
             fi
             exit 1
           fi
 
-          if [ "${VSCE_STATUS}" != "ok" ] || [ "${OVSX_STATUS}" != "ok" ]; then
+          if [ -n "$indeterminate" ]; then
             echo "::warning::probe inconclusive (VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}) — service unreachable, not a revocation signal"
             exit 0
           fi
@@ -1669,12 +1715,20 @@ Then insert immediately **after** the "Package .vsix" step:
 
 Add this section:
 
+<!-- Fix (finding 6): the original wording said "signed" (this is an
+     attestation, not a signature) and "every release" (only true going
+     forward — v0.5.0, the latest release at authoring time, predates this
+     PR, so `gh attestation verify` on it would FAIL and could wrongly read
+     as "your download is compromised"). State the version boundary and use
+     "attestation" throughout. -->
+
 ````markdown
 ## Verifying a release
 
-Every release attaches a signed `.vsix` to the GitHub Release with a build
-provenance attestation. To verify the file you downloaded was built by this
-repository's publish workflow:
+Starting with the next release after v0.5.0, every release attaches a build
+provenance attestation to the `.vsix` on the GitHub Release — this is an
+attestation, not a signature on the file itself. To verify a `.vsix` from one
+of those releases was built by this repository's publish workflow:
 
 ```bash
 gh attestation verify nimbus-<version>.vsix --repo nimbus-agent/nimbus-vscode

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -198,15 +198,22 @@ test("truncated base64 payload decodes to null", () => {
   assert.equal(decodeStatements(broken), null);
 });
 
-test("detail never contains the raw statement blob", () => {
+test("detail is a short summary, never the raw statement blob", () => {
   const r = classifyProvenance(statementsOf(real), EXPECTED);
-  assert.ok(r.detail.length < 200, "detail should be a short summary");
+  // Assert the actual content, not merely that it is short: a length bound
+  // would pass on a truncated blob just as happily as on a real summary.
+  assert.equal(
+    r.detail,
+    ".github/workflows/release.yml @ https://github.com/nimbus-agent/nimbus-sdk",
+  );
+  assert.ok(!/[A-Za-z0-9+/]{80,}={0,2}/.test(r.detail), "no base64 payload in detail");
+  assert.ok(!r.detail.includes("dsseEnvelope"), "no envelope internals in detail");
 });
 ```
 
 - [ ] **Step 4: Run the test to verify it fails**
 
-Run: `node --test actions/verify-npm-provenance/test/`
+Run: `node --test "actions/verify-npm-provenance/test/*.test.js"`
 
 Expected: FAIL — `Cannot find module '../src/classify.js'`
 
@@ -297,7 +304,7 @@ export function classifyProvenance(statements, expected) {
 
 - [ ] **Step 6: Run the tests to verify they pass**
 
-Run: `node --test actions/verify-npm-provenance/test/`
+Run: `node --test "actions/verify-npm-provenance/test/*.test.js"`
 
 Expected: PASS — 12 tests, 0 failures
 
@@ -331,7 +338,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Run action tests
-        run: node --test actions/**/test/
+        # A bare directory arg worked on Node 20 but fails on Node 24
+        # (MODULE_NOT_FOUND); runners now default to 24. Use an explicit glob.
+        run: node --test "actions/**/test/*.test.js"
 ```
 
 - [ ] **Step 8: Commit**
@@ -547,7 +556,7 @@ export async function fetchAttestations(pkg, version, deps) {
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test actions/verify-npm-provenance/test/`
+Run: `node --test "actions/verify-npm-provenance/test/*.test.js"`
 
 Expected: PASS — 21 tests total across both files, 0 failures
 
@@ -694,7 +703,7 @@ if (process.env["NODE_ENV"] !== "test" && process.argv[1]?.endsWith("main.js")) 
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `node --test actions/verify-npm-provenance/test/`
+Run: `node --test "actions/verify-npm-provenance/test/*.test.js"`
 
 Expected: PASS — 26 tests total, 0 failures
 
@@ -1680,7 +1689,7 @@ Follow the connector-docs convention: log the delivery in `docs/CHANGELOG.md`, n
 
 Do not report this plan complete until all of the following hold:
 
-- [ ] `node --test actions/**/test/` passes in `nimbus-agent/.github` (26 tests)
+- [ ] `node --test "actions/**/test/*.test.js"` passes in `nimbus-agent/.github` (26 tests)
 - [ ] `bun test scripts/release/check-secret-health.test.ts` passes in the monorepo
 - [ ] `bun run preflight:fast` passes in the monorepo worktree
 - [ ] The live smoke test in Task A3 Step 6 returns `ok` / exit 0 for the real package **and** exit 1 for the wrong-repo case

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -820,14 +820,15 @@ gh pr create --repo nimbus-agent/.github --fill
 **Interfaces:**
 
 - Consumes: nothing.
-- Produces: action inputs `tool` (`vsce`|`ovsx`), `namespace`; output `status` (`ok`|`dead`|`indeterminate`); token supplied by the caller as the `PUBLISH_TOKEN` env var.
+- Produces: action inputs `tool` (`vsce`|`ovsx`), `namespace`; output `status` (`ok`|`dead`|`not-configured`|`indeterminate`); token supplied by the caller as the `PUBLISH_TOKEN` env var.
 
 **Design note:** both CLIs ship a first-class `verify-pat` command and both read the token from the environment (`VSCE_PAT` / `OVSX_PAT`). Using them means our own code never handles the token at all — the non-disclosure contract is satisfied structurally rather than by careful coding. Do not hand-roll an HTTP probe here.
 
 **Two hazards this task must handle — do not simplify them away:**
 
 1. **A non-zero exit does not mean the token is dead.** Registry downtime, a network timeout, or marketplace rate-limiting all produce a non-zero exit. Treating those as `dead` would file a false critical alert claiming a working credential is revoked — worse than silence, because it trains the operator to ignore the alarm. The probe therefore distinguishes "the service said no" from "we could not reach the service" by checking a public unauthenticated endpoint after a failure, and reports `indeterminate` when the service is unreachable.
-2. **The token is handed to whatever `npx` resolves.** `npx --yes <pkg>` with no version pulls `@latest` — so a compromised release of `@vscode/vsce` or `ovsx` would receive a live publish credential. Pin **exact** versions, not ranges: a `^` range still resolves to the newest match and provides no protection here. This is a supply-chain program; running unpinned third-party code with a credential in scope would undercut its own premise.
+2. **An unset secret is not a revoked secret.** The empty-token branch reports `not-configured`, never `dead` — it contacts nothing, so it has no evidence of revocation. Emitting `dead` there would file a "token revoked, rotate now" alert for a credential that was never provisioned.
+3. **The token is handed to whatever `npx` resolves.** `npx --yes <pkg>` with no version pulls `@latest` — so a compromised release of `@vscode/vsce` or `ovsx` would receive a live publish credential. Pin **exact** versions, not ranges: a `^` range still resolves to the newest match and provides no protection here. This is a supply-chain program; running unpinned third-party code with a credential in scope would undercut its own premise.
 
 - [ ] **Step 1: Create the action**
 
@@ -850,7 +851,7 @@ inputs:
 
 outputs:
   status:
-    description: "ok | dead | indeterminate"
+    description: "ok | dead | not-configured | indeterminate"
     value: ${{ steps.probe.outputs.status }}
 
 runs:
@@ -870,8 +871,14 @@ runs:
       run: |
         set +e
         if [ -z "${PUBLISH_TOKEN}" ]; then
-          echo "status=dead" >> "$GITHUB_OUTPUT"
-          echo "probe ${TOOL}: token not configured"
+          # NOT `dead`: this branch never contacts the vendor and never runs the
+          # reachability check, so it cannot know the token was revoked — the
+          # secret simply is not set. `dead` is reserved for a confirmed
+          # rejection by a reachable service, so the alert text stays truthful.
+          # Severity is the CALLER's decision: a repo that requires this token
+          # may still treat not-configured as a hard failure.
+          echo "status=not-configured" >> "$GITHUB_OUTPUT"
+          echo "probe ${TOOL}: secret not configured (not a revocation signal)"
           exit 0
         fi
         if [ "${TOOL}" = "vsce" ]; then
@@ -1512,14 +1519,20 @@ jobs:
           # `indeterminate` means we could not reach the service, which is NOT
           # evidence the token is revoked. Filing a revocation alert on a network
           # blip trains the operator to ignore the alarm.
+          # Both tokens are REQUIRED to publish this extension, so `dead` and
+          # `not-configured` are both hard failures here — but they are reported
+          # distinctly, because "revoked" and "never provisioned" need different
+          # remedies. `indeterminate` means we could not reach the service, which
+          # is NOT evidence about the token; it only warns.
           hard=""
-          [ "${VSCE_STATUS}" = "dead" ] && hard="yes"
-          [ "${OVSX_STATUS}" = "dead" ] && hard="yes"
+          for s in "${VSCE_STATUS}" "${OVSX_STATUS}"; do
+            case "$s" in dead|not-configured) hard="yes" ;; esac
+          done
 
           if [ -n "$hard" ]; then
             title="🔑 Publish credential health alert"
             existing="$(gh issue list --state open --search "$title" --json number --jq '.[0].number // empty')"
-            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. A dead token blocks the next extension release. Cross-check the marketplace status page before rotating — see docs/ci-secrets.md in the Nimbus monorepo."
+            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. \`dead\` = the marketplace rejected a configured token (rotate it); \`not-configured\` = the secret is missing entirely (provision it — do NOT rotate). Either blocks the next extension release. Cross-check the marketplace status page first — see docs/ci-secrets.md in the Nimbus monorepo."
             if [ -n "$existing" ]; then
               gh issue comment "$existing" --body "$body"
             else
@@ -1604,6 +1617,7 @@ Expected: a completed run. **Read the step summary** and interpret it precisely:
 | --- | --- | --- |
 | `ok` | Token valid | Nothing |
 | `dead` | Service reachable and rejected the token | **A real finding** — the token is already expired and the next release would have failed. Report it; do not adjust the probe to pass. |
+| `not-configured` | The secret is unset | The secret was never provisioned or has been deleted. Provision it — do **not** rotate a credential that does not exist. |
 | `indeterminate` | Service unreachable — no signal either way | Re-run once. If it persists, check the marketplace status page before concluding anything about the token. |
 
 - [ ] **Step 6: File the deadline issue**

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -1315,8 +1315,12 @@ publishing and carry two attestations: the npm publish attestation and a
 SLSA provenance predicate naming the source repo, workflow, and commit.
 
 Publishing access on both packages is set to **require two-factor
-authentication and disallow tokens**, so OIDC is the only path that can
-publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
+authentication and disallow tokens**, so no automation or token-based publish
+is possible — CI's only path to publish is OIDC, and a leaked token cannot
+publish either. This does **not** mean only OIDC can publish, full stop: an
+interactive maintainer authenticating with a One-Time Password can still
+publish by hand from their own machine — the setting removes token-based
+publishing, not human publishing. `NPM_TOKEN` was revoked and deleted on
 2026-07-19; the weekly secret-health run asserts it stays absent.
 
 Verify a published version yourself:
@@ -1333,9 +1337,13 @@ curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0"
   | jq -r '.attestations[].predicateType'  # expect both predicates
 ```
 
-The release workflows gate on this automatically: a pre-publish preflight
-asserts OIDC is available and npm meets the 11.5.1 floor, and a post-publish
-step fails the release if provenance is missing or names the wrong source.
+This gate is landing in the two satellite release workflows as Task C1
+(`nimbus-sdk` [#12](https://github.com/nimbus-agent/nimbus-sdk/pull/12),
+`nimbus-client` [#5](https://github.com/nimbus-agent/nimbus-client/pull/5) —
+both open as of 2026-07-20, not yet merged): once merged, a pre-publish
+preflight will assert OIDC is available and npm meets the 11.5.1 floor, and a
+post-publish step will fail the release if provenance is missing or names the
+wrong source.
 
 ### Publish PATs that cannot yet be retired
 
@@ -1344,7 +1352,11 @@ step fails the release if provenance is missing or names the wrong source.
 | `VSCE_PAT` | `nimbus-vscode` | @AsafGolombek | Azure DevOps PAT. ⚠️ **Global ADO PATs are decommissioned 2026-12-01** and cannot be regenerated since 2026-03-15. Marketplace trusted publishing is unshipped (microsoft/vsmarketplace#1422). |
 | `OVSX_PAT` | `nimbus-vscode` | @AsafGolombek | Open VSX token. No OIDC path exists (eclipse-openvsx/openvsx#1534); rotation is the only mitigation. |
 
-Both are probed weekly for liveness by `nimbus-vscode`'s own `secret-health.yml`.
+Both will be probed weekly for liveness by `nimbus-vscode`'s own
+`secret-health.yml` — landing as
+[PR #35](https://github.com/nimbus-agent/nimbus-vscode/pull/35), open as of
+2026-07-20, not yet merged. Until it merges, neither PAT is under any
+automated liveness check.
 ````
 
 - [ ] **Step 6: Lint the docs**

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -28,6 +28,8 @@ The provenance action **parses the DSSE payload** served by the registry over TL
 
 `npm audit signatures` **does** perform registry-signature verification and is therefore included in the release gate as the cryptographic complement (Task C1). Do not describe the action alone as "verifying signatures" in any comment, log line, or doc — it checks claims, not cryptography.
 
+**`npm audit signatures` audits the tree it is run in, not the package you just published.** Run in the repo root it verifies our own *dependencies*, and the published package is never a dependency of itself — the shipped artifact would go cryptographically unchecked. The release gate therefore installs the just-published version from the registry into a clean temporary tree and audits *that*. Confirmed live against `@nimbus-dev/sdk@1.3.0`. Anywhere this doc or a workflow comment says "verify signatures", it means that clean-tree audit.
+
 ## File Structure
 
 **Repo `nimbus-agent/.github`** (new `actions/` tree):
@@ -1263,7 +1265,13 @@ publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
 Verify a published version yourself:
 
 ```bash
+# `npm audit signatures` audits the tree it runs in, so install the package
+# under test into a clean directory first — running it in a checkout would
+# audit that project's dependencies instead.
+tmp="$(mktemp -d)" && cd "$tmp" && npm init -y >/dev/null
+npm install @nimbus-dev/sdk@1.3.0 --no-audit --no-fund
 npm audit signatures                       # registry signature verification
+
 curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0" \
   | jq -r '.attestations[].predicateType'  # expect both predicates
 ```
@@ -1370,8 +1378,34 @@ Insert immediately **after** the "Publish to npm with provenance" step:
         id: published
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Verify npm signatures (cryptographic)
-        run: npm audit signatures
+      # `npm audit signatures` verifies the registry signatures of the packages
+      # in the CURRENT tree. Run in the repo root it would audit our own
+      # dependencies — which never includes the package we just shipped. To
+      # cryptographically verify the published artifact it must be installed
+      # from the registry into a clean tree first. Verified live against
+      # @nimbus-dev/sdk@1.3.0: "1 package has a verified registry signature /
+      # 1 package has a verified attestation", exit 0.
+      - name: Verify the published tarball's registry signature (cryptographic)
+        env:
+          PUBLISHED_VERSION: ${{ steps.published.outputs.version }}
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          cd "$tmp"
+          npm init -y >/dev/null
+          # The registry serves a fresh publish with a short propagation lag;
+          # retry so a few seconds of lag is not read as a supply-chain failure.
+          for attempt in 1 2 3 4 5; do
+            if npm install "@nimbus-dev/sdk@${PUBLISHED_VERSION}" --no-audit --no-fund; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "::error::@nimbus-dev/sdk@${PUBLISHED_VERSION} was not installable from the registry after 5 attempts."
+              exit 1
+            fi
+            sleep $(( attempt * 5 ))
+          done
+          npm audit signatures
 
       - name: Verify provenance names this repo, workflow and commit
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
@@ -1384,7 +1418,7 @@ Insert immediately **after** the "Publish to npm with provenance" step:
           severity: gate
 ```
 
-**For `nimbus-client`,** use `package: "@nimbus-dev/client"` and `expected-repo: nimbus-agent/nimbus-client`. Everything else is identical.
+**For `nimbus-client`,** three values change: the `npm install` line in the signature step becomes `"@nimbus-dev/client@${PUBLISHED_VERSION}"`, the error message names `@nimbus-dev/client`, and the action gets `package: "@nimbus-dev/client"` + `expected-repo: nimbus-agent/nimbus-client`. Everything else is identical. Grep the finished file for `sdk` before committing in `nimbus-client` — there must be no hits.
 
 - [ ] **Step 4: Validate the workflow parses**
 
@@ -1426,9 +1460,12 @@ git commit -m "ci: gate releases on npm provenance
 
 Pre-publish preflight asserts OIDC is available and npm meets the 11.5.1
 trusted-publishing floor — the two dominant causes of silent degradation,
-both detectable before the irreversible step. Post-publish, npm audit
-signatures verifies cryptographically and verify-npm-provenance asserts the
-SLSA source claim names this repo, workflow and commit."
+both detectable before the irreversible step. Post-publish, the just-shipped
+version is installed from the registry into a clean tree so npm audit
+signatures verifies THAT tarball cryptographically — run in the repo root it
+would audit our own dependencies, which never include the package we just
+published — and verify-npm-provenance asserts the SLSA source claim names
+this repo, workflow and commit."
 git push -u origin dev/asafgolombek/provenance-gate
 gh pr create --fill
 ```

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -986,7 +986,11 @@ describe("classifyProvenanceOutcome", () => {
   });
 
   test("fails closed: unset or unrecognised is never ok", () => {
-    expect(classifyProvenanceOutcome("")).toBe("not-configured");
+    // Empty means the probe never reported (renamed/skipped step id, or an
+    // action exiting before writing output) — not the same as a genuinely
+    // absent secret, so it must warn (`indeterminate`), never silently pass
+    // as `not-configured` (post-review fix; see Task B1 Step 3 below).
+    expect(classifyProvenanceOutcome("")).toBe("indeterminate");
     expect(classifyProvenanceOutcome("weird")).toBe("indeterminate");
   });
 });
@@ -1064,9 +1068,18 @@ export type AbsenceStatus = "ok" | "present";
  * check and its `steps.<id>.outputs.status` is passed in via env — the same
  * shape as the App-mint probe above. Fail closed: an unset value means the step
  * never ran, and an unrecognised value is never silently "ok".
+ *
+ * POST-REVIEW FIX: an earlier draft mapped "" to `not-configured`, but
+ * `not-configured` sits in neither `summarize`'s `hard` nor `warn` set — a
+ * renamed step id, a skipped step, or an action exiting before writing its
+ * output all interpolate to "" with NO workflow error, so that draft posted
+ * "all healthy" for a probe that reported nothing. `not-configured` is the
+ * right state for a genuinely absent PAT/cert secret (see
+ * `classifySecretAbsence`), but "no report" is not the same claim as
+ * "intentionally unconfigured" — map it to `indeterminate` so it warns.
  */
 export function classifyProvenanceOutcome(status: string): ProvenanceStatus {
-  if (status === "") return "not-configured";
+  if (status === "") return "indeterminate";
   if (
     status === "ok" ||
     status === "missing-provenance" ||
@@ -1197,13 +1210,37 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
 ```yaml
       - name: Resolve latest published versions
         id: versions
+        # Same reasoning as `app-mint` above: a registry hiccup here must
+        # degrade into a classified row, not abort the whole weekly job and
+        # silence PAT/cert monitoring too (post-review fix).
+        continue-on-error: true
         run: |
           set -euo pipefail
-          echo "sdk=$(npm view @nimbus-dev/sdk version)" >> "$GITHUB_OUTPUT"
-          echo "client=$(npm view @nimbus-dev/client version)" >> "$GITHUB_OUTPUT"
+          # POST-REVIEW FIX: `set -euo pipefail` does NOT catch a failing
+          # command substitution used as an echo argument — `echo
+          # "sdk=$(npm view …)"` still returns 0 (that's echo's own exit
+          # status), so a failed `npm view` silently wrote a literal "sdk=" to
+          # $GITHUB_OUTPUT and fed an empty version into the provenance probe
+          # below. Assigning to a variable first fixes it: the assignment's
+          # exit status IS the command substitution's, so `set -e` actually
+          # trips; the empty-check is a second line of defense; `printf`
+          # avoids re-embedding a command substitution in the output line.
+          sdk_version="$(npm view @nimbus-dev/sdk version)"
+          if [ -z "$sdk_version" ]; then
+            echo "::error::npm view @nimbus-dev/sdk version returned an empty version" >&2
+            exit 1
+          fi
+          client_version="$(npm view @nimbus-dev/client version)"
+          if [ -z "$client_version" ]; then
+            echo "::error::npm view @nimbus-dev/client version returned an empty version" >&2
+            exit 1
+          fi
+          printf 'sdk=%s\n' "$sdk_version" >> "$GITHUB_OUTPUT"
+          printf 'client=%s\n' "$client_version" >> "$GITHUB_OUTPUT"
 
       - name: Probe @nimbus-dev/sdk provenance
         id: sdk-provenance
+        continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/sdk"
@@ -1214,6 +1251,7 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
 
       - name: Probe @nimbus-dev/client provenance
         id: client-provenance
+        continue-on-error: true
         uses: nimbus-agent/.github/actions/verify-npm-provenance@5fb42792fa88287048fd24f704183b9a9b807a67
         with:
           package: "@nimbus-dev/client"
@@ -1222,6 +1260,12 @@ In `.github/workflows/secret-health.yml`, insert this block after the "Mint rele
           expected-workflow: .github/workflows/release.yml
           severity: monitor
 ```
+
+All three steps carry `continue-on-error: true`, matching the `app-mint` step
+above them: without it, one npm registry outage aborts the whole job and
+silences PAT/cert monitoring too, and it makes the `indeterminate`
+classification path unreachable (the scenario becomes a red job instead of a
+classified row) — a post-review fix.
 
 Note there is no `expected-sha` here: the monitor checks whatever version is currently latest, whose commit is not knowable from this workflow. The release-time gate in Task C1 is where the commit is pinned.
 

--- a/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
+++ b/docs/superpowers/plans/2026-07-19-npm-supply-chain-assurance.md
@@ -1,0 +1,1616 @@
+# npm Supply-Chain Assurance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the already-live npm OIDC/provenance guarantee verified and non-degradable, and gain liveness visibility on the two publish PATs that cannot yet be retired.
+
+**Architecture:** One tested implementation of each check lives as a composite action in the existing `nimbus-agent/.github` repo. The two npm satellites call the provenance action as a release-time gate; the Nimbus monorepo's existing weekly `secret-health.yml` calls the *same* action in monitor mode and converts its output into a `HealthRow` — exactly mirroring the existing `classifyAppMint` precedent, so no checker logic is duplicated in TypeScript. `nimbus-vscode` gets its own health workflow that probes its PATs where those secrets already live.
+
+**Tech Stack:** GitHub composite actions running dependency-free Node 20 (pre-installed on runners; no `setup-node`, no `npm install`); Bun + `bun:test` for the monorepo-side changes; `vsce` / `ovsx` CLIs for PAT probes.
+
+## Global Constraints
+
+- **No new runtime dependencies.** Action code uses only Node 20 built-ins (`node:test`, `node:assert`, global `fetch`, `Buffer`). Sub-project 1's precedent: no new dep.
+- **Secrets never touch argv.** Tokens flow only through the child process environment. Applies to every probe.
+- **Never log a token, request header, or raw response body.** Log only a derived classification and an HTTP status or exit code. Error paths must be scrubbed — client libraries embed request headers in thrown errors.
+- **SHA-pin every action reference.** The org sets `sha_pinning_required: true`. Use `uses: nimbus-agent/.github/actions/<name>@<full-40-char-sha>`.
+- **Attestation predicate constants (exact strings):**
+  - publish: `https://github.com/npm/attestation/tree/main/specs/publish/v0.1`
+  - SLSA: `https://slsa.dev/provenance/v1`
+- **npm floor for trusted publishing:** `11.5.1`.
+- **Fail closed.** Any unrecognised shape maps to `indeterminate`, never a false `ok`.
+- **Branch/commit rules:** work on `dev/asafgolombek/<topic>` branches; never commit to `main`. Monorepo work happens in a git worktree under `.claude/worktrees/`.
+- **`<ACTIONS_SHA>`** appears in Tasks B2, C1, and D1. It is the 40-character commit SHA of `nimbus-agent/.github` `main` **after Task A3's PR is merged**. Resolve it once with `gh api repos/nimbus-agent/.github/commits/main --jq '.sha'` and substitute the literal value everywhere. A tag or branch ref will fail the org's SHA-pinning requirement.
+
+## Scope of Verification — read before Task A1
+
+The provenance action **parses the DSSE payload** served by the registry over TLS. It asserts *completeness and source-consistency*. It does **not** perform Sigstore cryptographic verification — that would require a heavy dependency and is disproportionate to the threat model here, which is **accidental degradation** (a dropped `id-token: write`, an old npm), not registry compromise.
+
+`npm audit signatures` **does** perform registry-signature verification and is therefore included in the release gate as the cryptographic complement (Task C1). Do not describe the action alone as "verifying signatures" in any comment, log line, or doc — it checks claims, not cryptography.
+
+## File Structure
+
+**Repo `nimbus-agent/.github`** (new `actions/` tree):
+
+| Path | Responsibility |
+| --- | --- |
+| `actions/verify-npm-provenance/action.yml` | Composite action interface: inputs, outputs, `node` invocation |
+| `actions/verify-npm-provenance/src/classify.js` | **Pure**: decode DSSE payloads, classify against expected source. No I/O |
+| `actions/verify-npm-provenance/src/fetch-attestations.js` | Retry/backoff around `fetch`. Injected `fetch` + `sleep` |
+| `actions/verify-npm-provenance/src/main.js` | Entrypoint: reads inputs from env, wires the two above, writes outputs |
+| `actions/verify-npm-provenance/test/classify.test.js` | Classifier unit tests |
+| `actions/verify-npm-provenance/test/fetch-attestations.test.js` | Retry/backoff unit tests |
+| `actions/verify-npm-provenance/test/fixtures/*.json` | Real captured registry responses, trimmed |
+| `actions/probe-publish-token/action.yml` | Composite action wrapping `vsce`/`ovsx verify-pat` |
+| `.github/workflows/ci.yml` | Runs `node --test` over `actions/**/test` |
+
+**Repo `nimbus-agent/Nimbus`:**
+
+| Path | Responsibility |
+| --- | --- |
+| `scripts/release/check-secret-health.ts` | Modify: widen `HealthRow`, add two classifiers, wire env |
+| `scripts/release/check-secret-health.test.ts` | Modify: tests for the two new classifiers |
+| `.github/workflows/secret-health.yml` | Modify: call provenance action ×2 in monitor mode |
+| `docs/ci-secrets.md` | Modify: provenance section + PAT expiry/owner notes |
+
+**Repos `nimbus-sdk`, `nimbus-client`:** `.github/workflows/release.yml` — preflight + post-publish gate.
+
+**Repo `nimbus-vscode`:** `.github/workflows/secret-health.yml` (new), `.github/workflows/publish.yml` (attestation), `README.md` (verify docs).
+
+---
+
+## Task A1: Provenance classifier (pure logic)
+
+**Repo:** `nimbus-agent/.github` · branch `dev/asafgolombek/supply-chain-actions`
+
+**Files:**
+
+- Create: `actions/verify-npm-provenance/src/classify.js`
+- Create: `actions/verify-npm-provenance/test/classify.test.js`
+- Create: `actions/verify-npm-provenance/test/fixtures/sdk-1.3.0.json`
+- Create: `.github/workflows/ci.yml`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `PUBLISH_PREDICATE: string`, `SLSA_PREDICATE: string`
+  - `decodeStatements(body: unknown): object[] | null` — `null` means unparseable
+  - `classifyProvenance(statements: object[] | null, expected: {repo: string, workflow?: string, sha?: string}): {status: "ok"|"missing-provenance"|"source-mismatch"|"indeterminate", detail: string}`
+
+- [ ] **Step 1: Clone and branch**
+
+```bash
+git clone https://github.com/nimbus-agent/.github.git nimbus-org-github
+cd nimbus-org-github
+git switch -c dev/asafgolombek/supply-chain-actions
+mkdir -p actions/verify-npm-provenance/src actions/verify-npm-provenance/test/fixtures
+```
+
+- [ ] **Step 2: Capture the real fixture**
+
+The fixture must be a real capture, so a registry shape change surfaces as a test diff.
+
+```bash
+curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0" \
+  -o actions/verify-npm-provenance/test/fixtures/sdk-1.3.0.json
+node -e "const d=require('./actions/verify-npm-provenance/test/fixtures/sdk-1.3.0.json');console.log(d.attestations.length)"
+```
+
+Expected: `2`
+
+- [ ] **Step 3: Write the failing test**
+
+Create `actions/verify-npm-provenance/test/classify.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { decodeStatements, classifyProvenance } from "../src/classify.js";
+
+const real = JSON.parse(
+  readFileSync(new URL("./fixtures/sdk-1.3.0.json", import.meta.url), "utf8"),
+);
+const EXPECTED = { repo: "nimbus-agent/nimbus-sdk", workflow: ".github/workflows/release.yml" };
+
+function statementsOf(body) {
+  const s = decodeStatements(body);
+  assert.notEqual(s, null, "fixture should decode");
+  return s;
+}
+
+test("real published package classifies ok", () => {
+  const r = classifyProvenance(statementsOf(real), EXPECTED);
+  assert.equal(r.status, "ok");
+});
+
+test("missing SLSA predicate is missing-provenance, not ok", () => {
+  const only = {
+    attestations: real.attestations.filter(
+      (a) => a.predicateType === "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+    ),
+  };
+  const r = classifyProvenance(statementsOf(only), EXPECTED);
+  assert.equal(r.status, "missing-provenance");
+});
+
+test("missing npm publish predicate is missing-provenance", () => {
+  const only = {
+    attestations: real.attestations.filter(
+      (a) => a.predicateType === "https://slsa.dev/provenance/v1",
+    ),
+  };
+  const r = classifyProvenance(statementsOf(only), EXPECTED);
+  assert.equal(r.status, "missing-provenance");
+});
+
+test("wrong repo is source-mismatch", () => {
+  const r = classifyProvenance(statementsOf(real), { repo: "attacker/evil" });
+  assert.equal(r.status, "source-mismatch");
+});
+
+test("wrong workflow path is source-mismatch", () => {
+  const r = classifyProvenance(statementsOf(real), {
+    repo: "nimbus-agent/nimbus-sdk",
+    workflow: ".github/workflows/attacker.yml",
+  });
+  assert.equal(r.status, "source-mismatch");
+});
+
+test("wrong commit sha is source-mismatch", () => {
+  const r = classifyProvenance(statementsOf(real), {
+    repo: "nimbus-agent/nimbus-sdk",
+    sha: "0000000000000000000000000000000000000000",
+  });
+  assert.equal(r.status, "source-mismatch");
+});
+
+test("correct commit sha is ok", () => {
+  const r = classifyProvenance(statementsOf(real), {
+    repo: "nimbus-agent/nimbus-sdk",
+    sha: "7e5a45f325d588a0b21eb5e1718a31c4ccb306cb",
+  });
+  assert.equal(r.status, "ok");
+});
+
+test("empty attestation list is missing-provenance", () => {
+  const r = classifyProvenance(statementsOf({ attestations: [] }), EXPECTED);
+  assert.equal(r.status, "missing-provenance");
+});
+
+test("null statements is indeterminate, never ok", () => {
+  const r = classifyProvenance(null, EXPECTED);
+  assert.equal(r.status, "indeterminate");
+});
+
+test("malformed body decodes to null", () => {
+  assert.equal(decodeStatements(null), null);
+  assert.equal(decodeStatements({}), null);
+  assert.equal(decodeStatements({ attestations: "nope" }), null);
+  assert.equal(decodeStatements({ attestations: [{ bundle: {} }] }), null);
+});
+
+test("truncated base64 payload decodes to null", () => {
+  const broken = {
+    attestations: [{ bundle: { dsseEnvelope: { payload: "bm90IGpzb24=" } } }],
+  };
+  assert.equal(decodeStatements(broken), null);
+});
+
+test("detail never contains the raw statement blob", () => {
+  const r = classifyProvenance(statementsOf(real), EXPECTED);
+  assert.ok(r.detail.length < 200, "detail should be a short summary");
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `node --test actions/verify-npm-provenance/test/`
+
+Expected: FAIL — `Cannot find module '../src/classify.js'`
+
+- [ ] **Step 5: Implement the classifier**
+
+Create `actions/verify-npm-provenance/src/classify.js`:
+
+```js
+export const PUBLISH_PREDICATE =
+  "https://github.com/npm/attestation/tree/main/specs/publish/v0.1";
+export const SLSA_PREDICATE = "https://slsa.dev/provenance/v1";
+
+/**
+ * Decode the DSSE payloads out of a registry attestation response.
+ *
+ * The attestation content lives in `bundle.dsseEnvelope.payload` (base64 JSON),
+ * NOT at the top level. We read predicateType from the decoded statement rather
+ * than the unsigned outer wrapper.
+ *
+ * Returns null on any unrecognised shape — the caller maps that to
+ * "indeterminate", never a false "ok".
+ */
+export function decodeStatements(body) {
+  if (body === null || typeof body !== "object") return null;
+  const list = body.attestations;
+  if (!Array.isArray(list)) return null;
+  const statements = [];
+  for (const att of list) {
+    const payload = att?.bundle?.dsseEnvelope?.payload;
+    if (typeof payload !== "string") return null;
+    let decoded;
+    try {
+      decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+    } catch {
+      return null;
+    }
+    if (decoded === null || typeof decoded !== "object") return null;
+    statements.push(decoded);
+  }
+  return statements;
+}
+
+function fail(status, detail) {
+  return { status, detail };
+}
+
+/**
+ * Assert the attestation set is complete AND attested to the expected source.
+ * "An attestation exists" is a weaker claim than "attested to us".
+ */
+export function classifyProvenance(statements, expected) {
+  if (statements === null) return fail("indeterminate", "unparseable attestation response");
+  if (statements.length === 0) return fail("missing-provenance", "no attestations published");
+
+  const types = new Set(statements.map((s) => s?.predicateType));
+  if (!types.has(PUBLISH_PREDICATE)) {
+    return fail("missing-provenance", "no npm publish attestation");
+  }
+  const slsa = statements.find((s) => s?.predicateType === SLSA_PREDICATE);
+  if (slsa === undefined) {
+    return fail("missing-provenance", "no SLSA provenance predicate — publish degraded");
+  }
+
+  const wf = slsa?.predicate?.buildDefinition?.externalParameters?.workflow;
+  if (wf === null || typeof wf !== "object") {
+    return fail("indeterminate", "provenance carries no workflow claim");
+  }
+
+  const wantRepo = `https://github.com/${expected.repo}`;
+  if (wf.repository !== wantRepo) {
+    return fail("source-mismatch", `repository ${String(wf.repository)} != ${wantRepo}`);
+  }
+  if (expected.workflow !== undefined && wf.path !== expected.workflow) {
+    return fail("source-mismatch", `workflow ${String(wf.path)} != ${expected.workflow}`);
+  }
+  if (expected.sha !== undefined) {
+    const deps = slsa?.predicate?.buildDefinition?.resolvedDependencies;
+    const commit = Array.isArray(deps)
+      ? deps.find((d) => typeof d?.digest?.gitCommit === "string")?.digest?.gitCommit
+      : undefined;
+    if (commit !== expected.sha) {
+      return fail("source-mismatch", `commit ${String(commit)} != ${expected.sha}`);
+    }
+  }
+  return { status: "ok", detail: `${String(wf.path)} @ ${String(wf.repository)}` };
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `node --test actions/verify-npm-provenance/test/`
+
+Expected: PASS — 12 tests, 0 failures
+
+- [ ] **Step 7: Add the CI workflow**
+
+Create `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test composite actions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run action tests
+        run: node --test actions/**/test/
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add actions/verify-npm-provenance .github/workflows/ci.yml
+git commit -m "feat: npm provenance classifier with real-capture fixtures
+
+Asserts both the npm publish and SLSA provenance predicates are present AND
+that the SLSA source claim names the expected repo/workflow/commit — 'an
+attestation exists' is a weaker claim than 'attested to us'. Fails closed:
+any unrecognised shape is indeterminate, never a false ok."
+```
+
+---
+
+## Task A2: Fetch with backoff
+
+**Files:**
+
+- Create: `actions/verify-npm-provenance/src/fetch-attestations.js`
+- Create: `actions/verify-npm-provenance/test/fetch-attestations.test.js`
+
+**Interfaces:**
+
+- Consumes: nothing from A1 (kept independent so both are testable in isolation).
+- Produces:
+  - `BACKOFF_MS: readonly number[]` — the deterministic retry schedule
+  - `attestationUrl(pkg: string, version: string): string`
+  - `fetchAttestations(pkg, version, deps: {fetchFn, sleep, backoff?}): Promise<{outcome: "body"|"absent"|"error", body?: unknown, detail: string}>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `actions/verify-npm-provenance/test/fetch-attestations.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BACKOFF_MS, attestationUrl, fetchAttestations } from "../src/fetch-attestations.js";
+
+const noSleep = async () => {};
+
+test("url uses the raw scoped name (all forms verified 200; raw is canonical)", () => {
+  assert.equal(
+    attestationUrl("@nimbus-dev/sdk", "1.3.0"),
+    "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0",
+  );
+});
+
+test("backoff is deterministic, ~2.5 min, capped at 30s (no jitter)", () => {
+  assert.deepEqual([...BACKOFF_MS], [5000, 10000, 20000, 30000, 30000, 30000, 30000]);
+  const total = BACKOFF_MS.reduce((a, b) => a + b, 0);
+  assert.equal(total, 155000);
+  assert.ok(Math.max(...BACKOFF_MS) === 30000);
+});
+
+test("200 on first attempt returns body without sleeping", async () => {
+  let slept = 0;
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => new Response(JSON.stringify({ attestations: [] }), { status: 200 }),
+    sleep: async () => { slept += 1; },
+  });
+  assert.equal(r.outcome, "body");
+  assert.deepEqual(r.body, { attestations: [] });
+  assert.equal(slept, 0);
+});
+
+test("404 retries the full schedule then reports absent", async () => {
+  let calls = 0;
+  const slept = [];
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => { calls += 1; return new Response("", { status: 404 }); },
+    sleep: async (ms) => { slept.push(ms); },
+  });
+  assert.equal(r.outcome, "absent");
+  assert.equal(calls, BACKOFF_MS.length + 1, "initial attempt plus one per backoff step");
+  assert.deepEqual(slept, [...BACKOFF_MS]);
+});
+
+test("404 then 200 succeeds without exhausting the schedule", async () => {
+  let calls = 0;
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => {
+      calls += 1;
+      return calls < 3
+        ? new Response("", { status: 404 })
+        : new Response(JSON.stringify({ attestations: [1] }), { status: 200 });
+    },
+    sleep: noSleep,
+  });
+  assert.equal(r.outcome, "body");
+  assert.equal(calls, 3);
+});
+
+test("5xx exhausts retries and reports error, not absent", async () => {
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => new Response("", { status: 503 }),
+    sleep: noSleep,
+  });
+  assert.equal(r.outcome, "error");
+  assert.match(r.detail, /503/);
+});
+
+test("network throw is error, never absent", async () => {
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => { throw new Error("ECONNRESET"); },
+    sleep: noSleep,
+  });
+  assert.equal(r.outcome, "error");
+});
+
+test("invalid JSON body is error, never a false absent", async () => {
+  const r = await fetchAttestations("@x/y", "1.0.0", {
+    fetchFn: async () => new Response("<html>502</html>", { status: 200 }),
+    sleep: noSleep,
+  });
+  assert.equal(r.outcome, "error");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test actions/verify-npm-provenance/test/fetch-attestations.test.js`
+
+Expected: FAIL — `Cannot find module '../src/fetch-attestations.js'`
+
+- [ ] **Step 3: Implement the fetcher**
+
+Create `actions/verify-npm-provenance/src/fetch-attestations.js`:
+
+```js
+/**
+ * Deterministic retry schedule: 5s doubling to a 30s cap, ~2.5 min total.
+ *
+ * Jitter is deliberately omitted. Jitter decorrelates a FLEET of clients
+ * retrying in lockstep; here exactly one client retries per publish, so it
+ * would only add nondeterminism to these tests. Do not re-add it.
+ */
+export const BACKOFF_MS = Object.freeze([5000, 10000, 20000, 30000, 30000, 30000, 30000]);
+
+const REGISTRY = "https://registry.npmjs.org/-/npm/v1/attestations";
+
+/**
+ * All three encodings of a scoped name (raw, fully percent-encoded, mixed)
+ * return HTTP 200 — verified against the live registry 2026-07-19. The raw
+ * form is canonical here; no encoding is required.
+ */
+export function attestationUrl(pkg, version) {
+  return `${REGISTRY}/${pkg}@${version}`;
+}
+
+/**
+ * Attestations can trail a publish, and the registry is CDN-fronted, so a 404
+ * is only conclusive once the backoff schedule is exhausted.
+ *
+ * Distinguishes "absent" (404 throughout — the package genuinely has no
+ * attestation) from "error" (5xx / network / unparseable). Callers map those
+ * to different severities.
+ */
+export async function fetchAttestations(pkg, version, deps) {
+  const backoff = deps.backoff ?? BACKOFF_MS;
+  const url = attestationUrl(pkg, version);
+  let lastDetail = "no attempt made";
+
+  for (let attempt = 0; attempt <= backoff.length; attempt += 1) {
+    if (attempt > 0) await deps.sleep(backoff[attempt - 1]);
+    try {
+      const res = await deps.fetchFn(url, { headers: { accept: "application/json" } });
+      if (res.status === 200) {
+        try {
+          return { outcome: "body", body: await res.json(), detail: "200" };
+        } catch {
+          return { outcome: "error", detail: "200 with unparseable JSON body" };
+        }
+      }
+      if (res.status === 404) {
+        lastDetail = "404 after full backoff";
+        continue;
+      }
+      lastDetail = `HTTP ${res.status}`;
+    } catch {
+      // Never surface the thrown error object: fetch errors can embed request
+      // headers, and this action runs in public logs.
+      lastDetail = "network error";
+    }
+  }
+  return lastDetail === "404 after full backoff"
+    ? { outcome: "absent", detail: lastDetail }
+    : { outcome: "error", detail: lastDetail };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test actions/verify-npm-provenance/test/`
+
+Expected: PASS — 20 tests total across both files, 0 failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/verify-npm-provenance
+git commit -m "feat: attestation fetch with deterministic backoff
+
+Distinguishes absent (404 throughout) from error (5xx/network/unparseable) so
+callers can map them to different severities. Never surfaces a thrown fetch
+error: those can embed request headers and this runs in public logs."
+```
+
+---
+
+## Task A3: Action entrypoint and interface
+
+**Files:**
+
+- Create: `actions/verify-npm-provenance/src/main.js`
+- Create: `actions/verify-npm-provenance/action.yml`
+- Create: `actions/verify-npm-provenance/test/main.test.js`
+
+**Interfaces:**
+
+- Consumes: `classifyProvenance`, `decodeStatements` (A1); `fetchAttestations` (A2).
+- Produces: action inputs `package`, `version`, `expected-repo`, `expected-workflow`, `expected-sha`, `severity`; outputs `status`, `detail`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `actions/verify-npm-provenance/test/main.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decide, exitCodeFor } from "../src/main.js";
+
+test("absent attestation is missing-provenance", () => {
+  const r = decide({ outcome: "absent", detail: "404 after full backoff" }, { repo: "a/b" });
+  assert.equal(r.status, "missing-provenance");
+});
+
+test("registry error is indeterminate, not a false failure claim", () => {
+  const r = decide({ outcome: "error", detail: "HTTP 503" }, { repo: "a/b" });
+  assert.equal(r.status, "indeterminate");
+});
+
+test("gate severity fails on anything other than ok", () => {
+  assert.equal(exitCodeFor("ok", "gate"), 0);
+  assert.equal(exitCodeFor("missing-provenance", "gate"), 1);
+  assert.equal(exitCodeFor("source-mismatch", "gate"), 1);
+  assert.equal(exitCodeFor("indeterminate", "gate"), 1);
+});
+
+test("monitor severity never fails the job — the caller classifies", () => {
+  assert.equal(exitCodeFor("ok", "monitor"), 0);
+  assert.equal(exitCodeFor("missing-provenance", "monitor"), 0);
+  assert.equal(exitCodeFor("indeterminate", "monitor"), 0);
+});
+
+test("same input yields different severity, same status", () => {
+  const input = { outcome: "error", detail: "HTTP 503" };
+  const status = decide(input, { repo: "a/b" }).status;
+  assert.equal(exitCodeFor(status, "gate"), 1);
+  assert.equal(exitCodeFor(status, "monitor"), 0);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test actions/verify-npm-provenance/test/main.test.js`
+
+Expected: FAIL — `Cannot find module '../src/main.js'`
+
+- [ ] **Step 3: Implement the entrypoint**
+
+Create `actions/verify-npm-provenance/src/main.js`:
+
+```js
+import { appendFileSync } from "node:fs";
+import { classifyProvenance, decodeStatements } from "./classify.js";
+import { fetchAttestations } from "./fetch-attestations.js";
+
+/** Map a fetch outcome plus the classifier into a single status. */
+export function decide(fetched, expected) {
+  if (fetched.outcome === "absent") {
+    return { status: "missing-provenance", detail: fetched.detail };
+  }
+  if (fetched.outcome === "error") {
+    // A registry problem is NOT evidence the publish was bad.
+    return { status: "indeterminate", detail: fetched.detail };
+  }
+  return classifyProvenance(decodeStatements(fetched.body), expected);
+}
+
+/**
+ * The gate must not let a possibly-degraded publish through; the monitor must
+ * not turn a registry hiccup into issue spam. Same status, different severity.
+ */
+export function exitCodeFor(status, severity) {
+  if (severity === "monitor") return 0;
+  return status === "ok" ? 0 : 1;
+}
+
+function runbook(pkg, version, status, detail) {
+  return [
+    "::error::npm provenance verification FAILED",
+    `::error::package=${pkg}@${version} status=${status} detail=${detail}`,
+    "::error::RUNBOOK:",
+    "::error::  1. This version is already on the registry. npm allows unpublish",
+    "::error::     only within 72h of publish — check the publish timestamp now.",
+    "::error::  2. Within 72h: `npm unpublish <pkg>@<version>`, fix the cause, republish.",
+    "::error::  3. After 72h: `npm deprecate <pkg>@<version> \"no provenance; use <next>\"`",
+    "::error::     then publish a patch version with provenance.",
+    "::error::  4. Common causes: `id-token: write` missing from the publish job;",
+    "::error::     npm older than 11.5.1; trusted-publisher binding removed on npmjs.com.",
+  ].join("\n");
+}
+
+if (process.env["NODE_ENV"] !== "test" && process.argv[1]?.endsWith("main.js")) {
+  const pkg = process.env["INPUT_PACKAGE"] ?? "";
+  const version = process.env["INPUT_VERSION"] ?? "";
+  const severity = process.env["INPUT_SEVERITY"] === "monitor" ? "monitor" : "gate";
+  const expected = { repo: process.env["INPUT_EXPECTED_REPO"] ?? "" };
+  const wf = process.env["INPUT_EXPECTED_WORKFLOW"];
+  const sha = process.env["INPUT_EXPECTED_SHA"];
+  if (wf) expected.workflow = wf;
+  if (sha) expected.sha = sha;
+
+  const fetched = await fetchAttestations(pkg, version, {
+    fetchFn: fetch,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  });
+  const { status, detail } = decide(fetched, expected);
+
+  const out = process.env["GITHUB_OUTPUT"];
+  if (out) appendFileSync(out, `status=${status}\ndetail=${detail}\n`);
+  console.log(`npm provenance: ${pkg}@${version} -> ${status} (${detail})`);
+  if (status !== "ok" && severity === "gate") console.log(runbook(pkg, version, status, detail));
+  process.exit(exitCodeFor(status, severity));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test actions/verify-npm-provenance/test/`
+
+Expected: PASS — 25 tests total, 0 failures
+
+- [ ] **Step 5: Create the action interface**
+
+Create `actions/verify-npm-provenance/action.yml`:
+
+```yaml
+name: Verify npm provenance
+description: >-
+  Assert a published npm version carries both the npm publish attestation and a
+  SLSA provenance predicate, and that the provenance names the expected source
+  repo/workflow/commit. Checks claims, not cryptography — pair with
+  `npm audit signatures` for signature verification.
+
+inputs:
+  package:
+    description: "npm package name, e.g. @nimbus-dev/sdk"
+    required: true
+  version:
+    description: "Published version to verify"
+    required: true
+  expected-repo:
+    description: "owner/repo that must appear in the provenance source claim"
+    required: true
+  expected-workflow:
+    description: "Workflow path that must have produced it, e.g. .github/workflows/release.yml"
+    required: false
+  expected-sha:
+    description: "Commit SHA the build must have come from"
+    required: false
+  severity:
+    description: "'gate' (default) fails the job on any non-ok status; 'monitor' always exits 0"
+    required: false
+    default: gate
+
+outputs:
+  status:
+    description: "ok | missing-provenance | source-mismatch | indeterminate"
+    value: ${{ steps.verify.outputs.status }}
+  detail:
+    description: "Short human-readable reason"
+    value: ${{ steps.verify.outputs.detail }}
+
+runs:
+  using: composite
+  steps:
+    - id: verify
+      shell: bash
+      # Node 20+ is preinstalled on GitHub runners; no setup-node, no install.
+      run: node "${{ github.action_path }}/src/main.js"
+      env:
+        INPUT_PACKAGE: ${{ inputs.package }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_EXPECTED_REPO: ${{ inputs.expected-repo }}
+        INPUT_EXPECTED_WORKFLOW: ${{ inputs.expected-workflow }}
+        INPUT_EXPECTED_SHA: ${{ inputs.expected-sha }}
+        INPUT_SEVERITY: ${{ inputs.severity }}
+```
+
+- [ ] **Step 6: Smoke-test the entrypoint against the live registry**
+
+```bash
+INPUT_PACKAGE='@nimbus-dev/sdk' INPUT_VERSION=1.3.0 \
+INPUT_EXPECTED_REPO=nimbus-agent/nimbus-sdk \
+INPUT_EXPECTED_WORKFLOW=.github/workflows/release.yml \
+node actions/verify-npm-provenance/src/main.js; echo "exit=$?"
+```
+
+Expected: `npm provenance: @nimbus-dev/sdk@1.3.0 -> ok (.github/workflows/release.yml @ https://github.com/nimbus-agent/nimbus-sdk)` and `exit=0`
+
+Then verify the failure path exits non-zero:
+
+```bash
+INPUT_PACKAGE='@nimbus-dev/sdk' INPUT_VERSION=1.3.0 \
+INPUT_EXPECTED_REPO=attacker/evil \
+node actions/verify-npm-provenance/src/main.js; echo "exit=$?"
+```
+
+Expected: status `source-mismatch`, runbook printed, `exit=1`
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add actions/verify-npm-provenance
+git commit -m "feat: verify-npm-provenance composite action
+
+Gate severity fails on any non-ok status; monitor severity always exits 0 and
+lets the caller classify — so a registry hiccup cannot spam the weekly issue
+filer while a degraded release still fails loudly. Prints an operator runbook
+on gate failure, including the 72h unpublish window and the deprecate path."
+git push -u origin dev/asafgolombek/supply-chain-actions
+gh pr create --repo nimbus-agent/.github --fill
+```
+
+---
+
+## Task A4: `probe-publish-token` action
+
+**Files:**
+
+- Create: `actions/probe-publish-token/action.yml`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: action inputs `tool` (`vsce`|`ovsx`), `namespace`; output `status` (`ok`|`dead`); token supplied by the caller as the `PUBLISH_TOKEN` env var.
+
+**Design note:** both CLIs ship a first-class `verify-pat` command and both read the token from the environment (`VSCE_PAT` / `OVSX_PAT`). Using them means our own code never handles the token at all — the non-disclosure contract is satisfied structurally rather than by careful coding. Do not hand-roll an HTTP probe here.
+
+- [ ] **Step 1: Create the action**
+
+Create `actions/probe-publish-token/action.yml`:
+
+```yaml
+name: Probe publish token
+description: >-
+  Liveness probe for a marketplace publish token using the vendor CLI's own
+  verify-pat command. The token is passed only via environment — never argv —
+  and neither the token nor any response body is logged.
+
+inputs:
+  tool:
+    description: "'vsce' (VS Code Marketplace) or 'ovsx' (Open VSX)"
+    required: true
+  namespace:
+    description: "Publisher / namespace to verify against, e.g. nimbus-agent"
+    required: true
+
+outputs:
+  status:
+    description: "ok | dead"
+    value: ${{ steps.probe.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - id: probe
+      shell: bash
+      # PUBLISH_TOKEN is mapped by the caller from the appropriate secret.
+      # It is exported into the vendor CLI's expected env var and never echoed.
+      # Output is discarded wholesale: error messages from these CLIs can echo
+      # request context, and this runs in a public repository's logs.
+      run: |
+        set +e
+        if [ -z "${PUBLISH_TOKEN}" ]; then
+          echo "status=dead" >> "$GITHUB_OUTPUT"
+          echo "probe ${TOOL}: token not configured"
+          exit 0
+        fi
+        if [ "${TOOL}" = "vsce" ]; then
+          VSCE_PAT="${PUBLISH_TOKEN}" npx --yes @vscode/vsce verify-pat "${NAMESPACE}" >/dev/null 2>&1
+        else
+          OVSX_PAT="${PUBLISH_TOKEN}" npx --yes ovsx verify-pat "${NAMESPACE}" >/dev/null 2>&1
+        fi
+        code=$?
+        if [ $code -eq 0 ]; then
+          echo "status=ok" >> "$GITHUB_OUTPUT"
+        else
+          echo "status=dead" >> "$GITHUB_OUTPUT"
+        fi
+        echo "probe ${TOOL} (${NAMESPACE}): exit=${code}"
+        exit 0
+      env:
+        TOOL: ${{ inputs.tool }}
+        NAMESPACE: ${{ inputs.namespace }}
+```
+
+- [ ] **Step 2: Verify `verify-pat` exists in both CLIs before relying on it**
+
+```bash
+npx --yes @vscode/vsce --help 2>&1 | grep -i "verify-pat"
+npx --yes ovsx --help 2>&1 | grep -i "verify-pat"
+```
+
+Expected: both print a `verify-pat` line.
+
+**If either does not:** stop and report. Do not substitute an invented HTTP endpoint — re-check the CLI's current docs and adjust the command, then continue.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add actions/probe-publish-token
+git commit -m "feat: probe-publish-token action via vendor verify-pat
+
+Uses each CLI's own verify-pat with the token in env, never argv, and discards
+all command output — these CLIs can echo request context in errors and this
+runs in public logs. Our code never handles the token itself."
+git push
+```
+
+---
+
+## Task B1: Monorepo health classifiers
+
+**Repo:** `nimbus-agent/Nimbus` · worktree `.claude/worktrees/npm-supply-chain-assurance` · branch `dev/asafgolombek/npm-supply-chain-assurance` (already exists, carries the spec commits)
+
+**Files:**
+
+- Modify: `scripts/release/check-secret-health.ts:58-85` (`HealthRow`, `summarize`)
+- Modify: `scripts/release/check-secret-health.ts:313-377` (`import.meta.main` block)
+- Modify: `scripts/release/check-secret-health.test.ts`
+
+**Interfaces:**
+
+- Consumes: the `status` output of `verify-npm-provenance` in monitor mode (Task A3), passed in as an env var — exactly like the existing `APP_MINT_STATUS` pattern.
+- Produces:
+  - `ProvenanceStatus = "ok" | "missing-provenance" | "source-mismatch" | "indeterminate" | "not-configured"`
+  - `classifyProvenanceOutcome(status: string): ProvenanceStatus`
+  - `classifySecretAbsence(value: string | undefined): "ok" | "present"`
+  - Widened `HealthRow.kind` to include `"provenance" | "absence"`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/release/check-secret-health.test.ts`:
+
+```ts
+import {
+  classifyProvenanceOutcome,
+  classifySecretAbsence,
+  summarize,
+  type HealthRow,
+} from "./check-secret-health.ts";
+
+describe("classifyProvenanceOutcome", () => {
+  test("passes through the action's known statuses", () => {
+    expect(classifyProvenanceOutcome("ok")).toBe("ok");
+    expect(classifyProvenanceOutcome("missing-provenance")).toBe("missing-provenance");
+    expect(classifyProvenanceOutcome("source-mismatch")).toBe("source-mismatch");
+    expect(classifyProvenanceOutcome("indeterminate")).toBe("indeterminate");
+  });
+
+  test("fails closed: unset or unrecognised is never ok", () => {
+    expect(classifyProvenanceOutcome("")).toBe("not-configured");
+    expect(classifyProvenanceOutcome("weird")).toBe("indeterminate");
+  });
+});
+
+describe("classifySecretAbsence", () => {
+  test("absent secret is ok — that is the desired state", () => {
+    expect(classifySecretAbsence(undefined)).toBe("ok");
+    expect(classifySecretAbsence("")).toBe("ok");
+  });
+
+  test("a returned secret is present, which is a failure", () => {
+    expect(classifySecretAbsence("npm_something")).toBe("present");
+  });
+});
+
+describe("summarize with the new row kinds", () => {
+  test("missing-provenance and source-mismatch are hard failures", () => {
+    for (const status of ["missing-provenance", "source-mismatch"] as const) {
+      const rows: HealthRow[] = [
+        { name: "@nimbus-dev/sdk", kind: "provenance", status, detail: "latest" },
+      ];
+      expect(summarize(rows).hasHardFailure).toBe(true);
+    }
+  });
+
+  test("a returned NPM_TOKEN is a hard failure", () => {
+    const rows: HealthRow[] = [
+      { name: "NPM_TOKEN", kind: "absence", status: "present", detail: "must not exist" },
+    ];
+    expect(summarize(rows).hasHardFailure).toBe(true);
+  });
+
+  test("provenance indeterminate warns but does not hard-fail", () => {
+    const rows: HealthRow[] = [
+      { name: "@nimbus-dev/sdk", kind: "provenance", status: "indeterminate", detail: "HTTP 503" },
+    ];
+    const s = summarize(rows);
+    expect(s.hasHardFailure).toBe(false);
+    expect(s.hasWarning).toBe(true);
+  });
+
+  test("all-clear stays clean", () => {
+    const rows: HealthRow[] = [
+      { name: "@nimbus-dev/sdk", kind: "provenance", status: "ok", detail: "latest" },
+      { name: "NPM_TOKEN", kind: "absence", status: "ok", detail: "absent" },
+    ];
+    const s = summarize(rows);
+    expect(s.hasHardFailure).toBe(false);
+    expect(s.hasWarning).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test scripts/release/check-secret-health.test.ts`
+
+Expected: FAIL — `classifyProvenanceOutcome is not a function`
+
+- [ ] **Step 3: Widen the row types and add the classifiers**
+
+In `scripts/release/check-secret-health.ts`, replace the `HealthRow` interface (currently lines 58-63) with:
+
+```ts
+export type ProvenanceStatus =
+  | "ok"
+  | "missing-provenance"
+  | "source-mismatch"
+  | "indeterminate"
+  | "not-configured";
+export type AbsenceStatus = "ok" | "present";
+
+/**
+ * The `verify-npm-provenance` composite action runs in monitor mode before this
+ * check and its `steps.<id>.outputs.status` is passed in via env — the same
+ * shape as the App-mint probe above. Fail closed: an unset value means the step
+ * never ran, and an unrecognised value is never silently "ok".
+ */
+export function classifyProvenanceOutcome(status: string): ProvenanceStatus {
+  if (status === "") return "not-configured";
+  if (
+    status === "ok" ||
+    status === "missing-provenance" ||
+    status === "source-mismatch" ||
+    status === "indeterminate"
+  ) {
+    return status;
+  }
+  return "indeterminate";
+}
+
+/**
+ * Regression guard for a secret that must NOT exist. `NPM_TOKEN` was revoked and
+ * deleted 2026-07-19; publishing is OIDC-only. An absent secret interpolates to
+ * the empty string, so emptiness is the healthy state. Tests emptiness only —
+ * the value is never logged or passed on.
+ */
+export function classifySecretAbsence(value: string | undefined): AbsenceStatus {
+  return value === undefined || value.length === 0 ? "ok" : "present";
+}
+
+export interface HealthRow {
+  readonly name: string;
+  readonly kind: "pat" | "cert" | "provenance" | "absence";
+  readonly status: PatStatus | CertStatus | ProvenanceStatus | AbsenceStatus;
+  readonly detail: string;
+}
+```
+
+Then in `summarize`, replace the `hard` set (currently line 71) with:
+
+```ts
+  const hard = new Set<string>([
+    "dead",
+    "insufficient",
+    "expired",
+    "missing-provenance",
+    "source-mismatch",
+    "present",
+  ]);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test scripts/release/check-secret-health.test.ts`
+
+Expected: PASS — all tests including the pre-existing ones
+
+- [ ] **Step 5: Wire the new rows into the entrypoint**
+
+In the `import.meta.main` block, after the existing `appMintRow` definition (currently line 362-367), add:
+
+```ts
+  const provenanceRows: HealthRow[] = [
+    {
+      name: "@nimbus-dev/sdk",
+      kind: "provenance",
+      status: classifyProvenanceOutcome(process.env["SDK_PROVENANCE_STATUS"] ?? ""),
+      detail: "latest published version",
+    },
+    {
+      name: "@nimbus-dev/client",
+      kind: "provenance",
+      status: classifyProvenanceOutcome(process.env["CLIENT_PROVENANCE_STATUS"] ?? ""),
+      detail: "latest published version",
+    },
+  ];
+  const npmTokenRow: HealthRow = {
+    name: "NPM_TOKEN",
+    kind: "absence",
+    status: classifySecretAbsence(process.env["NPM_TOKEN"]),
+    detail: "revoked 2026-07-19; publishing is OIDC-only",
+  };
+```
+
+Then change the `extraRows` argument (currently line 374) to:
+
+```ts
+    extraRows: [appMintRow, ...provenanceRows, npmTokenRow],
+```
+
+- [ ] **Step 6: Verify types and lint**
+
+Run: `bun run preflight:fast`
+
+Expected: PASS. If Biome reports the worktree issue from the known trap, validate instead with `bunx biome check scripts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/release/check-secret-health.ts scripts/release/check-secret-health.test.ts
+git commit -m "feat(secret-health): provenance + secret-absence health rows
+
+Reuses the classifyAppMint pattern: the verify-npm-provenance action runs in
+monitor mode and this classifies its output, so no checker logic is duplicated
+in TypeScript. missing-provenance and source-mismatch are hard failures;
+indeterminate only warns, so a registry hiccup cannot spam the issue filer.
+
+Adds a regression guard asserting NPM_TOKEN stays absent — it is bound as env
+and tested for emptiness only, since GITHUB_TOKEN cannot list repo secrets."
+```
+
+---
+
+## Task B2: Monitor workflow and docs
+
+**Files:**
+
+- Modify: `.github/workflows/secret-health.yml`
+- Modify: `docs/ci-secrets.md`
+
+**Interfaces:**
+
+- Consumes: `classifyProvenanceOutcome` / `classifySecretAbsence` env contract from B1 (`SDK_PROVENANCE_STATUS`, `CLIENT_PROVENANCE_STATUS`, `NPM_TOKEN`); the `verify-npm-provenance` action from A3.
+
+- [ ] **Step 1: Resolve the pinned SHA of the actions PR merge commit**
+
+```bash
+gh api repos/nimbus-agent/.github/commits/main --jq '.sha'
+```
+
+Record this value; it is `<ACTIONS_SHA>` below. Task A3's PR must be merged first.
+
+- [ ] **Step 2: Add the version-resolution and provenance probe steps**
+
+In `.github/workflows/secret-health.yml`, insert this block after the "Mint release-bot token (health probe)" step and before "Run secret-health check". Add it exactly as written — the probes depend on the `versions` step id defined here.
+
+```yaml
+      - name: Resolve latest published versions
+        id: versions
+        run: |
+          set -euo pipefail
+          echo "sdk=$(npm view @nimbus-dev/sdk version)" >> "$GITHUB_OUTPUT"
+          echo "client=$(npm view @nimbus-dev/client version)" >> "$GITHUB_OUTPUT"
+
+      - name: Probe @nimbus-dev/sdk provenance
+        id: sdk-provenance
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        with:
+          package: "@nimbus-dev/sdk"
+          version: ${{ steps.versions.outputs.sdk }}
+          expected-repo: nimbus-agent/nimbus-sdk
+          expected-workflow: .github/workflows/release.yml
+          severity: monitor
+
+      - name: Probe @nimbus-dev/client provenance
+        id: client-provenance
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        with:
+          package: "@nimbus-dev/client"
+          version: ${{ steps.versions.outputs.client }}
+          expected-repo: nimbus-agent/nimbus-client
+          expected-workflow: .github/workflows/release.yml
+          severity: monitor
+```
+
+Note there is no `expected-sha` here: the monitor checks whatever version is currently latest, whose commit is not knowable from this workflow. The release-time gate in Task C1 is where the commit is pinned.
+
+- [ ] **Step 3: Wire the outputs into the check's environment**
+
+In the "Run secret-health check" step's `env:` block, add:
+
+```yaml
+          SDK_PROVENANCE_STATUS: ${{ steps.sdk-provenance.outputs.status }}
+          CLIENT_PROVENANCE_STATUS: ${{ steps.client-provenance.outputs.status }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+`secrets.NPM_TOKEN` no longer exists, so it interpolates to the empty string — which is exactly the healthy state the absence guard asserts. Binding a deleted secret is intentional, not an oversight.
+
+- [ ] **Step 4: Validate the workflow parses**
+
+```bash
+bunx --yes @action-validator/cli@latest .github/workflows/secret-health.yml || \
+  python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/secret-health.yml')); print('yaml ok')"
+```
+
+Expected: no parse errors.
+
+- [ ] **Step 5: Update `docs/ci-secrets.md`**
+
+Add this section (place it after the existing npm/OIDC paragraph near line 197-201):
+
+````markdown
+### npm provenance verification
+
+Both `@nimbus-dev/sdk` and `@nimbus-dev/client` publish via OIDC trusted
+publishing and carry two attestations: the npm publish attestation and a
+SLSA provenance predicate naming the source repo, workflow, and commit.
+
+Publishing access on both packages is set to **require two-factor
+authentication and disallow tokens**, so OIDC is the only path that can
+publish — a leaked token cannot. `NPM_TOKEN` was revoked and deleted on
+2026-07-19; the weekly secret-health run asserts it stays absent.
+
+Verify a published version yourself:
+
+```bash
+npm audit signatures                       # registry signature verification
+curl -s "https://registry.npmjs.org/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0" \
+  | jq -r '.attestations[].predicateType'  # expect both predicates
+```
+
+The release workflows gate on this automatically: a pre-publish preflight
+asserts OIDC is available and npm meets the 11.5.1 floor, and a post-publish
+step fails the release if provenance is missing or names the wrong source.
+
+### Publish PATs that cannot yet be retired
+
+| Secret | Repo | Owner | Notes |
+| --- | --- | --- | --- |
+| `VSCE_PAT` | `nimbus-vscode` | @AsafGolombek | Azure DevOps PAT. ⚠️ **Global ADO PATs are decommissioned 2026-12-01** and cannot be regenerated since 2026-03-15. Marketplace trusted publishing is unshipped (microsoft/vsmarketplace#1422). |
+| `OVSX_PAT` | `nimbus-vscode` | @AsafGolombek | Open VSX token. No OIDC path exists (eclipse-openvsx/openvsx#1534); rotation is the only mitigation. |
+
+Both are probed weekly for liveness by `nimbus-vscode`'s own `secret-health.yml`.
+````
+
+- [ ] **Step 6: Lint the docs**
+
+Run: `bunx markdownlint-cli2 --config .markdownlint-cli2.jsonc docs/ci-secrets.md`
+
+Expected: `Summary: 0 error(s)`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/secret-health.yml docs/ci-secrets.md
+git commit -m "feat(secret-health): weekly npm provenance monitoring
+
+Runs verify-npm-provenance in monitor mode for both packages and feeds the
+result into the existing de-duped issue filer. Binds the deleted NPM_TOKEN
+secret deliberately: it interpolates empty, which is the healthy state the
+absence guard asserts.
+
+Documents the provenance verification recipe and the two publish PATs that
+cannot be retired, including the 2026-12-01 ADO decommission deadline."
+```
+
+---
+
+## Task C1: Satellite release gates (`nimbus-sdk` and `nimbus-client`)
+
+**Repos:** `nimbus-agent/nimbus-sdk`, then `nimbus-agent/nimbus-client` — identical change, applied twice.
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml` (publish job)
+
+**Interfaces:**
+
+- Consumes: `verify-npm-provenance` at `<ACTIONS_SHA>` (Task A3).
+
+**Per-repo values** — do not mix these up:
+
+| Repo | `expected-repo` | package |
+| --- | --- | --- |
+| `nimbus-sdk` | `nimbus-agent/nimbus-sdk` | `@nimbus-dev/sdk` |
+| `nimbus-client` | `nimbus-agent/nimbus-client` | `@nimbus-dev/client` |
+
+- [ ] **Step 1: Clone and branch (repeat per repo)**
+
+```bash
+git clone https://github.com/nimbus-agent/nimbus-sdk.git
+cd nimbus-sdk
+git switch -c dev/asafgolombek/provenance-gate
+```
+
+- [ ] **Step 2: Add the pre-publish preflight**
+
+In `.github/workflows/release.yml`, insert immediately **before** the "Publish to npm with provenance" step:
+
+```yaml
+      # Catch the two dominant causes of silent provenance degradation BEFORE
+      # publishing. npm cannot unpublish after 72h, so a post-publish failure
+      # reports damage rather than preventing it.
+      - name: Preflight — OIDC available and npm meets the trusted-publishing floor
+        run: |
+          set -euo pipefail
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::ACTIONS_ID_TOKEN_REQUEST_TOKEN is unset — the job lacks 'id-token: write'."
+            echo "::error::Publishing now would succeed WITHOUT provenance and cannot be undone after 72h."
+            exit 1
+          fi
+          have="$(npm --version)"
+          need="11.5.1"
+          if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -n1)" != "$need" ]; then
+            echo "::error::npm $have is below the $need floor required for OIDC trusted publishing."
+            exit 1
+          fi
+          echo "preflight ok: OIDC token present, npm $have >= $need"
+```
+
+- [ ] **Step 3: Resolve the published version and verify after publishing**
+
+Insert immediately **after** the "Publish to npm with provenance" step:
+
+```yaml
+      - name: Resolve published version
+        id: published
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Verify npm signatures (cryptographic)
+        run: npm audit signatures
+
+      - name: Verify provenance names this repo, workflow and commit
+        uses: nimbus-agent/.github/actions/verify-npm-provenance@<ACTIONS_SHA>
+        with:
+          package: "@nimbus-dev/sdk"
+          version: ${{ steps.published.outputs.version }}
+          expected-repo: nimbus-agent/nimbus-sdk
+          expected-workflow: .github/workflows/release.yml
+          expected-sha: ${{ github.sha }}
+          severity: gate
+```
+
+**For `nimbus-client`,** use `package: "@nimbus-dev/client"` and `expected-repo: nimbus-agent/nimbus-client`. Everything else is identical.
+
+- [ ] **Step 4: Validate the workflow parses**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"
+```
+
+Expected: `yaml ok`
+
+- [ ] **Step 5: Verify the preflight logic locally**
+
+The version comparison is the only non-trivial line; confirm it behaves:
+
+```bash
+for have in 11.5.0 11.5.1 11.9.0 12.0.0; do
+  need=11.5.1
+  if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -n1)" != "$need" ]; then
+    echo "$have -> REJECT"
+  else
+    echo "$have -> accept"
+  fi
+done
+```
+
+Expected:
+
+```text
+11.5.0 -> REJECT
+11.5.1 -> accept
+11.9.0 -> accept
+12.0.0 -> accept
+```
+
+- [ ] **Step 6: Commit and open the PR**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: gate releases on npm provenance
+
+Pre-publish preflight asserts OIDC is available and npm meets the 11.5.1
+trusted-publishing floor — the two dominant causes of silent degradation,
+both detectable before the irreversible step. Post-publish, npm audit
+signatures verifies cryptographically and verify-npm-provenance asserts the
+SLSA source claim names this repo, workflow and commit."
+git push -u origin dev/asafgolombek/provenance-gate
+gh pr create --fill
+```
+
+- [ ] **Step 7: Repeat Steps 1-6 for `nimbus-client`**
+
+Use the `nimbus-client` row from the table above. Do not copy the `nimbus-sdk` values.
+
+---
+
+## Task D1: `nimbus-vscode` health, attestation, and deadline issue
+
+**Repo:** `nimbus-agent/nimbus-vscode` · branch `dev/asafgolombek/publish-token-health`
+
+**Files:**
+
+- Create: `.github/workflows/secret-health.yml`
+- Modify: `.github/workflows/publish.yml`
+- Modify: `README.md`
+
+**Interfaces:**
+
+- Consumes: `probe-publish-token` at `<ACTIONS_SHA>` (Task A4).
+
+- [ ] **Step 1: Create the health workflow**
+
+The secrets stay where they are. Copying `VSCE_PAT`/`OVSX_PAT` into the monorepo to centralise monitoring would spread credentials to save a workflow file — a net loss.
+
+Create `.github/workflows/secret-health.yml`:
+
+```yaml
+name: Secret health
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC, matching the monorepo monitor
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Probe publish credentials
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Probe VSCE_PAT
+        id: vsce
+        uses: nimbus-agent/.github/actions/probe-publish-token@<ACTIONS_SHA>
+        with:
+          tool: vsce
+          namespace: nimbus-agent
+        env:
+          PUBLISH_TOKEN: ${{ secrets.VSCE_PAT }}
+
+      - name: Probe OVSX_PAT
+        id: ovsx
+        uses: nimbus-agent/.github/actions/probe-publish-token@<ACTIONS_SHA>
+        with:
+          tool: ovsx
+          namespace: nimbus-agent
+        env:
+          PUBLISH_TOKEN: ${{ secrets.OVSX_PAT }}
+
+      - name: Report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VSCE_STATUS: ${{ steps.vsce.outputs.status }}
+          OVSX_STATUS: ${{ steps.ovsx.outputs.status }}
+        run: |
+          set -euo pipefail
+          echo "| Credential | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| VSCE_PAT | ${VSCE_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| OVSX_PAT | ${OVSX_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${VSCE_STATUS}" != "ok" ] || [ "${OVSX_STATUS}" != "ok" ]; then
+            title="🔑 Publish credential health alert"
+            existing="$(gh issue list --state open --search "$title" --json number --jq '.[0].number // empty')"
+            body="VSCE_PAT=${VSCE_STATUS}, OVSX_PAT=${OVSX_STATUS}. A dead token blocks the next extension release. See docs/ci-secrets.md in the Nimbus monorepo."
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "$body"
+            else
+              gh issue create --title "$title" --body "$body"
+            fi
+            exit 1
+          fi
+          echo "both publish credentials healthy"
+```
+
+- [ ] **Step 2: Attest the `.vsix`**
+
+In `.github/workflows/publish.yml`, add `attestations: write` and `id-token: write` to the `publish` job's `permissions:` block, so it reads:
+
+```yaml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+```
+
+Then insert immediately **after** the "Package .vsix" step:
+
+```yaml
+      # Verifiable for anyone who downloads the .vsix from the GitHub Release.
+      # The Marketplace does its own repository signing and does not surface
+      # this attestation; we do not claim it covers a Marketplace download.
+      - name: Attest .vsix build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist-vsix/nimbus-${{ steps.version.outputs.version }}.vsix
+```
+
+- [ ] **Step 3: Document verification in `README.md`**
+
+Add this section:
+
+````markdown
+## Verifying a release
+
+Every release attaches a signed `.vsix` to the GitHub Release with a build
+provenance attestation. To verify the file you downloaded was built by this
+repository's publish workflow:
+
+```bash
+gh attestation verify nimbus-<version>.vsix --repo nimbus-agent/nimbus-vscode
+```
+
+This covers the `.vsix` attached to the **GitHub Release**. The Visual Studio
+Marketplace performs its own repository signing, which VS Code verifies at
+install time; that is a separate mechanism and this attestation is not
+surfaced through it.
+````
+
+- [ ] **Step 4: Validate and lint**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/secret-health.yml')); yaml.safe_load(open('.github/workflows/publish.yml')); print('yaml ok')"
+npx --yes markdownlint-cli2 README.md
+```
+
+Expected: `yaml ok`, then `Summary: 0 error(s)`
+
+- [ ] **Step 5: Trigger the health workflow once to confirm the probes work**
+
+Merge the PR first, then:
+
+```bash
+gh workflow run secret-health.yml --repo nimbus-agent/nimbus-vscode
+sleep 60
+gh run list --workflow secret-health.yml --repo nimbus-agent/nimbus-vscode --limit 1
+```
+
+Expected: a completed run. **Read the step summary**: both credentials should report `ok`. If either reports `dead`, that is a real finding — the token is already expired and the next release would have failed. Report it rather than adjusting the probe to pass.
+
+- [ ] **Step 6: File the deadline issue**
+
+```bash
+gh issue create --repo nimbus-agent/nimbus-vscode \
+  --title "Determine VSCE_PAT scope before the 2026-12-01 ADO global-PAT decommission" \
+  --body "$(cat <<'EOF'
+Global Azure DevOps PATs were blocked from creation on 2026-03-15 and are
+decommissioned on **2026-12-01**. If our `VSCE_PAT` is a global PAT, Marketplace
+publishing breaks then and the PAT **cannot be regenerated**.
+
+Investigate in this order — the cheap answer may end it:
+
+1. **Is the current `VSCE_PAT` global or org-scoped?** Check its scope in Azure
+   DevOps user settings. If org-scoped, the decommission may not apply at all.
+2. **Is an org-scoped PAT accepted for Marketplace publishing?** This is the
+   pivotal unknown: https://github.com/microsoft/vscode/issues/322741 (open,
+   unanswered). If yes, an org-scoped PAT is the fallback and **no Azure tenant
+   is needed** — this becomes a credential swap, not an infrastructure project.
+3. **Only if both answers are unfavourable**, price the token-less path:
+   `azure/login` (GitHub OIDC → federated credential on an Entra user-assigned
+   managed identity) + `vsce publish --azure-credential`. This requires an Azure
+   subscription and tenant, and for GitHub Actions it is community-documented,
+   not officially supported.
+
+Context: true Marketplace trusted publishing is an open, unassigned feature
+request (https://github.com/microsoft/vsmarketplace/issues/1422). Open VSX has
+no OIDC path at all (https://github.com/eclipse-openvsx/openvsx/issues/1534), so
+`OVSX_PAT` remains long-lived regardless; rotation is its only mitigation.
+
+Weekly liveness probes now run in `.github/workflows/secret-health.yml`, so a
+dead token surfaces within 7 days instead of at the next release.
+EOF
+)"
+```
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add .github/workflows/secret-health.yml .github/workflows/publish.yml README.md
+git commit -m "ci: probe publish credentials weekly, attest the .vsix
+
+VSCE_PAT and OVSX_PAT cannot be retired — Marketplace trusted publishing is
+unshipped and Open VSX has no OIDC path — so probe them where the secrets
+already live rather than copying credentials into the monorepo. A dead token
+now surfaces within 7 days instead of at the next release.
+
+Attests the .vsix and documents gh attestation verify for the GitHub Release
+copy, without claiming it covers a Marketplace download."
+git push -u origin dev/asafgolombek/publish-token-health
+gh pr create --fill
+```
+
+---
+
+## Task E1: Close out
+
+- [ ] **Step 1: Confirm every PR is green and merged**
+
+```bash
+for r in .github Nimbus nimbus-sdk nimbus-client nimbus-vscode; do
+  echo "=== $r ==="
+  gh pr list --repo "nimbus-agent/$r" --state open --json number,title,statusCheckRollup \
+    --jq '.[] | "\(.number) \(.title) \(.statusCheckRollup | map(.conclusion) | unique)"'
+done
+```
+
+Expected: no open PRs from this plan. Do not merge anything not fully green.
+
+- [ ] **Step 2: Trigger the monorepo monitor and confirm the new rows appear**
+
+```bash
+gh workflow run secret-health.yml --repo nimbus-agent/Nimbus
+sleep 90
+gh run list --workflow secret-health.yml --repo nimbus-agent/Nimbus --limit 1
+```
+
+Expected: the step summary table contains `@nimbus-dev/sdk | provenance | ok`, `@nimbus-dev/client | provenance | ok`, and `NPM_TOKEN | absence | ok`.
+
+- [ ] **Step 3: Update the spec's cleanup table**
+
+Mark row 4 (the regression assertion) as done in
+`docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md`, then commit.
+
+- [ ] **Step 4: Record the outcome in `docs/CHANGELOG.md`**
+
+Follow the connector-docs convention: log the delivery in `docs/CHANGELOG.md`, not the `CLAUDE.md` status line.
+
+---
+
+## Verification Gate
+
+Do not report this plan complete until all of the following hold:
+
+- [ ] `node --test actions/**/test/` passes in `nimbus-agent/.github` (25 tests)
+- [ ] `bun test scripts/release/check-secret-health.test.ts` passes in the monorepo
+- [ ] `bun run preflight:fast` passes in the monorepo worktree
+- [ ] The live smoke test in Task A3 Step 6 returns `ok` / exit 0 for the real package **and** exit 1 for the wrong-repo case
+- [ ] `nimbus-vscode`'s `secret-health.yml` has completed one real run with both credentials `ok`
+- [ ] The monorepo `secret-health.yml` has completed one real run showing all three new rows
+- [ ] All five PRs merged green
+
+**Do not claim success on any step you have not actually run.** If a check fails, fix the cause — never adjust the check to pass.

--- a/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design-review.md
+++ b/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design-review.md
@@ -1,0 +1,87 @@
+# Design Review — npm Supply-Chain Assurance
+
+**Date:** 2026-07-19
+**Target:** [2026-07-19-npm-supply-chain-assurance-design.md](./2026-07-19-npm-supply-chain-assurance-design.md)
+
+## Open Questions & Suggestions
+
+### 1. Mitigation of Post-Publish Verification Failures
+
+* **Problem:** `verify-npm-provenance` is a post-publish check. If the check fails (e.g., provenance was not generated or mismatched the expected source), the package has already been published to the npm registry. Since npm packages can only be unpublished within 72 hours (and under strict conditions), a silent failure or degradation that is only caught after publishing requires immediate human intervention.
+* **Suggestion:**
+  * Define a clear runbook or alert procedure for when `verify-npm-provenance` fails in the release workflow. The failure must trigger a high-severity notification (e.g., filing a critical issue with specific labels, sending a slack hook if available, or printing a clear step-by-step guide in the run logs on how to retract the release).
+  * Consider adding a **pre-publish sanity check** in the CI workflow that asserts the presence of the `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variable (which verifies that `id-token: write` permission is active and GitHub's OIDC provider is available) before running `npm publish`.
+
+### 2. Registry Attestation API Retries and Backoff Strategy
+
+* **Problem:** The npm registry's attestation endpoint (`/-/npm/v1/attestations/`) can have replication delays across CDN edges. A simple linear retry mechanism (5 attempts over 60 seconds) might be too tight during peak registry loads or minor outages, leading to false-positive build failures.
+* **Suggestion:**
+  * Implement an exponential backoff retry strategy with a jitter (e.g., starting at 5s, doubling each time up to a maximum of 30s) spanning a slightly longer window (e.g., 2–3 minutes total) to ensure maximum robustness against registry lag.
+
+### 3. Masking & Redaction in `probe-publish-token`
+
+* **Problem:** The `probe-publish-token` action will handle extremely sensitive credentials (`VSCE_PAT` and `OVSX_PAT`). If the API responses or debug logs accidentally output parts of the request payload, headers, or error messages, these credentials could be leaked into the public GitHub Actions execution logs.
+* **Suggestion:**
+  * The design must explicitly state that `probe-publish-token` will never log the tokens, request headers, or raw response bodies.
+  * Ensure that standard `core.setSecret()` or environment masking is used if the tokens are processed dynamically, and sanitize any error outputs to strip potential credential leakages.
+
+### 4. Azure DevOps PAT Retirement Fallback Plan
+
+* **Problem:** The Microsoft Azure DevOps retirement of global PATs is scheduled for **2026-12-01**. The replacement path (`azure/login` + Entra user-assigned managed identity) requires an active Azure tenant and subscription, which adds overhead and configuration complexity.
+* **Suggestion:**
+  * The tracked issue for `nimbus-vscode` should prioritize confirming if org-scoped Azure DevOps PATs (which are NOT global PATs and might survive the transition) are supported for VS Marketplace publishing.
+  * If org-scoped PATs are supported, they should be used as the immediate fallback to avoid having to provision an Azure tenant/subscription solely for vscode extension publishing.
+
+### 5. Registry Attestation API Endpoint Structure
+
+* **Problem:** The endpoint `https://registry.npmjs.org/-/npm/v1/attestations/<package>@<version>` is used to retrieve attestations. The package name might contain a scope (e.g., `@nimbus-dev/sdk`), which means it contains a `/` character (e.g., `/-/npm/v1/attestations/@nimbus-dev/sdk@1.3.0`).
+* **Suggestion:**
+  * Ensure the package name scope is properly URI-encoded when constructing the request URL (e.g., replacing `@nimbus-dev/sdk` with `%40nimbus-dev%2Fsdk` if required by the registry endpoint design). The design and testing implementation should verify the exact URL format accepted by npm for scoped packages.
+
+## Resolutions
+
+Recorded 2026-07-19 against design revision 2. Each item is accepted, modified, or resolved by evidence — none are deferred.
+
+### 1. Post-publish failure mitigation — **ACCEPTED, and the design was strengthened beyond the suggestion**
+
+The strongest finding in this review. The critique that post-publish verification is structurally late is correct, and the suggested `ACTIONS_ID_TOKEN_REQUEST_TOKEN` assertion is the right lever: that variable is injected only when `id-token: write` is in effect, so its absence detects the most likely regression — an unrelated permissions edit — *before* anything irreversible occurs.
+
+The design now specifies a **pre-publish preflight** asserting both that variable's presence **and** an `npm >= 11.5.1` floor (the second dominant degradation cause, since it exceeds the npm bundled with Node 22 and both satellites currently paper over it with `npm install -g npm@latest`). The post-publish gate is retained — the preflight cannot prove an attestation was actually recorded — so the two are complementary, not alternatives.
+
+A failure runbook is specified for the gate's failure path (package, version, failed assertion, whether the 72-hour unpublish window is open, deprecate-and-republish path otherwise). **Slack notification was not adopted:** the org has no release webhook today, and creating one would add an unowned integration to a program whose purpose is reducing unowned surface. The existing de-duped issue filer from sub-project 1 carries the alert instead.
+
+### 2. Retry backoff — **ACCEPTED with one deliberate modification**
+
+Exponential backoff adopted: 5s doubling to a 30s cap, spanning roughly 2.5 minutes, replacing the original 5-attempts-over-60s.
+
+**Jitter was not adopted, deliberately.** Jitter decorrelates a *fleet* of clients retrying in lockstep. Here exactly one client retries per publish, so there is no correlated load to spread — it would only introduce nondeterminism into the backoff-schedule tests. The reasoning is recorded in the design so it is not re-proposed later.
+
+### 3. Credential masking in `probe-publish-token` — **ACCEPTED**
+
+Correct and load-bearing: this action handles two live publish credentials in a public repository's logs. The design now carries an explicit non-disclosure contract — tokens via environment only and never on argv (matching the cert-decoder precedent from sub-project 1), masking registered at entry, logging restricted to the derived classification and HTTP status, and **error paths scrubbed**, since client libraries routinely embed request headers in thrown errors. That last point is the one most easily missed, so it is called out separately and covered by a test asserting no token value appears on any path.
+
+### 4. Azure DevOps fallback ordering — **ACCEPTED**
+
+The suggestion to exhaust the cheap answer first is right, and the tracked issue is now explicitly **ordered**: (1) determine whether the current `VSCE_PAT` is global or org-scoped; (2) establish whether an org-scoped PAT is accepted for Marketplace publishing — the pivotal unknown, [microsoft/vscode#322741](https://github.com/microsoft/vscode/issues/322741), still open and unanswered; (3) price the Azure path **only** if both answers are unfavourable. If an org-scoped PAT works, this reduces from an infrastructure project to a credential swap and no Azure tenant is needed.
+
+### 5. Scoped-package URL encoding — **RESOLVED BY MEASUREMENT; no change required**
+
+Tested against the live registry rather than reasoned about. All three candidate forms return **HTTP 200**:
+
+| Form | Result |
+| --- | --- |
+| Raw — `@nimbus-dev/sdk@1.3.0` | 200 |
+| Fully percent-encoded — `%40nimbus-dev%2Fsdk@1.3.0` | 200 |
+| Mixed — `%40nimbus-dev/sdk@1.3.0` | 200 |
+| Nonexistent version — `@nimbus-dev/sdk@99.99.99` | 404 |
+
+The registry normalises all three, so the concern does not manifest. The implementation uses the raw form; the 404 result also confirms the "no attestation published" signal shape the classifier depends on. Both are now recorded in the design with fixtures pinning them, so a registry-side change surfaces as a test failure rather than a release-time surprise.
+
+### Note on the Alignment section below
+
+One wording correction: OIDC trusted publishing was **not** introduced by this sub-project — it was already live before it began, having landed as a side-effect of the SDK and client extractions. What this sub-project eliminates is the **orphan** `NPM_TOKEN` secret (referenced by zero workflows) and the token-publishing bypass that made OIDC merely preferred rather than enforced. The described detection mechanism is accurate.
+
+## Alignment with Invariants
+
+* **Credentials Handling (Non-Negotiable 3):** The OIDC migration completely eliminates the long-lived `NPM_TOKEN`. The `NPM_TOKEN` orphan detection mechanism safely verifies non-existence in `check-secret-health.ts` using binary presence detection (empty/non-empty env check) without ever logging or exposing the value if it exists.
+* **HITL Consent (Non-Negotiable 2 / I2):** Release checks and secret health checks operate entirely within the CI/CD pipeline and do not bypass local consent gates or execution controls on nimbus instances.

--- a/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
+++ b/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
@@ -49,16 +49,24 @@ Researched 2026-07-19. This section exists so the deferral in Non-goals is audit
 - **Open VSX.** Long-lived `OVSX_PAT` is the only option. Trusted publishing is [eclipse-openvsx/openvsx#1534](https://github.com/eclipse-openvsx/openvsx/issues/1534) — open, unassigned, nothing shipped.
 - **`.vsix` signing.** The Marketplace performs *repository* signing (proving "served by the Marketplace"), not publisher signing; publisher-held signing remains a proposal. A `attest-build-provenance` attestation on a `.vsix` is therefore verifiable only by someone who downloads the **GitHub release asset** and runs `gh attestation verify` deliberately.
 
-## Credential cleanup — ordered, human-gated
+## Credential cleanup — **executed 2026-07-19**
 
-Order matters: revoking before deleting preserves the token id needed to find it.
+Completed before implementation began, so the plan inherits a clean state.
 
-1. **Human:** `npm token list`, then revoke the token backing `NPM_TOKEN` on npmjs.com. *This is the step that removes the risk* — deleting the GitHub secret only removes a copy.
-2. **Automated:** `gh secret delete NPM_TOKEN --repo nimbus-agent/Nimbus`. Safe at any time: zero workflows reference it.
-3. **Human:** on both `@nimbus-dev/sdk` and `@nimbus-dev/client`, set publishing access to **require two-factor authentication and disallow tokens**. This is what converts OIDC from preferred to enforced.
-4. **Automated:** a regression assertion in the weekly monitor that fails if an `NPM_TOKEN` secret ever reappears.
+| # | Step | Status |
+| --- | --- | --- |
+| 1 | Set publishing access to **require 2FA and disallow tokens** on `@nimbus-dev/sdk` and `@nimbus-dev/client` (`npm access set mfa=publish`) | ✅ done (owner) |
+| 2 | Revoke the token backing `NPM_TOKEN` (`npm token revoke 301b01`) | ✅ done (owner) — verified: `npm token list` now returns empty |
+| 3 | `gh secret delete NPM_TOKEN --repo nimbus-agent/Nimbus` | ✅ done — verified absent from `gh secret list` |
+| 4 | Regression assertion in the weekly monitor so the secret cannot silently return | ⬜ implementation scope |
 
-Steps 1 and 3 are owner actions on npmjs.com and are prerequisites recorded in the plan, not something the implementation performs.
+**The documented order was inverted during execution, deliberately.** The original plan said revoke-then-configure, on the assumption that the CLI session and the CI credential were distinct. They were not: `npm token list` showed exactly **one** token, `id 301b01` created `2026-06-14` — matching the GitHub secret's creation date, and also authenticating the local CLI. Revoking first would have ended the session mid-sequence, before the package policies could be set. Configure-then-revoke was the correct order.
+
+Steps 1 and 2 each required an interactive one-time password (browser auth), so both are necessarily owner actions; automation cannot perform them.
+
+**Finding for sub-project 4.** A single npm credential appears to have served as *both* a workstation `~/.npmrc` token and the CI secret. That shared-credential pattern — one leak compromising two very differently-exposed environments — is precisely what the rotation-and-inventory work should detect, and it is not visible from CI-side inspection alone. Recorded here so #4 inherits it as evidence rather than a hunch.
+
+The `mfa=publish` setting is **not machine-verifiable**: npm exposes no `access get mfa` command and the value is absent from public registry metadata. Its failure mode surfaces only at the next release, which is an additional argument for the post-publish gate specified above.
 
 ## Architecture: shared actions in `nimbus-agent/.github`
 

--- a/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
+++ b/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
@@ -78,10 +78,14 @@ Both actions are **composite actions running dependency-free Node** (GitHub runn
 
 Fetches `https://registry.npmjs.org/-/npm/v1/attestations/<package>@<version>` and asserts:
 
+**URL form for scoped packages — empirically settled 2026-07-19.** All three candidate encodings return HTTP 200 against the live registry: the raw form (`@nimbus-dev/sdk@1.3.0`), the fully percent-encoded form (`%40nimbus-dev%2Fsdk@1.3.0`), and the mixed form (`%40nimbus-dev/sdk@1.3.0`). The implementation uses the **raw form**; no encoding gymnastics are required. A nonexistent version returns **404**, confirming 404 as the "no attestation published" signal. Fixtures pin both shapes so a registry-side change to either surfaces as a test failure.
+
 - **Both** predicate types are present — `https://github.com/npm/attestation/tree/main/specs/publish/v0.1` **and** `https://slsa.dev/provenance/v1`. A publish attestation alone means provenance silently degraded.
 - The SLSA predicate's `buildDefinition` source claim matches `expected-repo` (and `expected-workflow` / `expected-sha` when supplied). This is the difference between "an attestation exists" and "attested to us".
 
-**Attestation lag.** Attestations can trail the publish by seconds, so the action retries with backoff (5 attempts across roughly 60 seconds) before concluding absence.
+**Attestation lag.** Attestations can trail the publish, and the registry is CDN-fronted with edge replication delay, so the action retries before concluding absence: **exponential backoff starting at 5s and doubling to a 30s cap, spanning roughly 2.5 minutes total** (5s, 10s, 20s, 30s, 30s, 30s…). A 404 is only conclusive once that window is exhausted.
+
+**Jitter is deliberately omitted.** Jitter exists to decorrelate a *fleet* of clients retrying in lockstep. Here there is exactly one client per publish, so jitter adds nondeterminism to the test surface and buys nothing. Recorded so it isn't re-proposed later.
 
 **Failure semantics differ by caller, deliberately:**
 
@@ -93,9 +97,22 @@ Fetches `https://registry.npmjs.org/-/npm/v1/attestations/<package>@<version>` a
 
 The monitor must not convert a registry hiccup into issue spam; the release gate must not let a possibly-degraded publish through. Same classifier, different severity mapping supplied by the caller.
 
+### Pre-publish preflight — catching degradation *before* it is permanent
+
+Post-publish verification is necessary but structurally late: npm versions cannot be unpublished after 72 hours, so a failed gate reports damage rather than preventing it. The two dominant causes of silent provenance degradation are both detectable **before** `npm publish` runs, so the satellites gain a preflight step that converts a permanent problem into an ordinary job abort:
+
+- **Assert `ACTIONS_ID_TOKEN_REQUEST_TOKEN` is present.** This variable is injected into the job environment only when `id-token: write` is in effect. Its absence means OIDC is unavailable — the single most likely regression, since it can be introduced by an unrelated permissions edit. It is a short-lived request token, never logged; the check tests presence only.
+- **Assert `npm --version` is at least 11.5.1.** Trusted publishing requires it, and it is newer than the npm bundled with Node 22. Both satellites currently install `npm@latest` to compensate; asserting the floor means a regression in that step fails loudly instead of silently degrading to a token-era publish path.
+
+The post-publish gate remains — the preflight cannot prove the attestation was actually recorded — but the expensive, irreversible failure mode is now caught early.
+
+**Failure runbook.** When the post-publish gate fails, the release job prints an explicit operator runbook: the affected package and version, which assertion failed, whether the 72-hour unpublish window is still open, and the deprecate-and-republish path once it is not. The weekly monitor's finding routes through the **existing** de-duped issue filer from sub-project 1 rather than a new alerting channel. No Slack notification is specified: the org has no release webhook today, and inventing one here would add an unowned integration to a program about reducing unowned surface.
+
 ### `actions/probe-publish-token`
 
 Liveness probes for the two credentials that cannot be retired: `VSCE_PAT` against the Azure DevOps Marketplace API, `OVSX_PAT` against the open-vsx API. Classification matches the existing `check-secret-health.ts` vocabulary — HTTP 200 is `ok`, 401 is `dead`, anything else is `indeterminate`.
+
+**Non-disclosure contract (Non-Negotiable 3).** This action handles two live publish credentials in a public repository's logs. It therefore: passes tokens only via environment, never on argv (matching the cert-decoder precedent from sub-project 1); registers each token for masking at entry; logs **only** the derived classification and HTTP status — never the token, request headers, or raw response bodies; and scrubs error paths, since client libraries routinely embed request headers in thrown errors. Tests assert that no probe output contains the token value on **any** path, including the error path.
 
 The `.github` repo gains a minimal `bun test` CI workflow to cover both actions' classifiers. This is the cost of the chosen topology and is accepted.
 
@@ -103,7 +120,7 @@ The `.github` repo gains a minimal `bun test` CI workflow to cover both actions'
 
 | Repo | Change |
 | --- | --- |
-| `nimbus-sdk`, `nimbus-client` | A post-publish step in `release.yml` calling `verify-npm-provenance` (SHA-pinned) with the just-published version. A degraded publish now fails loudly at release time — the 72-hour unpublish window makes late detection worthless. |
+| `nimbus-sdk`, `nimbus-client` | A **pre-publish preflight** (OIDC token present, npm floor met) that aborts before anything irreversible happens, plus a **post-publish** step calling `verify-npm-provenance` (SHA-pinned) with the just-published version. A degraded publish now fails loudly at release time — the 72-hour unpublish window makes late detection worthless. |
 | `Nimbus` (this repo) | `scripts/release/check-secret-health.ts` gains one provenance row per package (latest published version attested to the expected repo) plus the no-orphan-`NPM_TOKEN` assertion. Both feed the **existing** de-duped issue filer from sub-project 1 — no new alerting surface. The registry endpoint is public, so this needs no credentials. |
 | `nimbus-vscode` | Its own `secret-health.yml` calling `probe-publish-token` **where the secrets already live**. `VSCE_PAT` / `OVSX_PAT` are deliberately **not** copied into the monorepo — spreading credentials to centralise monitoring would be a net loss. Also adds `attest-build-provenance` over the packaged `.vsix`. |
 
@@ -111,7 +128,13 @@ The `.github` repo gains a minimal `bun test` CI workflow to cover both actions'
 
 ## Deadline de-risk
 
-A tracked issue on `nimbus-vscode` to determine whether the current `VSCE_PAT` is global or org-scoped and to decide the Azure-OIDC question with real numbers. Combined with weekly probes, a dead token surfaces within seven days instead of at the next release — which is precisely the regression class this whole program exists to eliminate.
+A tracked issue on `nimbus-vscode`, with an explicitly **ordered** investigation so the cheap answer is exhausted before the expensive one:
+
+1. **Determine whether the current `VSCE_PAT` is global or org-scoped.** If org-scoped, it is not covered by the 2026-12-01 decommission and the cliff may not apply at all.
+2. **Establish whether an org-scoped PAT is accepted for Marketplace publishing.** This is the pivotal unknown ([microsoft/vscode#322741](https://github.com/microsoft/vscode/issues/322741), open, unanswered). If yes, an org-scoped PAT is the immediate fallback and **no Azure tenant is required** — reducing this from an infrastructure project to a credential swap.
+3. **Only if both answers are unfavourable**, price the `azure/login` + Entra managed-identity path. Provisioning an Azure subscription solely to publish one VS Code extension is a real cost and must be a deliberate, evidenced decision rather than a default.
+
+Combined with weekly probes, a dead token surfaces within seven days instead of at the next release — which is precisely the regression class this whole program exists to eliminate.
 
 ## Documentation
 
@@ -130,6 +153,10 @@ Pure classifiers are unit-tested against **real captured** attestation bundles, 
 - registry 5xx and network error
 - malformed / truncated JSON
 - the severity-mapping split: identical input classified `fail` for the gate and `indeterminate` for the monitor
+- backoff schedule shape (deterministic, since jitter is omitted) and the retry-exhaustion boundary
+- scoped-package URL construction, pinned against the empirically confirmed forms
+- preflight: missing `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, and npm below the 11.5.1 floor
+- **non-disclosure**: no probe output on any path — success, `dead`, `indeterminate`, or thrown error — contains a token value
 
 Monorepo-side changes follow the existing `scripts/release/` conventions — pure functions, injected API surface, Bun tests alongside.
 

--- a/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
+++ b/docs/superpowers/specs/2026-07-19-npm-supply-chain-assurance-design.md
@@ -1,0 +1,154 @@
+# npm Supply-Chain Assurance — Design
+
+> **Status:** Design — approved in brainstorm (2026-07-19); ready for implementation plan.
+> **Sub-project 3 of 4** in the org secrets-management program. Sub-project 1 (release-health verification + secret-health monitor) shipped in #768; sub-project 2 (GitHub App migration) shipped in #772. The remaining sub-project is #4 (rotation calendar + env/push-protection hardening).
+
+## Problem
+
+This sub-project was scoped as *"npm OIDC trusted publishing + keyless signing, to retire the long-lived `NPM_TOKEN`."* **That work is already live.** Verified against the registry, not the docs:
+
+| Check | Finding |
+| --- | --- |
+| `nimbus-sdk` / `nimbus-client` `release.yml` | `id-token: write`, `npm publish --provenance`, **no `NODE_AUTH_TOKEN`** — OIDC trusted publishing |
+| `@nimbus-dev/sdk@1.3.0` attestations | `npm/publish/v0.1` **and** `slsa.dev/provenance/v1` |
+| `@nimbus-dev/client@0.5.0` attestations | same, both predicates |
+| `NPM_TOKEN` referenced by any workflow in any of the 5 repos | **zero references** |
+
+It landed as a side-effect of the SDK and client extractions. So the residual risk is not *"we lack OIDC"* — it is that **the OIDC guarantee is unverified, silently degradable, and bypassable**:
+
+1. **`NPM_TOKEN` is a live orphan credential** on `nimbus-agent/Nimbus` (created 2026-06-14), consumed by nothing. A standing publish credential with no purpose.
+2. **Nothing verifies provenance actually landed.** `npm publish --provenance` degrades quietly — a missing `id-token: write`, an npm older than 11.5.1, or a registry hiccup can yield a *successful publish with no attestation*. npm versions cannot be unpublished after 72 hours, so a degraded release is permanent.
+3. **Nothing verifies provenance points at *us*.** "An attestation exists" is a weaker claim than "attested to this repo, this workflow, this commit."
+4. **Token publishing remains a bypass.** While the packages accept classic/granular tokens, OIDC is merely *preferred*, not *enforced*.
+5. **`nimbus-vscode` still carries two long-lived publish PATs** (`VSCE_PAT`, `OVSX_PAT`) with no expiry visibility — the exact failure mode that caused the v0.17–v0.21 phantom releases.
+
+## Goals
+
+- Revoke and remove the orphan `NPM_TOKEN`, and assert it never returns.
+- Make OIDC **load-bearing** rather than preferred, by disallowing token publishing on both packages.
+- **Verify** at release time that each publish produced a full attestation set naming this repo, this workflow, and this commit — failing the job when it does not.
+- Monitor published provenance **continuously**, folded into the existing weekly secret-health report.
+- Gain expiry/liveness **visibility** on `VSCE_PAT` and `OVSX_PAT`, and surface the 2026-12-01 Azure DevOps deadline as tracked work.
+- Ship the shared logic once, consumed by all repos that need it.
+
+## Non-goals
+
+- **Azure/Entra tenancy for Marketplace OIDC.** See "Marketplace and Open VSX — what is actually possible" below. Deliberately deferred to #4 as an informed decision, not an oversight.
+- **Open VSX federation.** Does not exist (see below).
+- **cosign for the Nimbus binaries.** `release.yml` already runs `actions/attest-build-provenance`; adding a second signing scheme is duplicated surface, not added assurance.
+- **The sub-project #2 leftovers** — deleting the three retired PATs after a full release cycle, and tightening `release-please.yml` job permissions to `contents: read`. Both stay on their own track.
+- **A new `release-tooling` repo.** Considered and rejected: the shareable surface is one small checker used by three repos, and a dedicated repo would need its own CI, branch protection, and publish pipeline — adding release surface to a program whose purpose is shrinking it. Revisit if the shared surface grows beyond two or three actions.
+
+## Marketplace and Open VSX — what is actually possible
+
+Researched 2026-07-19. This section exists so the deferral in Non-goals is auditable rather than assumed.
+
+- **Visual Studio Marketplace.** True trusted publishing (GitHub OIDC to Marketplace, npm-style) is an open, unassigned feature request: [microsoft/vsmarketplace#1422](https://github.com/microsoft/vsmarketplace/issues/1422). The only shipped token-less path is `azure/login` (GitHub OIDC to a federated credential on an Entra user-assigned managed identity) followed by `vsce publish --azure-credential` (requires `vsce` >= 2.26.1). That path needs **an Azure subscription and tenant**, and for GitHub Actions it is community-documented, not officially supported.
+- **Deadline.** Global Azure DevOps PATs were blocked from creation on **2026-03-15** and are decommissioned on **2026-12-01** ([retirement announcement](https://devblogs.microsoft.com/devops/retirement-of-global-personal-access-tokens-in-azure-devops/)). If the current `VSCE_PAT` is a global PAT, vscode publishing breaks then and the PAT **cannot be regenerated**. Whether an org-scoped PAT is even accepted for Marketplace publishing is itself unresolved: [microsoft/vscode#322741](https://github.com/microsoft/vscode/issues/322741).
+- **Auto-rotation is not available.** The Azure DevOps PAT Lifecycle Management API refuses service principals and managed identities, so a workflow cannot rotate its own `VSCE_PAT` unattended.
+- **Open VSX.** Long-lived `OVSX_PAT` is the only option. Trusted publishing is [eclipse-openvsx/openvsx#1534](https://github.com/eclipse-openvsx/openvsx/issues/1534) — open, unassigned, nothing shipped.
+- **`.vsix` signing.** The Marketplace performs *repository* signing (proving "served by the Marketplace"), not publisher signing; publisher-held signing remains a proposal. A `attest-build-provenance` attestation on a `.vsix` is therefore verifiable only by someone who downloads the **GitHub release asset** and runs `gh attestation verify` deliberately.
+
+## Credential cleanup — ordered, human-gated
+
+Order matters: revoking before deleting preserves the token id needed to find it.
+
+1. **Human:** `npm token list`, then revoke the token backing `NPM_TOKEN` on npmjs.com. *This is the step that removes the risk* — deleting the GitHub secret only removes a copy.
+2. **Automated:** `gh secret delete NPM_TOKEN --repo nimbus-agent/Nimbus`. Safe at any time: zero workflows reference it.
+3. **Human:** on both `@nimbus-dev/sdk` and `@nimbus-dev/client`, set publishing access to **require two-factor authentication and disallow tokens**. This is what converts OIDC from preferred to enforced.
+4. **Automated:** a regression assertion in the weekly monitor that fails if an `NPM_TOKEN` secret ever reappears.
+
+Steps 1 and 3 are owner actions on npmjs.com and are prerequisites recorded in the plan, not something the implementation performs.
+
+## Architecture: shared actions in `nimbus-agent/.github`
+
+The org's `.github` repo already exists, is public, and currently holds only community-health files. It gains an `actions/` directory. Consumers pin by SHA, matching the org's existing `sha_pinning_required` discipline.
+
+Both actions are **composite actions running dependency-free Node** (GitHub runners ship Node 20, so no setup step and no install), with **pure classifier functions separated from all I/O** so the decision logic is unit-testable without network.
+
+### `actions/verify-npm-provenance`
+
+| Input | Meaning |
+| --- | --- |
+| `package` | npm package name, e.g. `@nimbus-dev/sdk` |
+| `version` | version just published |
+| `expected-repo` | `owner/repo` that must appear in the provenance source claim |
+| `expected-workflow` | *(optional)* workflow path that must have produced it |
+| `expected-sha` | *(optional)* commit the build must have come from |
+
+Fetches `https://registry.npmjs.org/-/npm/v1/attestations/<package>@<version>` and asserts:
+
+- **Both** predicate types are present — `https://github.com/npm/attestation/tree/main/specs/publish/v0.1` **and** `https://slsa.dev/provenance/v1`. A publish attestation alone means provenance silently degraded.
+- The SLSA predicate's `buildDefinition` source claim matches `expected-repo` (and `expected-workflow` / `expected-sha` when supplied). This is the difference between "an attestation exists" and "attested to us".
+
+**Attestation lag.** Attestations can trail the publish by seconds, so the action retries with backoff (5 attempts across roughly 60 seconds) before concluding absence.
+
+**Failure semantics differ by caller, deliberately:**
+
+| Condition | Post-publish gate | Weekly monitor |
+| --- | --- | --- |
+| Predicate missing / source mismatch | **fail** | **fail** (files an issue) |
+| Registry 404 after retries | **fail** | `indeterminate` |
+| Registry 5xx / network error | **fail** | `indeterminate` |
+
+The monitor must not convert a registry hiccup into issue spam; the release gate must not let a possibly-degraded publish through. Same classifier, different severity mapping supplied by the caller.
+
+### `actions/probe-publish-token`
+
+Liveness probes for the two credentials that cannot be retired: `VSCE_PAT` against the Azure DevOps Marketplace API, `OVSX_PAT` against the open-vsx API. Classification matches the existing `check-secret-health.ts` vocabulary — HTTP 200 is `ok`, 401 is `dead`, anything else is `indeterminate`.
+
+The `.github` repo gains a minimal `bun test` CI workflow to cover both actions' classifiers. This is the cost of the chosen topology and is accepted.
+
+## Wiring
+
+| Repo | Change |
+| --- | --- |
+| `nimbus-sdk`, `nimbus-client` | A post-publish step in `release.yml` calling `verify-npm-provenance` (SHA-pinned) with the just-published version. A degraded publish now fails loudly at release time — the 72-hour unpublish window makes late detection worthless. |
+| `Nimbus` (this repo) | `scripts/release/check-secret-health.ts` gains one provenance row per package (latest published version attested to the expected repo) plus the no-orphan-`NPM_TOKEN` assertion. Both feed the **existing** de-duped issue filer from sub-project 1 — no new alerting surface. The registry endpoint is public, so this needs no credentials. |
+| `nimbus-vscode` | Its own `secret-health.yml` calling `probe-publish-token` **where the secrets already live**. `VSCE_PAT` / `OVSX_PAT` are deliberately **not** copied into the monorepo — spreading credentials to centralise monitoring would be a net loss. Also adds `attest-build-provenance` over the packaged `.vsix`. |
+
+**How the no-orphan assertion works.** `GITHUB_TOKEN` *cannot* list repository secrets — the Actions secrets API requires admin scope and there is no `secrets: read` workflow permission — so absence is asserted by binding rather than by listing. `secret-health.yml` passes `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` into the check's environment; an absent secret interpolates to the empty string. The check asserts the variable is empty and reports `ok`, or non-empty and reports a failure row. This reuses the `not-configured` detection already in `check-secret-health.ts`, requires no new permission, and — consistent with sub-project 1 — tests only for emptiness, never logging or passing the value onward.
+
+## Deadline de-risk
+
+A tracked issue on `nimbus-vscode` to determine whether the current `VSCE_PAT` is global or org-scoped and to decide the Azure-OIDC question with real numbers. Combined with weekly probes, a dead token surfaces within seven days instead of at the next release — which is precisely the regression class this whole program exists to eliminate.
+
+## Documentation
+
+`docs/ci-secrets.md` gains a provenance-verification section plus expiry and owner notes for the two surviving publish PATs.
+
+The `.vsix` documentation states plainly that `gh attestation verify` covers **the GitHub-release copy**. Whether the Marketplace serves byte-identical `.vsix` bytes could not be confirmed, so no claim is made that the attestation covers a Marketplace download.
+
+## Testing
+
+Pure classifiers are unit-tested against **real captured** attestation bundles, trimmed and committed as fixtures. No test touches the network. Failure paths are covered explicitly, not just the happy path:
+
+- missing `slsa.dev/provenance/v1` predicate (the silent-degradation case)
+- missing `npm/publish/v0.1` predicate
+- source repo mismatch, workflow mismatch, commit mismatch
+- registry 404 (distinguishing "retries exhausted" from "first attempt")
+- registry 5xx and network error
+- malformed / truncated JSON
+- the severity-mapping split: identical input classified `fail` for the gate and `indeterminate` for the monitor
+
+Monorepo-side changes follow the existing `scripts/release/` conventions — pure functions, injected API surface, Bun tests alongside.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Attestation lag causes false release failures | Bounded retry with backoff before concluding absence; tested against the retry-exhaustion path |
+| npm's attestation response shape changes | Classifier fails closed on unrecognised shape and reports the reason; fixtures are real captures, so a shape change surfaces as a test-visible diff |
+| Disallowing tokens breaks an unknown publish path | Verified zero workflow references to `NPM_TOKEN` across all five repos before step 3; OIDC path is already proven by the two live published versions |
+| `.github` repo becomes an untested dumping ground | It gains real CI in this sub-project; the topology decision is revisited if the shared surface exceeds two or three actions |
+| Five repos in one sub-project causes partial landing | Each repo lands as its own PR gated green; the monorepo PR is independently useful, and the satellite gates are additive — no repo depends on another's merge to keep working |
+
+## Sequencing
+
+The satellite gates depend on the shared actions existing and being SHA-pinnable, so `.github` lands first. Nothing else is order-dependent.
+
+1. `nimbus-agent/.github` — both composite actions plus their CI.
+2. `Nimbus` — monitor rows, no-orphan assertion, `docs/ci-secrets.md`.
+3. `nimbus-sdk`, `nimbus-client` — post-publish verification gates.
+4. `nimbus-vscode` — `secret-health.yml`, `.vsix` attestation, tracked deadline issue.
+5. Human prerequisites (npm revoke, disallow tokens), then the `NPM_TOKEN` secret deletion.

--- a/scripts/cast-driver/e2e.test.ts
+++ b/scripts/cast-driver/e2e.test.ts
@@ -17,7 +17,24 @@ describe("cast-driver e2e (incident-response committed snapshot)", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const code = await proc.exited;
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    // The driver's output was previously piped and then discarded, so any
+    // failure surfaced only as "expected 0, received 1" with no reason. That
+    // hid the most common cause outright: in a fresh worktree with no
+    // `bun install`, the spawned CLI cannot resolve its imports, crashes with
+    // no stdout, and the harness reports a misleading `expect missed` on the
+    // first step — which reads like a stale snapshot rather than absent deps.
+    if (code !== 0) {
+      throw new Error(
+        `cast-driver --check failed (exit ${code}).\n` +
+          `If stderr mentions an unresolved module, run \`bun install\` in this worktree.\n` +
+          `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+      );
+    }
     expect(code).toBe(0);
   });
 });

--- a/scripts/cast-driver/e2e.test.ts
+++ b/scripts/cast-driver/e2e.test.ts
@@ -28,13 +28,16 @@ describe("cast-driver e2e (incident-response committed snapshot)", () => {
     // `bun install`, the spawned CLI cannot resolve its imports, crashes with
     // no stdout, and the harness reports a misleading `expect missed` on the
     // first step — which reads like a stale snapshot rather than absent deps.
-    if (code !== 0) {
-      throw new Error(
-        `cast-driver --check failed (exit ${code}).\n` +
-          `If stderr mentions an unresolved module, run \`bun install\` in this worktree.\n` +
-          `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
-      );
-    }
-    expect(code).toBe(0);
+    //
+    // Fold the diagnostic into the assertion's own message rather than a
+    // separate `if (code !== 0) throw` before it: that prior form made this
+    // `expect` unreachable on failure (dead code) since the throw always
+    // fired first. One assertion path, still with the same diagnostic detail.
+    expect(
+      code,
+      `cast-driver --check failed (exit ${code}).\n` +
+        `If stderr mentions an unresolved module, run \`bun install\` in this worktree.\n` +
+        `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+    ).toBe(0);
   });
 });

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -453,7 +453,11 @@ describe("classifyProvenanceOutcome", () => {
   });
 
   test("fails closed: unset or unrecognised is never ok", () => {
-    expect(classifyProvenanceOutcome("")).toBe("not-configured");
+    // An empty string means the probe never reported (renamed step id, skipped
+    // step, or an action that exits before writing output) — never the same
+    // thing as a genuinely absent/unconfigured secret, so it must warn
+    // (`indeterminate`), not silently pass as `not-configured` (review finding #1).
+    expect(classifyProvenanceOutcome("")).toBe("indeterminate");
     expect(classifyProvenanceOutcome("weird")).toBe("indeterminate");
   });
 });
@@ -503,5 +507,23 @@ describe("summarize with the new row kinds", () => {
     const s = summarize(rows);
     expect(s.hasHardFailure).toBe(false);
     expect(s.hasWarning).toBe(false);
+  });
+
+  test("an unreported provenance probe (empty status — renamed/skipped step id, or an action that exits before writing output) warns, never closes the issue as healthy (review finding #1 regression guard)", () => {
+    const rows: HealthRow[] = [
+      {
+        name: "@nimbus-dev/sdk",
+        kind: "provenance",
+        status: classifyProvenanceOutcome(""),
+        detail: "latest published version",
+      },
+    ];
+    const s = summarize(rows);
+    // This is the exact defect the review caught: `not-configured` sits in
+    // neither `hard` nor `warn`, so a silently-unreported probe took the
+    // issue-CLOSING branch and posted "All release credentials healthy". A
+    // never-reported probe must warn — never a false ok.
+    expect(s.hasHardFailure).toBe(false);
+    expect(s.hasWarning).toBe(true);
   });
 });

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -4,6 +4,7 @@ import {
   classifyPatProbe,
   classifyProvenanceOutcome,
   classifySecretAbsence,
+  composeProvenanceDetail,
   evaluateCertExpiry,
   type HealthRow,
   type PatStrategy,
@@ -459,6 +460,33 @@ describe("classifyProvenanceOutcome", () => {
     // (`indeterminate`), not silently pass as `not-configured` (review finding #1).
     expect(classifyProvenanceOutcome("")).toBe("indeterminate");
     expect(classifyProvenanceOutcome("weird")).toBe("indeterminate");
+  });
+});
+
+describe("composeProvenanceDetail", () => {
+  test("both empty (skipped probe) → the original static placeholder, unchanged", () => {
+    expect(composeProvenanceDetail("", "")).toBe("latest published version");
+  });
+
+  test("version + action detail present → both are surfaced together", () => {
+    expect(
+      composeProvenanceDetail(
+        "1.3.0",
+        "repository https://github.com/attacker/x != https://github.com/nimbus-agent/nimbus-sdk",
+      ),
+    ).toBe(
+      "v1.3.0: repository https://github.com/attacker/x != https://github.com/nimbus-agent/nimbus-sdk",
+    );
+  });
+
+  test("version present, action detail empty → just the version, no dangling separator", () => {
+    expect(composeProvenanceDetail("0.5.0", "")).toBe("v0.5.0");
+  });
+
+  test("version empty, action detail present → detail alone with an explicit unknown-version marker", () => {
+    expect(composeProvenanceDetail("", "no SLSA provenance predicate — publish degraded")).toBe(
+      "unknown version: no SLSA provenance predicate — publish degraded",
+    );
   });
 });
 

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
   classifyAppMint,
   classifyPatProbe,
+  classifyProvenanceOutcome,
+  classifySecretAbsence,
   evaluateCertExpiry,
+  type HealthRow,
   type PatStrategy,
   runSecretHealth,
   safeParseDate,
@@ -438,5 +441,67 @@ describe("openOrUpdateHealthIssue", () => {
     });
     expect(api.calls.updateIssue.length).toBe(1);
     expect(api.calls.commentIssue.length).toBe(0);
+  });
+});
+
+describe("classifyProvenanceOutcome", () => {
+  test("passes through the action's known statuses", () => {
+    expect(classifyProvenanceOutcome("ok")).toBe("ok");
+    expect(classifyProvenanceOutcome("missing-provenance")).toBe("missing-provenance");
+    expect(classifyProvenanceOutcome("source-mismatch")).toBe("source-mismatch");
+    expect(classifyProvenanceOutcome("indeterminate")).toBe("indeterminate");
+  });
+
+  test("fails closed: unset or unrecognised is never ok", () => {
+    expect(classifyProvenanceOutcome("")).toBe("not-configured");
+    expect(classifyProvenanceOutcome("weird")).toBe("indeterminate");
+  });
+});
+
+describe("classifySecretAbsence", () => {
+  test("absent secret is ok — that is the desired state", () => {
+    expect(classifySecretAbsence(undefined)).toBe("ok");
+    expect(classifySecretAbsence("")).toBe("ok");
+  });
+
+  test("a returned secret is present, which is a failure", () => {
+    expect(classifySecretAbsence("npm_something")).toBe("present");
+  });
+});
+
+describe("summarize with the new row kinds", () => {
+  test("missing-provenance and source-mismatch are hard failures", () => {
+    for (const status of ["missing-provenance", "source-mismatch"] as const) {
+      const rows: HealthRow[] = [
+        { name: "@nimbus-dev/sdk", kind: "provenance", status, detail: "latest" },
+      ];
+      expect(summarize(rows).hasHardFailure).toBe(true);
+    }
+  });
+
+  test("a returned NPM_TOKEN is a hard failure", () => {
+    const rows: HealthRow[] = [
+      { name: "NPM_TOKEN", kind: "absence", status: "present", detail: "must not exist" },
+    ];
+    expect(summarize(rows).hasHardFailure).toBe(true);
+  });
+
+  test("provenance indeterminate warns but does not hard-fail", () => {
+    const rows: HealthRow[] = [
+      { name: "@nimbus-dev/sdk", kind: "provenance", status: "indeterminate", detail: "HTTP 503" },
+    ];
+    const s = summarize(rows);
+    expect(s.hasHardFailure).toBe(false);
+    expect(s.hasWarning).toBe(true);
+  });
+
+  test("all-clear stays clean", () => {
+    const rows: HealthRow[] = [
+      { name: "@nimbus-dev/sdk", kind: "provenance", status: "ok", detail: "latest" },
+      { name: "NPM_TOKEN", kind: "absence", status: "ok", detail: "absent" },
+    ];
+    const s = summarize(rows);
+    expect(s.hasHardFailure).toBe(false);
+    expect(s.hasWarning).toBe(false);
   });
 });

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -55,10 +55,47 @@ export function evaluateCertExpiry(
   return "ok";
 }
 
+export type ProvenanceStatus =
+  | "ok"
+  | "missing-provenance"
+  | "source-mismatch"
+  | "indeterminate"
+  | "not-configured";
+export type AbsenceStatus = "ok" | "present";
+
+/**
+ * The `verify-npm-provenance` composite action runs in monitor mode before this
+ * check and its `steps.<id>.outputs.status` is passed in via env — the same
+ * shape as the App-mint probe above. Fail closed: an unset value means the step
+ * never ran, and an unrecognised value is never silently "ok".
+ */
+export function classifyProvenanceOutcome(status: string): ProvenanceStatus {
+  if (status === "") return "not-configured";
+  if (
+    status === "ok" ||
+    status === "missing-provenance" ||
+    status === "source-mismatch" ||
+    status === "indeterminate"
+  ) {
+    return status;
+  }
+  return "indeterminate";
+}
+
+/**
+ * Regression guard for a secret that must NOT exist. `NPM_TOKEN` was revoked and
+ * deleted 2026-07-19; publishing is OIDC-only. An absent secret interpolates to
+ * the empty string, so emptiness is the healthy state. Tests emptiness only —
+ * the value is never logged or passed on.
+ */
+export function classifySecretAbsence(value: string | undefined): AbsenceStatus {
+  return value === undefined || value.length === 0 ? "ok" : "present";
+}
+
 export interface HealthRow {
   readonly name: string;
-  readonly kind: "pat" | "cert";
-  readonly status: PatStatus | CertStatus;
+  readonly kind: "pat" | "cert" | "provenance" | "absence";
+  readonly status: PatStatus | CertStatus | ProvenanceStatus | AbsenceStatus;
   readonly detail: string;
 }
 
@@ -68,7 +105,14 @@ export function summarize(rows: readonly HealthRow[]): {
   table: string;
   state: string;
 } {
-  const hard = new Set<string>(["dead", "insufficient", "expired"]);
+  const hard = new Set<string>([
+    "dead",
+    "insufficient",
+    "expired",
+    "missing-provenance",
+    "source-mismatch",
+    "present",
+  ]);
   const warn = new Set<string>(["expiring", "indeterminate"]);
   const hasHardFailure = rows.some((r) => hard.has(r.status));
   const hasWarning = rows.some((r) => warn.has(r.status));
@@ -365,13 +409,33 @@ if (import.meta.main) {
     status: classifyAppMint(process.env["APP_MINT_STATUS"] ?? ""),
     detail: "scoped mint: Nimbus+homebrew-tap+scoop-bucket+linux-repo",
   };
+  const provenanceRows: HealthRow[] = [
+    {
+      name: "@nimbus-dev/sdk",
+      kind: "provenance",
+      status: classifyProvenanceOutcome(process.env["SDK_PROVENANCE_STATUS"] ?? ""),
+      detail: "latest published version",
+    },
+    {
+      name: "@nimbus-dev/client",
+      kind: "provenance",
+      status: classifyProvenanceOutcome(process.env["CLIENT_PROVENANCE_STATUS"] ?? ""),
+      detail: "latest published version",
+    },
+  ];
+  const npmTokenRow: HealthRow = {
+    name: "NPM_TOKEN",
+    kind: "absence",
+    status: classifySecretAbsence(process.env["NPM_TOKEN"]),
+    detail: "revoked 2026-07-19; publishing is OIDC-only",
+  };
   const { hardFailure } = await runSecretHealth({
     api: createGitHubApi({ token, repo }),
     now: new Date(),
     thresholdDays,
     pats,
     certs,
-    extraRows: [appMintRow],
+    extraRows: [appMintRow, ...provenanceRows, npmTokenRow],
   });
   process.exit(hardFailure ? 1 : 0);
 }

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -68,9 +68,19 @@ export type AbsenceStatus = "ok" | "present";
  * check and its `steps.<id>.outputs.status` is passed in via env — the same
  * shape as the App-mint probe above. Fail closed: an unset value means the step
  * never ran, and an unrecognised value is never silently "ok".
+ *
+ * An empty string is NOT the same situation as an absent PAT/cert secret
+ * (`not-configured` there is a genuine, intentional healthy state — see
+ * `classifySecretAbsence`). Here it means the probe never reported at all: a
+ * renamed step id, a skipped step, or an action that exits before writing its
+ * output all interpolate to "" with no workflow error. `not-configured` sits
+ * in neither the `hard` nor `warn` set in `summarize`, so returning it here
+ * took the issue-closing "healthy" branch for a probe that told us nothing —
+ * a false `ok` for "we have no idea". Map it to `indeterminate` instead, so
+ * it lands in the warn path (review finding #1).
  */
 export function classifyProvenanceOutcome(status: string): ProvenanceStatus {
-  if (status === "") return "not-configured";
+  if (status === "") return "indeterminate";
   if (
     status === "ok" ||
     status === "missing-provenance" ||
@@ -427,7 +437,12 @@ if (import.meta.main) {
     name: "NPM_TOKEN",
     kind: "absence",
     status: classifySecretAbsence(process.env["NPM_TOKEN"]),
-    detail: "revoked 2026-07-19; publishing is OIDC-only",
+    // This probe can only observe a secret bound into THIS repo's env — it is
+    // not a global assurance about npm/org-wide token existence, even though
+    // that absence was separately verified by hand (org scope, Nimbus repo
+    // scope, the Nimbus `release` environment, and both satellite repos).
+    detail:
+      "absent from this repo's env (the only scope this check observes); revoked 2026-07-19, publishing is OIDC-only",
   };
   const { hardFailure } = await runSecretHealth({
     api: createGitHubApi({ token, repo }),

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -55,12 +55,7 @@ export function evaluateCertExpiry(
   return "ok";
 }
 
-export type ProvenanceStatus =
-  | "ok"
-  | "missing-provenance"
-  | "source-mismatch"
-  | "indeterminate"
-  | "not-configured";
+export type ProvenanceStatus = "ok" | "missing-provenance" | "source-mismatch" | "indeterminate";
 export type AbsenceStatus = "ok" | "present";
 
 /**
@@ -90,6 +85,26 @@ export function classifyProvenanceOutcome(status: string): ProvenanceStatus {
     return status;
   }
   return "indeterminate";
+}
+
+/**
+ * Composes a provenance row's `detail` from the resolved version and the
+ * `verify-npm-provenance` action's own `detail` output (e.g. `repository
+ * https://github.com/attacker/x != https://github.com/nimbus-agent/nimbus-sdk`
+ * or `no SLSA provenance predicate — publish degraded`). Without this, the
+ * single most alarming row this monitor can produce (`source-mismatch`) filed
+ * an issue naming neither the version that failed nor the reason — the two
+ * facts an on-call reader actually needs.
+ *
+ * When both inputs are empty (the probe never ran — the workflow's `if:`
+ * guard skips the probe step when version resolution failed) this returns the
+ * original static placeholder, so a skipped probe still classifies exactly as
+ * it did before this composition existed.
+ */
+export function composeProvenanceDetail(version: string, actionDetail: string): string {
+  if (version === "" && actionDetail === "") return "latest published version";
+  const versionPart = version === "" ? "unknown version" : `v${version}`;
+  return actionDetail === "" ? versionPart : `${versionPart}: ${actionDetail}`;
 }
 
 /**
@@ -424,13 +439,19 @@ if (import.meta.main) {
       name: "@nimbus-dev/sdk",
       kind: "provenance",
       status: classifyProvenanceOutcome(process.env["SDK_PROVENANCE_STATUS"] ?? ""),
-      detail: "latest published version",
+      detail: composeProvenanceDetail(
+        process.env["SDK_VERSION"] ?? "",
+        process.env["SDK_PROVENANCE_DETAIL"] ?? "",
+      ),
     },
     {
       name: "@nimbus-dev/client",
       kind: "provenance",
       status: classifyProvenanceOutcome(process.env["CLIENT_PROVENANCE_STATUS"] ?? ""),
-      detail: "latest published version",
+      detail: composeProvenanceDetail(
+        process.env["CLIENT_VERSION"] ?? "",
+        process.env["CLIENT_PROVENANCE_DETAIL"] ?? "",
+      ),
     },
   ];
   const npmTokenRow: HealthRow = {
@@ -452,5 +473,11 @@ if (import.meta.main) {
     certs,
     extraRows: [appMintRow, ...provenanceRows, npmTokenRow],
   });
-  process.exit(hardFailure ? 1 : 0);
+  // process.exit() after awaited I/O can truncate buffered stdout before it
+  // flushes — a recurring defect class in this project (it previously caused
+  // exit 127 on SUCCESS in a sibling task) — and the `console.log(s.table)`
+  // inside runSecretHealth just above is exactly that exposure, made larger by
+  // this branch's extra provenance/absence rows. process.exitCode lets the
+  // event loop drain naturally instead.
+  process.exitCode = hardFailure ? 1 : 0;
 }


### PR DESCRIPTION
Monorepo slice of secrets-management sub-project #3 — **npm supply-chain assurance**.

npm OIDC trusted publishing and SLSA provenance turned out to be **already live** for both packages (verified on the live registry, not from docs). So this program is *verify + harden + clean up*, not build.

## What lands here

- `scripts/release/check-secret-health.ts` — provenance classifiers + an `NPM_TOKEN` absence guard, folded into the existing weekly health table and its de-duped issue filer.
- `.github/workflows/secret-health.yml` — resolves each package's published version and probes provenance in **monitor** mode.
- `docs/ci-secrets.md` — npm provenance section + a per-kind alert runbook.
- `docs/CHANGELOG.md` — dated entry.

## Companion PRs (open, **not** merged)

| Repo | PR | Adds |
| --- | --- | --- |
| `nimbus-sdk` | #12 | pre-publish preflight + post-publish provenance gate |
| `nimbus-client` | #5 | same |
| `nimbus-vscode` | #35 | weekly PAT probe, `.vsix` attestation, verify docs |

Already merged: two composite actions in `nimbus-agent/.github` (pinned `5fb42792fa88287048fd24f704183b9a9b807a67`).

Docs here deliberately describe the satellite gates in the future tense — they are not merged yet.

## Defects caught during review (all fixed)

- **False `ok`.** An unreported provenance probe (renamed step id, skipped step, action exiting early — all silent, no workflow error) classified as `not-configured`, which sat in neither the hard nor warn set. The monitor would have posted "✅ All release credentials healthy" for *"we have no idea"*.
- **False alarm on a shipped artifact.** With the version-resolution step allowed to fail soft, an empty version made the action request `…/@pkg@` → 404 → `absent` → `missing-provenance`, a hard failure. A routine npm outage would have filed an issue claiming the published package lost its provenance. Both probes now carry an `if:` guard.
- **Unactionable alerts.** The action emits a `detail` explaining *why* provenance failed; the workflow discarded it along with the version, so a `source-mismatch` named neither.
- **Overclaiming docs.** "OIDC is the only path that can publish" — `mfa=publish` blocks automation, not an interactive maintainer with an OTP.
- **`npm audit signatures` in the repo root** audits the *dependency tree*; a package is never its own dependency, so the artifact just published went cryptographically unchecked. The satellite gates now install the published version into a clean tree and audit that.

## Verification

18 gates green (typecheck, biome, markdown, and all 15 audits). 42/42 tests in `check-secret-health.test.ts`, with break-it-and-watch-it-fail proofs on the fail-closed classifier and the detail composition.

`bun run preflight` aborts early on the known `.claude/worktrees/` biome trap, so gates were run individually.

## Not verified

The new workflow path has never executed live — that is close-out task E1, together with `nimbus-vscode`'s deferred first probe run.

## Follow-ups (not in this PR)

- `nimbus-vscode` `publish.yml` passes publish tokens on argv (`--pat` / `-p`); both CLIs accept them from env.
- The composite action writes `GITHUB_OUTPUT` as plain `key=value` with a registry-derived `detail` — not exploitable, but it is this project's own named defect class.
- `bun run test:ci` is broken on `main` (builds the deleted `packages/client`; surfaces on Windows as a misleading `ENOENT uv_spawn 'bun'`). Not a CI gate.
