### PR TITLE
fix(agents): report why a janitor resourceRef was rejected

### DIFF
--- a/packages/gateway/src/agents/janitor.test.ts
+++ b/packages/gateway/src/agents/janitor.test.ts
@@ -101,13 +101,34 @@ test("a gap suppresses the proposal unless allowGaps", async () => {
   expect(lenient.proposalSuppressed).toBe(false);
 });
 
-test("an invalid ref is flagged as a gap and never proposes", async () => {
+test("a too-short ref is flagged as a gap, naming the length, and never proposes", async () => {
   const brief = await runJanitor(
     { resourceRef: "ab", idleDays: 7, cleanupAction: null, allowGaps: true },
     baseCtx(freshDb(), async () => ({ touched: false })),
   );
   expect(brief.idle).toBe(false);
-  expect(brief.gaps.some((g) => g.detail.includes("malformed"))).toBe(true);
+  const gap = brief.gaps.find((g) => g.detail.includes("resourceRef"));
+  expect(gap?.detail).toContain("at least 4");
+  expect(gap?.detail).toContain("got 2");
+});
+
+test("a long ref with an unsupported character is flagged for its CHARACTER SET, not length", async () => {
+  // 29 chars. The gap used to read "too short or malformed (min 4 chars)", which
+  // sent anyone debugging it looking for a length problem that did not exist —
+  // `#` simply is not in the allowed set.
+  const brief = await runJanitor(
+    {
+      resourceRef: "repo:acme/payments#branch/wip",
+      idleDays: 7,
+      cleanupAction: null,
+      allowGaps: true,
+    },
+    baseCtx(freshDb(), async () => ({ touched: false })),
+  );
+  expect(brief.idle).toBe(false);
+  const gap = brief.gaps.find((g) => g.detail.includes("resourceRef"));
+  expect(gap?.detail).toContain("only letters, digits");
+  expect(gap?.detail).not.toContain("at least");
 });
 
 test("emitJanitorBrief fires janitor.briefReady", async () => {

--- a/packages/gateway/src/agents/janitor.ts
+++ b/packages/gateway/src/agents/janitor.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { fanOutProbe } from "../federation/peer-fanout.ts";
-import { isValidResourceRef } from "../federation/resource-probe.ts";
+import { describeInvalidResourceRef } from "../federation/resource-probe.ts";
 import type { KnownNamespaceStore } from "../index/known-namespace-store.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import type { sendFederatedOverWire } from "../ipc/lan-client.ts";
@@ -31,11 +31,12 @@ export type JanitorContext = {
 export async function runJanitor(input: JanitorInput, ctx: JanitorContext): Promise<JanitorBrief> {
   const start = performance.now();
   const gaps: GapNote[] = [];
-  const refValid = isValidResourceRef(input.resourceRef);
-  if (!refValid) {
+  const refProblem = describeInvalidResourceRef(input.resourceRef);
+  const refValid = refProblem === null;
+  if (refProblem !== null) {
     gaps.push({
       category: "missing_connector",
-      detail: "resourceRef too short or malformed (min 4 chars)",
+      detail: refProblem,
     });
   }
   if (ctx.index.listLanPeers().length === 0) {

--- a/packages/gateway/src/federation/resource-probe.test.ts
+++ b/packages/gateway/src/federation/resource-probe.test.ts
@@ -1,7 +1,11 @@
 import { Database } from "bun:sqlite";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
-import { isValidResourceRef, probeResourceRecency } from "./resource-probe.ts";
+import {
+  describeInvalidResourceRef,
+  isValidResourceRef,
+  probeResourceRecency,
+} from "./resource-probe.ts";
 
 function seed(): Database {
   const db = new Database(":memory:");
@@ -42,4 +46,29 @@ test("touched resource → recency from MAX(modified_at), content-free", () => {
 test("invalid ref never reports touched (fail-safe)", () => {
   const db = seed();
   expect(probeResourceRecency(db, { resourceRef: "ab" }, () => 1).touched).toBe(false);
+});
+
+describe("describeInvalidResourceRef", () => {
+  test("accepts a valid ref", () => {
+    expect(describeInvalidResourceRef("acme/payments")).toBeNull();
+  });
+
+  test("reports LENGTH for a short ref, quoting the actual length", () => {
+    const why = describeInvalidResourceRef("abc");
+    expect(why).toContain("at least 4");
+    expect(why).toContain("got 3");
+  });
+
+  test("reports CHARACTER SET, not length, for a long ref with an unsupported char", () => {
+    // 29 chars — the case that used to be reported as "too short (min 4 chars)".
+    const why = describeInvalidResourceRef("repo:acme/payments#branch/wip");
+    expect(why).toContain("only letters, digits");
+    expect(why).not.toContain("at least");
+  });
+
+  test("agrees with isValidResourceRef", () => {
+    for (const ref of ["abc", "abcd", "acme/payments", "repo:acme/payments#branch/wip", "a b"]) {
+      expect(describeInvalidResourceRef(ref) === null).toBe(isValidResourceRef(ref));
+    }
+  });
 });

--- a/packages/gateway/src/federation/resource-probe.ts
+++ b/packages/gateway/src/federation/resource-probe.ts
@@ -17,6 +17,24 @@ export function isValidResourceRef(ref: string): boolean {
   return ref.length >= MIN_RESOURCE_REF_LEN && RESOURCE_REF_RE.test(ref);
 }
 
+/**
+ * Why `isValidResourceRef` rejected a ref, or `null` if it did not.
+ *
+ * Two independent rules reject a ref and callers were reporting only the length
+ * one, so a ref failing on an unsupported character (`#` is the common case —
+ * `repo:acme/payments#branch/wip` is a natural thing to type) was told it was
+ * "too short" while being 29 characters long.
+ */
+export function describeInvalidResourceRef(ref: string): string | null {
+  if (ref.length < MIN_RESOURCE_REF_LEN) {
+    return `resourceRef must be at least ${MIN_RESOURCE_REF_LEN} characters (got ${ref.length})`;
+  }
+  if (!RESOURCE_REF_RE.test(ref)) {
+    return "resourceRef may contain only letters, digits, and _ : . - /";
+  }
+  return null;
+}
+
 /** Escape SQL LIKE metacharacters so the ref matches literally (no wildcard probing). */
 function escapeLikeWildcards(s: string): string {
   return s


### PR DESCRIPTION
## The bug

`isValidResourceRef` enforces **two** independent rules — a minimum length and an allowed character
set — but the janitor gap only ever mentioned the length:

```text
resourceRef too short or malformed (min 4 chars)
```

So `repo:acme/payments#branch/wip` — **29 characters**, rejected because `#` is not in
`/^[A-Za-z0-9_:.\-/]+$/` — was reported as too short. Anyone debugging that goes looking for a length
problem that doesn't exist, on a ref that is plainly long enough.

Found while generating agent-brief fixtures from real gateway output: the janitor brief came back
with that gap for a ref that was obviously not short.

## The fix

`describeInvalidResourceRef(ref)` returns the specific reason or `null`, and the janitor surfaces it:

- too short → `resourceRef must be at least 4 characters (got 2)`
- bad character → `resourceRef may contain only letters, digits, and _ : . - /`

Validation behaviour is unchanged — exactly the same refs are accepted and rejected.
`isValidResourceRef` is untouched for its other callers, and a test asserts the two functions always
agree.

## Tests

Both rejection paths, in both the probe and the agent:

- the length case asserts the message names the **actual** length (`got 2`);
- the long-ref/bad-character case asserts the message says character set **and explicitly does not
  mention length** — the assertion that would have caught the original bug.

Gateway agents: 170/170. `biome check packages scripts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)