### PR TITLE
test:ci crashed on a deleted package, and silently skipped a coverage gate

### DIFF
--- a/scripts/lib/ci-tests.test.ts
+++ b/scripts/lib/ci-tests.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { COVERAGE_GATES } from "./ci-tests.ts";
+import { REPO_ROOT } from "./root.ts";
+
+/**
+ * `test:ci` drives the per-subsystem coverage gates from its own list, which is
+ * separate from the `test:coverage:*` scripts in `package.json`. Nothing forced
+ * the two to agree, and they drifted in BOTH directions at once:
+ *
+ *   - `test:coverage:client` stayed in the gate list after `packages/client`
+ *     was extracted to `@nimbus-dev/client` (#758) and the script was deleted.
+ *   - `test:coverage:sandbox` was added to `package.json` but never wired in,
+ *     so `test:ci` silently skipped the sandbox gate entirely.
+ *
+ * The second is the dangerous one: a missing gate does not fail, it just
+ * quietly stops checking. These tests make either direction a hard failure.
+ */
+describe("ci-tests coverage gate manifest", () => {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    scripts: Record<string, string>;
+  };
+
+  const declared = Object.keys(pkg.scripts)
+    .filter((s) => s.startsWith("test:coverage:"))
+    .sort();
+  const wired = COVERAGE_GATES.map((g) => g.script).sort();
+
+  test("every test:coverage:* script in package.json is wired into test:ci", () => {
+    const missing = declared.filter((s) => !wired.includes(s));
+    expect(missing).toEqual([]);
+  });
+
+  test("every wired gate resolves to a real package.json script", () => {
+    const dangling = wired.filter((s) => !declared.includes(s));
+    expect(dangling).toEqual([]);
+  });
+
+  test("gate scripts are unique", () => {
+    expect(new Set(wired).size).toBe(wired.length);
+  });
+
+  test("the vault gate keeps its dbus wrapper", () => {
+    // Vault coverage needs libsecret on Linux; losing this flag would not fail
+    // the run, it would just make the gate flaky/red on CI for the wrong reason.
+    const vault = COVERAGE_GATES.find((g) => g.script === "test:coverage:vault");
+    expect(vault?.dbus).toBe(true);
+  });
+});

--- a/scripts/lib/ci-tests.ts
+++ b/scripts/lib/ci-tests.ts
@@ -77,36 +77,45 @@ function runInitialUnitTestsWithCoverage(): void {
   }
 }
 
