### PR TITLE
docs: correct the schema reference to the unified V3 `item` table

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1252,7 +1252,7 @@ The `AbortSignal` from `engine.cancelStream` is deliberately **not** plumbed int
 
 ## Local Database Schema
 
-The full table-by-table SQL — `indexed_items`, `items_fts`, `vec_items_384` / `vec_items_1536`, `audit_log`, `sync_state`, `connector_health_history`, `api_endpoint`, `obsidian_notes`, the latency/slow-query logs, `llm_models`, `sub_task_results`, `tool_call_log`, `extension_dependency`, `git_blame_line`, `extensions`, the Phase 6 federation / org-policy / share tables, and the V44 `egress_ledger` — lives in **[`schema-reference.md`](./schema-reference.md)**. It was extracted from this document so the architecture narrative stays focused on shape rather than every column; it grows with every migration.
+The full table-by-table SQL — the unified V3 `item`, `item_fts`, `vec_items_384` / `vec_items_1536`, `audit_log`, `sync_state`, `connector_health_history`, `api_endpoint`, `obsidian_notes`, the latency/slow-query logs, `llm_models`, `sub_task_results`, `tool_call_log`, `extension_dependency`, `git_blame_line`, `extensions`, the Phase 6 federation / org-policy / share tables, and the V44 `egress_ledger` — lives in **[`schema-reference.md`](./schema-reference.md)**. It was extracted from this document so the architecture narrative stays focused on shape rather than every column; it grows with every migration.
 
 **What you need to know here:**
 

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -7,40 +7,41 @@ The SQLite tables that back the local index, audit log, sync state, embeddings, 
 > The SQL block below is the **shape**, not a snapshot of every column. Phase 6+ tables will land as new migrations and new item types — `service` / `team` / `scorecard` / `dora_metric` (Phase 7), `security_finding` / `posture_finding` / `security_incident` / `sbom_artifact` (Phase 8), `llm_trace` / `ml_model` / `vector_index` / `ai_spend_event` (Phase 9), and the multimodal-understanding / sandbox-execution tables (Phase 14). See [`roadmap.md` § Planned](./roadmap.md#planned) for the phase index.
 
 ```sql
--- Core metadata index
--- item_type values: "file" | "email" | "event" | "photo"
---                   "pr" | "issue" | "pipeline_run" | "deployment"
---                   "alert" | "incident" | "infra_resource"
---                   "data_model" | "data_pipeline" | "dashboard" | "log_alarm"  -- Phase 5/6
---                   "ml_model" | "data_quality_test"                             -- Phase 5/6 (pass 2)
---                   "api_endpoint"                                               -- Phase 5 Wave A PR 1 (V25)
---                   "obsidian_note"                                              -- Phase 5 Wave A PR 2 (V26)
--- Phase 7+: "service" | "team" | "scorecard" | "dora_metric" | "feature_flag" | ...
--- Phase 8+: "security_finding" | "posture_finding" | "security_incident" | "sbom_artifact" | ...
--- Phase 9+: "llm_trace" | "prompt_version" | "eval_run" | "vector_index" | "ai_spend_event" | ...
--- Note: "task" is not a currently emitted item_type; use "issue" for Linear/Jira items.
-CREATE TABLE indexed_items (
-    id          TEXT PRIMARY KEY,   -- "<service>:<native_id>"
-    service     TEXT NOT NULL,      -- "google_drive" | "gmail" | "github" | "jenkins" | ...
-    item_type   TEXT NOT NULL,
-    name        TEXT NOT NULL,
-    mime_type   TEXT,
-    size_bytes  INTEGER,
-    created_at  INTEGER,            -- Unix ms
-    modified_at INTEGER,
-    url         TEXT,
-    parent_id   TEXT,
-    sync_token  TEXT,
-    raw_meta    TEXT                -- JSON blob: service-specific fields
+-- Core metadata index — the unified V3 `item` table.
+-- Authoritative source: packages/gateway/src/index/unified-item-v3-sql.ts
+--
+-- The `type` column stores the connector's raw value VERBATIM. The vocabulary
+-- lives in @nimbus-dev/sdk (`KnownItemType`) and is an OPEN enum
+-- (`KnownItemType | (string & {})`), so a new connector can emit a new type
+-- without a schema or SDK change. Never coerce an unrecognised type into a
+-- recognised one — doing exactly that silently relabelled 55% of a live index
+-- as "file" until #780 removed the coercion.
+CREATE TABLE item (
+    id            TEXT PRIMARY KEY,   -- "<service>:<external_id>"
+    service       TEXT NOT NULL,      -- "google_drive" | "gmail" | "github" | "jenkins" | ...
+    type          TEXT NOT NULL,      -- open enum; see above
+    external_id   TEXT NOT NULL,      -- native id, NOT unique across services
+    title         TEXT NOT NULL,
+    body_preview  TEXT,
+    url           TEXT,
+    canonical_url TEXT,
+    modified_at   INTEGER NOT NULL,   -- Unix ms
+    author_id     TEXT,               -- references person(id)
+    metadata      TEXT,               -- JSON blob: service-specific fields
+    synced_at     INTEGER NOT NULL,
+    pinned        INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(service, external_id)
 );
 
-CREATE INDEX idx_items_service_modified ON indexed_items(service, modified_at DESC);
-CREATE INDEX idx_items_name ON indexed_items(name COLLATE NOCASE);
+CREATE INDEX idx_item_service ON item(service);
+CREATE INDEX idx_item_type ON item(type);
+CREATE INDEX idx_item_modified_at ON item(modified_at);
 
--- Full-text search (FTS5)
-CREATE VIRTUAL TABLE items_fts USING fts5(
-    name, raw_meta,
-    content=indexed_items, content_rowid=rowid
+-- Full-text search (FTS5) — kept in sync by AFTER INSERT/DELETE/UPDATE triggers
+-- on `item` (item_fts_insert / item_fts_delete / item_fts_update).
+CREATE VIRTUAL TABLE item_fts USING fts5(
+    title, body_preview,
+    content='item', content_rowid='rowid'
 );
 
 -- Vector search (sqlite-vec)


### PR DESCRIPTION
`schema-reference.md` documents a table that does not exist — and that fiction has already cost real work.

## The problem

The doc describes a table named `indexed_items` with columns `item_type`, `name`, `mime_type`, `size_bytes`, `created_at`, `parent_id`.

```bash
$ grep -rn "indexed_items" packages/gateway/src --include=*.ts | grep -v test
# (no output)
```

The real table is the unified V3 `item` (`index/unified-item-v3-sql.ts`):

```text
id, service, type, external_id, title, body_preview, url,
canonical_url, modified_at, author_id, metadata, synced_at, pinned
```

The doc was wrong about the *legacy* shape too: the pre-V3 table was `items`, not `indexed_items` — see `UNIFIED_ITEM_V3_MIGRATE_FROM_LEGACY_SQL`, which selects from `items.`.

## Why this is worth fixing now

This is not cosmetic staleness. Stage 0's original implementation plan was written **from this document**, mapped `item_type` and `name`, and produced a validator that **rejected all 546 rows** of a real index — a hard failure replacing a silent one. It was caught before merge and discarded, but only after the work was done. #785 landed the corrected plan and recorded the diagnosis; this PR fixes the source that caused it.

## Changes

- Replaces the `indexed_items` block with the real `item` table, its three indexes, and `item_fts` (noting the triggers that maintain it).
- Replaces the hand-maintained `item_type` comment list with a pointer to `@nimbus-dev/sdk` `KnownItemType`, and states plainly that the column is an **open enum** (`KnownItemType | (string & {})`) stored verbatim. That list was a fourth copy of the very vocabulary Stage 0 exists to consolidate — left in place it would simply have drifted again.
- Records why coercion is forbidden, citing the 55%-relabelling bug #780 fixed.
- Fixes the matching stale table names in `architecture.md`.

Deliberately **not** in scope: auditing the remaining ~40 table definitions in this file. This corrects the one that has demonstrably caused damage; a full audit is a separate pass.

## Verification

| Gate | Result |
| --- | --- |
| `lint:markdown` | ✅ 0 errors, 96 files |
| `audit:doc-refs` | ✅ 605 refs across 15 docs, all resolve |
| `lychee` at CI scope (`--config lychee.toml 'docs/**/*.md' '*.md'`) | ✅ 797 total, 0 errors |
| `audit:status-drift` | ✅ OK |

## Secondary purpose

This is a docs-only PR, so it is also the live proof for #788. Before #788, six required contexts would sit on *"Expected — Waiting for status to be reported"* forever and this PR could only merge via an OrganizationAdmin bypass. Expected now: `PR quality — required gates` reports and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
