### PR TITLE
fix(ipc): the connector HITL prompts named params no caller sends

### DIFF
--- a/packages/gateway/src/ipc/connector-rpc-routing.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc-routing.test.ts
@@ -35,14 +35,25 @@ type GateResult =
   | { status: "rejected"; reason: string }
   | { status: "deferred"; reason: string };
 
+/**
+ * Records the FULL gate action, payload included.
+ *
+ * This stub used to keep only `{ type }`, which is exactly how #808 survived:
+ * both gated methods built their payload from parameter keys no caller sends,
+ * and every assertion here looked past the field that was empty. The payload is
+ * not decoration — `executor.gate()` feeds the same object to the consent
+ * prompt, the audit row (`auditPayload`) and the I29 egress-ledger row, so an
+ * empty payload means the owner authorizes, and the ledger attests to, nothing
+ * identifiable.
+ */
 function makeStubExecutor(gateResult: GateResult): {
   exec: ToolExecutor;
-  calls: Array<{ type: string }>;
+  calls: Array<{ type: string; payload: unknown }>;
 } {
-  const calls: Array<{ type: string }> = [];
+  const calls: Array<{ type: string; payload: unknown }> = [];
   const exec = {
-    async gate(args: { type: string }): Promise<GateResult> {
-      calls.push({ type: args.type });
+    async gate(args: { type: string; payload?: unknown }): Promise<GateResult> {
+      calls.push({ type: args.type, payload: args.payload });
       return gateResult;
     },
   } as unknown as ToolExecutor;
@@ -89,7 +100,13 @@ describe("dispatchConnectorRpc — addMcp gate", () => {
     expect(r.kind).toBe("hit");
     if (r.kind !== "hit") return;
     expect(r.value).toEqual({ status: "rejected", reason: "user declined" });
-    expect(calls).toEqual([{ type: "connector.addMcp" }]);
+    expect(calls).toEqual([
+      {
+        type: "connector.addMcp",
+        // The owner must see WHICH command they are authorizing a spawn of.
+        payload: { serviceId: "mcp_blocked", commandLine: "echo hi" },
+      },
+    ]);
     const row = db
       .query("SELECT service_id FROM user_mcp_connector WHERE service_id = ?")
       .get("mcp_blocked");
@@ -109,6 +126,33 @@ describe("dispatchConnectorRpc — addMcp gate", () => {
     if (r.kind !== "hit") return;
     expect(r.value).toEqual({ ok: true, serviceId: "mcp_ok" });
   });
+
+  test("the gated payload names the same keys handleConnectorAddMcp consumes", async () => {
+    // The regression guard for #808. The handler reads `serviceId`/`commandLine`
+    // and derives command+args itself; the gate previously read `command`/`args`
+    // straight off the params, which are never sent — so every field was
+    // `undefined` and JSON.stringify dropped them, leaving `"payload":{}` in the
+    // prompt, the audit row and the egress ledger.
+    const { exec, calls } = makeStubExecutor("proceed");
+    await dispatchConnectorRpc({
+      ...baseOpts({
+        toolExecutor: exec,
+        syncScheduler: { register: () => {} },
+        connectorMesh: { ensureUserMcpRunning: async () => {} },
+      }),
+      method: "connector.addMcp",
+      params: { serviceId: "mcp_probe", commandLine: "npx -y @evil/pkg" },
+    });
+
+    const payload = calls[0]?.payload as Record<string, unknown>;
+    // Asserted through a JSON round-trip because that is the transform the audit
+    // and egress sinks apply: a payload of all-`undefined` fields survives a
+    // naive toEqual against `{}` but is exactly the bug.
+    expect(JSON.parse(JSON.stringify(payload))).toEqual({
+      serviceId: "mcp_probe",
+      commandLine: "npx -y @evil/pkg",
+    });
+  });
 });
 
 describe("dispatchConnectorRpc — remove gate", () => {
@@ -117,7 +161,7 @@ describe("dispatchConnectorRpc — remove gate", () => {
       await dispatchConnectorRpc({
         ...baseOpts({}),
         method: "connector.remove",
-        params: { service: "github" },
+        params: { serviceId: "github" },
       });
       throw new Error("expected throw");
     } catch (e) {
@@ -130,11 +174,25 @@ describe("dispatchConnectorRpc — remove gate", () => {
     const r = await dispatchConnectorRpc({
       ...baseOpts({ toolExecutor: exec }),
       method: "connector.remove",
-      params: { service: "github" },
+      params: { serviceId: "github" },
     });
     expect(r.kind).toBe("hit");
     if (r.kind !== "hit") return;
     expect(r.value).toEqual({ status: "deferred", reason: "later" });
+  });
+
+  test("the gated payload names the service the handler will actually remove", async () => {
+    // Same defect as addMcp: the gate read `service` while
+    // `requireRegisteredSchedulerServiceId` reads `serviceId`, so the prompt for
+    // a destructive action (index entries deleted, Vault keys cleared) was blank.
+    const { exec, calls } = makeStubExecutor({ status: "rejected", reason: "no" });
+    await dispatchConnectorRpc({
+      ...baseOpts({ toolExecutor: exec }),
+      method: "connector.remove",
+      params: { serviceId: "github" },
+    });
+
+    expect(JSON.parse(JSON.stringify(calls[0]?.payload))).toEqual({ serviceId: "github" });
   });
 });
 

--- a/packages/gateway/src/ipc/connector-rpc.ts
+++ b/packages/gateway/src/ipc/connector-rpc.ts
@@ -61,11 +61,18 @@ export async function dispatchConnectorRpc(options: {
         throw new ConnectorRpcError(-32603, "connector.addMcp requires a toolExecutor");
       }
       const addMcpRec = asRecord(params) ?? {};
+      // The payload MUST name the keys the handler actually consumes
+      // (`serviceId`/`commandLine`) — it used to read `command`/`args`, which no
+      // caller sends, so the owner was asked to authorize spawning an arbitrary
+      // local process while the prompt, the audit row and the egress-ledger row
+      // all rendered empty (#808). `commandLine` is the raw string the handler
+      // parses; showing it verbatim keeps the prompt identical to what was asked
+      // for, rather than a re-derivation that could disagree with it.
       const gateResult = await toolExecutor.gate({
         type: "connector.addMcp",
         payload: {
-          command: addMcpRec["command"],
-          args: addMcpRec["args"],
+          serviceId: addMcpRec["serviceId"],
+          commandLine: addMcpRec["commandLine"],
         },
       });
       if (gateResult !== "proceed") return { kind: "hit", value: gateResult };
@@ -89,9 +96,13 @@ export async function dispatchConnectorRpc(options: {
       if (toolExecutor === undefined) {
         throw new ConnectorRpcError(-32603, "connector.remove requires a toolExecutor");
       }
+      // `serviceId`, not `service`: `handleConnectorRemove` resolves the id via
+      // `requireRegisteredSchedulerServiceId`, which reads `serviceId` only. The
+      // gate read `service`, so this destructive action (deletes index entries,
+      // clears Vault keys) also prompted blank (#808).
       const gateResult = await toolExecutor.gate({
         type: "connector.remove",
-        payload: { service: asRecord(params)?.["service"] },
+        payload: { serviceId: asRecord(params)?.["serviceId"] },
       });
       if (gateResult !== "proceed") return { kind: "hit", value: gateResult };
       return handleConnectorRemove(ctx);


### PR DESCRIPTION
Closes #808.

Both HITL-gated `connector.*` methods built their consent payload from parameter keys that no caller sends, so every field was `undefined`:

| Method | Gate read | Handler actually reads |
| --- | --- | --- |
| `connector.addMcp` | `command`, `args` | `serviceId`, `commandLine` (derives command/args itself via `parseUserMcpCommandLine`) |
| `connector.remove` | `service` | `serviceId` (via `requireRegisteredSchedulerServiceId`) |

## Why this is more than a blank prompt

`JSON.stringify` drops `undefined`, so `"payload":{}` reached all three sinks `executor.gate()` feeds:

- the owner's consent prompt
- the audit row (`auditPayload` → `redactAuditPayload({ action })`)
- the BLAKE3-chained I29 egress-ledger row (`buildEgressEntry({ action, ... })`)

For the one action class that causes the gateway to **spawn an arbitrary local process**, the prompt showed nothing about which binary was being authorized — and `nimbus prove` over a window containing an `addMcp` could attest that *an* addMcp was approved but not *which command*, which is most of what the proof is for.

**I2/I3 were never violated.** The gate fires, on `action.type`, for both methods; the frozen-set membership check is correct. What failed is the *informed* half of human-in-the-loop. A gate the owner cannot read is a gate the owner learns to click through.

## The fix

Each payload now names the keys its handler consumes. `addMcp` shows the raw `commandLine` rather than a re-derived `command` + `args` — it is what the caller asked for, so the prompt cannot disagree with what the handler goes on to parse.

## Why it survived until now

The test stub recorded only `{ type }` from the gate call and threw the payload away, so every existing assertion looked past the one field that was empty. It now records the full action.

Both new guards assert through a **JSON round-trip**, because that is the transform the audit and egress sinks apply: a payload of all-`undefined` fields passes a naive `toEqual({})` and is precisely the bug.

**Red-proven** — against the unfixed source, 3 failures (the two new guards plus the strengthened existing assertion), each reporting a received payload of `{}`.

## Verification

- `bun test packages/gateway/src/ipc/connector-rpc-routing.test.ts` — 15 pass
- `bun test packages/gateway/src/engine/ packages/gateway/src/egress/ packages/gateway/src/security-invariants.test.ts` — 501 pass, 0 fail (the gate's three consumers)
- `bun run typecheck` — clean; `bunx biome check packages scripts` — 2909 files, clean
- `scripts/structure-audit/check-nimbus-invariants.ts` — exit 0

**Unrelated pre-existing failure, not introduced here:** `handleConnectorAuth > google_drive reaches its provider arm...` times out in the combined `bun test packages/gateway/src/ipc/` run but passes in isolation. Confirmed identical on unmodified `main`. Filing separately rather than folding a flake fix into a security change.

Found while exposing `connector.*` in `@nimbus-dev/client` (Stage 1 wave 1g).

🤖 Generated with [Claude Code](https://claude.com/claude-code)