-function runCoverageGates(): void {
-  const gates: Array<{ script: string; dbus?: boolean }> = [
-    { script: "test:coverage:engine" },
-    { script: "test:coverage:agents" },
-    { script: "test:coverage:vault", dbus: true },
-    { script: "test:coverage:sync" },
-    { script: "test:coverage:rate-limiter" },
-    { script: "test:coverage:people" },
-    { script: "test:coverage:embedding" },
-    { script: "test:coverage:workflow" },
-    { script: "test:coverage:watcher" },
-    { script: "test:coverage:extensions" },
-    { script: "test:coverage:config" },
-    { script: "test:coverage:client" },
-    { script: "test:coverage:telemetry" },
-    { script: "test:coverage:db" },
-    { script: "test:coverage:deployment" },
-    { script: "test:coverage:health" },
-    { script: "test:coverage:metrics" },
-    { script: "test:coverage:preflight" },
-    { script: "test:coverage:doctor" },
-    { script: "test:coverage:tui" },
-    { script: "test:coverage:mcp" },
-    { script: "test:coverage:updater" },
-    { script: "test:coverage:lan" },
-    { script: "test:coverage:perf" },
-    { script: "test:coverage:security" },
-  ];
+/**
+ * The per-subsystem coverage gates `test:ci` runs, in execution order.
+ *
+ * Exported so `ci-tests.test.ts` can assert this list and the `test:coverage:*`
+ * scripts in `package.json` stay in agreement. They drifted in both directions
+ * once already: a `client` gate outlived the package it covered (extracted to
+ * `@nimbus-dev/client` in #758), while `sandbox` was added to `package.json`
+ * and never wired in here — so `test:ci` silently skipped it.
+ */
+export const COVERAGE_GATES: ReadonlyArray<{ script: string; dbus?: boolean }> = [
+  { script: "test:coverage:engine" },
+  { script: "test:coverage:agents" },
+  { script: "test:coverage:vault", dbus: true },
+  { script: "test:coverage:sync" },
+  { script: "test:coverage:rate-limiter" },
+  { script: "test:coverage:people" },
+  { script: "test:coverage:embedding" },
+  { script: "test:coverage:workflow" },
+  { script: "test:coverage:watcher" },
+  { script: "test:coverage:extensions" },
+  { script: "test:coverage:config" },
+  { script: "test:coverage:sandbox" },
+  { script: "test:coverage:telemetry" },
+  { script: "test:coverage:db" },
+  { script: "test:coverage:deployment" },
+  { script: "test:coverage:health" },
+  { script: "test:coverage:metrics" },
+  { script: "test:coverage:preflight" },
+  { script: "test:coverage:doctor" },
+  { script: "test:coverage:tui" },
+  { script: "test:coverage:mcp" },
+  { script: "test:coverage:updater" },
+  { script: "test:coverage:lan" },
+  { script: "test:coverage:perf" },
+  { script: "test:coverage:security" },
+];
 
-  for (const { script, dbus } of gates) {
+function runCoverageGates(): void {
+  for (const { script, dbus } of COVERAGE_GATES) {
     if (dbus && process.platform === "linux" && dbusAvailable()) {
       run(["bash", DBUS_WRAPPER, "bun", "run", script], REPO_ROOT, CI_ENV);
     } else {
@@ -116,8 +125,6 @@ function runCoverageGates(): void {
 }
 
 export async function runCiTestSuite(): Promise<void> {
-  run(["bun", "run", "build"], join(REPO_ROOT, "packages", "client"));
-
   run(["bun", "run", "typecheck"], REPO_ROOT);
   run(["bun", "run", "lint"], REPO_ROOT);
   run(["bun", "run", "build"], REPO_ROOT);


### PR DESCRIPTION
Closes #778.

## The reported bug

`runCiTestSuite()` opened with a build of `packages/client`, which no longer exists — it was extracted to `@nimbus-dev/client` in #758. Because the missing thing was the **working directory** rather than the executable, Windows reports:

```
ENOENT: no such file or directory, uv_spawn 'bun'
```

which reads as "bun is not on PATH". It is; `bun --version` succeeds in the same shell. The error points at the wrong problem, which is what made this expensive to diagnose rather than merely broken.

## The bug the report didn't mention

Fixing the crash alone would have left something worse in place. The coverage-gate list in `ci-tests.ts` had drifted from `package.json` **in both directions**:

| | |
|---|---|
| `test:coverage:client` | wired in, script deleted with the package |
| `test:coverage:sandbox` | declared in `package.json`, never wired in |

So beyond crashing, `test:ci` had **silently stopped running the sandbox coverage gate**. That asymmetry is the point: a dead gate fails loudly the moment you reach it, but a missing gate produces a clean green run that simply checks less than you think. Removing `client` and adding `sandbox` makes the two lists agree exactly — 25 gates either way.

## Why a test and not just a fix

Nothing forced the gate list and `package.json` to agree, which is how they drifted apart in the first place. `COVERAGE_GATES` is now exported and `ci-tests.test.ts` asserts both directions, following the existing `preflight-gates.test.ts` pattern.

Red/green proof — restoring the original drift (`sandbox` → `client`) fails both assertions, each naming the exact culprit:

```
every test:coverage:* script in package.json is wired into test:ci
  + [ "test:coverage:sandbox" ]
every wired gate resolves to a real package.json script
  + [ "test:coverage:client" ]
```

Restored: 4 pass / 0 fail.

## Verification

`bun test scripts/` → 516 pass / 20 skip / 0 fail. Standalone `tsc --strict` over both files exits 0 (the workspace `typecheck` is filtered and does not cover `scripts/`). Biome clean. `audit:{doc-refs,consumed-by,status-drift,invariants,cross-platform}` + `lint:markdown` all pass. `bun run test:ci` now runs past the old crash point into `typecheck` with no `ENOENT`.

Note this was never a CI outage — no workflow calls `test:ci`; CI drives `_test-suite.yml` directly. It broke the local script contributors reach for, and `preflight`'s full tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)