### PR TITLE
ci: one static required gate, so docs-only PRs stop needing an admin bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,84 @@ jobs:
     permissions:
       contents: read
 
+  # ── The single required PR gate ────────────────────────────────────────────
+  #
+  # Branch-protection rulesets match check names LITERALLY, and a job skipped by
+  # its own `if:` never expands `${{ }}` in its `name:` — it reports the raw
+  # template instead. So a skipped reusable-workflow child posts
+  # `… / Static — ${{ inputs.runner }}`, the required context
+  # `… / Static — ubuntu-24.04` is never created, and the PR sits on
+  # "Expected — Waiting for status to be reported" forever. That is why every
+  # docs-only PR needed an OrganizationAdmin bypass to merge.
+  #
+  # Passing `run-tests=false` to the reusable workflow (so the caller always
+  # runs) does NOT fix this: the children are still skipped at job level, so
+  # their names still never expand.
+  #
+  # This job is the durable fix. It always runs, its name is a static string
+  # with no interpolation, and it fails if any PR gate did not succeed. Make it
+  # the only required `pr-quality-*` context and the whole class of bug is gone
+  # — adding, renaming or matrix-ing a gate no longer needs a ruleset edit.
+  #
+  # `skipped` counts as a pass: it means `filter` legitimately decided the gate
+  # does not apply (no Rust change, docs-only diff). It never means a gate was
+  # silently lost — a gate that ran and failed reports `failure`, and one whose
+  # dependency failed reports `skipped` only after that dependency has already
+  # reported `failure` here.
+  pr-quality-required:
+    name: PR quality — required gates
+    if: always() && github.event_name == 'pull_request'
+    needs:
+      - filter
+      - pr-quality-ts
+      - pr-quality-rust
+      - pr-quality-cross-platform
+      - pr-quality-duplication
+      - pr-quality-structure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Fail if any required PR gate did not succeed
+        env:
+          # Space-separated results of every job in `needs`, in declaration order.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "PR gate results: ${RESULTS}"
+
+          # Fail CLOSED. An empty or short result set means the expression did
+          # not evaluate as expected (renamed job, edited `needs:`), and an
+          # empty list would otherwise skip the loop entirely and report green —
+          # turning the one job that exists to catch failures into a rubber
+          # stamp. Keep EXPECTED in step with the `needs:` list above.
+          EXPECTED=6
+          count=$(printf '%s\n' ${RESULTS} | grep -c . || true)
+          if [[ "${count}" -ne "${EXPECTED}" ]]; then
+            echo "::error::expected ${EXPECTED} gate results, got ${count} (${RESULTS}) — the needs: list and this check have drifted"
+            exit 1
+          fi
+
+          failed=0
+          for r in ${RESULTS}; do
+            case "${r}" in
+              success|skipped) ;;
+              *) echo "::error::a required PR gate reported '${r}'"; failed=1 ;;
+            esac
+          done
+          if [[ "${failed}" -ne 0 ]]; then
+            echo "::error::one or more required PR gates did not pass — see the jobs above"
+            exit 1
+          fi
+          echo "All ${count} required PR gates passed or were legitimately skipped."
+
   # ── Push: full cross-platform matrix (two parallel matrix jobs) ────────────
 
   # TS/Bun suite — all 3 OSes, runs in parallel with ci-rust


### PR DESCRIPTION
Every docs-only PR in this repo is permanently `BLOCKED` and can only be merged with the OrganizationAdmin ruleset bypass. #776 and #785 both went that way.

## The bug

Branch-protection rulesets match check names **literally**, and a job skipped by its own `if:` **never expands `${{ }}` in its `name:`** — it reports the raw template string.

`_test-suite.yml` gates its six jobs with `if: inputs.run-tests` while interpolating `${{ inputs.runner }}` into each name. So on a docs-only PR they post:

```text
PR quality — TS/Bun (ubuntu-24.04) / Static — ${{ inputs.runner }}      (skipped)
```

while the ruleset waits on:

```text
PR quality — TS/Bun (ubuntu-24.04) / Static — ubuntu-24.04
```

which is never created. Six required contexts sit on *"Expected — Waiting for status to be reported"* forever. `mergeable` reads `MERGEABLE`, `mergeStateStatus` reads `BLOCKED`, and nothing you do to the PR can ever satisfy it.

Note the redundancy the bug exposes: the runner is named twice, because the caller's job name already carries it.

## Why the previous fix wasn't enough

`ci.yml:126` already carries a comment describing this exact failure and a fix: always run the caller, pass `run-tests=false`, so the children "always REPORT". That was necessary but **not sufficient** — the children are still skipped *at job level*, so their names still never expand. Verified on #785, which failed exactly this way with that fix in place.

## The fix

Adds `pr-quality-required` — always runs, **static name, no interpolation** — which fails if any PR gate did not succeed:

```yaml
pr-quality-required:
  name: PR quality — required gates
  if: always() && github.event_name == 'pull_request'
  needs: [filter, pr-quality-ts, pr-quality-rust,
          pr-quality-cross-platform, pr-quality-duplication, pr-quality-structure]
```

Once it is the *only* required `pr-quality-*` context, this entire class of bug is gone: adding, renaming, or matrix-ing a gate no longer requires a ruleset edit.

`skipped` counts as a pass — that is `filter` legitimately deciding a gate does not apply (no Rust change, docs-only diff). A gate that ran and failed reports `failure` and is caught.

### Fail-closed, deliberately

The result list is asserted to be **exactly 6 entries** before it is inspected. Without that guard, a renamed job or an edited `needs:` would yield an empty list, `for r in $RESULTS` would not execute, and the one job whose entire purpose is catching failures would report green. That is a fail-open in the worst possible place. It now fails closed with a message naming the drift.

## This PR is inert on its own

The ruleset still requires the 12 old contexts. This PR touches `.github/`, so `code-changed=true`, so all 12 run and report normally — it satisfies the *current* ruleset with no bypass. **The ruleset swap (12 fragile contexts → this 1) is a deliberate follow-up, applied after merge**, so the repo is never left in a state where nothing can merge.

## Verification

| Check | Result |
| --- | --- |
| YAML parses; every `needs:` entry resolves to a real job | ✅ 6/6 |
| `audit:action-sha-pins` | ✅ OK |
| `audit:status-drift` | ✅ OK |
| preflight-gates drift tests | ✅ 8/8 pass |
| `typecheck` | ✅ clean |
| `biome check packages scripts` | ✅ clean, 2876 files |

The gate script was exercised against every result shape — passing exactly the three that should pass:

| Results | Expected | Got |
| --- | --- | --- |
| all `success` | pass | ✅ PASS |
| mixed `success`/`skipped` | pass | ✅ PASS |
| all `skipped` (docs-only PR) | pass | ✅ PASS |
| one `failure` | fail | ✅ GATE-FAIL |
| one `cancelled` | fail | ✅ GATE-FAIL |
| empty list | fail | ✅ DRIFT-FAIL |
| 3 entries | fail | ✅ DRIFT-FAIL |
| 7 entries | fail | ✅ DRIFT-FAIL |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
