### PR TITLE
Retire CODECOV_TOKEN — it never reached Codecov

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -341,7 +341,14 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # No `token:`. This is a reusable workflow, and GitHub only passes
+          # secrets declared in its `secrets:` contract above — which lists
+          # SONAR_TOKEN only. The old CODECOV_TOKEN reference therefore resolved
+          # to an empty string here and never reached the action. Uploads
+          # authenticate via OIDC (`id-token: write` is granted by the caller for
+          # exactly this), so the input was inert. See Nimbus#782.
+          # (Deliberately not writing the `secrets.` form above: audit:consumed-by
+          # scans for it textually and would read this comment as a live use.)
           use_oidc: true
           files: coverage/lcov.info,packages/ui/coverage/lcov.info
 
@@ -856,6 +863,6 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # No `token:` — same reason as the upload step above (Nimbus#782).
           use_oidc: true
           flags: ${{ matrix.gate.name }}

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -43,7 +43,7 @@ a plain repository secret.
 | `VSCE_PAT` | VS Code Marketplace publish | Azure DevOps PAT — Marketplace (Manage) | `publish-vscode.yml` |
 | `OVSX_PAT` | Open VSX publish | Open VSX token | `publish-vscode.yml` |
 | `SONAR_TOKEN` | SonarCloud quality gate (optional) | SonarCloud token | `ci.yml`, `_test-suite.yml`, `release.yml` |
-| `CODECOV_TOKEN` | Coverage upload (optional) | Codecov upload token | `_test-suite.yml` |
+| ~~`CODECOV_TOKEN`~~ | **Retired 2026-07-21** — uploads use OIDC | — | — |
 | `SCORECARD_TOKEN` | OSSF Scorecard (optional) | Fine-grained PAT — read-only | `scorecard.yml` |
 | `NIMBUS_CHECKS_TOKEN` | Cross-workflow check runs (optional) | Fine-grained PAT — Checks: RW | `ci.yml`, `_test-suite.yml` |
 | `GITHUB_TOKEN` | — | **Automatic**, no action needed | all |
@@ -270,8 +270,13 @@ file.
 
 - `SONAR_TOKEN` — SonarCloud analysis token. When unset the SonarQube step is
   silently skipped. Generate under your SonarCloud account → Security.
-- `CODECOV_TOKEN` — Codecov upload token (<https://app.codecov.io> → repo
-  settings). Coverage still computes locally without it; only the upload needs it.
+- **`CODECOV_TOKEN` — retired 2026-07-21, do not re-add.** Codecov uploads
+  authenticate via **OIDC** (`use_oidc: true` in `_test-suite.yml`, with
+  `id-token: write` granted by the calling workflow). The old `token:` input was
+  inert: `_test-suite.yml` is a reusable workflow, and GitHub passes only the
+  secrets named in its `secrets:` contract — which lists `SONAR_TOKEN` alone — so
+  `secrets.CODECOV_TOKEN` resolved to an empty string there and never reached the
+  action. Fork PRs use Codecov's tokenless path and are likewise unaffected.
 - `SCORECARD_TOKEN` — read-only fine-grained PAT used by the OSSF Scorecard
   workflow to read branch-protection metadata.
 - `NIMBUS_CHECKS_TOKEN` — optional fine-grained PAT with **Checks: Read and

--- a/scripts/release/credential-registry.ts
+++ b/scripts/release/credential-registry.ts
@@ -226,15 +226,15 @@ export const CREDENTIAL_REGISTRY: readonly CredentialEntry[] = [
   // --- Nimbus: optional / absent ---
   {
     name: "CODECOV_TOKEN",
-    state: "optional",
+    state: "forbidden",
     location: { scope: "repo", repo: "Nimbus" },
     product: "actions",
     type: "service-token",
     owner: OWNER,
-    consumedBy: [".github/workflows/_test-suite.yml"],
-    maxAgeDays: 90,
+    consumedBy: [],
+    maxAgeDays: null,
     hardDeadline: null,
-    note: "Coverage upload; the step degrades without it.",
+    note: "Deleted 2026-07-21. It never reached Codecov: _test-suite.yml is a reusable workflow and its secrets contract declares SONAR_TOKEN only, so secrets.CODECOV_TOKEN resolved to an empty string there. Uploads authenticate via OIDC (use_oidc + id-token: write). Surfaced as a staleness row (95d vs 90d), but the real finding was redundancy, not age. If this reappears, someone has added a token path where OIDC already works.",
   },
   {
     name: "BENCHER_API_KEY",


### PR DESCRIPTION
Refs #782. Secret already deleted; this lands the wiring and the manifest.

## Don't rotate it — it does nothing

The weekly monitor flagged `CODECOV_TOKEN` as stale (95d against a 90d policy). The obvious response was to rotate it. That would have restarted a 90-day clock on a credential with no effect.

`_test-suite.yml` is a **reusable workflow**, and GitHub passes only the secrets named in its `secrets:` contract:

```yaml
secrets:
  SONAR_TOKEN:      # ← the only one declared
```

`ci.yml` matches that — it passes `SONAR_TOKEN` and does not use `secrets: inherit`. So the `CODECOV_TOKEN` reference inside the reusable workflow resolved to an **empty string** and never reached the action.

The run log settles it rather than leaving it as inference:

```
INPUT_TOKEN:            (empty)
INPUT_CODECOV_TOKEN:    (empty)
INPUT_USE_OIDC: true
CC_FORK: false
```

against the action's own selection logic:

```bash
if [ "$INPUT_USE_OIDC" == 'true' ] && [ "$CC_FORK" != 'true' ]; then
  echo "CC_TOKEN=$CC_OIDC_TOKEN"     # ← the branch taken
```

followed by `Your upload is now queued for processing`. Uploads authenticate via **OIDC**, which is deliberate: `ci.yml` grants `id-token: write` with the comment *"Required by `_test-suite.yml` (Codecov `use_oidc: true` on coverage-gates)"*.

## What changed

- Both inert `token:` inputs removed from `_test-suite.yml`.
- Manifest entry → `forbidden`, so the secret **reappearing** is a hard failure rather than a shrug. Same treatment `NPM_TOKEN` got after the npm OIDC migration.
- `docs/ci-secrets.md` row and narrative updated to say retired, and why, so nobody helpfully re-adds it.

Ordering was deliberate: the secret was deleted **before** this merges. `forbidden` + still-present is a HARD monitor failure, so flipping the state first would have turned the monitor red in the gap. Deleted-then-merged means `optional`+absent (`"optional, unset"`) before, `forbidden`+absent (`"correctly absent"`) after — green either side.

Fork PRs are unaffected: they take Codecov's tokenless path, and the token was empty for them regardless.

## One wrinkle worth flagging

`audit:consumed-by` finds consumers by regexing `secrets\.([A-Z0-9_]+)` over workflow text — **including comments**. My explanatory comment originally wrote the `secrets.` form, which would have made the audit read a comment explaining that nothing uses the secret as evidence that something does. The comment now avoids the literal form and says why.

## Verification

`audit:{consumed-by,doc-refs,status-drift,action-sha-pins,invariants}` + `lint:markdown` pass. `bun test scripts/release/` → 143 pass / 6 skip / 0 fail. Biome clean. `_test-suite.yml` re-parsed with `js-yaml`. Zero `secrets.CODECOV_TOKEN` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)