### PR TITLE
ci: make the PR-title gate actually run

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -6,6 +6,18 @@ name: Lint PR Title
 # pull_request_target (not pull_request) so title validation also runs on PRs
 # from forks. Safe here: this job never checks out or runs PR code and keeps
 # read-only permissions, so the elevated context can't leak secrets.
+#
+# Validated inline rather than with amannn/action-semantic-pull-request. That
+# action is not on this repo's Actions allow-list — repo policy is
+# `allowed_actions: selected`, and the ORG's `all` does not override a repo's
+# own narrower setting — so every run of this workflow from #764 until now
+# ended in `startup_failure`. The gate existed and never once executed, which
+# is how three unparseable PR titles reached main. `startup_failure` is not a
+# required context, so nothing surfaced it.
+#
+# Checking a title against a regex needs no third-party action and no
+# checkout, so an inline step is both the smaller fix and the smaller attack
+# surface than widening the allow-list.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
@@ -19,13 +31,43 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      pull-requests: read
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - name: Validate Conventional Commit title
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed through the environment, never interpolated into the script
+          # body: a PR title is attacker-controlled text, and `${{ }}` expansion
+          # inside `run:` is a shell-injection sink.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # type(optional-scope)!: subject
+          # Types are the ones this repo actually uses, per `git log` on main.
+          pattern='^(feat|fix|chore|docs|ci|build|test|refactor|perf|style|revert)(\([a-z0-9._/-]+\))?!?: .+'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=PR title is not a Conventional Commit::${PR_TITLE}"
+            cat >&2 <<'EOF'
+          The repo squash-merges, so this title becomes the commit subject on main
+          and is what Release Please parses. A subject it cannot parse counts as
+          "no user facing commits": the change ships with no changelog entry and
+          triggers no release.
+
+          Expected:  type(optional-scope)!: subject
+          Types:     feat fix chore docs ci build test refactor perf style revert
+
+          Examples:
+            fix(db): enable WAL on the production SQLite write handles
+            feat: add nimbus prove
+            chore(deps)!: drop Node 20
+          EOF
+            exit 1
+          fi
+
+          echo "OK: ${PR_TITLE}"


### PR DESCRIPTION
## The gate has never run

Every invocation since #764 added it is `startup_failure`:

```
The action amannn/action-semantic-pull-request@0723387… is not allowed in
nimbus-agent/Nimbus because all actions must be from a repository owned by
nimbus-agent, created by GitHub, verified in the GitHub Marketplace, or match
one of the patterns…
```

This repo sets `allowed_actions: selected` with a 13-pattern allow-list that doesn't include `amannn/*`. The **org** is `all` — but a repo's narrower setting wins, which is why this looked fine when the App migration audited org-level policy and concluded no allow-list change was needed.

And `startup_failure` is **not a required context**, so a workflow that never ran was indistinguishable from one that passed.

## What it cost

Three unparseable PR titles reached `main` through the hole — #787, #789, #790. The repo squash-merges, so those became the commit subjects Release Please reads. It found no user-facing commits and cut no release:

```
✔ No user facing commits found since 6514f82c - skipping
```

So **the WAL fix in #789 has no changelog entry and is in no release**. The gate's own header comment predicted this exactly: *"a malformed one can't silently break a release."*

## The fix

Inline the check rather than widen the allow-list. Validating a title against a regex needs no third-party action and no checkout, so this is both the smaller change and the smaller attack surface — and it leaves the deliberately tight allow-list alone.

Two safety details kept from the original: `pull_request_target` so fork PRs are validated too, and the title passed via `env:` rather than interpolated into the `run:` body, since a PR title is attacker-controlled text and `${{ }}` in a script body is an injection sink.

## Verified against the real corpus

| Input | Result |
|---|---|
| `Retire CODECOV_TOKEN — it never reached Codecov` | ❌ fail |
| `Move App token minting off the deprecated app-id input` | ❌ fail |
| `Enable WAL on the production SQLite write handles` | ❌ fail |
| `fix(db): enable WAL on the production SQLite write handles` | ✅ pass |
| `chore(deps)!: drop Node 20` | ✅ pass |
| `refactor(index/migrations): split runner` | ✅ pass |
| `feat:no space after colon` | ❌ fail |
| `nope(scope): unknown type` | ❌ fail |

The allowed type list is derived from `git log` on `main`, not invented: feat, fix, chore, docs, ci, build, test, refactor, perf, style, revert.

`audit:action-sha-pins` passes; YAML re-parsed with `js-yaml`.

## This PR cannot self-test — correcting an earlier claim

I first wrote that this PR's own title would be the first passing run of the gate. **That is wrong.** `pull_request_target` always executes the workflow file from the **base** branch, so this PR is still validated by `main`'s broken copy — and its run is, correctly, another `startup_failure`.

The gate only starts working **after this merges**. The regex evidence above is local (`bash` against the real title corpus); the first genuine end-to-end proof will be the next PR opened after merge, which should show a `Validate PR title` check for the first time in this repo's history. Worth confirming on that PR rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)