### PR TITLE
chore(secrets): retire RELEASE_PLEASE_PAT — the last release PAT is gone

### DIFF
--- a/scripts/release/credential-registry.ts
+++ b/scripts/release/credential-registry.ts
@@ -61,20 +61,15 @@ export const CREDENTIAL_REGISTRY: readonly CredentialEntry[] = [
   // --- org scope ---
   {
     name: "RELEASE_PLEASE_PAT",
-    state: "required",
+    state: "forbidden",
     location: { scope: "org" },
     product: "actions",
     type: "pat",
     owner: OWNER,
-    consumedBy: [
-      "nimbus-sdk/.github/workflows/release.yml",
-      "nimbus-client/.github/workflows/release.yml",
-      "nimbus-vscode/.github/workflows/release-please.yml",
-    ],
-    maxAgeDays: 90,
+    consumedBy: [],
+    maxAgeDays: null,
     hardDeadline: null,
-    expectedVisibility: "selected",
-    note: "Interim state. Migrating the satellites onto the Release Bot App retires this entirely.",
+    note: "Deleted 2026-07-22 — the last long-lived release PAT retired. All four consumers now mint from the Release Bot App: Nimbus (#787), nimbus-client (#8), nimbus-sdk (#16), nimbus-vscode (#42), each proven with a live 'Mint release-bot token: success'. If this reappears, someone has reintroduced a PAT where the App now works.",
   },
   {
     name: "SONAR_TOKEN",


### PR DESCRIPTION
Deleted org-wide 2026-07-22. **The last long-lived credential on the release path.**

## All four consumers now mint from the App

| Repo | Migrated | Proven |
|---|---|---|
| Nimbus | #787 | ✅ |
| nimbus-client | #8 | ✅ |
| nimbus-sdk | #16 | ✅ live mint |
| nimbus-vscode | #42 | ✅ live mint on main |

Each shows `Mint release-bot token: success`. Zero live `secrets.RELEASE_PLEASE_PAT` references remain across all four repos.

## The manifest earned its keep

I nearly deleted this token after proving nimbus-sdk. The manifest's `consumedBy` listed **nimbus-vscode** as a fourth consumer — a check confirmed it still used the PAT, and deleting then would have broken its releases. That's the credential registry (#783) doing exactly what it's for.

Flipped `required → forbidden` (deletion first, so `forbidden` + absent reads "correctly absent" rather than the hard failure `forbidden` + present would give).

## The release credential surface is now fully App-based

`RELEASE_PAT`, `PACKAGE_MANAGER_PAT`, `RELEASE_BOT_APP_ID`, and `RELEASE_PLEASE_PAT` are all **deleted and forbidden**. The App credentials live as **org secrets** (client-id all, private-key scoped to the 4 release repos). Only `WINGET_PAT` remains — it forks `microsoft/winget-pkgs`, which the App cannot reach.

## Verification

`bun test scripts/release/` 11/11 registry + suite green; `audit:consumed-by` OK; standalone `tsc --strict` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)