### PR TITLE
feat(graph): make resolves, mentions and correlates_with real (why-lens step 1a)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -1317,13 +1317,31 @@ const CORRELATION_WINDOW_MS = 2 * 60 * 60 * 1000;
 
 type TimelineRow = { id: string; occurred_at: number };
 
+/**
+ * Counterparts within the window, ordered NEAREST-FIRST so `LIMIT 20` keeps the
+ * most plausibly causal ones.
+ *
+ * The direction of "nearest" differs per side, which is why it is a parameter
+ * rather than a constant. A deployment looks FORWARD (`[D, D+W]`), so nearest is
+ * the earliest incident — `ASC`. An incident looks BACKWARD (`[I-W, I]`), so
+ * nearest is the latest deployment — `DESC`. Using `ASC` for both silently
+ * keeps the 20 most temporally DISTANT deploys before an incident and drops the
+ * ones immediately preceding it: with 25 deploys in the window, the deploy four
+ * minutes before the incident is discarded while twenty from two hours earlier
+ * are retained — precisely inverting "which deploy caused this?".
+ *
+ * The `id` tie-break makes the ordering deterministic when two entities share a
+ * timestamp; SQLite is stable in practice but does not guarantee it.
+ */
 function timelineCounterparts(
   db: Database,
   counterpartType: "incident" | "deployment",
   affectedService: string,
   windowFrom: number,
   windowTo: number,
+  nearestFirst: "ASC" | "DESC",
 ): TimelineRow[] {
+  const order = nearestFirst === "ASC" ? "ASC" : "DESC";
   return db
     .query(
       `SELECT id,
@@ -1332,7 +1350,7 @@ function timelineCounterparts(
         WHERE type = ?
           AND json_extract(metadata, '$.affectedService') = ?
           AND CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) BETWEEN ? AND ?
-        ORDER BY occurred_at ASC
+        ORDER BY occurred_at ${order}, id ASC
         LIMIT 20`,
     )
     .all(counterpartType, affectedService, windowFrom, windowTo) as TimelineRow[];
@@ -1342,16 +1360,35 @@ function timelineCounterparts(
 Then replace the `void now;` line at the end of `syncTimelineEventGraph` with:
 
 ```ts
+  // Retire first, unconditionally. These clears MUST precede the
+  // `affectedService === undefined` bail-out: an entity that previously had a
+  // service (and so emitted edges) and is re-synced without one would otherwise
+  // return before retiring them, leaving the graph asserting "this deploy caused
+  // that incident" while the deploy itself no longer claims any service. The
+  // entity row updates to `affectedService: null`, but the orphaned edge
+  // survives forever.
+  //
+  // The pair is load-bearing because `clearRelationsTouchingEntity` skips
+  // `correlates_with` entirely (Task 1). Each side owns one direction: a
+  // deployment owns its outgoing edges, an incident its incoming ones, and only
+  // that entity's own sync knows its current window and service.
+  if (entityType === "deployment") {
+    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
+  } else {
+    clearIncomingRelationsOfType(db, entityId, "correlates_with");
+  }
+
+  // A null service correlates with nothing. Bail out only AFTER the clears.
   if (affectedService === undefined) return;
 
   if (entityType === "deployment") {
-    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
     for (const inc of timelineCounterparts(
       db,
       "incident",
       affectedService,
       occurredAt,
       occurredAt + CORRELATION_WINDOW_MS,
+      "ASC", // forward window: nearest incident is the earliest after the deploy
     )) {
       upsertGraphRelation(db, entityId, inc.id, "correlates_with", now);
     }
@@ -1360,19 +1397,13 @@ Then replace the `void now;` line at the end of `syncTimelineEventGraph` with:
 
   // An incident syncing after its deploy must still create the edge, and the
   // edge is always directed deployment -> incident.
-  //
-  // The incoming clear is load-bearing: `clearRelationsTouchingEntity` skips
-  // `correlates_with` (Task 1), so an incident that moved in time or changed
-  // service would otherwise keep every correlation it ever had. Only the
-  // incident's own sync knows its current window and service, so only it can
-  // retire those edges.
-  clearIncomingRelationsOfType(db, entityId, "correlates_with");
   for (const dep of timelineCounterparts(
     db,
     "deployment",
     affectedService,
     occurredAt - CORRELATION_WINDOW_MS,
     occurredAt,
+    "DESC", // backward window: nearest deploy is the latest before the incident
   )) {
     upsertGraphRelation(db, dep.id, entityId, "correlates_with", now);
   }
@@ -1781,6 +1812,14 @@ From `2026-07-23-why-lens-1a-populator-edges-feedback.md`.
 | 4 | Expression index on JSON fields | **Deferred**, premise corrected below. |
 | 5 | *(found during execution, Task 4 review)* `findCommitEntityIds` could not match short SHAs | **Fixed** — see below. |
 | 6 | *(found during execution, Task 5 review)* `occurredAtForItem` silently fabricated a `Date.now()` timestamp | **Fixed** — throws instead. |
+| 7 | *(found during execution, Task 6 review)* the retirement clears sat behind an early return | **Fixed** — clears moved above the bail-out. |
+| 8 | *(found during execution, Task 6 review)* `LIMIT 20` kept the most DISTANT counterparts | **Fixed** — nearest-first ordering per side. |
+
+**On #7 — a retirement guard that could be skipped entirely.** `syncTimelineEventGraph` bailed out on `affectedService === undefined` *before* reaching its `clear*` call. An entity that previously had a service, emitted a `correlates_with` edge, and was then re-synced without one returned early and never retired the edge. Reproduced: after re-syncing a deployment with no `service`, its `graph_entity` row correctly reads `affectedService: null` while the correlation edge survives — the graph asserts "this deploy caused that incident" about a deploy that no longer claims any service. The clears now run unconditionally, before the bail-out.
+
+**On #8 — the truncation kept exactly the wrong counterparts.** `timelineCounterparts` ordered `occurred_at ASC` for both directions. That is correct looking forward from a deployment, but inverted looking backward from an incident: the incident-side window is `[I-W, I]`, so `ASC` retains the twenty *oldest* deploys and discards the ones immediately preceding the incident. Reproduced with 25 deploys in a two-hour window: the deploy four minutes before the incident was dropped while twenty from nearly two hours earlier were kept — precisely inverting "which deploy caused this?". The helper now takes a per-side `nearestFirst` direction (`ASC` forward, `DESC` backward) and adds an `id` tie-break so ordering is deterministic under equal timestamps rather than relying on SQLite's incidental stability.
+
+Both were plan-text defects reproduced verbatim by the implementer, not deviations.
 
 **On #6 — a silent default that would have produced a confidently wrong answer.** The plan's `occurredAtForItem` ended `?? Date.now()`. On the production path that branch is unreachable: `upsertIndexedItem` inserts the row and then calls the populator synchronously on the same `bun:sqlite` handle. But `syncGraphFromIndexedItem` is exported, and six sibling test files already call it directly with no item row — an established local idiom. None passes `incident`/`deployment` today, so the fallback is latent rather than live; the moment one does, the entity gets a fabricated `occurredAt`, and Task 6 correlates deployments to incidents *on that timestamp*. The failure mode is a wrong correlation, not a missing one — strictly worse than an error. Now throws with a message naming the cause.
 

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -59,6 +59,7 @@ This task must land first — every later task depends on it.
 - Produces:
   - `CROSS_ITEM_RELATION_TYPES: readonly ["resolves", "mentions", "correlates_with"]` — module-private.
   - `clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void` — module-private. Later tasks call this immediately before re-emitting a cross-item edge, so the emitting side stays authoritative for its own edges.
+  - `clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void` — module-private. The mirror image, for the case where the *target* of a cross-item edge is authoritative for whether the edge should still exist (Task 6's incident side).
   - `clearRelationsTouchingEntity(db: Database, entityId: string): void` — unchanged signature, new behavior.
 
 - [ ] **Step 1: Write the failing test**
@@ -201,7 +202,19 @@ function clearRelationsTouchingEntity(db: Database, entityId: string): void {
 function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void {
   dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? AND type = ?", [fromId, relationType]);
 }
+
+/**
+ * The mirror image, for a cross-item edge whose *target* decides whether the
+ * edge still belongs. Task 6 needs this: an incident that moves in time or
+ * changes service must drop the correlations pointing at it, and only the
+ * incident's own sync knows that.
+ */
+function clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE to_id = ? AND type = ?", [toId, relationType]);
+}
 ```
+
+The two clears are disjoint in effect — one keys on `from_id`, the other on `to_id` — so each side stays authoritative for its own slice of a cross-item relation without racing the other.
 
 Note the placeholder string is built from array *length* only — every value still binds, so `I9` holds.
 
@@ -735,7 +748,13 @@ test("deduplicates SHAs", () => {
 });
 ```
 
-Note the second case: `1234567` is seven hex characters and is indistinguishable from a short SHA by shape alone. It is kept — a false positive that resolves to no commit entity emits no edge, so the cost is a wasted lookup, whereas excluding all-digit runs would drop real SHAs.
+Note the second case: `1234567` is seven hex characters and is indistinguishable from a short SHA by shape alone. **It is deliberately kept.**
+
+A reviewer proposed skipping all-decimal 7-character candidates to avoid false-positive lookups. The arithmetic argues against it: a hex character is decimal with probability 10/16, so an all-decimal 7-character SHA prefix occurs at rate (10/16)⁷ ≈ **3.7%**. That filter would silently drop roughly one in twenty-seven real short-SHA mentions.
+
+What it buys is one avoided lookup per false positive. That lookup is `external_id LIKE '%:' || ?`, which cannot use an index — but it is bounded by the `UNIQUE(type, external_id)` prefix on `type = 'commit'`, so it scans commit entities only, and a message body yields few candidates.
+
+The trade is a few milliseconds against a 3.7% silent miss rate. This entire phase exists because three lanes were silently empty; accepting a new silent-miss rate to save microseconds is the wrong direction. Keep the false positives — they resolve to nothing and emit nothing.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1206,13 +1225,39 @@ test("a different service does not correlate", () => {
 
   expect(correlations(db)).toEqual([]);
 });
+
+test("re-syncing an incident to a different service retires the stale correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The incident is re-classified against a different service.
+  seedIncident(db, t + HOUR, "search");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("re-syncing an incident out of the window retires the stale correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The incident's true start time turns out to be much later.
+  seedIncident(db, t + 5 * HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `bun test packages/gateway/src/graph/graph-populator-incidents.test.ts`
 
-Expected: FAIL — the first two tests get `[]`.
+Expected: FAIL — the first two tests get `[]`, and the two retirement tests fail on their second assertion with a surviving stale edge.
 
 - [ ] **Step 3: Implement the correlation**
 
@@ -1267,6 +1312,13 @@ Then replace the `void now;` line at the end of `syncTimelineEventGraph` with:
 
   // An incident syncing after its deploy must still create the edge, and the
   // edge is always directed deployment -> incident.
+  //
+  // The incoming clear is load-bearing: `clearRelationsTouchingEntity` skips
+  // `correlates_with` (Task 1), so an incident that moved in time or changed
+  // service would otherwise keep every correlation it ever had. Only the
+  // incident's own sync knows its current window and service, so only it can
+  // retire those edges.
+  clearIncomingRelationsOfType(db, entityId, "correlates_with");
   for (const dep of timelineCounterparts(
     db,
     "deployment",
@@ -1479,53 +1531,105 @@ function parseMetadata(raw: string | null): Record<string, unknown> {
 }
 
 /**
- * Re-run the graph populator over every indexed item.
+ * Item types graphed in dependency order. An entity that is only ever a
+ * reference *target* must already exist when the item referencing it is
+ * processed, or the edge is silently skipped: `findIssueEntityIds` and
+ * `findCommitEntityIds` resolve against `graph_entity`, not `item`.
  *
- * Needed because a populator change only reaches existing rows when they next
- * re-sync — and historical items may never re-sync. Paged so a large index
- * does not materialise every row at once. Idempotent: each sync function
- * clears and rebuilds the edges it owns.
+ * `deployment` / `incident` correlate symmetrically (either side emits the
+ * edge), so their relative order is free — they are listed only to keep the
+ * whole dependency story in one place.
  */
-export function regraphAllItems(db: Database, opts?: { batchSize?: number }): RegraphResult {
-  const batchSize = opts?.batchSize ?? 500;
-  let offset = 0;
-  let scanned = 0;
-  let graphed = 0;
+const REGRAPH_TYPE_ORDER: readonly string[] = Object.freeze([
+  "issue",
+  "git_commit",
+  "deployment",
+  "incident",
+  "pr",
+  "message",
+]);
 
+function graphOneRow(db: Database, r: ItemRow): boolean {
+  if (!isItemLinkedGraphType(r.type)) return false;
+  syncGraphFromIndexedItem(db, {
+    id: r.id,
+    service: r.service,
+    type: r.type,
+    title: r.title,
+    bodyPreview: r.body_preview,
+    authorId: r.author_id,
+    metadata: parseMetadata(r.metadata),
+  });
+  return true;
+}
+
+/**
+ * Page through one slice of the item table by keyset (`id > lastId`) rather
+ * than OFFSET. OFFSET makes SQLite re-walk every skipped row on each page,
+ * which turns a large backfill quadratic.
+ */
+function regraphSlice(
+  db: Database,
+  where: string,
+  params: readonly unknown[],
+  batchSize: number,
+  counters: { scanned: number; graphed: number },
+): void {
+  let lastId = "";
   for (;;) {
     const rows = db
       .query(
         `SELECT id, service, type, title, body_preview, author_id, metadata
            FROM item
+          WHERE ${where} AND id > ?
           ORDER BY id ASC
-          LIMIT ? OFFSET ?`,
+          LIMIT ?`,
       )
-      .all(batchSize, offset) as ItemRow[];
-    if (rows.length === 0) break;
+      .all(...params, lastId, batchSize) as ItemRow[];
+    if (rows.length === 0) return;
 
     for (const r of rows) {
-      scanned += 1;
-      if (!isItemLinkedGraphType(r.type)) continue;
-      syncGraphFromIndexedItem(db, {
-        id: r.id,
-        service: r.service,
-        type: r.type,
-        title: r.title,
-        bodyPreview: r.body_preview,
-        authorId: r.author_id,
-        metadata: parseMetadata(r.metadata),
-      });
-      graphed += 1;
+      counters.scanned += 1;
+      if (graphOneRow(db, r)) counters.graphed += 1;
     }
 
-    offset += rows.length;
+    const last = rows.at(-1);
+    if (last === undefined) return;
+    lastId = last.id;
+  }
+}
+
+/**
+ * Re-run the graph populator over every indexed item.
+ *
+ * Needed because a populator change only reaches existing rows when they next
+ * re-sync — and historical items may never re-sync.
+ *
+ * Processed in `REGRAPH_TYPE_ORDER` so reference targets are graphed before
+ * the items that reference them; every edge this plan emits therefore settles
+ * in a single pass. Idempotent regardless — each sync function clears and
+ * rebuilds the edges it owns — so re-running is always safe.
+ */
+export function regraphAllItems(db: Database, opts?: { batchSize?: number }): RegraphResult {
+  const batchSize = opts?.batchSize ?? 500;
+  const counters = { scanned: 0, graphed: 0 };
+
+  for (const type of REGRAPH_TYPE_ORDER) {
+    regraphSlice(db, "type = ?", [type], batchSize, counters);
   }
 
-  return { scanned, graphed };
+  // Everything else: graph-participating types with no ordering constraint,
+  // plus non-participating types, which are counted as scanned but skipped.
+  const placeholders = REGRAPH_TYPE_ORDER.map(() => "?").join(", ");
+  regraphSlice(db, `type NOT IN (${placeholders})`, REGRAPH_TYPE_ORDER, batchSize, counters);
+
+  return counters;
 }
 ```
 
-The ordering caveat is real and acceptable: a PR processed before the issue it references emits no `resolves` edge on that pass. Because the backfill is idempotent, running it twice resolves every forward reference — which the idempotency test above also demonstrates.
+The `where` fragment is a module-private literal built only from `REGRAPH_TYPE_ORDER.length`; every value still binds, so `I9` holds.
+
+**Why not `ORDER BY CASE type ... END`:** it expresses the same intent in one query, but no index can serve the computed sort key, so SQLite materialises and sorts the entire item table — and with `OFFSET` paging it redoes that sort for every page. Slicing by type keeps each query on `idx_item_type` and the keyset cursor keeps each page O(batch).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -1533,15 +1637,52 @@ Run: `bun test packages/gateway/src/graph/regraph.test.ts`
 
 Expected: PASS, 3 tests.
 
-- [ ] **Step 5: Document the two-pass caveat in the module**
+- [ ] **Step 5: Prove a single pass settles forward references**
 
-Append to the `regraphAllItems` doc comment:
+Append to `packages/gateway/src/graph/regraph.test.ts`:
 
 ```ts
- * Ordering caveat: items are processed in `id` order, so a PR seen before the
- * issue it references emits no `resolves` edge on that pass. Run twice to
- * settle forward references; the operation is idempotent.
+test("one pass settles a forward reference that sorts the wrong way by id", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  // `github:acme/app#1` (the PR) sorts BEFORE `github:acme/app#4` (the issue),
+  // so an id-ordered backfill processes the PR while the issue entity does not
+  // yet exist and emits nothing. Type ordering is what makes one pass enough.
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+
+  regraphAllItems(db);
+
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});
 ```
+
+Numeric refs resolve within one service (Task 3), so both items must share `service: "github"` for `#4` to bind — which is also the realistic case.
+
+Run: `bun test packages/gateway/src/graph/regraph.test.ts`
+
+Expected: PASS, 4 tests. If this one fails, `REGRAPH_TYPE_ORDER` is not being honoured — and note the Step 1 backfill test exercises the same ordering hazard, so it fails too.
 
 - [ ] **Step 6: Run the full gateway graph + agent suites**
 
@@ -1577,6 +1718,31 @@ Expected: no file below 80% line or branch. `audit:coverage-floor` is CI-Linux-a
 Run: `bun run audit:structure`
 
 Expected: PASS. This task adds no new invariant and no new `connectors.dispatch` call site, so `D12` (all writes via `dbRun`) is the only static check with new surface — every write added here goes through `dbRun`.
+
+---
+
+## Review dispositions
+
+From `2026-07-23-why-lens-1a-populator-edges-feedback.md`.
+
+| # | Item | Disposition |
+| --- | --- | --- |
+| 1 | Stale incoming `correlates_with` on incident re-sync | **Fixed** — real bug. `clearIncomingRelationsOfType` added in Task 1, called from the incident branch in Task 6, with two retirement regression tests. |
+| 2 | Backfill ordering | **Fixed, different mechanism** — and it was a bug, not an optimization. |
+| 3 | Filter all-decimal 7-char SHAs | **Rejected**, with the arithmetic recorded in Task 4 Step 1. |
+| 4 | Expression index on JSON fields | **Deferred**, premise corrected below. |
+
+**On #2 — it was a latent test failure, not a speed-up.** The reviewer framed it as avoiding a second pass. Checking the actual sort order shows worse: `github:acme/app#1` (the PR) sorts *before* `github:acme/app#4` (the issue), so under id-only ordering the Task 7 Step 1 test would have processed the PR against a non-existent issue entity and asserted `1` against `0`. The plan shipped a failing test. Type-ordered slicing fixes it, and a dedicated test now pins the ordering hazard.
+
+The suggested `ORDER BY CASE type ... END` was not adopted: no index can serve a computed sort key, so SQLite materialises and sorts the whole item table, and `OFFSET` paging repeats that sort per page. Slicing by type keeps each query on `idx_item_type`, and a keyset cursor (`id > ?`) keeps each page O(batch) instead of O(offset).
+
+**On #4 — the premise is wrong, the deferral is right.** The concern was that `json_extract` in `timelineCounterparts` forces full-table scans. It does not: the query leads with `type = ?`, and `EXPLAIN QUERY PLAN` confirms SQLite serves that from the `UNIQUE(type, external_id)` autoindex —
+
+```text
+SEARCH graph_entity USING INDEX sqlite_autoindex_graph_entity_2 (type=?)
+```
+
+So the `json_extract` predicates filter within deployments (or incidents) only, already bounded and further capped by `LIMIT 20`. No index is warranted now. If a very large history ever makes it measurable, the fix belongs in a migration alongside a benchmark that demonstrates the problem — not speculatively here.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -58,9 +58,16 @@ This task must land first — every later task depends on it.
 - Consumes: nothing from earlier tasks.
 - Produces:
   - `CROSS_ITEM_RELATION_TYPES: readonly ["resolves", "mentions", "correlates_with"]` — module-private.
-  - `clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void` — module-private. Later tasks call this immediately before re-emitting a cross-item edge, so the emitting side stays authoritative for its own edges.
-  - `clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void` — module-private. The mirror image, for the case where the *target* of a cross-item edge is authoritative for whether the edge should still exist (Task 6's incident side).
-  - `clearRelationsTouchingEntity(db: Database, entityId: string): void` — unchanged signature, new behavior.
+  - `CROSS_ITEM_RELATION_TYPES` and the new `clearRelationsTouchingEntity` behavior (unchanged signature).
+
+**The two directional clear helpers are deliberately NOT introduced here.** `clearOutgoingRelationsOfType` first has a caller in Task 3, `clearIncomingRelationsOfType` in Task 6, and `biome.json` sets `noUnusedVariables: "error"` — which fires on unused module-private functions. Introducing them early makes this task fail `lint` / `preflight:fast` / the pre-commit hook, so each is defined in the task that first calls it. Their contracts are stated here so the design reads as a whole:
+
+| Helper | Introduced in | Contract |
+| --- | --- | --- |
+| `clearOutgoingRelationsOfType(db, fromId, relationType)` | Task 3 | Deletes `from_id = fromId AND type = relationType`. The *source* of a cross-item edge is authoritative for it. |
+| `clearIncomingRelationsOfType(db, toId, relationType)` | Task 6 | Deletes `to_id = toId AND type = relationType`. The mirror, for when the *target* decides whether the edge still belongs. |
+
+The two are disjoint in effect — one keys `from_id`, the other `to_id` — so each side stays authoritative for its own slice of a cross-item relation without racing the other.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -193,32 +200,11 @@ function clearRelationsTouchingEntity(db: Database, entityId: string): void {
     [entityId, entityId, ...CROSS_ITEM_RELATION_TYPES],
   );
 }
-
-/**
- * Clear one entity's outgoing edges of a single cross-item relation type.
- * Call this from the *emitting* side before re-emitting, so a reference
- * removed from a PR body or message body disappears from the graph.
- */
-function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void {
-  dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? AND type = ?", [fromId, relationType]);
-}
-
-/**
- * The mirror image, for a cross-item edge whose *target* decides whether the
- * edge still belongs. Task 6 needs this: an incident that moves in time or
- * changes service must drop the correlations pointing at it, and only the
- * incident's own sync knows that.
- */
-function clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void {
-  dbRun(db, "DELETE FROM graph_relation WHERE to_id = ? AND type = ?", [toId, relationType]);
-}
 ```
-
-The two clears are disjoint in effect — one keys on `from_id`, the other on `to_id` — so each side stays authoritative for its own slice of a cross-item relation without racing the other.
 
 Note the placeholder string is built from array *length* only — every value still binds, so `I9` holds.
 
-`clearOutgoingRelationsOfType` is unused until Task 3. Biome flags unused module-private functions, so add the emission call in Task 3 rather than leaving it dangling; if `bun run lint` complains at this step, proceed to Task 3 before pushing.
+Nothing else is added in this task — see the note above on why the two directional clear helpers land with their first callers.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -642,6 +628,21 @@ In `packages/gateway/src/graph/graph-populator.ts`, add the import:
 ```ts
 import { itemPrimaryKey } from "../index/item-key.ts";
 import { type IssueRefs, extractIssueRefs } from "./graph-refs.ts";
+```
+
+Add the first directional clear helper (declared in Task 1, introduced here because this is its first caller):
+
+```ts
+/**
+ * Clear one entity's outgoing edges of a single cross-item relation type.
+ * Call this from the *emitting* side before re-emitting, so a reference
+ * removed from a PR body or message body disappears from the graph.
+ * `clearRelationsTouchingEntity` deliberately skips these types (Task 1),
+ * so this is the only thing that retires them.
+ */
+function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? AND type = ?", [fromId, relationType]);
+}
 ```
 
 Add this helper above `syncPrGraph`:
@@ -1261,7 +1262,21 @@ Expected: FAIL — the first two tests get `[]`, and the two retirement tests fa
 
 - [ ] **Step 3: Implement the correlation**
 
-In `packages/gateway/src/graph/graph-populator.ts`, add above `syncTimelineEventGraph`:
+In `packages/gateway/src/graph/graph-populator.ts`, add the second directional clear helper (declared in Task 1, introduced here because this is its first caller):
+
+```ts
+/**
+ * The mirror of `clearOutgoingRelationsOfType`, for a cross-item edge whose
+ * *target* decides whether the edge still belongs: an incident that moves in
+ * time or changes service must drop the correlations pointing at it, and only
+ * the incident's own sync knows that.
+ */
+function clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE to_id = ? AND type = ?", [toId, relationType]);
+}
+```
+
+Then add above `syncTimelineEventGraph`:
 
 ```ts
 /** An incident this long after a deploy of the same service is treated as related. */

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -915,14 +915,27 @@ import { type IssueRefs, extractCommitShas, extractIssueRefs } from "./graph-ref
 Add this helper above `syncMessageGraph`:
 
 ```ts
-/** Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id. */
+/**
+ * Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id.
+ *
+ * The extracted string is treated as a PREFIX of the stored SHA, anchored to the
+ * start of the SHA portion. This is load-bearing: commits are indexed with full
+ * 40-character SHAs, but people cite them in chat as 7-character short SHAs — the
+ * exact case `COMMIT_SHA_RE`'s `{7,40}` bound exists to catch. An exact-suffix
+ * match (`LIKE '%:' || ?`) matches only full-length SHAs and silently emits
+ * nothing for every realistic short-SHA mention.
+ *
+ * When a short prefix is ambiguous across services the tie-break is arbitrary,
+ * the same limitation `findIssueEntityIds` carries for duplicate ticket keys.
+ */
 function findCommitEntityIds(db: Database, shas: readonly string[]): string[] {
   const ids: string[] = [];
   for (const sha of shas) {
     const row = db
       .query(
         `SELECT id FROM graph_entity
-          WHERE type = 'commit' AND external_id LIKE '%:' || ?
+          WHERE type = 'commit'
+            AND substr(external_id, instr(external_id, ':') + 1) LIKE ? || '%'
           ORDER BY id ASC LIMIT 1`,
       )
       .get(sha) as { id?: string } | null;
@@ -1746,6 +1759,11 @@ From `2026-07-23-why-lens-1a-populator-edges-feedback.md`.
 | 2 | Backfill ordering | **Fixed, different mechanism** — and it was a bug, not an optimization. |
 | 3 | Filter all-decimal 7-char SHAs | **Rejected**, with the arithmetic recorded in Task 4 Step 1. |
 | 4 | Expression index on JSON fields | **Deferred**, premise corrected below. |
+| 5 | *(found during execution, Task 4 review)* `findCommitEntityIds` could not match short SHAs | **Fixed** — see below. |
+
+**On #5 — the plan reproduced the very bug this phase exists to fix.** Task 4's review flagged the commit lookup as Critical, and a probe confirmed it: with a commit indexed at `github:a1b2c3d4e5f6…ab` (40 chars) and a message citing `a1b2c3d` (7 chars), `external_id LIKE '%:' || ?` returns `null` — it is an exact-*suffix* match, so it only ever matches full-length SHAs. `COMMIT_SHA_RE`'s `{7,40}` bound exists precisely to catch short SHAs, and the (10/16)⁷ rationale for keeping all-decimal candidates is about short SHAs — so the lookup silently discarded the dominant real-world case. The relation would have been "declared, populated, and still empty," one level below the failure this phase was written to close.
+
+Fixed by anchoring the extracted string as a prefix of the SHA portion: `substr(external_id, instr(external_id, ':') + 1) LIKE ? || '%'`. Verified to match a 7-character prefix, still match a full 40-character SHA, and reject a non-matching prefix. `findIssueEntityIds` is unaffected — a ticket key like `NIM-88` *is* the whole suffix, so exact-suffix matching is correct there.
 
 **On #2 — it was a latent test failure, not a speed-up.** The reviewer framed it as avoiding a second pass. Checking the actual sort order shows worse: `github:acme/app#1` (the PR) sorts *before* `github:acme/app#4` (the issue), so under id-only ordering the Task 7 Step 1 test would have processed the PR against a non-existent issue entity and asserted `1` against `0`. The plan shipped a failing test. Type-ordered slicing fixes it, and a dedicated test now pins the ordering hazard.
 

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -1,0 +1,1596 @@
+# Why-Lens Step 1a — Graph-Populator Edges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `resolves`, `mentions` and `correlates_with` graph edges real — they are declared in the schema but written by no populator — so the `nimbus why` agent (step 1b) can traverse them instead of returning permanently-empty lanes.
+
+**Architecture:** All work is inside `packages/gateway/src/graph/graph-populator.ts` and its callers. Edges are emitted from `syncGraphFromIndexedItem`, the single function `index/item-store.ts` calls on every item upsert. Three of the new edges are *cross-item* (their two endpoints come from different items' syncs), which today's blanket relation-clear would silently delete — so the clear is scoped first, in Task 1, before any cross-item edge is emitted. `incident` and `deployment` have no graph entities at all today, so they are created before they can be correlated. A backfill re-runs the populator over already-indexed items, since edges otherwise appear only when an item next re-syncs.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6.x strict, `bun:sqlite`, `bun:test`, Biome.
+
+## Global Constraints
+
+- **No `any`** — use `unknown` for external data. TypeScript strict mode is non-negotiable.
+- **All SQL writes go through `dbRun` / `dbExec` / `dbStmtRun`** from `db/write.ts` (invariant `I14`, static check `D12`). Never call `db.run` directly in production code.
+- **Bound parameters only** (invariant `I9`). No string interpolation of values into SQL. Placeholder *counts* may be built from array length; values always bind.
+- **No new migration.** Every table and relation type used here already exists (V7 / V12 / V27). `graph_relation.type` is FK-constrained to `graph_relation_type(name)` — all five types used here are already rows in that table.
+- **No circular imports.** `index/item-store.ts` imports `graph/graph-populator.ts`; the reverse is forbidden.
+- **Cross-platform paths** — `path.join()`, never hardcoded separators.
+- **Test isolation** — real SQLite (`new Database(":memory:")` + `LocalIndex.ensureSchema(db)`), no DB-layer mocks.
+- **Per-file coverage floor ≥80% line and branch.** The floor is Docker-Linux-authoritative; verify there, not on native Windows.
+- Run `bun run preflight:fast` after every task; `bun run preflight` before the first push.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/gateway/src/index/item-key.ts` | `itemPrimaryKey` as a dependency-free leaf, so the populator can build item keys without importing `item-store` | **Create** (Task 3) |
+| `packages/gateway/src/index/item-store.ts` | Item upsert; re-exports `itemPrimaryKey`; passes `bodyPreview` to the populator | Modify (Tasks 2, 3) |
+| `packages/gateway/src/graph/graph-populator.ts` | All entity + relation emission | Modify (Tasks 1–6) |
+| `packages/gateway/src/graph/graph-refs.ts` | Pure reference extraction from text (issue refs, ticket keys, PR/commit refs) — no DB, no I/O | **Create** (Task 3) |
+| `packages/gateway/src/graph/graph-refs.test.ts` | Unit tests for the pure extractors | **Create** (Task 3) |
+| `packages/gateway/src/graph/graph-populator-clear.test.ts` | Proves cross-item edges survive a far-entity re-sync | **Create** (Task 1) |
+| `packages/gateway/src/graph/graph-populator-resolves.test.ts` | `resolves` emission | **Create** (Task 3) |
+| `packages/gateway/src/graph/graph-populator-mentions.test.ts` | `mentions` emission | **Create** (Task 4) |
+| `packages/gateway/src/graph/graph-populator-incidents.test.ts` | `incident` / `deployment` entities + `correlates_with` | **Create** (Tasks 5, 6) |
+| `packages/gateway/src/graph/regraph.ts` | Re-run the populator over every indexed item | **Create** (Task 7) |
+| `packages/gateway/src/graph/regraph.test.ts` | Backfill tests | **Create** (Task 7) |
+
+Reference extraction lives in its own file because it is pure, heavily branched, and the part most worth testing exhaustively — keeping it out of the DB-touching populator lets it be tested without a database.
+
+---
+
+### Task 1: Scope the relation clear so cross-item edges survive
+
+Every sync function opens with `clearRelationsTouchingEntity`, which deletes **every** relation touching the entity in either direction. That is safe today only because every existing edge is emitted by the sync of one of its own endpoints. The moment a message emits `mentions → pr`, the next PR re-sync deletes it.
+
+This task must land first — every later task depends on it.
+
+**Files:**
+
+- Modify: `packages/gateway/src/graph/graph-populator.ts:37-39`
+- Test: `packages/gateway/src/graph/graph-populator-clear.test.ts` (create)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `CROSS_ITEM_RELATION_TYPES: readonly ["resolves", "mentions", "correlates_with"]` — module-private.
+  - `clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void` — module-private. Later tasks call this immediately before re-emitting a cross-item edge, so the emitting side stays authoritative for its own edges.
+  - `clearRelationsTouchingEntity(db: Database, entityId: string): void` — unchanged signature, new behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/graph/graph-populator-clear.test.ts`:
+
+```ts
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+import { upsertGraphRelation } from "./relationship-graph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function relationCount(db: Database, type: string): number {
+  const row = db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = ?").get(type) as {
+    n: number;
+  };
+  return row.n;
+}
+
+test("a cross-item `mentions` edge survives a re-sync of the entity it points at", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "patch",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+  upsertIndexedItem(db, {
+    service: "slack",
+    type: "message",
+    externalId: "C1/1000.1",
+    title: "shipping acme/app#1 now",
+    bodyPreview: "shipping acme/app#1 now",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { channel: "C1" },
+  });
+
+  const pr = db
+    .query("SELECT id FROM graph_entity WHERE type = 'pr' LIMIT 1")
+    .get() as { id: string };
+  const msg = db
+    .query("SELECT id FROM graph_entity WHERE type = 'message' LIMIT 1")
+    .get() as { id: string };
+
+  // Stand in for what Task 4 will emit from the message side.
+  upsertGraphRelation(db, msg.id, pr.id, "mentions", now);
+  expect(relationCount(db, "mentions")).toBe(1);
+
+  // Re-sync the PR. Its own edges are rebuilt; the message's edge must not be collateral.
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login (v2)",
+    bodyPreview: "patch",
+    modifiedAt: now + 1,
+    syncedAt: now + 1,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(relationCount(db, "mentions")).toBe(1);
+});
+
+test("a re-sync still rebuilds the entity's own edges rather than duplicating them", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  for (const [i, title] of ["Fix login", "Fix login (v2)"].entries()) {
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title,
+      bodyPreview: "patch",
+      modifiedAt: now + i,
+      syncedAt: now + i,
+      metadata: { repo: "acme/app" },
+    });
+  }
+
+  expect(relationCount(db, "targets")).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-clear.test.ts`
+
+Expected: FAIL. The first test fails with `expect(1).toBe(1)` on the *second* assertion receiving `0` — the PR re-sync deleted the message's `mentions` edge. The second test passes already (it documents behavior that must not regress).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/gateway/src/graph/graph-populator.ts`, replace the existing `clearRelationsTouchingEntity` (currently lines 37-39) with:
+
+```ts
+/**
+ * Relation types whose two endpoints come from *different* items' syncs.
+ * The blanket clear below must not touch them: the entity being cleared is
+ * only one endpoint, and the other side is authoritative for the edge.
+ * Each emitting sync function clears its own outgoing edges of these types
+ * via `clearOutgoingRelationsOfType` immediately before re-emitting them.
+ */
+const CROSS_ITEM_RELATION_TYPES: readonly string[] = Object.freeze([
+  "resolves",
+  "mentions",
+  "correlates_with",
+]);
+
+function clearRelationsTouchingEntity(db: Database, entityId: string): void {
+  const placeholders = CROSS_ITEM_RELATION_TYPES.map(() => "?").join(", ");
+  dbRun(
+    db,
+    `DELETE FROM graph_relation
+      WHERE (from_id = ? OR to_id = ?)
+        AND type NOT IN (${placeholders})`,
+    [entityId, entityId, ...CROSS_ITEM_RELATION_TYPES],
+  );
+}
+
+/**
+ * Clear one entity's outgoing edges of a single cross-item relation type.
+ * Call this from the *emitting* side before re-emitting, so a reference
+ * removed from a PR body or message body disappears from the graph.
+ */
+function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? AND type = ?", [fromId, relationType]);
+}
+```
+
+Note the placeholder string is built from array *length* only — every value still binds, so `I9` holds.
+
+`clearOutgoingRelationsOfType` is unused until Task 3. Biome flags unused module-private functions, so add the emission call in Task 3 rather than leaving it dangling; if `bun run lint` complains at this step, proceed to Task 3 before pushing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-clear.test.ts`
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Verify nothing else regressed**
+
+Run: `bun test packages/gateway/src/graph/ packages/gateway/src/agents/impact.test.ts`
+
+Expected: PASS. The existing graph and impact suites must be green **unchanged** — this task alters shared behavior, so their passing is the honesty gate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-clear.test.ts
+git commit -m "fix(graph): scope the relation clear so cross-item edges survive re-sync"
+```
+
+---
+
+### Task 2: Carry the item body into the populator
+
+Reference extraction needs the PR and message body. `IndexedItemGraphInput` carries only `{id, service, type, title, authorId, metadata}`.
+
+**Files:**
+
+- Modify: `packages/gateway/src/graph/graph-populator.ts:12-19`
+- Modify: `packages/gateway/src/index/item-store.ts:104-111`
+- Test: `packages/gateway/src/graph/graph-populator-clear.test.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: Task 1's scoped clear.
+- Produces: `IndexedItemGraphInput` gains `bodyPreview: string | null`. Every later task reads `row.bodyPreview`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/graph/graph-populator-clear.test.ts`:
+
+```ts
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
+
+test("the populator receives the item body", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  // Compiles only once IndexedItemGraphInput carries bodyPreview.
+  syncGraphFromIndexedItem(db, {
+    id: "github:acme/app#7",
+    service: "github",
+    type: "pr",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    authorId: null,
+    metadata: { repo: "acme/app" },
+  });
+
+  const pr = db.query("SELECT id FROM graph_entity WHERE type = 'pr' LIMIT 1").get() as
+    | { id: string }
+    | null;
+  expect(pr).not.toBeNull();
+  void now;
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-clear.test.ts`
+
+Expected: FAIL at typecheck — `Object literal may only specify known properties, and 'bodyPreview' does not exist in type 'IndexedItemGraphInput'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `packages/gateway/src/graph/graph-populator.ts`, extend the type:
+
+```ts
+export type IndexedItemGraphInput = {
+  id: string;
+  service: string;
+  type: string;
+  title: string;
+  bodyPreview: string | null;
+  authorId: string | null;
+  metadata: Record<string, unknown>;
+};
+```
+
+In `packages/gateway/src/index/item-store.ts`, at the `syncGraphFromIndexedItem` call (currently line 104), add the field. `preview` is already computed above the `dbRun`:
+
+```ts
+  syncGraphFromIndexedItem(db, {
+    id,
+    service: row.service,
+    type: row.type,
+    title: row.title,
+    bodyPreview: preview,
+    authorId: row.authorId ?? null,
+    metadata: row.metadata ?? {},
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/ && bunx tsc --noEmit -p packages/gateway/tsconfig.json`
+
+Expected: PASS, and a clean typecheck. `bun test` does not typecheck — run both. Any other construction site of `IndexedItemGraphInput` (tests included) will fail the typecheck until it supplies `bodyPreview`; fix each by adding `bodyPreview: null`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/graph/graph-populator.ts packages/gateway/src/index/item-store.ts packages/gateway/src/graph/graph-populator-clear.test.ts
+git commit -m "feat(graph): carry the item body into the populator"
+```
+
+---
+
+### Task 3: Emit `resolves` — PR body to issue
+
+**Files:**
+
+- Create: `packages/gateway/src/index/item-key.ts`
+- Create: `packages/gateway/src/graph/graph-refs.ts`
+- Create: `packages/gateway/src/graph/graph-refs.test.ts`
+- Create: `packages/gateway/src/graph/graph-populator-resolves.test.ts`
+- Modify: `packages/gateway/src/index/item-store.ts:26-31`
+- Modify: `packages/gateway/src/graph/graph-populator.ts` (`syncPrGraph`)
+
+**Interfaces:**
+
+- Consumes: Task 1's `clearOutgoingRelationsOfType`; Task 2's `row.bodyPreview`.
+- Produces:
+  - `itemPrimaryKey(service: string, externalId: string): string` — moved to `index/item-key.ts`, re-exported from `item-store.ts` so existing importers are untouched.
+  - `extractIssueRefs(text: string): { numeric: number[]; ticketKeys: string[] }` from `graph/graph-refs.ts`.
+
+`itemPrimaryKey` must move because `item-store.ts` imports `graph-populator.ts`; importing it back would be a circular dependency, which the project forbids. A dependency-free leaf module is the fix — not a second copy.
+
+- [ ] **Step 1: Write the failing test for the pure extractor**
+
+Create `packages/gateway/src/graph/graph-refs.test.ts`:
+
+```ts
+import { expect, test } from "bun:test";
+
+import { extractIssueRefs } from "./graph-refs.ts";
+
+test("extracts GitHub-style numeric issue references", () => {
+  expect(extractIssueRefs("closes #4 and fixes #17")).toEqual({
+    numeric: [4, 17],
+    ticketKeys: [],
+  });
+});
+
+test("extracts ticket keys", () => {
+  expect(extractIssueRefs("part of NIM-88, follows ABC-7")).toEqual({
+    numeric: [],
+    ticketKeys: ["NIM-88", "ABC-7"],
+  });
+});
+
+test("deduplicates and preserves first-seen order", () => {
+  expect(extractIssueRefs("#4 #4 NIM-1 NIM-1 #9")).toEqual({
+    numeric: [4, 9],
+    ticketKeys: ["NIM-1"],
+  });
+});
+
+test("ignores lowercase and over-long keys that are not ticket keys", () => {
+  expect(extractIssueRefs("abc-1 and VERYLONGPROJECT-2")).toEqual({
+    numeric: [],
+    ticketKeys: [],
+  });
+});
+
+test("ignores a bare hash with no digits", () => {
+  expect(extractIssueRefs("# heading and #")).toEqual({ numeric: [], ticketKeys: [] });
+});
+
+test("handles empty input", () => {
+  expect(extractIssueRefs("")).toEqual({ numeric: [], ticketKeys: [] });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-refs.test.ts`
+
+Expected: FAIL — `Cannot find module './graph-refs.ts'`.
+
+- [ ] **Step 3: Write the extractor**
+
+Create `packages/gateway/src/graph/graph-refs.ts`:
+
+```ts
+/**
+ * Pure reference extraction from indexed text. No DB, no I/O — every
+ * function here is a total function of its input string, which is what
+ * makes the branch-heavy parsing cheap to test exhaustively.
+ */
+
+const NUMERIC_REF_RE = /#(\d+)/g;
+// Ticket keys: 2-10 uppercase alphanumerics, a hyphen, then digits.
+// The bounded length is what keeps SHOUTING-1 style prose out.
+const TICKET_KEY_RE = /\b([A-Z][A-Z0-9]{1,9})-(\d+)\b/g;
+
+export type IssueRefs = {
+  numeric: number[];
+  ticketKeys: string[];
+};
+
+export function extractIssueRefs(text: string): IssueRefs {
+  const numeric: number[] = [];
+  const seenNumeric = new Set<number>();
+  for (const m of text.matchAll(NUMERIC_REF_RE)) {
+    const raw = m[1];
+    if (raw === undefined) continue;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n) || seenNumeric.has(n)) continue;
+    seenNumeric.add(n);
+    numeric.push(n);
+  }
+
+  const ticketKeys: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const m of text.matchAll(TICKET_KEY_RE)) {
+    const key = m[0];
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    ticketKeys.push(key);
+  }
+
+  return { numeric, ticketKeys };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/src/graph/graph-refs.test.ts`
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Extract `itemPrimaryKey` to a leaf module**
+
+Create `packages/gateway/src/index/item-key.ts`:
+
+```ts
+/**
+ * The `<service>:<externalId>` primary key shared by the item table and the
+ * graph populator. Lives in its own dependency-free module because
+ * `item-store.ts` imports the populator — importing the key helper back out
+ * of `item-store` would close a cycle.
+ */
+export function itemPrimaryKey(service: string, externalId: string): string {
+  const prefix = `${service}:`;
+  if (externalId.startsWith(prefix)) {
+    return externalId;
+  }
+  return `${service}:${externalId}`;
+}
+```
+
+In `packages/gateway/src/index/item-store.ts`, delete the local `itemPrimaryKey` definition (currently lines 26-31) and replace it with a re-export near the top of the file, so every existing importer keeps working:
+
+```ts
+export { itemPrimaryKey } from "./item-key.ts";
+```
+
+Add the matching value import for internal use:
+
+```ts
+import { itemPrimaryKey } from "./item-key.ts";
+```
+
+- [ ] **Step 6: Verify the extraction is behavior-neutral**
+
+Run: `bun test packages/gateway/src/index/ && bunx tsc --noEmit -p packages/gateway/tsconfig.json`
+
+Expected: PASS and a clean typecheck. No test should change — this is a pure move.
+
+- [ ] **Step 7: Write the failing test for `resolves` emission**
+
+Create `packages/gateway/src/graph/graph-populator-resolves.test.ts`:
+
+```ts
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function seedIssue(db: Database, externalId: string, title: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "issue",
+    externalId,
+    title,
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { repo: "acme/app" },
+  });
+}
+
+function resolvesTargets(db: Database): string[] {
+  const rows = db
+    .query(
+      `SELECT e.external_id AS ext
+         FROM graph_relation r
+         JOIN graph_entity e ON e.id = r.to_id
+        WHERE r.type = 'resolves'
+        ORDER BY ext`,
+    )
+    .all() as Array<{ ext: string }>;
+  return rows.map((r) => r.ext);
+}
+
+test("a PR body referencing #4 emits resolves to that repo's issue 4", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
+});
+
+test("a numeric ref with no matching issue emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #999",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual([]);
+});
+
+test("a ticket key matches an issue indexed by another service", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff is wrong",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix retry backoff",
+    bodyPreview: "part of NIM-88",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["linear:NIM-88"]);
+});
+
+test("removing the reference from the PR body removes the edge on re-sync", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+
+  for (const [i, body] of ["closes #4", "no longer references anything"].entries()) {
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Fix login",
+      bodyPreview: body,
+      modifiedAt: now + i,
+      syncedAt: now + i,
+      metadata: { repo: "acme/app" },
+    });
+  }
+
+  expect(resolvesTargets(db)).toEqual([]);
+});
+```
+
+- [ ] **Step 8: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-resolves.test.ts`
+
+Expected: FAIL — the first test gets `[]` instead of `["github:acme/app#4"]`; nothing emits `resolves` yet.
+
+- [ ] **Step 9: Emit `resolves` from `syncPrGraph`**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add the import:
+
+```ts
+import { itemPrimaryKey } from "../index/item-key.ts";
+import { type IssueRefs, extractIssueRefs } from "./graph-refs.ts";
+```
+
+Add this helper above `syncPrGraph`:
+
+```ts
+/**
+ * Resolve a PR/message reference to an existing `issue` graph entity.
+ * Numeric refs are scoped to the referring item's own repo and service —
+ * `#4` means a different issue in a different repo. Ticket keys are
+ * service-agnostic, since the tracker is usually not the forge.
+ */
+function findIssueEntityIds(
+  db: Database,
+  service: string,
+  repoFull: string | undefined,
+  refs: IssueRefs,
+): string[] {
+  const ids: string[] = [];
+
+  if (repoFull !== undefined) {
+    for (const n of refs.numeric) {
+      const ext = itemPrimaryKey(service, `${repoFull}#${n}`);
+      const row = db
+        .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")
+        .get(ext) as { id?: string } | null;
+      if (row?.id !== undefined) ids.push(row.id);
+    }
+  }
+
+  for (const key of refs.ticketKeys) {
+    const row = db
+      .query(
+        `SELECT id FROM graph_entity
+          WHERE type = 'issue' AND (external_id = ? OR external_id LIKE '%:' || ?)
+          ORDER BY id ASC LIMIT 1`,
+      )
+      .get(key, key) as { id?: string } | null;
+    if (row?.id !== undefined) ids.push(row.id);
+  }
+
+  return Array.from(new Set(ids));
+}
+```
+
+Then at the end of `syncPrGraph`, after the `merged_as` block, append:
+
+```ts
+  clearOutgoingRelationsOfType(db, prEntityId, "resolves");
+  const refs = extractIssueRefs(`${row.title}\n${row.bodyPreview ?? ""}`);
+  for (const issueId of findIssueEntityIds(db, row.service, repoFull, refs)) {
+    upsertGraphRelation(db, prEntityId, issueId, "resolves", now);
+  }
+```
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/`
+
+Expected: PASS. All four `resolves` tests green, and every pre-existing graph test still green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/gateway/src/index/item-key.ts packages/gateway/src/index/item-store.ts packages/gateway/src/graph/graph-refs.ts packages/gateway/src/graph/graph-refs.test.ts packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-resolves.test.ts
+git commit -m "feat(graph): emit resolves edges from PR bodies to issues"
+```
+
+---
+
+### Task 4: Emit `mentions` — message body to PR, issue, or commit
+
+**Files:**
+
+- Modify: `packages/gateway/src/graph/graph-refs.ts`
+- Modify: `packages/gateway/src/graph/graph-refs.test.ts`
+- Modify: `packages/gateway/src/graph/graph-populator.ts` (`syncMessageGraph`)
+- Create: `packages/gateway/src/graph/graph-populator-mentions.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 3's `extractIssueRefs`, `itemPrimaryKey`, `clearOutgoingRelationsOfType`.
+- Produces: `extractCommitShas(text: string): string[]` from `graph/graph-refs.ts`.
+
+- [ ] **Step 1: Write the failing test for SHA extraction**
+
+Append to `packages/gateway/src/graph/graph-refs.test.ts`:
+
+```ts
+import { extractCommitShas } from "./graph-refs.ts";
+
+test("extracts 7-to-40 character hex SHAs", () => {
+  expect(extractCommitShas("see a1b2c3d and 0123456789abcdef0123456789abcdef01234567")).toEqual([
+    "a1b2c3d",
+    "0123456789abcdef0123456789abcdef01234567",
+  ]);
+});
+
+test("ignores short hex runs and decimal numbers", () => {
+  expect(extractCommitShas("abc123 and 1234567")).toEqual(["1234567"]);
+});
+
+test("deduplicates SHAs", () => {
+  expect(extractCommitShas("a1b2c3d a1b2c3d")).toEqual(["a1b2c3d"]);
+});
+```
+
+Note the second case: `1234567` is seven hex characters and is indistinguishable from a short SHA by shape alone. It is kept — a false positive that resolves to no commit entity emits no edge, so the cost is a wasted lookup, whereas excluding all-digit runs would drop real SHAs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-refs.test.ts`
+
+Expected: FAIL — `extractCommitShas is not a function`.
+
+- [ ] **Step 3: Add the extractor**
+
+Append to `packages/gateway/src/graph/graph-refs.ts`:
+
+```ts
+const COMMIT_SHA_RE = /\b([0-9a-f]{7,40})\b/g;
+
+export function extractCommitShas(text: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const m of text.matchAll(COMMIT_SHA_RE)) {
+    const sha = m[1];
+    if (sha === undefined || seen.has(sha)) continue;
+    seen.add(sha);
+    out.push(sha);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/src/graph/graph-refs.test.ts`
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Write the failing test for `mentions` emission**
+
+Create `packages/gateway/src/graph/graph-populator-mentions.test.ts`:
+
+```ts
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function mentionTargets(db: Database): string[] {
+  const rows = db
+    .query(
+      `SELECT e.type || ':' || e.external_id AS ref
+         FROM graph_relation r
+         JOIN graph_entity e ON e.id = r.to_id
+        WHERE r.type = 'mentions'
+        ORDER BY ref`,
+    )
+    .all() as Array<{ ref: string }>;
+  return rows.map((r) => r.ref);
+}
+
+function seedMessage(db: Database, body: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "slack",
+    type: "message",
+    externalId: "C1/1000.1",
+    title: body,
+    bodyPreview: body,
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { channel: "C1" },
+  });
+}
+
+test("a message naming a ticket key mentions that issue", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  seedMessage(db, "anyone looking at NIM-88?", now);
+
+  expect(mentionTargets(db)).toEqual(["issue:linear:NIM-88"]);
+});
+
+test("a message naming a commit SHA mentions that commit", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "git_commit",
+    externalId: "a1b2c3d4e5f6",
+    title: "Fix retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha: "a1b2c3d4e5f6", repoRoot: "/repo" },
+  });
+
+  seedMessage(db, "this broke in a1b2c3d4e5f6", now);
+
+  expect(mentionTargets(db)).toEqual(["commit:github:a1b2c3d4e5f6"]);
+});
+
+test("a message referencing nothing indexed emits no edges", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedMessage(db, "lunch?", now);
+  expect(mentionTargets(db)).toEqual([]);
+});
+
+test("editing a message to drop the reference drops the edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  seedMessage(db, "anyone looking at NIM-88?", now);
+  seedMessage(db, "never mind", now + 1);
+
+  expect(mentionTargets(db)).toEqual([]);
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-mentions.test.ts`
+
+Expected: FAIL — first test gets `[]`; nothing emits `mentions`.
+
+- [ ] **Step 7: Emit `mentions` from `syncMessageGraph`**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add to the import from `./graph-refs.ts`:
+
+```ts
+import { type IssueRefs, extractCommitShas, extractIssueRefs } from "./graph-refs.ts";
+```
+
+Add this helper above `syncMessageGraph`:
+
+```ts
+/** Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id. */
+function findCommitEntityIds(db: Database, shas: readonly string[]): string[] {
+  const ids: string[] = [];
+  for (const sha of shas) {
+    const row = db
+      .query(
+        `SELECT id FROM graph_entity
+          WHERE type = 'commit' AND external_id LIKE '%:' || ?
+          ORDER BY id ASC LIMIT 1`,
+      )
+      .get(sha) as { id?: string } | null;
+    if (row?.id !== undefined) ids.push(row.id);
+  }
+  return ids;
+}
+```
+
+At the end of `syncMessageGraph`, after the channel block, append:
+
+```ts
+  clearOutgoingRelationsOfType(db, msgEntityId, "mentions");
+  const text = `${row.title}\n${row.bodyPreview ?? ""}`;
+  const mentioned = new Set<string>([
+    ...findIssueEntityIds(db, row.service, undefined, extractIssueRefs(text)),
+    ...findCommitEntityIds(db, extractCommitShas(text)),
+  ]);
+  for (const targetId of mentioned) {
+    upsertGraphRelation(db, msgEntityId, targetId, "mentions", now);
+  }
+```
+
+`findIssueEntityIds` is passed `undefined` for the repo: a `#4` in Slack has no repo context, so only ticket keys resolve. That is deliberate — a repo-less numeric ref would otherwise match an arbitrary repo's issue 4.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/`
+
+Expected: PASS — all four `mentions` tests, plus every earlier graph test.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/gateway/src/graph/graph-refs.ts packages/gateway/src/graph/graph-refs.test.ts packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-mentions.test.ts
+git commit -m "feat(graph): emit mentions edges from messages to issues and commits"
+```
+
+---
+
+### Task 5: Create `incident` and `deployment` graph entities
+
+Both types are indexed as items by real connectors and both are in `ITEM_LINKED_ENTITY_TYPES`, but `syncGraphFromIndexedItem` has no branch for either — so no entity is ever created. Nothing can be correlated until they exist.
+
+**Files:**
+
+- Modify: `packages/gateway/src/graph/graph-populator.ts`
+- Create: `packages/gateway/src/graph/graph-populator-incidents.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 2's `row.bodyPreview` (unused here, but the type is shared).
+- Produces: `incident` and `deployment` graph entity types, each with `external_id = row.id`, `service = row.service`, and `metadata` carrying `occurredAt` (epoch ms) plus the item's `service` field. Task 6 correlates on `occurredAt`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/graph/graph-populator-incidents.test.ts`:
+
+```ts
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function entityTypes(db: Database): string[] {
+  const rows = db
+    .query("SELECT DISTINCT type FROM graph_entity ORDER BY type")
+    .all() as Array<{ type: string }>;
+  return rows.map((r) => r.type);
+}
+
+test("an indexed incident becomes an incident graph entity", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  });
+
+  expect(entityTypes(db)).toContain("incident");
+  const row = db
+    .query("SELECT external_id, service FROM graph_entity WHERE type = 'incident'")
+    .get() as { external_id: string; service: string };
+  expect(row.external_id).toBe("pagerduty:PD-1");
+  expect(row.service).toBe("pagerduty");
+});
+
+test("an indexed deployment becomes a deployment graph entity", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  });
+
+  expect(entityTypes(db)).toContain("deployment");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-incidents.test.ts`
+
+Expected: FAIL — `entityTypes(db)` is `[]`; no branch handles either type.
+
+- [ ] **Step 3: Write the sync functions**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add above `syncGraphFromIndexedItem`:
+
+```ts
+/**
+ * Incidents and deployments are timeline anchors: the graph needs them as
+ * entities so a change can be correlated with what it responded to or
+ * caused. `occurredAt` is the item's `modified_at`, which every connector
+ * sets to the event time.
+ */
+function syncTimelineEventGraph(
+  db: Database,
+  row: IndexedItemGraphInput,
+  entityType: "incident" | "deployment",
+  occurredAt: number,
+  now: number,
+): void {
+  const affectedService = stringField(row.metadata, "service");
+  const entityId = upsertGraphEntity(db, {
+    type: entityType,
+    externalId: row.id,
+    label: row.title,
+    service: row.service,
+    metadata: { occurredAt, affectedService: affectedService ?? null },
+  });
+  clearRelationsTouchingEntity(db, entityId);
+  void now;
+}
+```
+
+`syncGraphFromIndexedItem` does not currently receive the item's `modified_at`. Rather than widen the input a second time, read it back — the row was written immediately before the populator call, so it is always present:
+
+```ts
+function occurredAtForItem(db: Database, itemId: string): number {
+  const row = db.query("SELECT modified_at FROM item WHERE id = ?").get(itemId) as
+    | { modified_at: number }
+    | null;
+  return row?.modified_at ?? Date.now();
+}
+```
+
+Then add the dispatch branches inside `syncGraphFromIndexedItem`, before the closing brace:
+
+```ts
+  if (row.type === "incident") {
+    syncTimelineEventGraph(db, row, "incident", occurredAtForItem(db, row.id), now);
+    return;
+  }
+  if (row.type === "deployment") {
+    syncTimelineEventGraph(db, row, "deployment", occurredAtForItem(db, row.id), now);
+    return;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-incidents.test.ts`
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-incidents.test.ts
+git commit -m "feat(graph): create incident and deployment graph entities"
+```
+
+---
+
+### Task 6: Emit `correlates_with` — deployment to incident
+
+**Files:**
+
+- Modify: `packages/gateway/src/graph/graph-populator.ts`
+- Modify: `packages/gateway/src/graph/graph-populator-incidents.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 5's `incident` / `deployment` entities and their `occurredAt` metadata; Task 1's `clearOutgoingRelationsOfType`.
+- Produces: `correlates_with` edges, always directed **deployment → incident**, emitted from whichever side syncs. Window: the incident occurred within `CORRELATION_WINDOW_MS` (2 hours) **after** the deployment, and both name the same `affectedService`.
+
+The direction is fixed regardless of which item triggers the sync, so the `why` agent's driver lane has one traversal to write.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/graph/graph-populator-incidents.test.ts`:
+
+```ts
+const HOUR = 60 * 60 * 1000;
+
+function correlations(db: Database): Array<{ from: string; to: string }> {
+  return db
+    .query(
+      `SELECT f.type || ':' || f.external_id AS "from",
+              t.type || ':' || t.external_id AS "to"
+         FROM graph_relation r
+         JOIN graph_entity f ON f.id = r.from_id
+         JOIN graph_entity t ON t.id = r.to_id
+        WHERE r.type = 'correlates_with'
+        ORDER BY "from", "to"`,
+    )
+    .all() as Array<{ from: string; to: string }>;
+}
+
+function seedDeploy(db: Database, at: number, service: string): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { service },
+  });
+}
+
+function seedIncident(db: Database, at: number, service: string): void {
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { service },
+  });
+}
+
+test("an incident shortly after a deploy of the same service correlates", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("correlation is emitted regardless of which side syncs last", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedIncident(db, t + HOUR, "checkout");
+  seedDeploy(db, t, "checkout");
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("an incident outside the window does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + 5 * HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("an incident before the deploy does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t - HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("a different service does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "search");
+
+  expect(correlations(db)).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-incidents.test.ts`
+
+Expected: FAIL — the first two tests get `[]`.
+
+- [ ] **Step 3: Implement the correlation**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add above `syncTimelineEventGraph`:
+
+```ts
+/** An incident this long after a deploy of the same service is treated as related. */
+const CORRELATION_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+type TimelineRow = { id: string; occurred_at: number };
+
+function timelineCounterparts(
+  db: Database,
+  counterpartType: "incident" | "deployment",
+  affectedService: string,
+  windowFrom: number,
+  windowTo: number,
+): TimelineRow[] {
+  return db
+    .query(
+      `SELECT id,
+              CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) AS occurred_at
+         FROM graph_entity
+        WHERE type = ?
+          AND json_extract(metadata, '$.affectedService') = ?
+          AND CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) BETWEEN ? AND ?
+        ORDER BY occurred_at ASC
+        LIMIT 20`,
+    )
+    .all(counterpartType, affectedService, windowFrom, windowTo) as TimelineRow[];
+}
+```
+
+Then replace the `void now;` line at the end of `syncTimelineEventGraph` with:
+
+```ts
+  if (affectedService === undefined) return;
+
+  if (entityType === "deployment") {
+    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
+    for (const inc of timelineCounterparts(
+      db,
+      "incident",
+      affectedService,
+      occurredAt,
+      occurredAt + CORRELATION_WINDOW_MS,
+    )) {
+      upsertGraphRelation(db, entityId, inc.id, "correlates_with", now);
+    }
+    return;
+  }
+
+  // An incident syncing after its deploy must still create the edge, and the
+  // edge is always directed deployment -> incident.
+  for (const dep of timelineCounterparts(
+    db,
+    "deployment",
+    affectedService,
+    occurredAt - CORRELATION_WINDOW_MS,
+    occurredAt,
+  )) {
+    upsertGraphRelation(db, dep.id, entityId, "correlates_with", now);
+  }
+```
+
+`clearRelationsTouchingEntity` already leaves `correlates_with` alone (Task 1), which is what lets the incident-side emission survive a later deployment re-sync.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/`
+
+Expected: PASS — all five correlation tests plus every earlier graph test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-incidents.test.ts
+git commit -m "feat(graph): correlate deployments with the incidents that follow them"
+```
+
+---
+
+### Task 7: Backfill already-indexed items
+
+New edges appear only when an item next re-syncs. Historical PRs, messages and incidents may never re-sync, so without a backfill the graph stays sparse exactly where the history lives.
+
+**Files:**
+
+- Create: `packages/gateway/src/graph/regraph.ts`
+- Create: `packages/gateway/src/graph/regraph.test.ts`
+
+**Interfaces:**
+
+- Consumes: `syncGraphFromIndexedItem` (Tasks 3–6).
+- Produces: `regraphAllItems(db: Database, opts?: { batchSize?: number }): { scanned: number; graphed: number }`. Step 1b's CLI wiring consumes this; exposing it over IPC is deliberately deferred to 1b so this task stays gateway-internal and independently mergeable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/graph/regraph.test.ts`:
+
+```ts
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { LocalIndex } from "../index/local-index.ts";
+import { regraphAllItems } from "./regraph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+/** Insert an item directly, bypassing the populator, to simulate pre-existing data. */
+function insertRawItem(
+  db: Database,
+  o: { service: string; type: string; externalId: string; title: string; body: string; at: number },
+): void {
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at, metadata, pinned)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [
+      `${o.service}:${o.externalId}`,
+      o.service,
+      o.type,
+      o.externalId,
+      o.title,
+      o.body,
+      o.at,
+      o.at,
+      JSON.stringify({ repo: "acme/app" }),
+    ],
+  );
+}
+
+test("backfill graphs items that were indexed before the populator knew how", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+
+  expect(
+    (db.query("SELECT COUNT(*) AS n FROM graph_relation").get() as { n: number }).n,
+  ).toBe(0);
+
+  const result = regraphAllItems(db);
+
+  expect(result.scanned).toBe(2);
+  expect(result.graphed).toBe(2);
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});
+
+test("backfill skips item types the graph does not participate in", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "gdrive",
+    type: "file",
+    externalId: "f1",
+    title: "Notes",
+    body: "",
+    at: now,
+  });
+
+  const result = regraphAllItems(db);
+  expect(result.scanned).toBe(1);
+  expect(result.graphed).toBe(0);
+});
+
+test("backfill is idempotent", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+
+  regraphAllItems(db);
+  regraphAllItems(db);
+
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/regraph.test.ts`
+
+Expected: FAIL — `Cannot find module './regraph.ts'`.
+
+- [ ] **Step 3: Write the backfill**
+
+Create `packages/gateway/src/graph/regraph.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
+import { isItemLinkedGraphType } from "./relationship-graph.ts";
+
+export type RegraphResult = {
+  scanned: number;
+  graphed: number;
+};
+
+type ItemRow = {
+  id: string;
+  service: string;
+  type: string;
+  title: string;
+  body_preview: string | null;
+  author_id: string | null;
+  metadata: string | null;
+};
+
+function parseMetadata(raw: string | null): Record<string, unknown> {
+  if (raw === null || raw === "") return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Re-run the graph populator over every indexed item.
+ *
+ * Needed because a populator change only reaches existing rows when they next
+ * re-sync — and historical items may never re-sync. Paged so a large index
+ * does not materialise every row at once. Idempotent: each sync function
+ * clears and rebuilds the edges it owns.
+ */
+export function regraphAllItems(db: Database, opts?: { batchSize?: number }): RegraphResult {
+  const batchSize = opts?.batchSize ?? 500;
+  let offset = 0;
+  let scanned = 0;
+  let graphed = 0;
+
+  for (;;) {
+    const rows = db
+      .query(
+        `SELECT id, service, type, title, body_preview, author_id, metadata
+           FROM item
+          ORDER BY id ASC
+          LIMIT ? OFFSET ?`,
+      )
+      .all(batchSize, offset) as ItemRow[];
+    if (rows.length === 0) break;
+
+    for (const r of rows) {
+      scanned += 1;
+      if (!isItemLinkedGraphType(r.type)) continue;
+      syncGraphFromIndexedItem(db, {
+        id: r.id,
+        service: r.service,
+        type: r.type,
+        title: r.title,
+        bodyPreview: r.body_preview,
+        authorId: r.author_id,
+        metadata: parseMetadata(r.metadata),
+      });
+      graphed += 1;
+    }
+
+    offset += rows.length;
+  }
+
+  return { scanned, graphed };
+}
+```
+
+The ordering caveat is real and acceptable: a PR processed before the issue it references emits no `resolves` edge on that pass. Because the backfill is idempotent, running it twice resolves every forward reference — which the idempotency test above also demonstrates.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/regraph.test.ts`
+
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Document the two-pass caveat in the module**
+
+Append to the `regraphAllItems` doc comment:
+
+```ts
+ * Ordering caveat: items are processed in `id` order, so a PR seen before the
+ * issue it references emits no `resolves` edge on that pass. Run twice to
+ * settle forward references; the operation is idempotent.
+```
+
+- [ ] **Step 6: Run the full gateway graph + agent suites**
+
+Run: `bun test packages/gateway/src/graph/ packages/gateway/src/agents/ packages/gateway/src/index/`
+
+Expected: PASS. `impact.ts`'s suite must be green **unchanged**.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/gateway/src/graph/regraph.ts packages/gateway/src/graph/regraph.test.ts
+git commit -m "feat(graph): backfill the graph over already-indexed items"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full pre-flight**
+
+Run: `bun run preflight`
+
+Expected: all gates green. `test:ci` alone is **not** the gate set.
+
+- [ ] **Verify the coverage floor on Linux**
+
+Run: `docker run --rm -v "$PWD":/w -w /w oven/bun:latest bash -c "bun install --frozen-lockfile && bun run audit:coverage-floor"`
+
+Expected: no file below 80% line or branch. `audit:coverage-floor` is CI-Linux-authoritative — a native-Windows run produces false results. Every file created here is small and directly tested; if `graph-populator.ts` dips below the floor because of the new branches, add cases to the per-edge test files rather than excluding the file.
+
+- [ ] **Confirm no invariant drift**
+
+Run: `bun run audit:structure`
+
+Expected: PASS. This task adds no new invariant and no new `connectors.dispatch` call site, so `D12` (all writes via `dbRun`) is the only static check with new surface — every write added here goes through `dbRun`.
+
+---
+
+## What step 1b consumes from this plan
+
+Step 1b's six lanes traverse, in the direction shown:
+
+| Lane | Traversal now real |
+| --- | --- |
+| `subAuthorship` | `git_blame_line` → `commit` entity (existing) |
+| `subPullRequest` | `commit` ← `merged_as` ← `pr` (existing; reverse) |
+| `subTicket` | `pr` → `resolves` → `issue` (**Task 3**) |
+| `subDiscussion` | `message` → `mentions` → `pr` / `issue` / `commit` (**Task 4**; reverse from the PR) |
+| `subDriver` | `deployment` → `correlates_with` → `incident` (**Tasks 5, 6**) |
+| `subDownstream` | `depends_on` / `defined_in` / `in_repo` (existing) |
+
+`regraphAllItems` (Task 7) is what step 1b's `nimbus index regraph` CLI command wraps.

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -1094,11 +1094,31 @@ function syncTimelineEventGraph(
 `syncGraphFromIndexedItem` does not currently receive the item's `modified_at`. Rather than widen the input a second time, read it back — the row was written immediately before the populator call, so it is always present:
 
 ```ts
+/**
+ * Read the item's event time back from the row written immediately before this
+ * populator call. `upsertIndexedItem` inserts and then calls the populator
+ * synchronously on the same handle, so the row is always present on the
+ * production path.
+ *
+ * A missing row therefore means the caller reached the populator without
+ * writing the item — a programming error, and the only way to get here is a
+ * direct `syncGraphFromIndexedItem` call that skipped the insert (an idiom six
+ * sibling test files already use for other item types). Throw rather than
+ * default: Task 6 correlates deployments to incidents on this timestamp, so a
+ * fabricated `Date.now()` would yield a confidently WRONG correlation instead
+ * of an obvious failure.
+ */
 function occurredAtForItem(db: Database, itemId: string): number {
   const row = db.query("SELECT modified_at FROM item WHERE id = ?").get(itemId) as
     | { modified_at: number }
     | null;
-  return row?.modified_at ?? Date.now();
+  if (row === null) {
+    throw new Error(
+      `occurredAtForItem: no item row for "${itemId}" — the populator was called without ` +
+        "writing the item first; the timeline entity would carry a fabricated timestamp.",
+    );
+  }
+  return row.modified_at;
 }
 ```
 
@@ -1760,6 +1780,9 @@ From `2026-07-23-why-lens-1a-populator-edges-feedback.md`.
 | 3 | Filter all-decimal 7-char SHAs | **Rejected**, with the arithmetic recorded in Task 4 Step 1. |
 | 4 | Expression index on JSON fields | **Deferred**, premise corrected below. |
 | 5 | *(found during execution, Task 4 review)* `findCommitEntityIds` could not match short SHAs | **Fixed** — see below. |
+| 6 | *(found during execution, Task 5 review)* `occurredAtForItem` silently fabricated a `Date.now()` timestamp | **Fixed** — throws instead. |
+
+**On #6 — a silent default that would have produced a confidently wrong answer.** The plan's `occurredAtForItem` ended `?? Date.now()`. On the production path that branch is unreachable: `upsertIndexedItem` inserts the row and then calls the populator synchronously on the same `bun:sqlite` handle. But `syncGraphFromIndexedItem` is exported, and six sibling test files already call it directly with no item row — an established local idiom. None passes `incident`/`deployment` today, so the fallback is latent rather than live; the moment one does, the entity gets a fabricated `occurredAt`, and Task 6 correlates deployments to incidents *on that timestamp*. The failure mode is a wrong correlation, not a missing one — strictly worse than an error. Now throws with a message naming the cause.
 
 **On #5 — the plan reproduced the very bug this phase exists to fix.** Task 4's review flagged the commit lookup as Critical, and a probe confirmed it: with a commit indexed at `github:a1b2c3d4e5f6…ab` (40 chars) and a message citing `a1b2c3d` (7 chars), `external_id LIKE '%:' || ?` returns `null` — it is an exact-*suffix* match, so it only ever matches full-length SHAs. `COMMIT_SHA_RE`'s `{7,40}` bound exists precisely to catch short SHAs, and the (10/16)⁷ rationale for keeping all-decimal candidates is about short SHAs — so the lookup silently discarded the dominant real-world case. The relation would have been "declared, populated, and still empty," one level below the failure this phase was written to close.
 

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -57,8 +57,8 @@ This task must land first — every later task depends on it.
 
 - Consumes: nothing from earlier tasks.
 - Produces:
-  - `CROSS_ITEM_RELATION_TYPES: readonly ["resolves", "mentions", "correlates_with"]` — module-private.
-  - `CROSS_ITEM_RELATION_TYPES` and the new `clearRelationsTouchingEntity` behavior (unchanged signature).
+  - `CROSS_ITEM_RELATION_TYPES` — module-private, `readonly string[]` frozen to `["resolves", "mentions", "correlates_with"]`.
+  - `clearRelationsTouchingEntity(db: Database, entityId: string): void` — unchanged signature, new behavior.
 
 **The two directional clear helpers are deliberately NOT introduced here.** `clearOutgoingRelationsOfType` first has a caller in Task 3, `clearIncomingRelationsOfType` in Task 6, and `biome.json` sets `noUnusedVariables: "error"` — which fires on unused module-private functions. Introducing them early makes this task fail `lint` / `preflight:fast` / the pre-commit hook, so each is defined in the task that first calls it. Their contracts are stated here so the design reads as a whole:
 

--- a/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
+++ b/docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md
@@ -1841,6 +1841,54 @@ So the `json_extract` predicates filter within deployments (or incidents) only, 
 
 ---
 
+## Post-review remediation (Tasks 8–12)
+
+The whole-branch review found that the per-task suites all passed against **hand-written fixtures that no connector emits**. Two of the three new edge types were correct in code but unreachable against real connector data — the same "declared but always empty" failure this phase exists to eliminate, relocated one layer up. Tasks 8–12 close that.
+
+**Standing rule for every task below:** a regression test must be seeded from the connector's own `externalId` / metadata builder, or from a literal copied verbatim out of the connector source — never from a hand-written shape.
+
+### Task 8 — C2: the `resolves` numeric path cannot match a GitHub issue
+
+`findIssueEntityIds` builds `${repoFull}#${n}`. That is the shape `github-sync.ts:197` uses for **pull requests**; issues are indexed at `:237` as `${repoFull}#issue-${n}`, deliberately disambiguated because PRs and issues share a number space. The lookup is `type='issue'`-scoped, so it is a clean miss, not a mis-link.
+
+GitLab is the mirror image: its issue externalId *is* `path/ns#4` (`connectors/_lib/gitlab/events.ts:57`) and would match — but GitLab MR items are written with `bodyPreview: ""` (same file, line 79), so there is no body text to extract a reference from.
+
+Fix: resolve numerically against `item.metadata.number` + `metadata.repo`, which both forges populate, rather than reconstructing an externalId string. Falls back to the existing exact-key lookup. Tests seeded from `github-sync.ts`'s own builders for both a PR body `closes #4` and the issue it names.
+
+### Task 9 — C1: `correlates_with` is unreachable on every real index
+
+`syncTimelineEventGraph` keys on `stringField(row.metadata, "service")`. No first-party connector writes that key: `pagerduty-sync.ts` writes `pagerduty_service_id`, `vercel-deployment-mapping.ts` writes `name`, `prefect-deployment-mapping.ts` writes `deployment_id`, and `deployment/annotate.ts` writes `nimbus_service_id` *and* bypasses the populator entirely via a raw `dbRun`. Both entities are created, then the correlation bails at the `affectedService === undefined` guard, so the relation stays exactly as empty as before.
+
+A metadata fallback chain cannot fix this: correlation is always cross-provider, and PagerDuty's `PSVC1` never equals Vercel's `checkout-web`. It needs the service-identity binding that `ServiceConfig` already carries (`serviceId`, `repos`, `pagerdutyServices`) — but that lives in `nimbus.toml`, loaded at the IPC layer, while the populator sits below `item-store` with no config access.
+
+**Design (decided):** thread an **optional** resolver through `SyncContext`.
+
+- `SyncContext` gains `resolveServiceId?: (item: {service: string; type: string; metadata: Record<string, unknown>}) => string | undefined`.
+- It is populated where `loadNimbusServiceConfigsFromConfigDir` already runs, mapping `metadata.pagerduty_service_id` via `ServiceConfig.pagerdutyServices`, `metadata.nimbus_service_id` directly, and repo-bearing deployments via `ServiceConfig.repos`.
+- `upsertIndexedItemForSync` passes it to the populator; `syncGraphFromIndexedItem` takes it as an optional third argument.
+- **Optional is load-bearing:** ~80 connectors and every existing test compile unchanged, and the populator degrades to today's `metadata.service` when it is absent.
+- No migration, no new table.
+
+### Task 10 — I1: `expert.ts` loses a gap note and goes silently empty
+
+`agents/expert.ts:295-298`'s `subIncidentResolved` is a pure gap-reporter: it emits `detectMissingEntityType(db, "incident")` and otherwise returns `{}`. Before this branch `incident` entities never existed, so it always explained itself. Task 5 creates them, so for any user with PagerDuty connected the detector returns `null` and the lane now contributes nothing **with no gap note** — a shipped agent silently losing a lane it used to explain. Fix: key the gap note on the relation being absent, not the entity type.
+
+### Task 11 — I2: `LIMIT 20` × two-sided ownership destroys far-side edges
+
+Each side clears its whole direction before re-emitting at most 20. With a deployment and >20 counterpart incidents in-window — an ordinary big-outage fan-out — re-syncing the *deployment alone* deletes the surplus edges the incident side legitimately created. Reproduced: 30 edges → 20 after a deployment re-sync. It self-heals on the next incident sync and a full backfill converges, but between syncs the driver lane is sync-order dependent. Fix: make the clear symmetric with the emit, or lift the cap on the emitting side.
+
+### Task 12 — I3: the backfill is non-transactional and non-resumable
+
+`regraphSlice` issues every delete and insert in autocommit: measured 3.7 s for 3,000 message items on a file-backed WAL database (~124 s per 100k). Worse than the wall time, an interrupted or throwing pass leaves the graph half-rebuilt with each processed item's **old edges already cleared**. Fix: wrap each batch in `db.transaction`, add the per-item guard (logged Minor #5) so one bad row cannot abort the pass, and stop counting `ci_run` / `alert` / `error_issue` as `graphed` (logged Minor #4) since they pass `isItemLinkedGraphType` but have no dispatch branch.
+
+### Corrected record
+
+Logged review item #4 was **wrong**: `foreign_keys` is **ON**, not off. `local-index.ts:279` sets `PRAGMA foreign_keys = ON` inside `ensureSchema` (verified: `PRAGMA foreign_keys` returns 1 on a fresh handle). `graph_relation`'s `ON DELETE CASCADE` is live, so deleting an item cleanly cascades away the new cross-item edges. There is no dangling-relation risk. The earlier note claiming otherwise checked `bun:sqlite`'s default rather than the production path.
+
+Deferred Minors, with reasons: the `findCommitEntityIds` doc note and the "service ids contain no colon" comment are cosmetic; `REGRAPH_TYPE_ORDER` omitting `obsidian_note` is near-zero risk because ordering only matters when the target entity does not yet exist and note entities are created by every vault sync. Ticket-key extraction firing on prose (`UTF-8`, `RFC-2119`, `SHA-256`) is logged as a real precision issue for step 1b — each costs an unindexed scan and a project literally named `SHA` would emit a wrong edge.
+
+---
+
 ## What step 1b consumes from this plan
 
 Step 1b's six lanes traverse, in the direction shown:

--- a/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
+++ b/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
@@ -1,0 +1,436 @@
+# `nimbus why` + the VS Code why-lens — design
+
+> **Status:** design approved 2026-07-23. Spine **S1 (Local Brain)**, implicit-knowledge triad — the
+> first of the three agents. Simultaneously delivers the ecosystem roadmap's **Stage 2a headline**.
+>
+> Roadmap: [`docs/roadmap.md`](../../roadmap.md) § Active → Spine S1 · Phase 7 Wave 5.
+> Ecosystem: [`docs/ecosystem-roadmap.md`](../../ecosystem-roadmap.md) § Stage 2a.
+
+---
+
+## Contents
+
+- [Goal](#goal)
+- [Why this is buildable today](#why-this-is-buildable-today)
+- [Correction 1 — blame is not full-file](#correction-1--blame-is-not-full-file)
+- [Correction 2 — Wave 1a is already built at eight agents](#correction-2--wave-1a-is-already-built-at-eight-agents)
+- [Correction 3 — a 10-second hover is not a hover](#correction-3--a-10-second-hover-is-not-a-hover)
+- [Design](#design)
+  - [Landing sequence](#landing-sequence)
+  - [The `why` agent](#the-why-agent)
+  - [Input resolution](#input-resolution)
+  - [The six lanes](#the-six-lanes)
+  - [On-demand blame](#on-demand-blame)
+  - [Graceful degradation](#graceful-degradation)
+  - [The two gateway entry points](#the-two-gateway-entry-points)
+  - [Output types](#output-types)
+  - [CLI](#cli)
+  - [SDK + client hop](#sdk--client-hop)
+  - [The VS Code lens](#the-vs-code-lens)
+- [Security posture](#security-posture)
+- [Testing](#testing)
+- [Risks](#risks)
+- [Out of scope](#out-of-scope)
+- [Exit criteria](#exit-criteria)
+
+---
+
+## Goal
+
+For any source location, answer the question `git blame` gestures at but cannot answer:
+
+> **who** wrote this, **why**, **what drove it**, and **what depends on it** —
+> entirely from the local index, with no live API call.
+
+A cloud agent structurally cannot do this. It does not see the team's private Slack thread, the
+Linear ticket, or the incident that the change was a response to. Nimbus already has all four
+indexed; they are simply not queryable in a conversational shape yet.
+
+Two surfaces:
+
+- **`nimbus why <ref>`** — the full brief, CLI + IPC.
+- **A VS Code hover lens** — the demo. Hover a line, see author → PR → ticket inline; click through
+  for the full brief.
+
+---
+
+## Why this is buildable today
+
+Every edge the agent traverses already exists in the index. **No new graph relation type, no new
+item type, no migration, no new invariant, no HITL action type.**
+
+| Lane | Substrate in the index today |
+| --- | --- |
+| who | `git_blame_line` (V32, `index/git-blame-line-v32-sql.ts`) → `commit_sha`, author, time |
+| which PR | `merged_as` (V27) commit → PR |
+| why | `authored` / `reviewed` / `resolves` (V7) → PR body, reviewer thread, Linear/Jira ticket |
+| the thread | `mentions` / `posted` (V7) → `message` entities |
+| what drove it | `correlates_with` / `affects` (V7) → `incident`, `alert`, `deployment` |
+| downstream | `depends_on` / `defined_in` / `in_repo` (V12) → dependent symbols, repos |
+
+`agents/impact.ts` is a near-exact structural
+template: `AgentCoordinator` → five parallel `SubTask`s → `emitBriefWithSynthesis`. `why` is the
+same shape pointed backwards in the graph.
+
+---
+
+## Correction 1 — blame is not full-file
+
+**The brief assumed `git_blame_line` covers every line. It does not.**
+
+`connectors/filesystem-v2-sync.ts:363`
+calls `blameIndexedExcerptRanges`, which blames **only the indexed code-symbol excerpt ranges** —
+and skips the file entirely when the merged ranges exceed `MAX_BLAME_LINES = 5000`. Coverage is
+further bounded to paths under a configured `[[filesystem.roots]]`.
+
+So a hover on a comment, an import, a blank line, or any line outside an indexed symbol's excerpt
+has **no blame row** — and those are exactly the lines a lens fires on. Designing against the
+assumption of full coverage would have shipped a lens that is empty most of the time.
+
+The resolution is [on-demand blame](#on-demand-blame), below.
+
+## Correction 2 — Wave 1a is already built at eight agents
+
+Ecosystem Stage 1 Wave 1a (`agents.*` in `@nimbus-dev/client`) was assumed spec'd-but-unstarted.
+It is in fact **fully built and release-committed locally, unpushed and unpublished**:
+
+- `nimbus-sdk` worktree `.worktrees/agents-briefs`, branch `dev/asafgolombek/promote-agent-briefs`,
+  release commit `chore(release): 1.5.0`
+- `nimbus-client` worktree `.worktrees/agents-namespace`, branch `dev/asafgolombek/agents-namespace`,
+  release commit `chore(release): 0.7.0` — 226 tests green
+
+Widening those branches to nine agents would mean reverting two release commits and holding two
+finished branches hostage to a gateway agent that does not exist yet. The generic
+`subscribeAgentBrief<A extends AgentName>` wrapper was explicitly designed so the ninth agent is a
+**follow-on** costing one `AGENT_NAMES` entry, one brief type, and one promise method.
+
+**Decision: ship Wave 1a unchanged at eight; `why` rides a later `sdk 1.6.0` → `client 0.8.0` hop.**
+
+**Blocking prerequisite, not scope:** the client's ESM `dist/index.js` throws under Node (a
+pre-existing SDK extensionless-specifier bug, newly hit). VS Code extensions run on Node, so the
+lens cannot work until that is fixed. It is tracked as landing step 0 and is independent of this
+spec.
+
+## Correction 3 — a 10-second hover is not a hover
+
+The roadmap budgets `why` at **under 10 s**. VS Code cancels hovers on cursor movement and users
+expect roughly 300 ms. A single entry point cannot serve both the CLI brief and the lens.
+
+The surface therefore splits in two: a synchronous **peek** for the hover and the **full agent** for
+the click-through. See [The two gateway entry points](#the-two-gateway-entry-points).
+
+---
+
+## Design
+
+### Landing sequence
+
+| # | Repo | Ships | Gate |
+| --- | --- | --- | --- |
+| **0** *(prereq — not this spec)* | `nimbus-client` | Fix ESM `dist/index.js` under Node; push + publish `sdk 1.5.0`, then `client 0.7.0` | existing client suite + provenance audit |
+| **1** | `Nimbus` | `why` agent, `agents.why` + `agents.whyPeek`, Tauri allowlist, `nimbus why` CLI | `bun run preflight` |
+| **2** | `nimbus-sdk` **1.6.0** → `nimbus-client` **0.8.0** | `why` as the ninth agent | guard units, `MockClient` parity, conformance gate |
+| **3** | `nimbus-vscode` | hover provider + `nimbus.why` command | extension test suite + marketplace release |
+
+Step 1 is a hard prerequisite for step 2 — the SDK cannot promote a type the gateway has not
+defined. Step 0 is independent and should land first regardless.
+
+### The `why` agent
+
+New file `packages/gateway/src/agents/why.ts`, following
+`nimbus-agent-patterns`: read-only, HITL-free,
+parallel sub-agent decomposition via `AgentCoordinator`, terminating in
+`emitBriefWithSynthesis` from `agents/_lib/emit-brief.ts`.
+
+Latency target **under 10 s** on a mid-range laptop against a populated index.
+
+### Input resolution
+
+```ts
+export type WhyInput = {
+  ref: string;      // "path/to/file.ts:42" | "path/to/file.ts" | "<symbolName>"
+  line?: number;    // alternative to the ":42" suffix
+};
+```
+
+Resolution order:
+
+1. `path:line` (or `path` + `line`) → resolve `repoRoot` by matching the path against the configured
+   `[[filesystem.roots]]`. **A path that matches no root resolves to `null`** — see
+   [Security posture](#security-posture).
+2. A bare token → look up a `code_symbol` graph entity by name; take its file and
+   `excerptStartLine` metadata.
+3. No match → `subject: null` plus a `GapNote`, mirroring how `impact.ts` handles an unresolvable
+   start entity. The brief still renders; it simply has nothing to anchor on.
+
+### The six lanes
+
+Six `SubTask`s run in parallel under one `AgentCoordinator`, exactly as `impact.ts` runs five.
+
+| Lane | Traversal | Produces |
+| --- | --- | --- |
+| `subAuthorship` | `git_blame_line` → `commit_sha` → `git_commit` entity → `authored` → person | author name/email, commit SHA, commit subject, authored date |
+| `subPullRequest` | commit → `merged_as` → `pr`; `reviewed` → reviewers | PR number, title, body, URL, reviewer set, review-thread comments |
+| `subTicket` | pr → `resolves` / `mentions` → `issue` | ticket key, title, URL, status |
+| `subDiscussion` | pr / commit / issue → `mentions` / `posted` → `message` | Slack/Teams thread excerpts with permalinks |
+| `subDriver` | `correlates_with` / `affects` → `incident`, `alert`, `deployment` within the commit's time window | the incident or deploy the change responded to |
+| `subDownstream` | `depends_on` / `defined_in` / `in_repo` from the resolved symbol | dependent symbols, repos, services |
+
+**Shared traversal.** `subDownstream` overlaps `impact.ts`'s `subDownstreamCode` and
+`subDownstreamRepos`. Given this repo's standing jscpd duplication floor, the traversal is extracted
+into `agents/_lib/` and **both** agents call it. `impact.ts` is refactored to consume the extracted
+helper in the same PR — a sixth copy of a graph walk is not acceptable here.
+
+Each lane returns `{ findings?: WhyFinding[]; gap?: GapNote }` and a failed lane degrades to a gap
+note rather than failing the brief — the established `impact.ts` contract.
+
+### On-demand blame
+
+When `subAuthorship` finds no `git_blame_line` row for the resolved `(repoRoot, filePath, lineNo)`:
+
+1. Confirm the resolved path is inside a configured `[[filesystem.roots]]`. If not, stop — emit a
+   gap note, spawn nothing.
+2. Run `git blame -L <n>,<n> --porcelain -- <file>` in `repoRoot`, reusing the existing spawn shape
+   from `filesystem-v2-sync.ts` including `AbortSignal.timeout(BLAME_TIMEOUT_MS)`.
+3. Parse with the existing `parseBlamePorcelain`
+   (`security/blame-store.ts`).
+4. Persist with the existing `upsertBlameLines`, so the next hover on that line is a pure DB hit.
+5. A non-zero exit, spawn failure, or timeout yields no rows — treated identically to a miss, with a
+   gap note. Never an error.
+
+One line, one bounded subprocess, cached forever after. This is a **local** git read: it is not a
+connector dispatch, so `I29` / the egress ledger does not apply, and it is not a write, so `I2` /
+HITL does not apply.
+
+The `security/blame-store.ts` helpers are reused as-is; nothing in that module changes. The new
+single-line spawn helper is the only added code, and it is placed alongside the agent rather than in
+`security/`, which owns the scan-attribution use case.
+
+### Graceful degradation
+
+Degradation is the **existing** mechanism, not new code.
+`agents/_lib/gap-notes.ts` already
+provides `detectEmptyIndex`, `detectMissingConnector`, `detectMissingEntityType`, and
+`aggregateMissingEntityTypes`.
+
+| Connectors present | Lanes that light up |
+| --- | --- |
+| git only | `subAuthorship`, `subDownstream` |
+| \+ GitHub / GitLab | `subPullRequest`, `subTicket` (GitHub issues) |
+| \+ Linear / Jira | `subTicket` (full) |
+| \+ Slack / Teams | `subDiscussion` |
+| \+ PagerDuty / deploy annotation | `subDriver` |
+
+Every dark lane produces a gap note naming the connector that would light it. This is what makes the
+ecosystem roadmap's "degrades gracefully" claim true by construction rather than by special-casing.
+
+### The two gateway entry points
+
+Both registered in the handler map in
+`ipc/agents-rpc.ts` alongside the existing eight,
+and both added to `ALLOWED_METHODS` in
+`ui/src-tauri/src/gateway_bridge.rs`
+(read-only, renderer-safe). Neither is an HTTP write route: **no `I13`, no `WRITE_ROUTE_ALLOWLIST`
+change.**
+
+**`agents.why`** — the full agent. Returns `{ sessionId }` synchronously and emits the
+`why.briefReady` / `why.briefError` **pair**. Standard agent shape.
+
+**`agents.whyPeek`** — synchronous, no coordinator, no LLM, no notification, returns its payload
+directly:
+
+```ts
+export type WhyPeek = {
+  subject: { repoRoot: string; filePath: string; lineNo: number } | null;
+  author: string | null;
+  authorEmail: string | null;
+  commitSha: string | null;
+  committedAt: number | null;
+  commitSubject: string | null;
+  pr: { number: number; title: string; url: string } | null;
+  ticket: { key: string; title: string; url: string } | null;
+  hasMore: boolean;   // true when the full agent would add lanes beyond these
+};
+```
+
+Pure indexed `SELECT`s plus at most one on-demand blame spawn. **Target under 300 ms.**
+
+**On the name:** `agents.whyPeek`, not `agents.why.peek`. Every existing method in the namespace is
+two-segment (`agents.expert`, `agents.impact`, …); a three-segment name would be the first in the
+codebase for no benefit. It stays inside `agents.*` despite not emitting a brief so that it inherits
+the same allowlist grouping, client namespace, and conformance treatment as its sibling.
+
+### Output types
+
+```ts
+export type WhyLane =
+  | "authorship" | "pull_request" | "ticket" | "discussion" | "driver" | "downstream";
+
+export type WhyFinding = {
+  lane: WhyLane;
+  title: string;
+  detail: string;
+  url: string | null;
+  occurredAt: number | null;
+  entityId: string | null;
+};
+
+export type WhyBrief = AgentBriefBase & {
+  kind: "why";
+  query: { ref: string; line: number | null };
+  subject: { repoRoot: string; filePath: string; lineNo: number; symbol: string | null } | null;
+  findings: WhyFinding[];
+};
+```
+
+`AgentBriefBase` (`agentVersion`, `generatedAt`, `latencyMs`, `gaps`) comes from the SDK, matching
+how the other eight briefs are composed. `kind` is `"why"` — it matches the agent name, unlike
+`conflicts`, whose kind is the singular `"conflict"`.
+
+Markdown rendering goes through the existing `agents/_lib/render.ts`.
+
+### CLI
+
+```text
+nimbus why <ref> [--line <n>] [--peek] [--json]
+```
+
+`<ref>` accepts `path:line`, a bare path, or a symbol name. `--peek` hits `agents.whyPeek` for the
+one-line answer; the default runs the full agent and renders the brief as Markdown.
+
+The command must be registered in the CLI `COMMAND_NAMES` registry as well as `index.ts` — the
+registry silently lags, and `audit:readme-cli` reds when a doc names a command the registry lacks.
+Documented in [`docs/cli-reference.md`](../../cli-reference.md).
+
+### SDK + client hop
+
+Deliberately deferred behind Wave 1a's unchanged eight-agent release.
+
+`nimbus-sdk` **1.6.0** (additive, non-breaking):
+
+- `AGENT_NAMES` gains `"why"`; `AGENT_KIND.why = "why"`
+- `WhyBrief`, `WhyFinding`, `WhyLane`, `WhyPeek` exported from the root
+- `BriefFor<"why">` resolves via the existing mapped type
+- one concrete guard `isWhyBrief` via the existing `createBriefGuard` factory
+
+`nimbus-client` **0.8.0**:
+
+- `agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>` — rides the existing
+  generic `subscribeAgentBrief` + buffer-and-correlate machinery unchanged
+- `agentsWhyPeek(p: WhyPeekParams): Promise<WhyPeek>` — a plain request/response method, no
+  subscription
+- validators for both in `src/validate.ts`
+- `MockClient` parity, which the shared interface makes compiler-enforced
+- both added to the `agents.*` conformance gate
+
+### The VS Code lens
+
+- `vscode.languages.registerHoverProvider`, scoped to files resolving inside a Nimbus
+  `[[filesystem.roots]]` path. Files outside it get no provider activity at all.
+- The hover calls `client.agentsWhyPeek` with a ~1 s timeout, wired to the hover's
+  `CancellationToken`.
+- **Gateway down, slow, cancelled, or line unknown → render nothing.** No error chrome, no spinner
+  that outlives the hover. The lens is never the reason the editor feels slow.
+- Rendered `MarkdownString`:
+
+  ```markdown
+  **alice** committed `a1b2c3d` · 3 months ago
+  [#412 Fix retry backoff](https://…) · [NIM-88](https://…)
+  [Why — full brief](command:nimbus.why?…)
+  ```
+
+  The command link appears only when `hasMore` is true.
+- `nimbus.why` command → `client.agentsWhy` → renders into the extension's existing agent-chat
+  webview (`nimbus.openAgentChat` already ships).
+- New setting `nimbus.whyLens.enabled`, default `true`.
+- Extension stays at its current `engines.vscode` floor of `^1.95.0` — `registerHoverProvider` and
+  command URIs in `MarkdownString` are long-stable APIs. No engines bump, no proposed API.
+
+---
+
+## Security posture
+
+No new invariant. The relevant existing ones and why they are untouched:
+
+| Invariant | Relationship |
+| --- | --- |
+| `I2` / `I3` / `I4` (HITL) | Not engaged — `why` is read-only and dispatches no action. Same posture as the other eight built-in agents. |
+| `I11` (`wrapToolOutput`) | Engaged only through `emitBriefWithSynthesis`, which already wraps the synthesis step's tool output. No new LLM-facing tool surface is added. |
+| `I13` (HTTP write surface) | Untouched — both methods are local-socket IPC reads. `WRITE_ROUTE_ALLOWLIST` count is unchanged. |
+| `I7` (Tauri allowlist) | Two entries added; both read-only, neither RCE-class. The Rust count assertion moves from eight `agents.*` entries to ten. |
+| `I29` / `D22` (egress ledger) | Not engaged — the on-demand blame is a local `git` read, not a `connectors.dispatch`. `D22`'s static confinement is unaffected. |
+| `I9` (bound-param SQL) | All lane queries use bound parameters; no identifier interpolation. |
+
+**The one genuinely new attack surface is the on-demand blame subprocess**, and it is fenced by a
+single rule: *the resolved path must be inside a configured `[[filesystem.roots]]`, or nothing
+spawns.* The path is passed as an argv element after `--`, never through a shell. This rule gets a
+dedicated test that is **red-proven** before it is trusted — a guard asserted against a leftover
+import rather than a real call site is a failure mode this repo has already hit once.
+
+---
+
+## Testing
+
+Per `nimbus-testing`: real SQLite, fresh temp dirs,
+no DB-layer mocks.
+
+| Test | Asserts |
+| --- | --- |
+| `why.test.ts` per-lane units | each lane against a fixture DB containing only that lane's edges |
+| Resolution units | `path:line`, `path` + `--line`, bare symbol, and unresolvable ref |
+| Degradation | git-only fixture → lanes 2–5 emit `GapNote`s, **not** errors; brief still renders |
+| On-demand blame — hit | DB row present → **zero** spawns |
+| On-demand blame — miss | miss → one spawn → row persisted → second call is a DB hit with **zero** further spawns |
+| On-demand blame — failure | non-zero exit / timeout → gap note, no throw |
+| **Path escape** | ref outside every `[[filesystem.roots]]` → gap note and **zero** spawns; red-proven |
+| `agents-rpc` handlers | malformed params → `-32602` for both methods, matching the existing eight |
+| Peek shape | `hasMore` true iff a lane beyond authorship/PR/ticket has data |
+| E2E CLI | real gateway subprocess + mock MCP servers; `nimbus why <file>:<line>` end to end |
+| Latency | full brief under 10 s, peek under 300 ms against the fixture index |
+| Tauri allowlist | Rust count assertion updated 8 → 10 `agents.*` entries |
+
+Gates: per-file ≥80% line and branch coverage (the floor is Docker-Linux-authoritative — verify
+there, not on native Windows), `audit:readme-cli` after the CLI registration, and
+`bun run preflight` before the first push.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| The blame subprocess makes a hover feel slow on a cold line | The peek path spawns at most once per line and caches; the hover's 1 s timeout renders nothing rather than blocking. A cold line degrades to a fast empty hover, not a slow populated one. |
+| `hasMore` requires knowing what the full agent would find, which is what makes the full agent expensive | `hasMore` is computed from cheap existence checks (does any `mentions` / `correlates_with` / `depends_on` edge leave the resolved entity), not from running the lanes. |
+| Extracting the shared traversal touches `impact.ts`, a shipped agent | The refactor lands with `impact.ts`'s existing suite passing **unchanged** — the same honesty gate Wave 1a applied to its de-dup PR. |
+| Step 0 (the client ESM bug) slips and blocks step 3 | Steps 1 and 2 are unblocked by it; only the lens waits. The gateway agent and the CLI ship value on their own. |
+| Wave 1a never publishes, stranding the client hop | Step 2 is explicitly sequenced *behind* Wave 1a's publish. If that stalls, `why` still ships on the gateway + CLI, which is where the roadmap acceptance criterion lives. |
+
+---
+
+## Out of scope
+
+Each is its own spec:
+
+- `nimbus glossary` and `nimbus decisions` — the other two thirds of the S1 implicit-knowledge triad
+- `nimbus pre-mortem`, `nimbus negotiate`
+- The implicit-knowledge dashboard (Tauri)
+- The ownership graph — `service` / `team` item types, `nimbus services list/show` (Phase 7 Wave 1)
+- Ecosystem Stage 2b (ops vocabulary), 2c (egress receipts), 2d (Language Model Tool registration)
+- Full-file blame indexing
+
+---
+
+## Exit criteria
+
+1. `nimbus why packages/gateway/src/engine/executor.ts:42` returns a brief naming the PR author, the
+   linked ticket, the driving incident where one exists, and the downstream dependents — from the
+   local index, with zero live API calls, in under 10 s on a mid-range laptop. *(This is the
+   roadmap's stated Wave 5 acceptance criterion.)*
+2. On a git-only index the same command still returns authorship and downstream lanes, with gap
+   notes naming the connectors that would light the rest. No errors.
+3. `nimbus why <ref> --peek` returns in under 300 ms.
+4. A hover in VS Code over any line inside an indexed root shows author, commit, PR, and ticket; a
+   hover with the gateway stopped shows nothing and logs nothing user-visible.
+5. Clicking **Why — full brief** opens the rendered brief in the agent-chat view.
+6. The path-escape test is red-proven: it fails when the root check is removed.
+7. `bun run preflight` green; coverage floor green on Docker-Linux.

--- a/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
+++ b/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
@@ -106,10 +106,12 @@ finished branches hostage to a gateway agent that does not exist yet. The generi
 
 **Decision: ship Wave 1a unchanged at eight; `why` rides a later `sdk 1.6.0` → `client 0.8.0` hop.**
 
-**Blocking prerequisite, not scope:** the client's ESM `dist/index.js` throws under Node (a
+**External prerequisite — owned elsewhere:** the client's ESM `dist/index.js` throws under Node (a
 pre-existing SDK extensionless-specifier bug, newly hit). VS Code extensions run on Node, so the
-lens cannot work until that is fixed. It is tracked as landing step 0 and is independent of this
-spec.
+lens cannot work until that is fixed. **That fix, and the Wave 1a push/publish it gates, are being
+handled in a separate workstream and are not scope here.** This spec depends on their outcome but
+plans no work for them: it is listed as landing step 0 to make the dependency explicit, and only
+step 3 (the lens) waits on it.
 
 ## Correction 3 — a 10-second hover is not a hover
 
@@ -127,13 +129,18 @@ the click-through. See [The two gateway entry points](#the-two-gateway-entry-poi
 
 | # | Repo | Ships | Gate |
 | --- | --- | --- | --- |
-| **0** *(prereq — not this spec)* | `nimbus-client` | Fix ESM `dist/index.js` under Node; push + publish `sdk 1.5.0`, then `client 0.7.0` | existing client suite + provenance audit |
+| **0** *(external — owned by a separate workstream)* | `nimbus-sdk` / `nimbus-client` | Fix ESM `dist/index.js` under Node; push + publish `sdk 1.5.0`, then `client 0.7.0` | not planned here; only step 3 waits on it |
 | **1** | `Nimbus` | `why` agent, `agents.why` + `agents.whyPeek`, Tauri allowlist, `nimbus why` CLI | `bun run preflight` |
 | **2** | `nimbus-sdk` **1.6.0** → `nimbus-client` **0.8.0** | `why` as the ninth agent | guard units, `MockClient` parity, conformance gate |
 | **3** | `nimbus-vscode` | hover provider + `nimbus.why` command | extension test suite + marketplace release |
 
 Step 1 is a hard prerequisite for step 2 — the SDK cannot promote a type the gateway has not
-defined. Step 0 is independent and should land first regardless.
+defined. Step 0 is external to this spec and progresses independently; steps 1 and 2 do not wait on
+it, and step 3 does.
+
+**Therefore this spec yields three implementation plans, not one** — step 1 (gateway), step 2 (the
+SDK + client hop), step 3 (the extension). Step 1 is the only one that can start immediately, and it
+delivers the roadmap's stated acceptance criterion on its own.
 
 ### The `why` agent
 

--- a/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
+++ b/docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md
@@ -15,6 +15,7 @@
 - [Correction 1 — blame is not full-file](#correction-1--blame-is-not-full-file)
 - [Correction 2 — Wave 1a is already built at eight agents](#correction-2--wave-1a-is-already-built-at-eight-agents)
 - [Correction 3 — a 10-second hover is not a hover](#correction-3--a-10-second-hover-is-not-a-hover)
+- [Correction 4 — three of the six lanes ride edges nothing emits](#correction-4--three-of-the-six-lanes-ride-edges-nothing-emits)
 - [Design](#design)
   - [Landing sequence](#landing-sequence)
   - [The `why` agent](#the-why-agent)
@@ -56,8 +57,13 @@ Two surfaces:
 
 ## Why this is buildable today
 
-Every edge the agent traverses already exists in the index. **No new graph relation type, no new
-item type, no migration, no new invariant, no HITL action type.**
+Every relation type the agent traverses is already **declared** in the schema, and every item it
+reads is already **indexed**. **No new graph relation type, no new item type, no migration, no new
+invariant, no HITL action type.**
+
+Three of those relation types are declared but never written by any populator, so a prerequisite
+phase makes them real — see [Correction 4](#correction-4--three-of-the-six-lanes-ride-edges-nothing-emits).
+That is populator work on existing tables, not schema work.
 
 | Lane | Substrate in the index today |
 | --- | --- |
@@ -121,6 +127,49 @@ expect roughly 300 ms. A single entry point cannot serve both the CLI brief and 
 The surface therefore splits in two: a synchronous **peek** for the hover and the **full agent** for
 the click-through. See [The two gateway entry points](#the-two-gateway-entry-points).
 
+## Correction 4 — three of the six lanes ride edges nothing emits
+
+**Added 2026-07-23, after auditing every `upsertGraphRelation` call site in the gateway.**
+
+The relation types are all declared in the schema (V7/V12/V26/V27/V40). Only some are ever written.
+
+| | Relation types |
+| --- | --- |
+| **Emitted by a populator** | `authored`, `targets`, `in_repo`, `depends_on`, `belongs_to`, `upstream_refs`, `reviewed`, `posted`, `opened`, `monitors`, `merged_as`, `derived_from`, `defined_in`, `backlinks` |
+| **Declared but emitted by nothing** | `resolves`, `mentions`, `correlates_with`, `affects`, `triggers`, `tests`, `fires_on`, `assigned` |
+
+The original lane table put `subTicket` on `resolves` / `mentions`, `subDiscussion` on `mentions`,
+and `subDriver` on `correlates_with` / `affects`. **All three would return zero rows on every index,
+forever** — three of six lanes permanently dark, and the headline claim about the ticket, the thread
+and the incident hollow.
+
+**Decision: emit the missing edges in the graph populator first.** `why` then traverses real edges,
+and `impact.ts` plus every future agent inherits the same benefit. The alternative — reading the
+`item` table and `item_fts` heuristically from inside the agent — was rejected as reaching around
+the graph.
+
+This makes the populator a prerequisite **phase**, not a footnote. Grounding it surfaced three
+further constraints that shape its task list:
+
+1. **`clearRelationsTouchingEntity` clobbers cross-item edges.** Every sync function opens with
+   `DELETE FROM graph_relation WHERE from_id = ? OR to_id = ?`. Today that is safe only because
+   every existing edge is emitted by the sync of its *own* `from` entity. A `mentions` edge from a
+   message to a PR would be silently deleted the next time that PR re-syncs, and would not come back
+   until the message itself re-synced. The clear must be scoped to the relation types the calling
+   sync function actually owns, on `from_id` only, before any cross-item edge is trustworthy.
+2. **`IndexedItemGraphInput` carries no body.** It is `{id, service, type, title, authorId,
+   metadata}`. Parsing ticket references out of a PR body or mention references out of a message
+   body requires widening it with `bodyPreview` — one field, one call site (`index/item-store.ts`).
+3. **`incident` and `deployment` have no graph entities at all.** Both are indexed as items by real
+   connectors and both are listed in `ITEM_LINKED_ENTITY_TYPES`, but `syncGraphFromIndexedItem` has
+   no branch for either — so nothing is ever created to correlate. `correlates_with` therefore needs
+   the entities built first. This is also why `impact.ts`'s on-call and dashboard lanes are gap
+   notes today.
+
+**Consequence for the landing sequence:** gateway step 1 splits into **1a (populator edges)** and
+**1b (the agent)**. 1a is independently valuable and independently shippable — it lights up
+`impact.ts` on its own — and 1b depends on it.
+
 ---
 
 ## Design
@@ -130,17 +179,19 @@ the click-through. See [The two gateway entry points](#the-two-gateway-entry-poi
 | # | Repo | Ships | Gate |
 | --- | --- | --- | --- |
 | **0** *(external — owned by a separate workstream)* | `nimbus-sdk` / `nimbus-client` | Fix ESM `dist/index.js` under Node; push + publish `sdk 1.5.0`, then `client 0.7.0` | not planned here; only step 3 waits on it |
-| **1** | `Nimbus` | `why` agent, `agents.why` + `agents.whyPeek`, Tauri allowlist, `nimbus why` CLI | `bun run preflight` |
+| **1a** | `Nimbus` | Graph-populator edges: scoped relation clear, `resolves`, `mentions`, `incident` + `deployment` entities, `correlates_with`, backfill | `bun run preflight`; `impact.ts` suite green |
+| **1b** | `Nimbus` | `why` agent, `agents.why` + `agents.whyPeek`, Tauri allowlist, `nimbus why` CLI | `bun run preflight` |
 | **2** | `nimbus-sdk` **1.6.0** → `nimbus-client` **0.8.0** | `why` as the ninth agent | guard units, `MockClient` parity, conformance gate |
 | **3** | `nimbus-vscode` | hover provider + `nimbus.why` command | extension test suite + marketplace release |
 
-Step 1 is a hard prerequisite for step 2 — the SDK cannot promote a type the gateway has not
-defined. Step 0 is external to this spec and progresses independently; steps 1 and 2 do not wait on
-it, and step 3 does.
+Step 1a is a hard prerequisite for 1b (the lanes need real edges), and 1b for step 2 (the SDK cannot
+promote a type the gateway has not defined). Step 0 is external to this spec and progresses
+independently; steps 1a/1b/2 do not wait on it, and step 3 does.
 
-**Therefore this spec yields three implementation plans, not one** — step 1 (gateway), step 2 (the
-SDK + client hop), step 3 (the extension). Step 1 is the only one that can start immediately, and it
-delivers the roadmap's stated acceptance criterion on its own.
+**Therefore this spec yields four implementation plans, not one** — 1a (populator edges), 1b (the
+agent), 2 (the SDK + client hop), 3 (the extension). **1a can start immediately and is independently
+valuable**: it lights up `impact.ts`'s currently-dark lanes on its own, with no dependency on `why`.
+1b delivers the roadmap's stated acceptance criterion.
 
 ### The `why` agent
 

--- a/packages/gateway/src/agents/_lib/gap-notes.test.ts
+++ b/packages/gateway/src/agents/_lib/gap-notes.test.ts
@@ -6,6 +6,7 @@ import {
   detectMissingConnector,
   detectMissingEntityType,
   detectMissingRelationEmit,
+  detectMissingRelationToEntityType,
   remediationForEntityType,
 } from "./gap-notes.ts";
 
@@ -116,6 +117,59 @@ describe("detectMissingRelationEmit", () => {
        VALUES ('e2', 'e1', 'reviewed', 1.0, 0)`,
     );
     expect(detectMissingRelationEmit(db, "reviewed")).toBeNull();
+  });
+});
+
+describe("detectMissingRelationToEntityType", () => {
+  test("returns a missing_relation_emit gap when no edge of the type targets the given entity type", () => {
+    const db = withSchema(freshDb());
+    const note = detectMissingRelationToEntityType(db, "resolves", "incident");
+    expect(note?.category).toBe("missing_relation_emit");
+    expect(note?.detail).toMatch(/`resolves`/);
+    expect(note?.detail).toMatch(/`incident`/);
+  });
+
+  test("includes the supplied remediation string when provided", () => {
+    const db = withSchema(freshDb());
+    const note = detectMissingRelationToEntityType(
+      db,
+      "resolves",
+      "incident",
+      "graph-populator follow-up",
+    );
+    expect(note?.remediation).toBe("graph-populator follow-up");
+  });
+
+  test("returns null when an edge of the type targets the given entity type", () => {
+    const db = withSchema(freshDb());
+    db.run(
+      `INSERT INTO graph_entity (id, type, external_id, label, service)
+       VALUES ('e1', 'incident', 'inc:1', 'Incident', 'pagerduty'),
+              ('e2', 'person', 'alice', 'Alice', 'github')`,
+    );
+    db.run(
+      `INSERT INTO graph_relation (from_id, to_id, type, weight, created_at)
+       VALUES ('e2', 'e1', 'resolves', 1.0, 0)`,
+    );
+    expect(detectMissingRelationToEntityType(db, "resolves", "incident")).toBeNull();
+  });
+
+  test("I-2: an edge of the type that targets a DIFFERENT entity type does not suppress the gap — the exact bug this fixes", () => {
+    const db = withSchema(freshDb());
+    // A real `pr -> issue "resolves"` edge exists (this branch's own new edge
+    // type), but nothing targets `incident`. The unscoped `detectMissingRelationEmit`
+    // would find this row and wrongly report no gap.
+    db.run(
+      `INSERT INTO graph_entity (id, type, external_id, label, service)
+       VALUES ('e1', 'issue', 'r/x#1', 'Issue', 'github'),
+              ('e2', 'pr', 'r/x#2', 'PR', 'github')`,
+    );
+    db.run(
+      `INSERT INTO graph_relation (from_id, to_id, type, weight, created_at)
+       VALUES ('e2', 'e1', 'resolves', 1.0, 0)`,
+    );
+    expect(detectMissingRelationEmit(db, "resolves")).toBeNull();
+    expect(detectMissingRelationToEntityType(db, "resolves", "incident")).not.toBeNull();
   });
 });
 

--- a/packages/gateway/src/agents/_lib/gap-notes.ts
+++ b/packages/gateway/src/agents/_lib/gap-notes.ts
@@ -67,6 +67,41 @@ export function detectMissingRelationEmit(
   return note;
 }
 
+/**
+ * I-2: like `detectMissingRelationEmit`, but scoped to edges of `relationType`
+ * whose TARGET is `targetEntityType`. `detectMissingRelationEmit` probes for
+ * *any* `graph_relation` row of the given type, of any endpoint shape — once
+ * a second populator starts emitting the same relation type between different
+ * entity kinds (e.g. `pr -> issue "resolves"` alongside a future
+ * `person -> incident "resolves"`), that broad probe finds the unrelated edge
+ * and the gap note for the lane that still has nothing goes silently missing.
+ * Scoping to the endpoint the caller's lane actually reads keeps the two
+ * independent.
+ */
+export function detectMissingRelationToEntityType(
+  db: Database,
+  relationType: string,
+  targetEntityType: string,
+  remediation?: string,
+): GapNote | null {
+  const row = db
+    .query(
+      `SELECT 1 AS n
+         FROM graph_relation r
+         JOIN graph_entity e ON e.id = r.to_id
+        WHERE r.type = ? AND e.type = ?
+        LIMIT 1`,
+    )
+    .get(relationType, targetEntityType) as { n?: number } | null;
+  if (row !== null) return null;
+  const note: GapNote = {
+    category: "missing_relation_emit",
+    detail: `\`${relationType}\` edges targeting \`${targetEntityType}\` are defined in the schema but not yet emitted by the graph populator.`,
+  };
+  if (remediation !== undefined) note.remediation = remediation;
+  return note;
+}
+
 export function aggregateMissingEntityTypes(notes: GapNote[]): GapNote[] {
   const missing = notes.filter((n) => n.category === "missing_entity_type");
   if (missing.length < 2) return notes;

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -463,13 +463,40 @@ describe("runExpert — subIncidentResolved regression: entity exists but relati
       metadata: { service: "checkout" },
     });
 
+    // I-2: also index a real GitHub issue + a PR whose body says "closes #4" —
+    // this branch's graph populator now emits a genuine `pr -> issue "resolves"`
+    // edge for that. On unscoped code, `detectMissingRelationEmit(db, "resolves")`
+    // finds THIS edge (wrong endpoint type) and wrongly suppresses the incident
+    // lane's gap note — the exact silent-empty-lane bug this fixture proves fixed.
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "issue",
+      externalId: "acme/app#4",
+      title: "Login broken",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app" },
+    });
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Fix login",
+      bodyPreview: "closes #4",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app" },
+    });
+
     const ctx = { db, notify: () => {}, sessionId: "s-incident-entity-no-relation" };
     const brief = await runExpert({ topicOrFile: "auth" }, ctx);
 
     // The old `detectMissingEntityType`-only check would find `incident`
     // entities and silently drop this lane with no explanation at all. The
     // lane must still explain itself via a `missing_relation_emit` gap note
-    // keyed on the `resolves` relation it actually needs.
+    // keyed on the `resolves` relation it actually needs — even though a
+    // `resolves` edge now genuinely exists elsewhere in the graph (pr -> issue).
     const cats = brief.gaps.map((g) => g.category);
     expect(cats).toContain("missing_relation_emit");
     const relationGap = brief.gaps.find(

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
+import { upsertIndexedItem } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
 import { emitExpertBrief, rankExpertFindings, runExpert } from "./expert.ts";
 
@@ -402,7 +403,7 @@ describe("runExpert — subPrAuthored data path", () => {
 });
 
 describe("runExpert — subPrReviewed / subIncidentResolved suppressed gaps", () => {
-  test("existing reviewed relation + incident entity produces no gap for those", async () => {
+  test("existing reviewed + resolves relations and an incident entity produce no gap for those", async () => {
     const db = makePopulatedDb();
     const now = Date.now();
     // Populate graph with 'reviewed' relation so subPrReviewed returns {}
@@ -420,11 +421,18 @@ describe("runExpert — subPrReviewed / subIncidentResolved suppressed gaps", ()
       "reviewed",
       now,
     ]);
-    // Populate graph with 'incident' entity so subIncidentResolved returns {}
+    // Populate graph with 'incident' entity so the entity-type check passes,
+    // AND a 'resolves' relation so the relation-emit check also passes.
     db.run(
       "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
       ["ge:inc:1", "incident", "inc:1", "Incident", "pagerduty"],
     );
+    db.run("INSERT INTO graph_relation (from_id, to_id, type, created_at) VALUES (?, ?, ?, ?)", [
+      "ge:person:1",
+      "ge:inc:1",
+      "resolves",
+      now,
+    ]);
 
     const ctx = { db, notify: () => {}, sessionId: "s-reviewed-inc" };
     const brief = await runExpert({ topicOrFile: "auth" }, ctx);
@@ -432,6 +440,42 @@ describe("runExpert — subPrReviewed / subIncidentResolved suppressed gaps", ()
     const cats = brief.gaps.map((g) => g.category);
     expect(cats).not.toContain("missing_relation_emit");
     expect(cats).not.toContain("missing_entity_type");
+  });
+});
+
+describe("runExpert — subIncidentResolved regression: entity exists but relation does not", () => {
+  test("indexing a real PagerDuty-shaped incident item still surfaces a gap note (no silent empty lane)", async () => {
+    const db = makePopulatedDb();
+    const now = Date.now();
+
+    // Index a real PagerDuty-shaped incident item through the same
+    // item-store path a connector sync uses. This drives the real graph
+    // populator, so `incident` graph entities genuinely exist — nothing here
+    // fabricates a `resolves` relation, because no populator emits one.
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "PD-1",
+      title: "Checkout 500s",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { service: "checkout" },
+    });
+
+    const ctx = { db, notify: () => {}, sessionId: "s-incident-entity-no-relation" };
+    const brief = await runExpert({ topicOrFile: "auth" }, ctx);
+
+    // The old `detectMissingEntityType`-only check would find `incident`
+    // entities and silently drop this lane with no explanation at all. The
+    // lane must still explain itself via a `missing_relation_emit` gap note
+    // keyed on the `resolves` relation it actually needs.
+    const cats = brief.gaps.map((g) => g.category);
+    expect(cats).toContain("missing_relation_emit");
+    const relationGap = brief.gaps.find(
+      (g) => g.category === "missing_relation_emit" && g.detail.includes("resolves"),
+    );
+    expect(relationGap).toBeDefined();
   });
 });
 

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -293,8 +293,18 @@ async function subPrReviewed(db: Database, _input: string): Promise<SubAgentResu
 }
 
 async function subIncidentResolved(db: Database, _input: string): Promise<SubAgentResult> {
-  const gap = detectMissingEntityType(db, "incident");
-  if (gap !== null) return { gap };
+  const missingEntityGap = detectMissingEntityType(db, "incident");
+  if (missingEntityGap !== null) return { gap: missingEntityGap };
+  // `incident` entities existing is necessary but not sufficient: this lane's
+  // findings depend on the `resolves` relation (person -> incident), which no
+  // populator currently emits. Without this check, once incident entities
+  // exist the lane goes silently empty instead of explaining why.
+  const missingRelationGap = detectMissingRelationEmit(
+    db,
+    "resolves",
+    "Tracked as a graph-populator follow-up on existing PagerDuty / Sentry connectors.",
+  );
+  if (missingRelationGap !== null) return { gap: missingRelationGap };
   return {};
 }
 

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -6,6 +6,7 @@ import {
   detectMissingConnector,
   detectMissingEntityType,
   detectMissingRelationEmit,
+  detectMissingRelationToEntityType,
 } from "./_lib/gap-notes.ts";
 import { type SynthesizerLlm, synthesize } from "./_lib/synthesize.ts";
 
@@ -296,12 +297,16 @@ async function subIncidentResolved(db: Database, _input: string): Promise<SubAge
   const missingEntityGap = detectMissingEntityType(db, "incident");
   if (missingEntityGap !== null) return { gap: missingEntityGap };
   // `incident` entities existing is necessary but not sufficient: this lane's
-  // findings depend on the `resolves` relation (person -> incident), which no
-  // populator currently emits. Without this check, once incident entities
-  // exist the lane goes silently empty instead of explaining why.
-  const missingRelationGap = detectMissingRelationEmit(
+  // findings depend on a `resolves` edge targeting an `incident` (person ->
+  // incident), which no populator currently emits. Scoped to that endpoint
+  // (not `detectMissingRelationEmit`'s any-endpoint probe) because this
+  // branch made `pr -> issue "resolves"` edges real — an unscoped probe would
+  // find those and suppress this gap note even though this lane still has
+  // nothing, going silently empty instead of explaining why.
+  const missingRelationGap = detectMissingRelationToEntityType(
     db,
     "resolves",
+    "incident",
     "Tracked as a graph-populator follow-up on existing PagerDuty / Sentry connectors.",
   );
   if (missingRelationGap !== null) return { gap: missingRelationGap };

--- a/packages/gateway/src/connectors/vercel-deployment-mapping.ts
+++ b/packages/gateway/src/connectors/vercel-deployment-mapping.ts
@@ -46,6 +46,16 @@ export function mapVercelDeploymentToItem(
   const commitMessage = stringField(meta, "githubCommitMessage") ?? null;
   const commitRef = stringField(meta, "githubCommitRef") ?? null;
   const prId = stringField(meta, "githubPrId") ?? null;
+  // Vercel's git-integration `meta` also carries the owning repo, under either the
+  // top-level keys (githubOrg/githubRepo) or the commit-scoped ones
+  // (githubCommitOrg/githubCommitRepo) depending on API version. Surfaced as
+  // `repo` (the same key `graph-populator.ts` / `metrics/service-identity.ts`
+  // already read off PR/issue/CI items) so a git-integrated Vercel deployment
+  // can bind to a `[metrics.dora.<id>]`/`[ci.service.<id>]` repo URN.
+  const githubOrg = stringField(meta, "githubOrg") ?? stringField(meta, "githubCommitOrg") ?? null;
+  const githubRepo =
+    stringField(meta, "githubRepo") ?? stringField(meta, "githubCommitRepo") ?? null;
+  const repo = githubOrg !== null && githubRepo !== null ? `${githubOrg}/${githubRepo}` : null;
 
   const creatorObj = asRecord(row["creator"]) ?? {};
   const creator = stringField(creatorObj, "username") ?? stringField(creatorObj, "email") ?? null;
@@ -67,6 +77,7 @@ export function mapVercelDeploymentToItem(
     commit_message: commitMessage,
     commit_ref: commitRef,
     pr_id: prId,
+    repo,
     creator,
     created_at: createdAt,
     canonical_url: canonicalUrl,

--- a/packages/gateway/src/graph/graph-populator-api-endpoint.test.ts
+++ b/packages/gateway/src/graph/graph-populator-api-endpoint.test.ts
@@ -16,6 +16,7 @@ test("syncing an api_endpoint item creates an api_endpoint entity and a `targets
     service: "openapi",
     type: "api_endpoint",
     title: "GET /v1/payments",
+    bodyPreview: null,
     authorId: null,
     metadata: { service_name: "payments-api", spec_file: "/tmp/openapi.yaml" },
   });

--- a/packages/gateway/src/graph/graph-populator-bi.test.ts
+++ b/packages/gateway/src/graph/graph-populator-bi.test.ts
@@ -48,6 +48,7 @@ test("data_model item emits a derived_from edge to its upstream key", () => {
     service: "looker",
     type: "data_model",
     title: "revenue",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "analytics.public.revenue", derivedFromKeys: ["dbt.marts.revenue"] },
   });
@@ -68,6 +69,7 @@ test("data_model without dataModelKey falls back to item id", () => {
     service: "dbt",
     type: "data_model",
     title: "orders",
+    bodyPreview: null,
     authorId: null,
     metadata: { derivedFromKeys: [] },
   });
@@ -86,6 +88,7 @@ test("data_model with no derivedFromKeys creates no edges", () => {
     service: "dbt",
     type: "data_model",
     title: "sessions",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "analytics.public.sessions" },
   });
@@ -108,6 +111,7 @@ test("dashboard item emits upstream_refs from each upstream data_model", () => {
     service: "tableau",
     type: "dashboard",
     title: "Q1 Revenue",
+    bodyPreview: null,
     authorId: null,
     metadata: { upstreamDataModelKeys: ["analytics.public.revenue"] },
   });
@@ -128,6 +132,7 @@ test("dashboard with no upstreamDataModelKeys creates no edges", () => {
     service: "tableau",
     type: "dashboard",
     title: "Empty dash",
+    bodyPreview: null,
     authorId: null,
     metadata: {},
   });
@@ -150,6 +155,7 @@ test("data_quality_test item emits a monitors edge to its table", () => {
     service: "montecarlo",
     type: "data_quality_test",
     title: "freshness breach on revenue",
+    bodyPreview: null,
     authorId: null,
     metadata: { monitoredDataModelKeys: ["analytics.public.revenue"] },
   });
@@ -170,6 +176,7 @@ test("data_quality_test with no monitoredDataModelKeys creates no edges", () => 
     service: "montecarlo",
     type: "data_quality_test",
     title: "schema drift alert",
+    bodyPreview: null,
     authorId: null,
     metadata: {},
   });
@@ -190,6 +197,7 @@ test("re-syncing data_model replaces stale derived_from edges (no leak)", () => 
     service: "dbt",
     type: "data_model",
     title: "orders",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "db.schema.orders", derivedFromKeys: ["old.upstream"] },
   });
@@ -198,6 +206,7 @@ test("re-syncing data_model replaces stale derived_from edges (no leak)", () => 
     service: "dbt",
     type: "data_model",
     title: "orders",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "db.schema.orders", derivedFromKeys: ["new.upstream"] },
   });
@@ -225,6 +234,7 @@ test("upstream_refs edge survives a data_model re-sync (cross-connector edge not
     service: "tableau",
     type: "dashboard",
     title: "Dash 1",
+    bodyPreview: null,
     authorId: null,
     metadata: { upstreamDataModelKeys: ["a.b.c"] },
   });
@@ -244,6 +254,7 @@ test("upstream_refs edge survives a data_model re-sync (cross-connector edge not
     service: "snowflake",
     type: "data_model",
     title: "a.b.c",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "a.b.c", derivedFromKeys: [] },
   });
@@ -252,6 +263,7 @@ test("upstream_refs edge survives a data_model re-sync (cross-connector edge not
     service: "snowflake",
     type: "data_model",
     title: "a.b.c",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "a.b.c", derivedFromKeys: [] },
   });
@@ -279,6 +291,7 @@ test("tableau upstream reference does not overwrite service of a snowflake-owned
     service: "snowflake",
     type: "data_model",
     title: "a.b.c",
+    bodyPreview: null,
     authorId: null,
     metadata: { dataModelKey: "a.b.c", derivedFromKeys: [] },
   });
@@ -295,6 +308,7 @@ test("tableau upstream reference does not overwrite service of a snowflake-owned
     service: "tableau",
     type: "dashboard",
     title: "Dash 1",
+    bodyPreview: null,
     authorId: null,
     metadata: { upstreamDataModelKeys: ["a.b.c"] },
   });
@@ -317,6 +331,7 @@ test("stringArrayField drops non-string entries in monitoredDataModelKeys", () =
     service: "bigeye",
     type: "data_quality_test",
     title: "mixed array test",
+    bodyPreview: null,
     authorId: null,
     metadata: { monitoredDataModelKeys: ["analytics.public.revenue", 42, null, true] },
   });

--- a/packages/gateway/src/graph/graph-populator-branches.test.ts
+++ b/packages/gateway/src/graph/graph-populator-branches.test.ts
@@ -80,6 +80,7 @@ describe("syncGraphFromIndexedItem — version guard", () => {
       service: "github",
       type: "pr",
       title: "My PR",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -97,6 +98,7 @@ describe("syncGraphFromIndexedItem — unknown type guard", () => {
       service: "unknown",
       type: "not_a_real_type",
       title: "Whatever",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -117,6 +119,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "Add feature",
+      bodyPreview: null,
       authorId: "user:42",
       metadata: {
         repo: "acme/app",
@@ -142,6 +145,7 @@ describe("syncPrGraph", () => {
       service: "gitlab",
       type: "pr",
       title: "MR title",
+      bodyPreview: null,
       authorId: null,
       metadata: { project: "group/project" },
     });
@@ -160,6 +164,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "No repo PR",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -176,6 +181,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "No author",
+      bodyPreview: null,
       authorId: "",
       metadata: {},
     });
@@ -191,6 +197,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "Open PR",
+      bodyPreview: null,
       authorId: null,
       metadata: { merged: false, merge_commit_sha: "abc123" },
     });
@@ -205,6 +212,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "Merged PR no sha",
+      bodyPreview: null,
       authorId: null,
       metadata: { merged: true },
     });
@@ -220,6 +228,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "Alice PR",
+      bodyPreview: null,
       authorId: "user:77",
       metadata: {},
     });
@@ -238,6 +247,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "PR with user meta",
+      bodyPreview: null,
       authorId: "user:88",
       metadata: { user: "bob_the_builder" },
     });
@@ -256,6 +266,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "PR fallback label",
+      bodyPreview: null,
       authorId: "raw:user:id:99",
       metadata: {},
     });
@@ -274,6 +285,7 @@ describe("syncPrGraph", () => {
       service: "github",
       type: "pr",
       title: "Whitespace name",
+      bodyPreview: null,
       authorId: "user:55",
       metadata: { user: "trimmed_fallback" },
     });
@@ -297,6 +309,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "Bug report",
+      bodyPreview: null,
       authorId: "user:10",
       metadata: { repo: "acme/app" },
     });
@@ -315,6 +328,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "No repo issue",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -331,6 +345,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "Anonymous issue",
+      bodyPreview: null,
       authorId: "",
       metadata: {},
     });
@@ -347,6 +362,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "Carol's issue",
+      bodyPreview: null,
       authorId: "user:33",
       metadata: {},
     });
@@ -364,6 +380,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "Issue user fallback",
+      bodyPreview: null,
       authorId: "no-such-person",
       metadata: { user: "dave_handle" },
     });
@@ -381,6 +398,7 @@ describe("syncIssueGraph", () => {
       service: "github",
       type: "issue",
       title: "Issue raw id",
+      bodyPreview: null,
       authorId: "raw:author:id",
       metadata: {},
     });
@@ -404,6 +422,7 @@ describe("syncMessageGraph", () => {
       service: "slack",
       type: "message",
       title: "Hello world",
+      bodyPreview: null,
       authorId: "user:slack:1",
       metadata: { channel: "C123GENERAL" },
     });
@@ -422,6 +441,7 @@ describe("syncMessageGraph", () => {
       service: "slack",
       type: "message",
       title: "Bot message",
+      bodyPreview: null,
       authorId: null,
       metadata: { channel: "C456BOT" },
     });
@@ -439,6 +459,7 @@ describe("syncMessageGraph", () => {
       service: "slack",
       type: "message",
       title: "DM message",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -454,6 +475,7 @@ describe("syncMessageGraph", () => {
       service: "slack",
       type: "message",
       title: "User meta fallback",
+      bodyPreview: null,
       authorId: "unknown:person:7",
       metadata: { user: "eva_user" },
     });
@@ -477,6 +499,7 @@ describe("syncGitCommitGraph", () => {
       service: "filesystem",
       type: "git_commit",
       title: "Missing sha",
+      bodyPreview: null,
       authorId: null,
       metadata: { repoRoot: "/home/user/project" },
     });
@@ -491,6 +514,7 @@ describe("syncGitCommitGraph", () => {
       service: "filesystem",
       type: "git_commit",
       title: "Some commit",
+      bodyPreview: null,
       authorId: null,
       metadata: { sha: "abc123def456" },
     });
@@ -507,6 +531,7 @@ describe("syncGitCommitGraph", () => {
       service: "filesystem",
       type: "git_commit",
       title: "Full commit",
+      bodyPreview: null,
       authorId: null,
       metadata: { sha: "deadcafe0000", repoRoot: "/home/user/project" },
     });
@@ -529,6 +554,7 @@ describe("syncDependencyGraph", () => {
       service: "filesystem",
       type: "dependency",
       title: "No name",
+      bodyPreview: null,
       authorId: null,
       metadata: { version: "1.0.0" },
     });
@@ -543,6 +569,7 @@ describe("syncDependencyGraph", () => {
       service: "filesystem",
       type: "dependency",
       title: "No version",
+      bodyPreview: null,
       authorId: null,
       metadata: { packageName: "lodash" },
     });
@@ -557,6 +584,7 @@ describe("syncDependencyGraph", () => {
       service: "filesystem",
       type: "dependency",
       title: "lodash@4.17.21",
+      bodyPreview: null,
       authorId: null,
       metadata: { packageName: "lodash", version: "4.17.21" },
     });
@@ -573,6 +601,7 @@ describe("syncDependencyGraph", () => {
       service: "filesystem",
       type: "dependency",
       title: "express@4.18.0",
+      bodyPreview: null,
       authorId: null,
       metadata: { packageName: "express", version: "4.18.0", repoRoot: "/home/user/app" },
     });
@@ -595,6 +624,7 @@ describe("syncCodeSymbolGraph", () => {
       service: "filesystem",
       type: "code_symbol",
       title: "myFunc",
+      bodyPreview: null,
       authorId: null,
       metadata: { name: "myFunc" },
     });
@@ -609,6 +639,7 @@ describe("syncCodeSymbolGraph", () => {
       service: "filesystem",
       type: "code_symbol",
       title: "unknown",
+      bodyPreview: null,
       authorId: null,
       metadata: { file: "src/index.ts" },
     });
@@ -623,6 +654,7 @@ describe("syncCodeSymbolGraph", () => {
       service: "filesystem",
       type: "code_symbol",
       title: "bareFunc",
+      bodyPreview: null,
       authorId: null,
       metadata: { file: "src/util.ts", name: "bareFunc" },
     });
@@ -643,6 +675,7 @@ describe("syncCodeSymbolGraph", () => {
       service: "filesystem",
       type: "code_symbol",
       title: "fullFunc",
+      bodyPreview: null,
       authorId: null,
       metadata: { file: "src/main.ts", name: "fullFunc", repoRoot: "/home/user/repo" },
     });
@@ -667,6 +700,7 @@ describe("syncApiEndpointGraph", () => {
       service: "openapi",
       type: "api_endpoint",
       title: "GET /health",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -691,6 +725,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note",
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "vault-abc" },
     });
@@ -709,6 +744,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note2",
+      bodyPreview: null,
       authorId: null,
       metadata: {},
     });
@@ -727,6 +763,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note3",
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "v3", resolved_wikilink_ids: "not-an-array" },
     });
@@ -741,6 +778,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note4",
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "v4", resolved_wikilink_ids: ["", "   "] },
     });
@@ -755,6 +793,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note5",
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "v5", resolved_wikilink_ids: [42, true, null] },
     });
@@ -770,6 +809,7 @@ describe("syncObsidianNoteGraph — extra branches", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: "Note6",
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "v6", resolved_wikilink_ids: ["obsidian:v6#NonExistent.md"] },
     });
@@ -791,6 +831,7 @@ describe("stringField edge cases (exercised via metadata lookup)", () => {
       service: "filesystem",
       type: "git_commit",
       title: "Numeric sha",
+      bodyPreview: null,
       authorId: null,
       metadata: { sha: 12345 },
     });
@@ -806,6 +847,7 @@ describe("stringField edge cases (exercised via metadata lookup)", () => {
       service: "filesystem",
       type: "git_commit",
       title: "Empty sha",
+      bodyPreview: null,
       authorId: null,
       metadata: { sha: "" },
     });

--- a/packages/gateway/src/graph/graph-populator-clear.test.ts
+++ b/packages/gateway/src/graph/graph-populator-clear.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 
 import { upsertIndexedItem } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 import { upsertGraphRelation } from "./relationship-graph.ts";
 
 function freshDb(): Database {
@@ -87,4 +88,26 @@ test("a re-sync still rebuilds the entity's own edges rather than duplicating th
   }
 
   expect(relationCount(db, "targets")).toBe(1);
+});
+
+test("the populator receives the item body", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  // Compiles only once IndexedItemGraphInput carries bodyPreview.
+  syncGraphFromIndexedItem(db, {
+    id: "github:acme/app#7",
+    service: "github",
+    type: "pr",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    authorId: null,
+    metadata: { repo: "acme/app" },
+  });
+
+  const pr = db.query("SELECT id FROM graph_entity WHERE type = 'pr' LIMIT 1").get() as {
+    id: string;
+  } | null;
+  expect(pr).not.toBeNull();
+  void now;
 });

--- a/packages/gateway/src/graph/graph-populator-clear.test.ts
+++ b/packages/gateway/src/graph/graph-populator-clear.test.ts
@@ -92,7 +92,6 @@ test("a re-sync still rebuilds the entity's own edges rather than duplicating th
 
 test("the populator receives the item body", () => {
   const db = freshDb();
-  const now = Date.now();
 
   // Compiles only once IndexedItemGraphInput carries bodyPreview.
   syncGraphFromIndexedItem(db, {
@@ -109,5 +108,4 @@ test("the populator receives the item body", () => {
     id: string;
   } | null;
   expect(pr).not.toBeNull();
-  void now;
 });

--- a/packages/gateway/src/graph/graph-populator-clear.test.ts
+++ b/packages/gateway/src/graph/graph-populator-clear.test.ts
@@ -1,0 +1,90 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+import { upsertGraphRelation } from "./relationship-graph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function relationCount(db: Database, type: string): number {
+  const row = db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = ?").get(type) as {
+    n: number;
+  };
+  return row.n;
+}
+
+test("a cross-item `mentions` edge survives a re-sync of the entity it points at", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "patch",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+  upsertIndexedItem(db, {
+    service: "slack",
+    type: "message",
+    externalId: "C1/1000.1",
+    title: "shipping acme/app#1 now",
+    bodyPreview: "shipping acme/app#1 now",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { channel: "C1" },
+  });
+
+  const pr = db.query("SELECT id FROM graph_entity WHERE type = 'pr' LIMIT 1").get() as {
+    id: string;
+  };
+  const msg = db.query("SELECT id FROM graph_entity WHERE type = 'message' LIMIT 1").get() as {
+    id: string;
+  };
+
+  // Stand in for what Task 4 will emit from the message side.
+  upsertGraphRelation(db, msg.id, pr.id, "mentions", now);
+  expect(relationCount(db, "mentions")).toBe(1);
+
+  // Re-sync the PR. Its own edges are rebuilt; the message's edge must not be collateral.
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login (v2)",
+    bodyPreview: "patch",
+    modifiedAt: now + 1,
+    syncedAt: now + 1,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(relationCount(db, "mentions")).toBe(1);
+});
+
+test("a re-sync still rebuilds the entity's own edges rather than duplicating them", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  for (const [i, title] of ["Fix login", "Fix login (v2)"].entries()) {
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title,
+      bodyPreview: "patch",
+      modifiedAt: now + i,
+      syncedAt: now + i,
+      metadata: { repo: "acme/app" },
+    });
+  }
+
+  expect(relationCount(db, "targets")).toBe(1);
+});

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -1,8 +1,14 @@
 import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 
-import { upsertIndexedItem } from "../index/item-store.ts";
+import { EMPTY_NIMBUS_VAULT, syncTestContext } from "../connectors/connector-sync-test-helpers.ts";
+import { syncPagerdutyIncidentItems } from "../connectors/pagerduty-sync.ts";
+import { mapVercelDeploymentToItem } from "../connectors/vercel-deployment-mapping.ts";
+import { upsertIndexedItem, upsertIndexedItemForSync } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
+import type { ServiceConfig } from "../metrics/dora-config.ts";
+import { buildServiceIdentityResolver } from "../metrics/service-identity.ts";
+import type { SyncContext } from "../sync/types.ts";
 import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 
 function freshDb(): Database {
@@ -394,4 +400,144 @@ test("an incident with more than 20 deployments in its window keeps the ones nea
   // The nearest deploy is the most plausibly causal one and must survive
   // the LIMIT 20 truncation.
   expect(rels.map((r) => r.from)).toContain("deployment:github:d24");
+});
+
+// ---------------------------------------------------------------------------
+// Service-identity binding (SyncContext.resolveServiceId): the real-world
+// case neither PagerDuty nor Vercel writes a plain `metadata.service` key,
+// so correlation only fires when the [metrics.dora.<id>]/[ci.service.<id>]
+// binding resolves both sides to the same nimbus service id.
+// ---------------------------------------------------------------------------
+
+const CHECKOUT_SERVICE_CONFIG: ServiceConfig = {
+  serviceId: "checkout",
+  repos: [{ provider: "github", providerId: "acme/checkout" }],
+  pagerdutyServices: ["PSVC1"],
+  deployWorkflowPattern: /^Deploy/,
+  incidentWindowMinutes: 60,
+  excludePrLabels: [],
+  deployEnvironments: ["prod"],
+  severityP1Aliases: ["P1"],
+};
+
+function ctxWithResolver(db: Database, configs: Map<string, ServiceConfig>): SyncContext {
+  return {
+    ...syncTestContext(db, EMPTY_NIMBUS_VAULT),
+    resolveServiceId: buildServiceIdentityResolver(configs),
+  };
+}
+
+test("a PagerDuty incident (pagerduty_service_id) and a Vercel deployment (repo) bind to the same nimbus service via resolveServiceId and correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  // Real `buildPagerdutyMetadata`-shaped raw incident payload: carries
+  // `pagerduty_service_id`, never a plain `service` key.
+  const incidentRaw = {
+    id: "PD-1",
+    title: "Checkout 500s",
+    status: "triggered",
+    html_url: "https://acme.pagerduty.com/incidents/PD-1",
+    created_at: new Date(t + HOUR).toISOString(),
+    updated_at: new Date(t + HOUR).toISOString(),
+    service: { id: "PSVC1" },
+    priority: { name: "P1" },
+    urgency: "high",
+  };
+  syncPagerdutyIncidentItems(ctx, [incidentRaw], "1970-01-01T00:00:00Z", t + HOUR);
+
+  // Real `mapVercelDeploymentToItem`-shaped raw deployment payload: the
+  // git-integrated `meta` block carries the owning GitHub repo, never a
+  // plain `service` key.
+  const deploymentRaw = {
+    uid: "dpl_123",
+    name: "checkout-web",
+    readyState: "READY",
+    target: "production",
+    url: "checkout-web.vercel.app",
+    inspectorUrl: "https://vercel.com/acme/checkout-web/dpl_123",
+    created: t,
+    meta: {
+      githubCommitSha: "abc123def456",
+      githubCommitMessage: "Fix checkout bug",
+      githubCommitRef: "main",
+      githubOrg: "acme",
+      githubRepo: "checkout",
+    },
+    creator: { username: "alice" },
+  };
+  const mapped = mapVercelDeploymentToItem(deploymentRaw, { syncedAt: t });
+  if (mapped === null) throw new Error("mapVercelDeploymentToItem returned null");
+  upsertIndexedItemForSync(ctx, mapped);
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:vercel:dpl_123", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("without resolveServiceId wired, the same PagerDuty/Vercel pair emits no correlation (proves the fix is load-bearing)", () => {
+  const db = freshDb();
+  const t = Date.now();
+  // No `resolveServiceId` on the context: exercises the pre-fix production
+  // shape, `syncTestContext` builds a SyncContext with the field absent.
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+
+  const incidentRaw = {
+    id: "PD-1",
+    title: "Checkout 500s",
+    status: "triggered",
+    created_at: new Date(t + HOUR).toISOString(),
+    updated_at: new Date(t + HOUR).toISOString(),
+    service: { id: "PSVC1" },
+    priority: { name: "P1" },
+    urgency: "high",
+  };
+  syncPagerdutyIncidentItems(ctx, [incidentRaw], "1970-01-01T00:00:00Z", t + HOUR);
+
+  const deploymentRaw = {
+    uid: "dpl_123",
+    name: "checkout-web",
+    readyState: "READY",
+    created: t,
+    meta: { githubOrg: "acme", githubRepo: "checkout" },
+  };
+  const mapped = mapVercelDeploymentToItem(deploymentRaw, { syncedAt: t });
+  if (mapped === null) throw new Error("mapVercelDeploymentToItem returned null");
+  upsertIndexedItemForSync(ctx, mapped);
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("fallback preserved: with no resolver supplied, metadata.service still correlates exactly as before", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  expect(ctx.resolveServiceId).toBeUndefined();
+
+  upsertIndexedItemForSync(ctx, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-fallback",
+    title: "Deploy checkout v3",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { service: "checkout" },
+  });
+  upsertIndexedItemForSync(ctx, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-fallback",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: { service: "checkout" },
+  });
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-fallback", to: "incident:pagerduty:PD-fallback" },
+  ]);
 });

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -657,7 +657,11 @@ test("I-1: a Vercel preview deployment does not correlate, but a production depl
   ]);
 });
 
-test("I-1: a deployment with no environment signal at all still binds and correlates (fail-open decision)", () => {
+// F2: a deployment with no environment signal at all now resolves EXCLUDED
+// (fail CLOSED), not bound. Was "fail-open decision" before F2 — see
+// service-identity.ts's F2 doc comment for why the "Vercel always writes
+// target" assumption this used to rely on is not trustworthy.
+test("F2: a deployment with no environment signal at all does not correlate (fails closed)", () => {
   const db = freshDb();
   const t = Date.now();
   const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
@@ -684,7 +688,120 @@ test("I-1: a deployment with no environment signal at all still binds and correl
     metadata: { pagerduty_service_id: "PSVC1" },
   });
 
+  expect(correlations(db)).toEqual([]);
+});
+
+// F2: keep proving the converse — a deployment WITH a production signal
+// still correlates, so F2's fail-closed change didn't just silence
+// everything.
+test("F2: a deployment with an explicit production environment still correlates", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  upsertIndexedItemForSync(ctx, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-with-env-signal",
+    title: "Deploy checkout",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { repo: "acme/checkout", environment: "prod" },
+  });
+  upsertIndexedItemForSync(ctx, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-with-env-signal",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: { pagerduty_service_id: "PSVC1" },
+  });
+
   expect(correlations(db)).toEqual([
-    { from: "deployment:github:deploy-no-env-signal", to: "incident:pagerduty:PD-no-env-signal" },
+    {
+      from: "deployment:github:deploy-with-env-signal",
+      to: "incident:pagerduty:PD-with-env-signal",
+    },
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// F1: `resolveServiceId` returning "excluded" must bind nothing — the graph
+// populator must NOT fall back to `metadata.service` in that case. A bare
+// `undefined` couldn't tell "explicitly excluded" apart from "no binding
+// known", and the `?? stringField(row.metadata, "service")` fallback
+// silently re-bound a gate-excluded preview deployment from
+// `metadata.service`, producing the exact false causal edge I-1 exists to
+// prevent.
+// ---------------------------------------------------------------------------
+
+test("F1: a Vercel preview deployment carrying metadata.service does not correlate — the environment-gate exclusion is not bypassed by the metadata.service fallback", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  upsertIndexedItemForSync(ctx, {
+    service: "vercel",
+    type: "deployment",
+    externalId: "dpl_preview",
+    title: "Deploy checkout (preview)",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { repo: "acme/checkout", target: "preview", service: "checkout" },
+  });
+  upsertIndexedItemForSync(ctx, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-f1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: { pagerduty_service_id: "PSVC1" },
+  });
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("F1: a deployment resolveServiceId can't claim (unknown) still falls back to metadata.service, unchanged", () => {
+  const db = freshDb();
+  const t = Date.now();
+  // No ServiceConfig binds "acme/other" or "PSVC-OTHER" — the resolver
+  // returns `unknown` for this deployment, which must still fall back.
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  upsertIndexedItemForSync(ctx, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-unknown-binding",
+    title: "Deploy other",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { service: "other-service" },
+  });
+  upsertIndexedItemForSync(ctx, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-unknown-binding",
+    title: "Other 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: { service: "other-service" },
+  });
+
+  expect(correlations(db)).toEqual([
+    {
+      from: "deployment:github:deploy-unknown-binding",
+      to: "incident:pagerduty:PD-unknown-binding",
+    },
   ]);
 });

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 
 import { upsertIndexedItem } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 
 function freshDb(): Database {
   const db = new Database(":memory:");
@@ -33,10 +34,11 @@ test("an indexed incident becomes an incident graph entity", () => {
 
   expect(entityTypes(db)).toContain("incident");
   const row = db
-    .query("SELECT external_id, service FROM graph_entity WHERE type = 'incident'")
-    .get() as { external_id: string; service: string };
+    .query("SELECT external_id, service, label FROM graph_entity WHERE type = 'incident'")
+    .get() as { external_id: string; service: string; label: string };
   expect(row.external_id).toBe("pagerduty:PD-1");
   expect(row.service).toBe("pagerduty");
+  expect(row.label).toBe("Checkout 500s");
 });
 
 test("an indexed deployment becomes a deployment graph entity", () => {
@@ -54,4 +56,71 @@ test("an indexed deployment becomes a deployment graph entity", () => {
   });
 
   expect(entityTypes(db)).toContain("deployment");
+  const row = db
+    .query("SELECT external_id, service FROM graph_entity WHERE type = 'deployment'")
+    .get() as { external_id: string; service: string };
+  expect(row.external_id).toBe("github:deploy-9");
+  expect(row.service).toBe("github");
+});
+
+test("an incident with no metadata.service still gets a graph entity with affectedService null", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-2",
+    title: "Payments latency spike",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  const row = db
+    .query("SELECT metadata FROM graph_entity WHERE type = 'incident' AND external_id = ?")
+    .get("pagerduty:PD-2") as { metadata: string };
+  const parsed = JSON.parse(row.metadata) as { affectedService: unknown };
+  expect(parsed.affectedService).toBeNull();
+});
+
+test("occurredAtForItem throws when the populator is called without a backing item row", () => {
+  const db = freshDb();
+  expect(() =>
+    syncGraphFromIndexedItem(db, {
+      id: "pagerduty:PD-missing",
+      service: "pagerduty",
+      type: "incident",
+      title: "No backing item row",
+      bodyPreview: null,
+      authorId: null,
+      metadata: {},
+    }),
+  ).toThrow(/no item row/);
+});
+
+test("re-syncing an incident twice does not accumulate duplicate or stale relations", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const item = {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-3",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  };
+
+  upsertIndexedItem(db, item);
+  upsertIndexedItem(db, item);
+
+  const entity = db
+    .query("SELECT id FROM graph_entity WHERE type = 'incident' AND external_id = ?")
+    .get("pagerduty:PD-3") as { id: string };
+  const relationCount = db
+    .query("SELECT COUNT(*) AS n FROM graph_relation WHERE from_id = ? OR to_id = ?")
+    .get(entity.id, entity.id) as { n: number };
+  expect(relationCount.n).toBe(0);
 });

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -1,0 +1,57 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function entityTypes(db: Database): string[] {
+  const rows = db.query("SELECT DISTINCT type FROM graph_entity ORDER BY type").all() as Array<{
+    type: string;
+  }>;
+  return rows.map((r) => r.type);
+}
+
+test("an indexed incident becomes an incident graph entity", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  });
+
+  expect(entityTypes(db)).toContain("incident");
+  const row = db
+    .query("SELECT external_id, service FROM graph_entity WHERE type = 'incident'")
+    .get() as { external_id: string; service: string };
+  expect(row.external_id).toBe("pagerduty:PD-1");
+  expect(row.service).toBe("pagerduty");
+});
+
+test("an indexed deployment becomes a deployment graph entity", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  });
+
+  expect(entityTypes(db)).toContain("deployment");
+});

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -371,13 +371,14 @@ test("an incident fans in from every deployment of the same service in its windo
   ]);
 });
 
-test("an incident with more than 20 deployments in its window keeps the ones nearest to it", () => {
+test("an incident with more than 20 deployments in its window correlates with all of them, nearest included", () => {
   const db = freshDb();
   const t = Date.now();
 
   // 25 deployments of the same service, spread across the two hours before
   // the incident. d24 is nearest (4 minutes before); d00 is farthest (100
-  // minutes before) but still inside the window.
+  // minutes before) but still inside the window. There is no row cap: the
+  // 2-hour window is the only bound, so every one of the 25 must correlate.
   for (let i = 0; i < 25; i++) {
     const minutesBefore = 4 + 4 * (24 - i);
     const at = t - minutesBefore * 60 * 1000;
@@ -396,10 +397,71 @@ test("an incident with more than 20 deployments in its window keeps the ones nea
   seedIncident(db, t, "checkout");
 
   const rels = correlations(db);
-  expect(rels).toHaveLength(20);
-  // The nearest deploy is the most plausibly causal one and must survive
-  // the LIMIT 20 truncation.
+  expect(rels).toHaveLength(25);
+  // The nearest deploy (most plausibly causal) and the farthest-but-still-
+  // in-window deploy are both present — nothing is truncated.
   expect(rels.map((r) => r.from)).toContain("deployment:github:d24");
+  expect(rels.map((r) => r.from)).toContain("deployment:github:d00");
+});
+
+test("re-syncing the deployment after 30 incidents in its window preserves every correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+
+  for (let i = 0; i < 30; i++) {
+    const at = t + (i + 1) * 60 * 1000;
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: `PD-${i}`,
+      title: `Checkout 500s ${i}`,
+      bodyPreview: "",
+      modifiedAt: at,
+      syncedAt: at,
+      metadata: { service: "checkout" },
+    });
+  }
+
+  expect(correlations(db)).toHaveLength(30);
+
+  // Re-syncing the deployment clears its ENTIRE outgoing direction (every
+  // `correlates_with` edge from this deployment) and re-emits from scratch.
+  // A cap on the re-emit side would destroy the surplus edges the incident
+  // side legitimately created.
+  seedDeploy(db, t, "checkout");
+
+  expect(correlations(db)).toHaveLength(30);
+});
+
+test("re-syncing the incident after 30 deployments in its window preserves every correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+
+  for (let i = 0; i < 30; i++) {
+    const at = t - (i + 1) * 60 * 1000;
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "deployment",
+      externalId: `deploy-${i}`,
+      title: `Deploy checkout v${i}`,
+      bodyPreview: "",
+      modifiedAt: at,
+      syncedAt: at,
+      metadata: { service: "checkout" },
+    });
+  }
+
+  seedIncident(db, t, "checkout");
+  expect(correlations(db)).toHaveLength(30);
+
+  // Re-syncing the incident clears its ENTIRE incoming direction (every
+  // `correlates_with` edge into this incident) and re-emits from scratch.
+  // A cap on the re-emit side would destroy the surplus edges the
+  // deployment side legitimately created.
+  seedIncident(db, t, "checkout");
+
+  expect(correlations(db)).toHaveLength(30);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -124,3 +124,120 @@ test("re-syncing an incident twice does not accumulate duplicate or stale relati
     .get(entity.id, entity.id) as { n: number };
   expect(relationCount.n).toBe(0);
 });
+
+const HOUR = 60 * 60 * 1000;
+
+function correlations(db: Database): Array<{ from: string; to: string }> {
+  return db
+    .query(
+      `SELECT f.type || ':' || f.external_id AS "from",
+              t.type || ':' || t.external_id AS "to"
+         FROM graph_relation r
+         JOIN graph_entity f ON f.id = r.from_id
+         JOIN graph_entity t ON t.id = r.to_id
+        WHERE r.type = 'correlates_with'
+        ORDER BY "from", "to"`,
+    )
+    .all() as Array<{ from: string; to: string }>;
+}
+
+function seedDeploy(db: Database, at: number, service: string): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { service },
+  });
+}
+
+function seedIncident(db: Database, at: number, service: string): void {
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { service },
+  });
+}
+
+test("an incident shortly after a deploy of the same service correlates", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("correlation is emitted regardless of which side syncs last", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedIncident(db, t + HOUR, "checkout");
+  seedDeploy(db, t, "checkout");
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("an incident outside the window does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + 5 * HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("an incident before the deploy does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t - HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("a different service does not correlate", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "search");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("re-syncing an incident to a different service retires the stale correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The incident is re-classified against a different service.
+  seedIncident(db, t + HOUR, "search");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("re-syncing an incident out of the window retires the stale correlation", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The incident's true start time turns out to be much later.
+  seedIncident(db, t + 5 * HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -241,3 +241,157 @@ test("re-syncing an incident out of the window retires the stale correlation", (
 
   expect(correlations(db)).toEqual([]);
 });
+
+test("re-syncing a deployment without a service retires the correlation it emitted", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The deployment's service classification is retracted.
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: {},
+  });
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("re-syncing an incident without a service retires the correlation pointing at it", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The incident's service classification is retracted.
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: {},
+  });
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("re-syncing a deployment far outside the window retires the correlation it emitted", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+  seedIncident(db, t + HOUR, "checkout");
+  expect(correlations(db)).toHaveLength(1);
+
+  // The deployment's true time turns out to be much earlier, well outside
+  // the incident's backward-looking window.
+  seedDeploy(db, t - 10 * HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([]);
+});
+
+test("a deployment fans out to every incident of the same service in its window", () => {
+  const db = freshDb();
+  const t = Date.now();
+  seedDeploy(db, t, "checkout");
+
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + 30 * 60 * 1000,
+    syncedAt: t + 30 * 60 * 1000,
+    metadata: { service: "checkout" },
+  });
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-2",
+    title: "Checkout 500s again",
+    bodyPreview: "",
+    modifiedAt: t + 90 * 60 * 1000,
+    syncedAt: t + 90 * 60 * 1000,
+    metadata: { service: "checkout" },
+  });
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-1" },
+    { from: "deployment:github:deploy-9", to: "incident:pagerduty:PD-2" },
+  ]);
+});
+
+test("an incident fans in from every deployment of the same service in its window", () => {
+  const db = freshDb();
+  const t = Date.now();
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-1",
+    title: "Deploy checkout v1",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { service: "checkout" },
+  });
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-2",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: t + 30 * 60 * 1000,
+    syncedAt: t + 30 * 60 * 1000,
+    metadata: { service: "checkout" },
+  });
+
+  seedIncident(db, t + HOUR, "checkout");
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-1", to: "incident:pagerduty:PD-1" },
+    { from: "deployment:github:deploy-2", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("an incident with more than 20 deployments in its window keeps the ones nearest to it", () => {
+  const db = freshDb();
+  const t = Date.now();
+
+  // 25 deployments of the same service, spread across the two hours before
+  // the incident. d24 is nearest (4 minutes before); d00 is farthest (100
+  // minutes before) but still inside the window.
+  for (let i = 0; i < 25; i++) {
+    const minutesBefore = 4 + 4 * (24 - i);
+    const at = t - minutesBefore * 60 * 1000;
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "deployment",
+      externalId: `d${String(i).padStart(2, "0")}`,
+      title: `Deploy ${i}`,
+      bodyPreview: "",
+      modifiedAt: at,
+      syncedAt: at,
+      metadata: { service: "checkout" },
+    });
+  }
+
+  seedIncident(db, t, "checkout");
+
+  const rels = correlations(db);
+  expect(rels).toHaveLength(20);
+  // The nearest deploy is the most plausibly causal one and must survive
+  // the LIMIT 20 truncation.
+  expect(rels.map((r) => r.from)).toContain("deployment:github:d24");
+});

--- a/packages/gateway/src/graph/graph-populator-incidents.test.ts
+++ b/packages/gateway/src/graph/graph-populator-incidents.test.ts
@@ -603,3 +603,88 @@ test("fallback preserved: with no resolver supplied, metadata.service still corr
     { from: "deployment:github:deploy-fallback", to: "incident:pagerduty:PD-fallback" },
   ]);
 });
+
+// ---------------------------------------------------------------------------
+// I-1: a Vercel preview deployment must not correlate — a git-integrated
+// Vercel project creates a preview deployment on every push, so left
+// unfiltered they numerically dominate and drown out real prod correlations.
+// ---------------------------------------------------------------------------
+
+test("I-1: a Vercel preview deployment does not correlate, but a production deployment of the same repo does", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  const incidentRaw = {
+    id: "PD-1",
+    title: "Checkout 500s",
+    status: "triggered",
+    created_at: new Date(t + HOUR).toISOString(),
+    updated_at: new Date(t + HOUR).toISOString(),
+    service: { id: "PSVC1" },
+    priority: { name: "P1" },
+    urgency: "high",
+  };
+  syncPagerdutyIncidentItems(ctx, [incidentRaw], "1970-01-01T00:00:00Z", t + HOUR);
+
+  const previewRaw = {
+    uid: "dpl_preview",
+    name: "checkout-web",
+    readyState: "READY",
+    target: "preview",
+    created: t,
+    meta: { githubOrg: "acme", githubRepo: "checkout" },
+  };
+  const previewMapped = mapVercelDeploymentToItem(previewRaw, { syncedAt: t });
+  if (previewMapped === null) throw new Error("mapVercelDeploymentToItem returned null");
+  upsertIndexedItemForSync(ctx, previewMapped);
+
+  const prodRaw = {
+    uid: "dpl_prod",
+    name: "checkout-web",
+    readyState: "READY",
+    target: "production",
+    created: t,
+    meta: { githubOrg: "acme", githubRepo: "checkout" },
+  };
+  const prodMapped = mapVercelDeploymentToItem(prodRaw, { syncedAt: t });
+  if (prodMapped === null) throw new Error("mapVercelDeploymentToItem returned null");
+  upsertIndexedItemForSync(ctx, prodMapped);
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:vercel:dpl_prod", to: "incident:pagerduty:PD-1" },
+  ]);
+});
+
+test("I-1: a deployment with no environment signal at all still binds and correlates (fail-open decision)", () => {
+  const db = freshDb();
+  const t = Date.now();
+  const configs = new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]);
+  const ctx = ctxWithResolver(db, configs);
+
+  upsertIndexedItemForSync(ctx, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-no-env-signal",
+    title: "Deploy checkout",
+    bodyPreview: "",
+    modifiedAt: t,
+    syncedAt: t,
+    metadata: { repo: "acme/checkout" },
+  });
+  upsertIndexedItemForSync(ctx, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-no-env-signal",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: t + HOUR,
+    syncedAt: t + HOUR,
+    metadata: { pagerduty_service_id: "PSVC1" },
+  });
+
+  expect(correlations(db)).toEqual([
+    { from: "deployment:github:deploy-no-env-signal", to: "incident:pagerduty:PD-no-env-signal" },
+  ]);
+});

--- a/packages/gateway/src/graph/graph-populator-mentions.test.ts
+++ b/packages/gateway/src/graph/graph-populator-mentions.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function mentionTargets(db: Database): string[] {
+  const rows = db
+    .query(
+      `SELECT e.type || ':' || e.external_id AS ref
+         FROM graph_relation r
+         JOIN graph_entity e ON e.id = r.to_id
+        WHERE r.type = 'mentions'
+        ORDER BY ref`,
+    )
+    .all() as Array<{ ref: string }>;
+  return rows.map((r) => r.ref);
+}
+
+function seedMessage(db: Database, body: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "slack",
+    type: "message",
+    externalId: "C1/1000.1",
+    title: body,
+    bodyPreview: body,
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { channel: "C1" },
+  });
+}
+
+test("a message naming a ticket key mentions that issue", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  seedMessage(db, "anyone looking at NIM-88?", now);
+
+  expect(mentionTargets(db)).toEqual(["issue:linear:NIM-88"]);
+});
+
+test("a message naming a commit SHA mentions that commit", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "git_commit",
+    externalId: "a1b2c3d4e5f6",
+    title: "Fix retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha: "a1b2c3d4e5f6", repoRoot: "/repo" },
+  });
+
+  seedMessage(db, "this broke in a1b2c3d4e5f6", now);
+
+  expect(mentionTargets(db)).toEqual(["commit:github:a1b2c3d4e5f6"]);
+});
+
+test("a message referencing nothing indexed emits no edges", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedMessage(db, "lunch?", now);
+  expect(mentionTargets(db)).toEqual([]);
+});
+
+test("editing a message to drop the reference drops the edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  seedMessage(db, "anyone looking at NIM-88?", now);
+  seedMessage(db, "never mind", now + 1);
+
+  expect(mentionTargets(db)).toEqual([]);
+});

--- a/packages/gateway/src/graph/graph-populator-mentions.test.ts
+++ b/packages/gateway/src/graph/graph-populator-mentions.test.ts
@@ -100,3 +100,88 @@ test("editing a message to drop the reference drops the edge", () => {
 
   expect(mentionTargets(db)).toEqual([]);
 });
+
+test("a message citing a short SHA prefix mentions the full-length indexed commit", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const fullSha = "a1b2c3d4e5f60123456789abcdef0123456789ab";
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "git_commit",
+    externalId: fullSha,
+    title: "Fix retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha: fullSha, repoRoot: "/repo" },
+  });
+
+  // 7-character short SHA — the dominant real-world citation form, and
+  // exactly the case `COMMIT_SHA_RE`'s `{7,40}` lower bound exists to catch.
+  // Against the old exact-suffix `LIKE '%:' || ?` SQL this matches nothing.
+  seedMessage(db, "this broke in a1b2c3d", now);
+
+  expect(mentionTargets(db)).toEqual([`commit:github:${fullSha}`]);
+});
+
+test("a message citing both an issue and a commit mentions both", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const fullSha = "a1b2c3d4e5f60123456789abcdef0123456789ab";
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "git_commit",
+    externalId: fullSha,
+    title: "Fix retry backoff",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha: fullSha, repoRoot: "/repo" },
+  });
+
+  seedMessage(db, "NIM-88 was fixed by a1b2c3d", now);
+
+  expect(mentionTargets(db)).toEqual([`commit:github:${fullSha}`, "issue:linear:NIM-88"]);
+});
+
+test("a SHA colliding across two services resolves to exactly one commit", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const sha = "a1b2c3d4e5f60123456789abcdef0123456789ab";
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "git_commit",
+    externalId: sha,
+    title: "Fix retry backoff (github)",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha, repoRoot: "/repo" },
+  });
+  upsertIndexedItem(db, {
+    service: "gitlab",
+    type: "git_commit",
+    externalId: sha,
+    title: "Fix retry backoff (gitlab)",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { sha, repoRoot: "/repo" },
+  });
+
+  seedMessage(db, `this broke in ${sha}`, now);
+
+  const targets = mentionTargets(db);
+  expect(targets).toHaveLength(1);
+  expect(targets[0]).toMatch(new RegExp(`^commit:(github|gitlab):${sha}$`));
+});

--- a/packages/gateway/src/graph/graph-populator-obsidian.test.ts
+++ b/packages/gateway/src/graph/graph-populator-obsidian.test.ts
@@ -17,6 +17,7 @@ test("syncObsidianNoteGraph upserts an obsidian_note entity and backlink edges f
     service: "obsidian",
     type: "obsidian_note",
     title: "Other",
+    bodyPreview: null,
     authorId: null,
     metadata: { vault_id: "abc", resolved_wikilink_ids: [] },
   });
@@ -26,6 +27,7 @@ test("syncObsidianNoteGraph upserts an obsidian_note entity and backlink edges f
     service: "obsidian",
     type: "obsidian_note",
     title: "Welcome",
+    bodyPreview: null,
     authorId: null,
     metadata: { vault_id: "abc", resolved_wikilink_ids: [linkedId] },
   });
@@ -53,6 +55,7 @@ test("re-syncing a note replaces its outgoing backlink edges (no leak)", () => {
       service: "obsidian",
       type: "obsidian_note",
       title: id,
+      bodyPreview: null,
       authorId: null,
       metadata: { vault_id: "abc", resolved_wikilink_ids: [] },
     });
@@ -63,6 +66,7 @@ test("re-syncing a note replaces its outgoing backlink edges (no leak)", () => {
     service: "obsidian",
     type: "obsidian_note",
     title: "A",
+    bodyPreview: null,
     authorId: null,
     metadata: { vault_id: "abc", resolved_wikilink_ids: [b] },
   });
@@ -72,6 +76,7 @@ test("re-syncing a note replaces its outgoing backlink edges (no leak)", () => {
     service: "obsidian",
     type: "obsidian_note",
     title: "A",
+    bodyPreview: null,
     authorId: null,
     metadata: { vault_id: "abc", resolved_wikilink_ids: [c] },
   });

--- a/packages/gateway/src/graph/graph-populator-resolves.test.ts
+++ b/packages/gateway/src/graph/graph-populator-resolves.test.ts
@@ -156,6 +156,66 @@ test("an incoming resolves edge survives the target issue's own re-sync", () => 
   expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
 });
 
+// Fixtures below are built with the exact expressions github-sync.ts uses
+// to index PRs and issues (`${repoFull}#${num}` / `${repoFull}#issue-${num}`,
+// plus the same `number`/`repo` metadata keys), NOT hand-picked shapes — see
+// `upsertFromPullRequest`/`upsertFromIssue` in connectors/github-sync.ts.
+function seedGithubIssue(
+  db: Database,
+  repoFull: string,
+  num: number,
+  title: string,
+  at: number,
+): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: `${repoFull}#issue-${String(num)}`,
+    title,
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { number: num, repo: repoFull, state: "open", user: "octocat" },
+  });
+}
+
+function seedGithubPr(
+  db: Database,
+  repoFull: string,
+  num: number,
+  title: string,
+  bodyPreview: string,
+  at: number,
+): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: `${repoFull}#${String(num)}`,
+    title,
+    bodyPreview,
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { number: num, repo: repoFull, state: "open", draft: false, merged: false },
+  });
+}
+
+test("a GitHub PR body referencing #4, with the issue indexed under github-sync.ts's real externalId shape, emits a resolves edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedGithubIssue(db, "acme/app", 4, "Login broken", now);
+  seedGithubPr(db, "acme/app", 1, "Fix login", "closes #4", now);
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#issue-4"]);
+});
+
+test("a GitHub PR body referencing #4 with no matching issue (real externalId shape) emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedGithubPr(db, "acme/app", 1, "Fix login", "closes #4", now);
+
+  expect(resolvesTargets(db)).toEqual([]);
+});
+
 test("removing the reference from the PR body removes the edge on re-sync", () => {
   const db = freshDb();
   const now = Date.now();

--- a/packages/gateway/src/graph/graph-populator-resolves.test.ts
+++ b/packages/gateway/src/graph/graph-populator-resolves.test.ts
@@ -1,0 +1,123 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function seedIssue(db: Database, externalId: string, title: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "issue",
+    externalId,
+    title,
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    metadata: { repo: "acme/app" },
+  });
+}
+
+function resolvesTargets(db: Database): string[] {
+  const rows = db
+    .query(
+      `SELECT e.external_id AS ext
+         FROM graph_relation r
+         JOIN graph_entity e ON e.id = r.to_id
+        WHERE r.type = 'resolves'
+        ORDER BY ext`,
+    )
+    .all() as Array<{ ext: string }>;
+  return rows.map((r) => r.ext);
+}
+
+test("a PR body referencing #4 emits resolves to that repo's issue 4", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
+});
+
+test("a numeric ref with no matching issue emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #999",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual([]);
+});
+
+test("a ticket key matches an issue indexed by another service", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "linear",
+    type: "issue",
+    externalId: "NIM-88",
+    title: "Retry backoff is wrong",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: {},
+  });
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix retry backoff",
+    bodyPreview: "part of NIM-88",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["linear:NIM-88"]);
+});
+
+test("removing the reference from the PR body removes the edge on re-sync", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+
+  for (const [i, body] of ["closes #4", "no longer references anything"].entries()) {
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Fix login",
+      bodyPreview: body,
+      modifiedAt: now + i,
+      syncedAt: now + i,
+      metadata: { repo: "acme/app" },
+    });
+  }
+
+  expect(resolvesTargets(db)).toEqual([]);
+});

--- a/packages/gateway/src/graph/graph-populator-resolves.test.ts
+++ b/packages/gateway/src/graph/graph-populator-resolves.test.ts
@@ -101,6 +101,61 @@ test("a ticket key matches an issue indexed by another service", () => {
   expect(resolvesTargets(db)).toEqual(["linear:NIM-88"]);
 });
 
+test("a numeric ref is scoped to the referring PR's own repo — same key in another repo is excluded", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "other/app#4",
+    title: "Unrelated issue in a different repo",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "other/app" },
+  });
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
+});
+
+test("an incoming resolves edge survives the target issue's own re-sync", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedIssue(db, "acme/app#4", "Login broken", now);
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    bodyPreview: "closes #4",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app" },
+  });
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
+
+  // Re-sync the ISSUE itself (not the PR) — this runs syncIssueGraph, which
+  // calls clearRelationsTouchingEntity on the issue entity. The incoming
+  // `resolves` edge from the PR must not be swept up in that blanket clear.
+  seedIssue(db, "acme/app#4", "Login broken — retitled", now + 1);
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#4"]);
+});
+
 test("removing the reference from the PR body removes the edge on re-sync", () => {
   const db = freshDb();
   const now = Date.now();

--- a/packages/gateway/src/graph/graph-populator-resolves.test.ts
+++ b/packages/gateway/src/graph/graph-populator-resolves.test.ts
@@ -208,6 +208,29 @@ test("a GitHub PR body referencing #4, with the issue indexed under github-sync.
   expect(resolvesTargets(db)).toEqual(["github:acme/app#issue-4"]);
 });
 
+test("I-3: a GitHub closes #4 resolves via the indexed external_id path, not the metadata scan", () => {
+  const db = freshDb();
+  const now = Date.now();
+  // The issue is indexed under github-sync.ts's real externalId shape
+  // (`${repo}#issue-${n}`), but its OWN metadata.number is deliberately
+  // wrong (999, not 4). A metadata-scan-first lookup (`number=4 AND repo=...`)
+  // would never match this row — proving the resolution came from the fast,
+  // indexed external_id lookup (I-3's fix), not the metadata fallback.
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#issue-4",
+    title: "Login broken",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { number: 999, repo: "acme/app", state: "open", user: "octocat" },
+  });
+  seedGithubPr(db, "acme/app", 4, "Fix login", "closes #4", now);
+
+  expect(resolvesTargets(db)).toEqual(["github:acme/app#issue-4"]);
+});
+
 test("a GitHub PR body referencing #4 with no matching issue (real externalId shape) emits no edge", () => {
   const db = freshDb();
   const now = Date.now();

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -509,13 +509,29 @@ const CORRELATION_WINDOW_MS = 2 * 60 * 60 * 1000;
 
 type TimelineRow = { id: string; occurred_at: number };
 
+/**
+ * Counterparts within the window, ordered NEAREST-FIRST so `LIMIT 20` keeps the
+ * most plausibly causal ones.
+ *
+ * The direction of "nearest" differs per side, which is why it is a parameter
+ * rather than a constant. A deployment looks FORWARD (`[D, D+W]`), so nearest is
+ * the earliest incident — `ASC`. An incident looks BACKWARD (`[I-W, I]`), so
+ * nearest is the latest deployment — `DESC`. Using `ASC` for both silently keeps
+ * the 20 most temporally DISTANT deploys before an incident and drops the ones
+ * immediately preceding it.
+ *
+ * The `id` tie-break makes the ordering deterministic when two entities share a
+ * timestamp; SQLite is stable in practice but does not guarantee it.
+ */
 function timelineCounterparts(
   db: Database,
   counterpartType: "incident" | "deployment",
   affectedService: string,
   windowFrom: number,
   windowTo: number,
+  nearestFirst: "ASC" | "DESC",
 ): TimelineRow[] {
+  const order = nearestFirst === "ASC" ? "ASC" : "DESC";
   return db
     .query(
       `SELECT id,
@@ -524,7 +540,7 @@ function timelineCounterparts(
         WHERE type = ?
           AND json_extract(metadata, '$.affectedService') = ?
           AND CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) BETWEEN ? AND ?
-        ORDER BY occurred_at ASC
+        ORDER BY occurred_at ${order}, id ASC
         LIMIT 20`,
     )
     .all(counterpartType, affectedService, windowFrom, windowTo) as TimelineRow[];
@@ -553,16 +569,33 @@ function syncTimelineEventGraph(
   });
   clearRelationsTouchingEntity(db, entityId);
 
+  // Retire first, unconditionally. These clears MUST precede the
+  // `affectedService === undefined` bail-out: an entity that previously had a
+  // service (and so emitted edges) and is re-synced without one would otherwise
+  // return before retiring them, leaving the graph asserting "this deploy caused
+  // that incident" while the deploy itself no longer claims any service.
+  //
+  // The pair is load-bearing because `clearRelationsTouchingEntity` skips
+  // `correlates_with` entirely. Each side owns one direction: a deployment owns
+  // its outgoing edges, an incident its incoming ones, and only that entity's
+  // own sync knows its current window and service.
+  if (entityType === "deployment") {
+    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
+  } else {
+    clearIncomingRelationsOfType(db, entityId, "correlates_with");
+  }
+
+  // A null service correlates with nothing. Bail out only AFTER the clears.
   if (affectedService === undefined) return;
 
   if (entityType === "deployment") {
-    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
     for (const inc of timelineCounterparts(
       db,
       "incident",
       affectedService,
       occurredAt,
       occurredAt + CORRELATION_WINDOW_MS,
+      "ASC", // forward window: nearest incident is the earliest after the deploy
     )) {
       upsertGraphRelation(db, entityId, inc.id, "correlates_with", now);
     }
@@ -571,19 +604,13 @@ function syncTimelineEventGraph(
 
   // An incident syncing after its deploy must still create the edge, and the
   // edge is always directed deployment -> incident.
-  //
-  // The incoming clear is load-bearing: `clearRelationsTouchingEntity` skips
-  // `correlates_with` (Task 1), so an incident that moved in time or changed
-  // service would otherwise keep every correlation it ever had. Only the
-  // incident's own sync knows its current window and service, so only it can
-  // retire those edges.
-  clearIncomingRelationsOfType(db, entityId, "correlates_with");
   for (const dep of timelineCounterparts(
     db,
     "deployment",
     affectedService,
     occurredAt - CORRELATION_WINDOW_MS,
     occurredAt,
+    "DESC", // backward window: nearest deploy is the latest before the incident
   )) {
     upsertGraphRelation(db, dep.id, entityId, "correlates_with", now);
   }

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -520,17 +520,30 @@ function syncTimelineEventGraph(
 }
 
 /**
- * `syncGraphFromIndexedItem` does not receive the item's `modified_at`
- * directly — reading it back from the `item` table avoids widening
- * `IndexedItemGraphInput` a second time. The row is always written
- * immediately before the populator runs, so this read-back is always
- * populated.
+ * Read the item's event time back from the row written immediately before this
+ * populator call. `upsertIndexedItem` inserts and then calls the populator
+ * synchronously on the same handle, so the row is always present on the
+ * production path.
+ *
+ * A missing row therefore means the caller reached the populator without
+ * writing the item — a programming error, and the only way to get here is a
+ * direct `syncGraphFromIndexedItem` call that skipped the insert (an idiom six
+ * sibling test files already use for other item types). Throw rather than
+ * default: the correlation task correlates deployments to incidents on this
+ * timestamp, so a fabricated `Date.now()` would yield a confidently WRONG
+ * correlation instead of an obvious failure.
  */
 function occurredAtForItem(db: Database, itemId: string): number {
   const row = db.query("SELECT modified_at FROM item WHERE id = ?").get(itemId) as {
     modified_at: number;
   } | null;
-  return row?.modified_at ?? Date.now();
+  if (row === null) {
+    throw new Error(
+      `occurredAtForItem: no item row for "${itemId}" — the populator was called without ` +
+        "writing the item first; the timeline entity would carry a fabricated timestamp.",
+    );
+  }
+  return row.modified_at;
 }
 
 export function syncGraphFromIndexedItem(db: Database, row: IndexedItemGraphInput): void {

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -34,8 +34,28 @@ function repoPathFromMetadata(meta: Record<string, unknown>): string | undefined
   return stringField(meta, "repo") ?? stringField(meta, "project");
 }
 
+/**
+ * Relation types whose two endpoints come from *different* items' syncs.
+ * The blanket clear below must not touch them: the entity being cleared is
+ * only one endpoint, and the other side is authoritative for the edge.
+ * Each emitting sync function clears its own outgoing edges of these types
+ * via `clearOutgoingRelationsOfType` immediately before re-emitting them.
+ */
+const CROSS_ITEM_RELATION_TYPES: readonly string[] = Object.freeze([
+  "resolves",
+  "mentions",
+  "correlates_with",
+]);
+
 function clearRelationsTouchingEntity(db: Database, entityId: string): void {
-  dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? OR to_id = ?", [entityId, entityId]);
+  const placeholders = CROSS_ITEM_RELATION_TYPES.map(() => "?").join(", ");
+  dbRun(
+    db,
+    `DELETE FROM graph_relation
+      WHERE (from_id = ? OR to_id = ?)
+        AND type NOT IN (${placeholders})`,
+    [entityId, entityId, ...CROSS_ITEM_RELATION_TYPES],
+  );
 }
 
 function personDisplayName(db: Database, personId: string): string | null {

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -97,6 +97,15 @@ function findIssueEntityIds(
   }
 
   for (const key of refs.ticketKeys) {
+    // If two different trackers both use the ticket key (e.g. two services
+    // each with a "NIM-88"), `id` is a SHA-256 hash, so `ORDER BY id ASC`
+    // picks a winner arbitrarily rather than by any meaningful precedence.
+    //
+    // The `LIKE '%:' || ?` pattern is injection-safe only because
+    // `TICKET_KEY_RE` (graph-refs.ts) cannot emit `%` or `_` — its charset
+    // is `[A-Z][A-Z0-9]{1,9}-\d+`. If that regex is ever loosened to allow
+    // those characters, this LIKE clause would silently start producing
+    // false matches.
     const row = db
       .query(
         `SELECT id FROM graph_entity

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -73,6 +73,16 @@ function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType
 }
 
 /**
+ * The mirror of `clearOutgoingRelationsOfType`, for a cross-item edge whose
+ * *target* decides whether the edge still belongs: an incident that moves in
+ * time or changes service must drop the correlations pointing at it, and only
+ * the incident's own sync knows that.
+ */
+function clearIncomingRelationsOfType(db: Database, toId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE to_id = ? AND type = ?", [toId, relationType]);
+}
+
+/**
  * Resolve a PR/message reference to an existing `issue` graph entity.
  * Numeric refs are scoped to the referring item's own repo and service —
  * `#4` means a different issue in a different repo. Ticket keys are
@@ -494,6 +504,32 @@ function syncDataQualityTestGraph(db: Database, row: IndexedItemGraphInput, now:
   }
 }
 
+/** An incident this long after a deploy of the same service is treated as related. */
+const CORRELATION_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+type TimelineRow = { id: string; occurred_at: number };
+
+function timelineCounterparts(
+  db: Database,
+  counterpartType: "incident" | "deployment",
+  affectedService: string,
+  windowFrom: number,
+  windowTo: number,
+): TimelineRow[] {
+  return db
+    .query(
+      `SELECT id,
+              CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) AS occurred_at
+         FROM graph_entity
+        WHERE type = ?
+          AND json_extract(metadata, '$.affectedService') = ?
+          AND CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) BETWEEN ? AND ?
+        ORDER BY occurred_at ASC
+        LIMIT 20`,
+    )
+    .all(counterpartType, affectedService, windowFrom, windowTo) as TimelineRow[];
+}
+
 /**
  * Incidents and deployments are timeline anchors: the graph needs them as
  * entities so a change can be correlated with what it responded to or
@@ -516,7 +552,41 @@ function syncTimelineEventGraph(
     metadata: { occurredAt, affectedService: affectedService ?? null },
   });
   clearRelationsTouchingEntity(db, entityId);
-  void now;
+
+  if (affectedService === undefined) return;
+
+  if (entityType === "deployment") {
+    clearOutgoingRelationsOfType(db, entityId, "correlates_with");
+    for (const inc of timelineCounterparts(
+      db,
+      "incident",
+      affectedService,
+      occurredAt,
+      occurredAt + CORRELATION_WINDOW_MS,
+    )) {
+      upsertGraphRelation(db, entityId, inc.id, "correlates_with", now);
+    }
+    return;
+  }
+
+  // An incident syncing after its deploy must still create the edge, and the
+  // edge is always directed deployment -> incident.
+  //
+  // The incoming clear is load-bearing: `clearRelationsTouchingEntity` skips
+  // `correlates_with` (Task 1), so an incident that moved in time or changed
+  // service would otherwise keep every correlation it ever had. Only the
+  // incident's own sync knows its current window and service, so only it can
+  // retire those edges.
+  clearIncomingRelationsOfType(db, entityId, "correlates_with");
+  for (const dep of timelineCounterparts(
+    db,
+    "deployment",
+    affectedService,
+    occurredAt - CORRELATION_WINDOW_MS,
+    occurredAt,
+  )) {
+    upsertGraphRelation(db, dep.id, entityId, "correlates_with", now);
+  }
 }
 
 /**

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -94,20 +94,56 @@ function clearIncomingRelationsOfType(db: Database, toId: string, relationType: 
 }
 
 /**
+ * I-3 fast path: try the two REAL, indexed `external_id` shapes a numeric
+ * ref can resolve to before falling back to a metadata scan. Both are exact
+ * primary-key lookups (`graph_entity` is unique-indexed on `external_id`),
+ * so this is O(log n) regardless of how many issues are indexed:
+ *   - `${repo}#issue-${n}` — GitHub issues (`connectors/github-sync.ts`
+ *     `upsertFromIssue`; GitHub's PRs and issues share one number space, so
+ *     issues are namespaced under `#issue-<n>` to avoid colliding with a PR
+ *     indexed as plain `${repo}#${n}`).
+ *   - `${repo}#${n}` — GitLab issues (`connectors/_lib/gitlab/events.ts`).
+ * Returns `undefined` when neither shape matches, so the caller falls
+ * through to the metadata scan (still required for correctness — a repo
+ * that indexes issues under neither shape, or where the ref's number
+ * doesn't line up 1:1 with either flat key, only resolves that way).
+ */
+function findIssueByIndexedExternalId(
+  db: Database,
+  service: string,
+  repoFull: string,
+  n: number,
+): string | undefined {
+  const githubExt = itemPrimaryKey(service, `${repoFull}#issue-${n}`);
+  const githubRow = db
+    .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")
+    .get(githubExt) as { id?: string } | null;
+  if (githubRow?.id !== undefined) return githubRow.id;
+
+  const gitlabExt = itemPrimaryKey(service, `${repoFull}#${n}`);
+  const gitlabRow = db
+    .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")
+    .get(gitlabExt) as { id?: string } | null;
+  return gitlabRow?.id;
+}
+
+/**
  * Resolve a PR/message reference to an existing `issue` graph entity.
  * Numeric refs are scoped to the referring item's own repo and service —
  * `#4` means a different issue in a different repo. Ticket keys are
  * service-agnostic, since the tracker is usually not the forge.
  *
- * Numeric refs are matched primarily against the referenced item's own
- * `metadata.number` + `metadata.repo` (a sub-select/join against `item`,
- * since `graph_entity` itself carries no item metadata) rather than by
- * reconstructing an `externalId` string: PRs and issues share GitHub's
- * number space, so a forge-agnostic `<repo>#<n>` guess collides with the
- * `<repo>#issue-<n>` shape github-sync.ts actually indexes issues under
- * (see github-sync.ts `upsertFromIssue`/`upsertFromPullRequest`). The old
- * exact-`external_id` lookup is kept as a fallback so any item indexed
- * under that flat shape keeps resolving.
+ * Numeric refs try the indexed `external_id` shapes first
+ * (`findIssueByIndexedExternalId`) — an exact-match lookup against
+ * `graph_entity`'s unique index, ~3000x cheaper than the fallback below at
+ * realistic issue counts (measured 0.002ms vs 5.8ms/ref). Only when NEITHER
+ * indexed shape matches does this fall back to matching against the
+ * referenced item's own `metadata.number` + `metadata.repo` (a sub-select/join
+ * against `item`, since `graph_entity` itself carries no item metadata) —
+ * this scan is what originally replaced a forge-agnostic `<repo>#<n>` guess,
+ * which collides with GitHub's shared PR/issue number space; it stays as the
+ * correctness fallback for any repo/ref combination the two indexed shapes
+ * don't cover.
  */
 function findIssueEntityIds(
   db: Database,
@@ -119,6 +155,12 @@ function findIssueEntityIds(
 
   if (repoFull !== undefined) {
     for (const n of refs.numeric) {
+      const indexedId = findIssueByIndexedExternalId(db, service, repoFull, n);
+      if (indexedId !== undefined) {
+        ids.push(indexedId);
+        continue;
+      }
+
       const metaRow = db
         .query(
           `SELECT e.id AS id
@@ -131,16 +173,7 @@ function findIssueEntityIds(
             LIMIT 1`,
         )
         .get(service, n, repoFull) as { id?: string } | null;
-      if (metaRow?.id !== undefined) {
-        ids.push(metaRow.id);
-        continue;
-      }
-
-      const ext = itemPrimaryKey(service, `${repoFull}#${n}`);
-      const row = db
-        .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")
-        .get(ext) as { id?: string } | null;
-      if (row?.id !== undefined) ids.push(row.id);
+      if (metaRow?.id !== undefined) ids.push(metaRow.id);
     }
   }
 

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -21,6 +21,17 @@ export type IndexedItemGraphInput = {
   metadata: Record<string, unknown>;
 };
 
+/**
+ * Matches `SyncContext["resolveServiceId"]` (`sync/types.ts`). Threaded down
+ * to `syncTimelineEventGraph` only — every other populator branch keys off
+ * `metadata.repo`/`metadata.channel`/etc, not a service-identity binding.
+ */
+export type ResolveServiceId = (item: {
+  readonly service: string;
+  readonly type: string;
+  readonly metadata: Record<string, unknown>;
+}) => string | undefined;
+
 function stringField(meta: Record<string, unknown>, key: string): string | undefined {
   const v = meta[key];
   return typeof v === "string" && v.trim() !== "" ? v : undefined;
@@ -585,8 +596,9 @@ function syncTimelineEventGraph(
   entityType: "incident" | "deployment",
   occurredAt: number,
   now: number,
+  resolveServiceId: ResolveServiceId | undefined,
 ): void {
-  const affectedService = stringField(row.metadata, "service");
+  const affectedService = resolveServiceId?.(row) ?? stringField(row.metadata, "service");
   const entityId = upsertGraphEntity(db, {
     type: entityType,
     externalId: row.id,
@@ -670,7 +682,11 @@ function occurredAtForItem(db: Database, itemId: string): number {
   return row.modified_at;
 }
 
-export function syncGraphFromIndexedItem(db: Database, row: IndexedItemGraphInput): void {
+export function syncGraphFromIndexedItem(
+  db: Database,
+  row: IndexedItemGraphInput,
+  resolveServiceId?: ResolveServiceId,
+): void {
   if (readIndexedUserVersion(db) < 7) {
     return;
   }
@@ -725,10 +741,24 @@ export function syncGraphFromIndexedItem(db: Database, row: IndexedItemGraphInpu
     return;
   }
   if (row.type === "incident") {
-    syncTimelineEventGraph(db, row, "incident", occurredAtForItem(db, row.id), now);
+    syncTimelineEventGraph(
+      db,
+      row,
+      "incident",
+      occurredAtForItem(db, row.id),
+      now,
+      resolveServiceId,
+    );
     return;
   }
   if (row.type === "deployment") {
-    syncTimelineEventGraph(db, row, "deployment", occurredAtForItem(db, row.id), now);
+    syncTimelineEventGraph(
+      db,
+      row,
+      "deployment",
+      occurredAtForItem(db, row.id),
+      now,
+      resolveServiceId,
+    );
   }
 }

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -87,6 +87,16 @@ function clearIncomingRelationsOfType(db: Database, toId: string, relationType: 
  * Numeric refs are scoped to the referring item's own repo and service —
  * `#4` means a different issue in a different repo. Ticket keys are
  * service-agnostic, since the tracker is usually not the forge.
+ *
+ * Numeric refs are matched primarily against the referenced item's own
+ * `metadata.number` + `metadata.repo` (a sub-select/join against `item`,
+ * since `graph_entity` itself carries no item metadata) rather than by
+ * reconstructing an `externalId` string: PRs and issues share GitHub's
+ * number space, so a forge-agnostic `<repo>#<n>` guess collides with the
+ * `<repo>#issue-<n>` shape github-sync.ts actually indexes issues under
+ * (see github-sync.ts `upsertFromIssue`/`upsertFromPullRequest`). The old
+ * exact-`external_id` lookup is kept as a fallback so any item indexed
+ * under that flat shape keeps resolving.
  */
 function findIssueEntityIds(
   db: Database,
@@ -98,6 +108,23 @@ function findIssueEntityIds(
 
   if (repoFull !== undefined) {
     for (const n of refs.numeric) {
+      const metaRow = db
+        .query(
+          `SELECT e.id AS id
+             FROM graph_entity e
+             JOIN item i ON i.id = e.external_id
+            WHERE e.type = 'issue'
+              AND e.service = ?
+              AND json_extract(i.metadata, '$.number') = ?
+              AND json_extract(i.metadata, '$.repo') = ?
+            LIMIT 1`,
+        )
+        .get(service, n, repoFull) as { id?: string } | null;
+      if (metaRow?.id !== undefined) {
+        ids.push(metaRow.id);
+        continue;
+      }
+
       const ext = itemPrimaryKey(service, `${repoFull}#${n}`);
       const row = db
         .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -1,7 +1,9 @@
 import type { Database } from "bun:sqlite";
 
 import { dbRun } from "../db/write.ts";
+import { itemPrimaryKey } from "../index/item-key.ts";
 import { readIndexedUserVersion } from "../index/migrations/runner.ts";
+import { extractIssueRefs, type IssueRefs } from "./graph-refs.ts";
 import {
   ensureGraphEntity,
   isItemLinkedGraphType,
@@ -59,6 +61,55 @@ function clearRelationsTouchingEntity(db: Database, entityId: string): void {
   );
 }
 
+/**
+ * Clear one entity's outgoing edges of a single cross-item relation type.
+ * Call this from the *emitting* side before re-emitting, so a reference
+ * removed from a PR body or message body disappears from the graph.
+ * `clearRelationsTouchingEntity` deliberately skips these types (Task 1),
+ * so this is the only thing that retires them.
+ */
+function clearOutgoingRelationsOfType(db: Database, fromId: string, relationType: string): void {
+  dbRun(db, "DELETE FROM graph_relation WHERE from_id = ? AND type = ?", [fromId, relationType]);
+}
+
+/**
+ * Resolve a PR/message reference to an existing `issue` graph entity.
+ * Numeric refs are scoped to the referring item's own repo and service —
+ * `#4` means a different issue in a different repo. Ticket keys are
+ * service-agnostic, since the tracker is usually not the forge.
+ */
+function findIssueEntityIds(
+  db: Database,
+  service: string,
+  repoFull: string | undefined,
+  refs: IssueRefs,
+): string[] {
+  const ids: string[] = [];
+
+  if (repoFull !== undefined) {
+    for (const n of refs.numeric) {
+      const ext = itemPrimaryKey(service, `${repoFull}#${n}`);
+      const row = db
+        .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ? LIMIT 1")
+        .get(ext) as { id?: string } | null;
+      if (row?.id !== undefined) ids.push(row.id);
+    }
+  }
+
+  for (const key of refs.ticketKeys) {
+    const row = db
+      .query(
+        `SELECT id FROM graph_entity
+          WHERE type = 'issue' AND (external_id = ? OR external_id LIKE '%:' || ?)
+          ORDER BY id ASC LIMIT 1`,
+      )
+      .get(key, key) as { id?: string } | null;
+    if (row?.id !== undefined) ids.push(row.id);
+  }
+
+  return Array.from(new Set(ids));
+}
+
 function personDisplayName(db: Database, personId: string): string | null {
   const row = db.query("SELECT display_name FROM person WHERE id = ?").get(personId) as
     | { display_name: string | null }
@@ -113,6 +164,12 @@ function syncPrGraph(db: Database, row: IndexedItemGraphInput, now: number): voi
       metadata: { sha: mergeSha },
     });
     upsertGraphRelation(db, prEntityId, commitEntityId, "merged_as", now);
+  }
+
+  clearOutgoingRelationsOfType(db, prEntityId, "resolves");
+  const refs = extractIssueRefs(`${row.title}\n${row.bodyPreview ?? ""}`);
+  for (const issueId of findIssueEntityIds(db, row.service, repoFull, refs)) {
+    upsertGraphRelation(db, prEntityId, issueId, "resolves", now);
   }
 }
 

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -548,18 +548,26 @@ const CORRELATION_WINDOW_MS = 2 * 60 * 60 * 1000;
 type TimelineRow = { id: string; occurred_at: number };
 
 /**
- * Counterparts within the window, ordered NEAREST-FIRST so `LIMIT 20` keeps the
- * most plausibly causal ones.
+ * Every counterpart within the window — unbounded. The 2-hour same-service
+ * window (`CORRELATION_WINDOW_MS`) is itself the only cap: it already bounds
+ * the result to genuine activity, so a row cap on top of it is not a safety
+ * net. Both call sites clear their entire owned direction before re-emitting
+ * (see `syncTimelineEventGraph`'s clear/emit pair), so this query's result
+ * MUST be the complete in-window set — a truncated re-emit after a full clear
+ * silently destroys edges the other side legitimately created. If a service
+ * genuinely produces 200 incidents within two hours of a deploy, 200 edges is
+ * the correct answer; ranking or truncating for display belongs to a reader
+ * (e.g. the `why` agent), where it is visible rather than destructive.
  *
- * The direction of "nearest" differs per side, which is why it is a parameter
- * rather than a constant. A deployment looks FORWARD (`[D, D+W]`), so nearest is
- * the earliest incident — `ASC`. An incident looks BACKWARD (`[I-W, I]`), so
- * nearest is the latest deployment — `DESC`. Using `ASC` for both silently keeps
- * the 20 most temporally DISTANT deploys before an incident and drops the ones
- * immediately preceding it.
+ * Results are still ordered NEAREST-FIRST, purely for determinism now that
+ * there is no cap for the ordering to protect. The direction of "nearest"
+ * differs per side, which is why it is a parameter rather than a constant. A
+ * deployment looks FORWARD (`[D, D+W]`), so nearest is the earliest incident
+ * — `ASC`. An incident looks BACKWARD (`[I-W, I]`), so nearest is the latest
+ * deployment — `DESC`.
  *
- * The `id` tie-break makes the ordering deterministic when two entities share a
- * timestamp; SQLite is stable in practice but does not guarantee it.
+ * The `id` tie-break makes the ordering deterministic when two entities share
+ * a timestamp; SQLite is stable in practice but does not guarantee it.
  */
 function timelineCounterparts(
   db: Database,
@@ -578,8 +586,7 @@ function timelineCounterparts(
         WHERE type = ?
           AND json_extract(metadata, '$.affectedService') = ?
           AND CAST(json_extract(metadata, '$.occurredAt') AS INTEGER) BETWEEN ? AND ?
-        ORDER BY occurred_at ${order}, id ASC
-        LIMIT 20`,
+        ORDER BY occurred_at ${order}, id ASC`,
     )
     .all(counterpartType, affectedService, windowFrom, windowTo) as TimelineRow[];
 }

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -22,6 +22,25 @@ export type IndexedItemGraphInput = {
 };
 
 /**
+ * F1: structurally mirrors `metrics/service-identity.ts`'s
+ * `ServiceIdentityResolution` — declared independently here (not imported)
+ * for the same reason `ResolveServiceId` below is structural rather than an
+ * import: `graph/` must stay free of a `metrics/` import (`audit:boundaries`
+ * depends on this). `bound`/`excluded`/`unknown` are distinguished on
+ * purpose: `excluded` (a `ServiceConfig` claimed the item but I-1/F2's
+ * deploy-environment gate rejected it) must bind nothing, while `unknown`
+ * (nothing in the config map claims the item at all) is the only case where
+ * `syncTimelineEventGraph` may still fall back to `metadata.service`. A bare
+ * `undefined` could not tell these apart, which is exactly what let a
+ * gate-excluded preview deployment get silently re-bound via the
+ * `metadata.service` fallback.
+ */
+export type ResolveServiceIdResult =
+  | { readonly kind: "bound"; readonly serviceId: string }
+  | { readonly kind: "excluded" }
+  | { readonly kind: "unknown" };
+
+/**
  * Matches `SyncContext["resolveServiceId"]` (`sync/types.ts`). Threaded down
  * to `syncTimelineEventGraph` only — every other populator branch keys off
  * `metadata.repo`/`metadata.channel`/etc, not a service-identity binding.
@@ -30,7 +49,7 @@ export type ResolveServiceId = (item: {
   readonly service: string;
   readonly type: string;
   readonly metadata: Record<string, unknown>;
-}) => string | undefined;
+}) => ResolveServiceIdResult;
 
 function stringField(meta: Record<string, unknown>, key: string): string | undefined {
   const v = meta[key];
@@ -625,6 +644,28 @@ function timelineCounterparts(
 }
 
 /**
+ * F1: `resolveServiceId` returning `excluded` means a `ServiceConfig`
+ * claimed this item but I-1/F2's deploy-environment gate rejected it — the
+ * caller MUST bind nothing, so this must NOT fall back to
+ * `metadata.service`. Only `unknown` (nothing in the config map claims the
+ * item at all) or no resolver being wired at all falls back, exactly as
+ * before this fix. Falling back on `excluded` is precisely the bug F1 fixed:
+ * a gate-excluded preview deployment carrying `metadata.service` (e.g. from
+ * a future or third-party deploy connector) would otherwise silently
+ * re-bind and produce the false causal edge the gate exists to prevent.
+ */
+function resolveAffectedService(
+  row: IndexedItemGraphInput,
+  resolveServiceId: ResolveServiceId | undefined,
+): string | undefined {
+  const resolution = resolveServiceId?.(row);
+  if (resolution === undefined || resolution.kind === "unknown") {
+    return stringField(row.metadata, "service");
+  }
+  return resolution.kind === "bound" ? resolution.serviceId : undefined;
+}
+
+/**
  * Incidents and deployments are timeline anchors: the graph needs them as
  * entities so a change can be correlated with what it responded to or
  * caused. `occurredAt` is the item's `modified_at`, which every connector
@@ -638,7 +679,7 @@ function syncTimelineEventGraph(
   now: number,
   resolveServiceId: ResolveServiceId | undefined,
 ): void {
-  const affectedService = resolveServiceId?.(row) ?? stringField(row.metadata, "service");
+  const affectedService = resolveAffectedService(row, resolveServiceId);
   const entityId = upsertGraphEntity(db, {
     type: entityType,
     externalId: row.id,

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -354,14 +354,27 @@ function syncCodeSymbolGraph(db: Database, row: IndexedItemGraphInput, now: numb
   }
 }
 
-/** Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id. */
+/**
+ * Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id.
+ *
+ * The extracted string is treated as a PREFIX of the stored SHA, anchored to the
+ * start of the SHA portion. This is load-bearing: commits are indexed with full
+ * 40-character SHAs, but people cite them in chat as 7-character short SHAs — the
+ * exact case `COMMIT_SHA_RE`'s `{7,40}` bound exists to catch. An exact-suffix
+ * match (`LIKE '%:' || ?`) matches only full-length SHAs and silently emits
+ * nothing for every realistic short-SHA mention.
+ *
+ * When a short prefix is ambiguous across services the tie-break is arbitrary,
+ * the same limitation `findIssueEntityIds` carries for duplicate ticket keys.
+ */
 function findCommitEntityIds(db: Database, shas: readonly string[]): string[] {
   const ids: string[] = [];
   for (const sha of shas) {
     const row = db
       .query(
         `SELECT id FROM graph_entity
-          WHERE type = 'commit' AND external_id LIKE '%:' || ?
+          WHERE type = 'commit'
+            AND substr(external_id, instr(external_id, ':') + 1) LIKE ? || '%'
           ORDER BY id ASC LIMIT 1`,
       )
       .get(sha) as { id?: string } | null;

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -494,6 +494,45 @@ function syncDataQualityTestGraph(db: Database, row: IndexedItemGraphInput, now:
   }
 }
 
+/**
+ * Incidents and deployments are timeline anchors: the graph needs them as
+ * entities so a change can be correlated with what it responded to or
+ * caused. `occurredAt` is the item's `modified_at`, which every connector
+ * sets to the event time.
+ */
+function syncTimelineEventGraph(
+  db: Database,
+  row: IndexedItemGraphInput,
+  entityType: "incident" | "deployment",
+  occurredAt: number,
+  now: number,
+): void {
+  const affectedService = stringField(row.metadata, "service");
+  const entityId = upsertGraphEntity(db, {
+    type: entityType,
+    externalId: row.id,
+    label: row.title,
+    service: row.service,
+    metadata: { occurredAt, affectedService: affectedService ?? null },
+  });
+  clearRelationsTouchingEntity(db, entityId);
+  void now;
+}
+
+/**
+ * `syncGraphFromIndexedItem` does not receive the item's `modified_at`
+ * directly — reading it back from the `item` table avoids widening
+ * `IndexedItemGraphInput` a second time. The row is always written
+ * immediately before the populator runs, so this read-back is always
+ * populated.
+ */
+function occurredAtForItem(db: Database, itemId: string): number {
+  const row = db.query("SELECT modified_at FROM item WHERE id = ?").get(itemId) as {
+    modified_at: number;
+  } | null;
+  return row?.modified_at ?? Date.now();
+}
+
 export function syncGraphFromIndexedItem(db: Database, row: IndexedItemGraphInput): void {
   if (readIndexedUserVersion(db) < 7) {
     return;
@@ -546,5 +585,13 @@ export function syncGraphFromIndexedItem(db: Database, row: IndexedItemGraphInpu
   }
   if (row.type === "data_quality_test") {
     syncDataQualityTestGraph(db, row, now);
+    return;
+  }
+  if (row.type === "incident") {
+    syncTimelineEventGraph(db, row, "incident", occurredAtForItem(db, row.id), now);
+    return;
+  }
+  if (row.type === "deployment") {
+    syncTimelineEventGraph(db, row, "deployment", occurredAtForItem(db, row.id), now);
   }
 }

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -3,7 +3,7 @@ import type { Database } from "bun:sqlite";
 import { dbRun } from "../db/write.ts";
 import { itemPrimaryKey } from "../index/item-key.ts";
 import { readIndexedUserVersion } from "../index/migrations/runner.ts";
-import { extractIssueRefs, type IssueRefs } from "./graph-refs.ts";
+import { extractCommitShas, extractIssueRefs, type IssueRefs } from "./graph-refs.ts";
 import {
   ensureGraphEntity,
   isItemLinkedGraphType,
@@ -354,6 +354,22 @@ function syncCodeSymbolGraph(db: Database, row: IndexedItemGraphInput, now: numb
   }
 }
 
+/** Resolve commit SHAs to `commit` entities by their `<service>:<sha>` external id. */
+function findCommitEntityIds(db: Database, shas: readonly string[]): string[] {
+  const ids: string[] = [];
+  for (const sha of shas) {
+    const row = db
+      .query(
+        `SELECT id FROM graph_entity
+          WHERE type = 'commit' AND external_id LIKE '%:' || ?
+          ORDER BY id ASC LIMIT 1`,
+      )
+      .get(sha) as { id?: string } | null;
+    if (row?.id !== undefined) ids.push(row.id);
+  }
+  return ids;
+}
+
 function syncMessageGraph(db: Database, row: IndexedItemGraphInput, now: number): void {
   const msgEntityId = upsertGraphEntity(db, {
     type: "message",
@@ -386,6 +402,16 @@ function syncMessageGraph(db: Database, row: IndexedItemGraphInput, now: number)
       service: row.service,
     });
     upsertGraphRelation(db, msgEntityId, chId, "belongs_to", now);
+  }
+
+  clearOutgoingRelationsOfType(db, msgEntityId, "mentions");
+  const text = `${row.title}\n${row.bodyPreview ?? ""}`;
+  const mentioned = new Set<string>([
+    ...findIssueEntityIds(db, row.service, undefined, extractIssueRefs(text)),
+    ...findCommitEntityIds(db, extractCommitShas(text)),
+  ]);
+  for (const targetId of mentioned) {
+    upsertGraphRelation(db, msgEntityId, targetId, "mentions", now);
   }
 }
 

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -14,6 +14,7 @@ export type IndexedItemGraphInput = {
   service: string;
   type: string;
   title: string;
+  bodyPreview: string | null;
   authorId: string | null;
   metadata: Record<string, unknown>;
 };

--- a/packages/gateway/src/graph/graph-refs.test.ts
+++ b/packages/gateway/src/graph/graph-refs.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+
+import { extractIssueRefs } from "./graph-refs.ts";
+
+test("extracts GitHub-style numeric issue references", () => {
+  expect(extractIssueRefs("closes #4 and fixes #17")).toEqual({
+    numeric: [4, 17],
+    ticketKeys: [],
+  });
+});
+
+test("extracts ticket keys", () => {
+  expect(extractIssueRefs("part of NIM-88, follows ABC-7")).toEqual({
+    numeric: [],
+    ticketKeys: ["NIM-88", "ABC-7"],
+  });
+});
+
+test("deduplicates and preserves first-seen order", () => {
+  expect(extractIssueRefs("#4 #4 NIM-1 NIM-1 #9")).toEqual({
+    numeric: [4, 9],
+    ticketKeys: ["NIM-1"],
+  });
+});
+
+test("ignores lowercase and over-long keys that are not ticket keys", () => {
+  expect(extractIssueRefs("abc-1 and VERYLONGPROJECT-2")).toEqual({
+    numeric: [],
+    ticketKeys: [],
+  });
+});
+
+test("ignores a bare hash with no digits", () => {
+  expect(extractIssueRefs("# heading and #")).toEqual({ numeric: [], ticketKeys: [] });
+});
+
+test("handles empty input", () => {
+  expect(extractIssueRefs("")).toEqual({ numeric: [], ticketKeys: [] });
+});

--- a/packages/gateway/src/graph/graph-refs.test.ts
+++ b/packages/gateway/src/graph/graph-refs.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { extractIssueRefs } from "./graph-refs.ts";
+import { extractCommitShas, extractIssueRefs } from "./graph-refs.ts";
 
 test("extracts GitHub-style numeric issue references", () => {
   expect(extractIssueRefs("closes #4 and fixes #17")).toEqual({
@@ -36,4 +36,19 @@ test("ignores a bare hash with no digits", () => {
 
 test("handles empty input", () => {
   expect(extractIssueRefs("")).toEqual({ numeric: [], ticketKeys: [] });
+});
+
+test("extracts 7-to-40 character hex SHAs", () => {
+  expect(extractCommitShas("see a1b2c3d and 0123456789abcdef0123456789abcdef01234567")).toEqual([
+    "a1b2c3d",
+    "0123456789abcdef0123456789abcdef01234567",
+  ]);
+});
+
+test("ignores short hex runs and decimal numbers", () => {
+  expect(extractCommitShas("abc123 and 1234567")).toEqual(["1234567"]);
+});
+
+test("deduplicates SHAs", () => {
+  expect(extractCommitShas("a1b2c3d a1b2c3d")).toEqual(["a1b2c3d"]);
 });

--- a/packages/gateway/src/graph/graph-refs.ts
+++ b/packages/gateway/src/graph/graph-refs.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure reference extraction from indexed text. No DB, no I/O — every
+ * function here is a total function of its input string, which is what
+ * makes the branch-heavy parsing cheap to test exhaustively.
+ */
+
+const NUMERIC_REF_RE = /#(\d+)/g;
+// Ticket keys: 2-10 uppercase alphanumerics, a hyphen, then digits.
+// The bounded length is what keeps SHOUTING-1 style prose out.
+const TICKET_KEY_RE = /\b([A-Z][A-Z0-9]{1,9})-(\d+)\b/g;
+
+export type IssueRefs = {
+  numeric: number[];
+  ticketKeys: string[];
+};
+
+export function extractIssueRefs(text: string): IssueRefs {
+  const numeric: number[] = [];
+  const seenNumeric = new Set<number>();
+  for (const m of text.matchAll(NUMERIC_REF_RE)) {
+    const raw = m[1];
+    if (raw === undefined) continue;
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n) || seenNumeric.has(n)) continue;
+    seenNumeric.add(n);
+    numeric.push(n);
+  }
+
+  const ticketKeys: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const m of text.matchAll(TICKET_KEY_RE)) {
+    const key = m[0];
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    ticketKeys.push(key);
+  }
+
+  return { numeric, ticketKeys };
+}

--- a/packages/gateway/src/graph/graph-refs.ts
+++ b/packages/gateway/src/graph/graph-refs.ts
@@ -37,3 +37,17 @@ export function extractIssueRefs(text: string): IssueRefs {
 
   return { numeric, ticketKeys };
 }
+
+const COMMIT_SHA_RE = /\b([0-9a-f]{7,40})\b/g;
+
+export function extractCommitShas(text: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const m of text.matchAll(COMMIT_SHA_RE)) {
+    const sha = m[1];
+    if (sha === undefined || seen.has(sha)) continue;
+    seen.add(sha);
+    out.push(sha);
+  }
+  return out;
+}

--- a/packages/gateway/src/graph/regraph.test.ts
+++ b/packages/gateway/src/graph/regraph.test.ts
@@ -1,7 +1,10 @@
 import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 
+import { upsertIndexedItem } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
+import type { ServiceConfig } from "../metrics/dora-config.ts";
+import { buildServiceIdentityResolver } from "../metrics/service-identity.ts";
 import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 import { type RegraphResult, regraphAllItems } from "./regraph.ts";
 import { deterministicGraphEntityId } from "./relationship-graph.ts";
@@ -489,4 +492,143 @@ test("D3: graphed does not count item types with no populator dispatch branch (c
     }
   ).n;
   expect(relatedGraphEntities).toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// C-1: without threading `resolveServiceId` through, the backfill destroys
+// every `correlates_with` edge bound via `[metrics.dora.<id>]`/
+// `[ci.service.<id>]` service identity (the class of edge neither side's
+// `metadata.service` covers — PagerDuty's `pagerduty_service_id`, a repo URN).
+// ---------------------------------------------------------------------------
+
+const CHECKOUT_SERVICE_CONFIG: ServiceConfig = {
+  serviceId: "checkout",
+  repos: [{ provider: "github", providerId: "acme/checkout" }],
+  pagerdutyServices: ["PSVC1"],
+  deployWorkflowPattern: /^Deploy/,
+  incidentWindowMinutes: 60,
+  excludePrLabels: [],
+  deployEnvironments: ["prod"],
+  severityP1Aliases: ["P1"],
+};
+
+function correlationEdgeCount(db: Database): number {
+  return (
+    db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'correlates_with'").get() as {
+      n: number;
+    }
+  ).n;
+}
+
+/** Seed a PagerDuty incident + a deployment whose only shared service identity
+ * is the `resolveServiceId` binding — neither carries a plain `metadata.service`. */
+function seedResolverBoundIncidentAndDeploy(
+  db: Database,
+  now: number,
+  resolveServiceId: ReturnType<typeof buildServiceIdentityResolver>,
+): void {
+  upsertIndexedItem(
+    db,
+    {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "PD-1",
+      title: "Checkout 500s",
+      bodyPreview: "",
+      modifiedAt: now + 60 * 60 * 1000,
+      syncedAt: now + 60 * 60 * 1000,
+      metadata: { pagerduty_service_id: "PSVC1" },
+    },
+    resolveServiceId,
+  );
+  upsertIndexedItem(
+    db,
+    {
+      service: "github",
+      type: "deployment",
+      externalId: "deploy-9",
+      title: "Deploy checkout v2",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/checkout", target: "production" },
+    },
+    resolveServiceId,
+  );
+}
+
+test("C-1: regraphAllItems with resolveServiceId threaded through preserves an existing correlates_with edge and its affectedService binding", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const resolveServiceId = buildServiceIdentityResolver(
+    new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]),
+  );
+  seedResolverBoundIncidentAndDeploy(db, now, resolveServiceId);
+
+  expect(correlationEdgeCount(db)).toBe(1);
+
+  const result = regraphAllItems(db, { resolveServiceId });
+
+  expect(result.scanned).toBe(2);
+  expect(correlationEdgeCount(db)).toBe(1);
+
+  const entity = db
+    .query("SELECT metadata FROM graph_entity WHERE type = 'deployment' AND external_id = ?")
+    .get("github:deploy-9") as { metadata: string };
+  const parsed = JSON.parse(entity.metadata) as { affectedService: unknown };
+  expect(parsed.affectedService).toBe("checkout");
+});
+
+test("C-1 regression: regraphAllItems called without resolveServiceId destroys the correlates_with edge (reproduces the pre-fix bug)", () => {
+  const db = freshDb();
+  const now = Date.now();
+  const resolveServiceId = buildServiceIdentityResolver(
+    new Map([["checkout", CHECKOUT_SERVICE_CONFIG]]),
+  );
+  seedResolverBoundIncidentAndDeploy(db, now, resolveServiceId);
+
+  expect(correlationEdgeCount(db)).toBe(1);
+
+  // The no-resolver call: mirrors every pre-fix production call site, and
+  // still the correct call shape when the caller genuinely has no resolver.
+  regraphAllItems(db);
+
+  expect(correlationEdgeCount(db)).toBe(0);
+  const entity = db
+    .query("SELECT metadata FROM graph_entity WHERE type = 'deployment' AND external_id = ?")
+    .get("github:deploy-9") as { metadata: string };
+  const parsed = JSON.parse(entity.metadata) as { affectedService: unknown };
+  expect(parsed.affectedService).toBeNull();
+});
+
+test("C-1: the no-resolver case behaves exactly as it did before — plain metadata.service correlation is unaffected", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "pagerduty",
+    type: "incident",
+    externalId: "PD-1",
+    title: "Checkout 500s",
+    bodyPreview: "",
+    modifiedAt: now + 60 * 60 * 1000,
+    syncedAt: now + 60 * 60 * 1000,
+    metadata: { service: "checkout" },
+  });
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "deployment",
+    externalId: "deploy-9",
+    title: "Deploy checkout v2",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { service: "checkout" },
+  });
+
+  expect(correlationEdgeCount(db)).toBe(1);
+
+  const result = regraphAllItems(db);
+
+  expect(result.scanned).toBe(2);
+  expect(correlationEdgeCount(db)).toBe(1);
 });

--- a/packages/gateway/src/graph/regraph.test.ts
+++ b/packages/gateway/src/graph/regraph.test.ts
@@ -2,7 +2,23 @@ import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 
 import { LocalIndex } from "../index/local-index.ts";
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 import { type RegraphResult, regraphAllItems } from "./regraph.ts";
+import { deterministicGraphEntityId } from "./relationship-graph.ts";
+
+/** Every `graph_relation` row touching one entity, ignoring weight/created_at. */
+function relationsTouching(
+  db: Database,
+  entityId: string,
+): Array<{ type: string; from_id: string; to_id: string }> {
+  return db
+    .query(
+      `SELECT type, from_id, to_id FROM graph_relation
+        WHERE from_id = ? OR to_id = ?
+        ORDER BY type, from_id, to_id`,
+    )
+    .all(entityId, entityId) as Array<{ type: string; from_id: string; to_id: string }>;
+}
 
 function freshDb(): Database {
   const db = new Database(":memory:");
@@ -306,4 +322,171 @@ test("a corrupt metadata JSON row degrades to {} instead of aborting the backfil
       .get("github:acme/app#4") as { n: number }
   ).n;
   expect(validItemGraphed).toBe(1);
+});
+
+test("D1: a throw partway through a batch rolls back only that item — no item half-cleared", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#1",
+    title: "Issue 1",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#2",
+    title: "Issue 2",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#3",
+    title: "Issue 3",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#101",
+    title: "Fix 2",
+    body: "closes #2",
+    at: now,
+  });
+
+  // First pass: give issue #2 real edges (a `resolves` edge from the PR) so
+  // there is something for a half-clear to destroy.
+  regraphAllItems(db);
+
+  const poisonItemId = "github:acme/app#2";
+  const poisonEntityId = deterministicGraphEntityId("issue", poisonItemId);
+  const beforeRelations = relationsTouching(db, poisonEntityId);
+  expect(beforeRelations.length).toBeGreaterThan(0);
+
+  // Second pass with batchSize 3: issues #1, #2, #3 land in ONE batch
+  // (transaction). Issue #2's sync does the real clear+rebuild work and then
+  // fails — whether the throw lands before or after the rebuild finishes,
+  // the whole attempt must roll back atomically via the per-item savepoint,
+  // leaving issue #2 exactly as it was before this pass, never half-cleared.
+  const flaky: typeof syncGraphFromIndexedItem = (flakyDb, row, resolveServiceId) => {
+    if (row.id === poisonItemId) {
+      syncGraphFromIndexedItem(flakyDb, row, resolveServiceId);
+      throw new Error("simulated failure after partial work");
+    }
+    syncGraphFromIndexedItem(flakyDb, row, resolveServiceId);
+  };
+
+  const result = regraphAllItems(db, { batchSize: 3, _syncItem: flaky });
+
+  expect(result.scanned).toBe(4);
+  expect(result.skipped).toBe(1);
+  // Issue #1, #3 (siblings in the same batch) and the PR (separate batch,
+  // different slice) all still landed.
+  expect(result.graphed).toBe(3);
+
+  // Issue #2 is left exactly as it was before the failed attempt — not
+  // cleared-and-not-rebuilt.
+  expect(relationsTouching(db, poisonEntityId)).toEqual(beforeRelations);
+});
+
+test("D2: a throwing row is skipped, not fatal — the rest of the backfill still completes", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#1",
+    title: "Issue 1",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#2",
+    title: "Issue 2",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#3",
+    title: "Issue 3",
+    body: "",
+    at: now,
+  });
+
+  const poisonItemId = "github:acme/app#2";
+  const throwing: typeof syncGraphFromIndexedItem = (throwingDb, row, resolveServiceId) => {
+    if (row.id === poisonItemId) {
+      throw new Error("simulated sync failure");
+    }
+    syncGraphFromIndexedItem(throwingDb, row, resolveServiceId);
+  };
+
+  const result = regraphAllItems(db, { _syncItem: throwing });
+
+  // On unfixed code this throws out of regraphAllItems entirely (no catch),
+  // so scanned/graphed/skipped never get returned.
+  expect(result.scanned).toBe(3);
+  expect(result.graphed).toBe(2);
+  expect(result.skipped).toBe(1);
+
+  const graphedIssues = (
+    db.query("SELECT COUNT(*) AS n FROM graph_entity WHERE type = 'issue'").get() as {
+      n: number;
+    }
+  ).n;
+  expect(graphedIssues).toBe(2);
+});
+
+test("D3: graphed does not count item types with no populator dispatch branch (ci_run, alert)", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "circleci",
+    type: "ci_run",
+    externalId: "build-1",
+    title: "Build #1",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "pagerduty",
+    type: "alert",
+    externalId: "alert-1",
+    title: "High CPU",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#9",
+    title: "Issue 9",
+    body: "",
+    at: now,
+  });
+
+  const result = regraphAllItems(db);
+
+  expect(result.scanned).toBe(3);
+  // ci_run and alert both satisfy `isItemLinkedGraphType`, but
+  // `syncGraphFromIndexedItem` has no dispatch branch for either — no graph
+  // work happens, so they must not be counted as graphed.
+  expect(result.graphed).toBe(1);
+
+  const relatedGraphEntities = (
+    db.query("SELECT COUNT(*) AS n FROM graph_entity WHERE type IN ('ci_run', 'alert')").get() as {
+      n: number;
+    }
+  ).n;
+  expect(relatedGraphEntities).toBe(0);
 });

--- a/packages/gateway/src/graph/regraph.test.ts
+++ b/packages/gateway/src/graph/regraph.test.ts
@@ -1,0 +1,152 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { LocalIndex } from "../index/local-index.ts";
+import { regraphAllItems } from "./regraph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+/** Insert an item directly, bypassing the populator, to simulate pre-existing data. */
+function insertRawItem(
+  db: Database,
+  o: { service: string; type: string; externalId: string; title: string; body: string; at: number },
+): void {
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at, metadata, pinned)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [
+      `${o.service}:${o.externalId}`,
+      o.service,
+      o.type,
+      o.externalId,
+      o.title,
+      o.body,
+      o.at,
+      o.at,
+      JSON.stringify({ repo: "acme/app" }),
+    ],
+  );
+}
+
+test("backfill graphs items that were indexed before the populator knew how", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+
+  expect((db.query("SELECT COUNT(*) AS n FROM graph_relation").get() as { n: number }).n).toBe(0);
+
+  const result = regraphAllItems(db);
+
+  expect(result.scanned).toBe(2);
+  expect(result.graphed).toBe(2);
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});
+
+test("backfill skips item types the graph does not participate in", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "gdrive",
+    type: "file",
+    externalId: "f1",
+    title: "Notes",
+    body: "",
+    at: now,
+  });
+
+  const result = regraphAllItems(db);
+  expect(result.scanned).toBe(1);
+  expect(result.graphed).toBe(0);
+});
+
+test("backfill is idempotent", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+
+  regraphAllItems(db);
+  regraphAllItems(db);
+
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});
+
+test("one pass settles a forward reference that sorts the wrong way by id", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  // `github:acme/app#1` (the PR) sorts BEFORE `github:acme/app#4` (the issue),
+  // so an id-ordered backfill processes the PR while the issue entity does not
+  // yet exist and emits nothing. Type ordering is what makes one pass enough.
+  insertRawItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Fix login",
+    body: "closes #4",
+    at: now,
+  });
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+
+  regraphAllItems(db);
+
+  expect(
+    (
+      db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+});

--- a/packages/gateway/src/graph/regraph.test.ts
+++ b/packages/gateway/src/graph/regraph.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 
 import { LocalIndex } from "../index/local-index.ts";
-import { regraphAllItems } from "./regraph.ts";
+import { type RegraphResult, regraphAllItems } from "./regraph.ts";
 
 function freshDb(): Database {
   const db = new Database(":memory:");
@@ -149,4 +149,161 @@ test("one pass settles a forward reference that sorts the wrong way by id", () =
       }
     ).n,
   ).toBe(1);
+});
+
+/**
+ * 5 issues + 5 PRs, each PR resolving the issue with the matching number.
+ * Both groups land in their own `REGRAPH_TYPE_ORDER` slice (issue, then pr),
+ * and each slice has >= 5 rows so a `batchSize: 1` run pages 5 times per
+ * slice instead of settling in one page.
+ */
+function insertIssuePrFixture(db: Database, now: number): void {
+  for (let n = 1; n <= 5; n++) {
+    insertRawItem(db, {
+      service: "github",
+      type: "issue",
+      externalId: `acme/app#${n}`,
+      title: `Issue ${n}`,
+      body: "",
+      at: now,
+    });
+  }
+  for (let n = 1; n <= 5; n++) {
+    insertRawItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: `acme/app#${100 + n}`,
+      title: `Fix ${n}`,
+      body: `closes #${n}`,
+      at: now,
+    });
+  }
+}
+
+test("keyset pagination scans and graphs every row exactly once across multiple pages", () => {
+  const db = freshDb();
+  const now = Date.now();
+  insertIssuePrFixture(db, now);
+
+  const paged = regraphAllItems(db, { batchSize: 1 });
+
+  // 5 issues + 5 PRs. A skipped row would undercount; a repeated row (e.g. a
+  // cursor using `id >= lastId` re-fetching the same row) would overcount.
+  expect(paged.scanned).toBe(10);
+  expect(paged.graphed).toBe(10);
+
+  const pagedResolves = (
+    db.query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'").get() as {
+      n: number;
+    }
+  ).n;
+  // Real resolves edges, not just row counts: each of the 5 PRs resolves its
+  // matching issue, and a skipped issue row would leave its PR's edge unresolved.
+  expect(pagedResolves).toBe(5);
+
+  // The same fixture run single-page (default batchSize, well above 10 rows)
+  // in a fresh DB must produce an identical graph — pagination must not
+  // change the outcome, only how many round trips it takes to get there.
+  const singlePageDb = freshDb();
+  insertIssuePrFixture(singlePageDb, now);
+  const singlePage = regraphAllItems(singlePageDb);
+
+  expect(singlePage.scanned).toBe(paged.scanned);
+  expect(singlePage.graphed).toBe(paged.graphed);
+  expect(
+    (
+      singlePageDb
+        .query("SELECT COUNT(*) AS n FROM graph_relation WHERE type = 'resolves'")
+        .get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(pagedResolves);
+});
+
+test("a corrupt metadata JSON row degrades to {} instead of aborting the backfill", () => {
+  const db = freshDb();
+  const now = Date.now();
+
+  // Malformed metadata, inserted directly with db.run: insertRawItem always
+  // JSON.stringifies, so it can never produce invalid JSON.
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at, metadata, pinned)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [
+      "github:acme/app#corrupt",
+      "github",
+      "issue",
+      "acme/app#corrupt",
+      "Corrupt metadata issue",
+      "",
+      now,
+      now,
+      "{not json",
+    ],
+  );
+
+  // NULL metadata: same fallback path (`parseMetadata`'s early return), no
+  // JSON.parse attempted at all.
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at, metadata, pinned)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [
+      "github:acme/app#nullmeta",
+      "github",
+      "issue",
+      "acme/app#nullmeta",
+      "Null metadata issue",
+      "",
+      now,
+      now,
+      null,
+    ],
+  );
+
+  // Empty-string metadata: the other explicit early-return branch.
+  db.run(
+    `INSERT INTO item (id, service, type, external_id, title, body_preview, modified_at, synced_at, metadata, pinned)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    [
+      "github:acme/app#emptymeta",
+      "github",
+      "issue",
+      "acme/app#emptymeta",
+      "Empty metadata issue",
+      "",
+      now,
+      now,
+      "",
+    ],
+  );
+
+  insertRawItem(db, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/app#4",
+    title: "Login broken",
+    body: "",
+    at: now,
+  });
+
+  let result: RegraphResult | undefined;
+  expect(() => {
+    result = regraphAllItems(db);
+  }).not.toThrow();
+
+  expect(result?.scanned).toBe(4);
+  // All four rows are the graph-participating `issue` type: the metadata
+  // fallback only affects what fields the sync reads, never whether the row
+  // is graphed at all.
+  expect(result?.graphed).toBe(4);
+
+  // The valid item — indexed alongside three corrupt/null/empty metadata
+  // siblings — still got graphed; the corrupt rows did not abort the pass.
+  const validItemGraphed = (
+    db
+      .query("SELECT COUNT(*) AS n FROM graph_entity WHERE type = 'issue' AND external_id = ?")
+      .get("github:acme/app#4") as { n: number }
+  ).n;
+  expect(validItemGraphed).toBe(1);
 });

--- a/packages/gateway/src/graph/regraph.ts
+++ b/packages/gateway/src/graph/regraph.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import type { Logger } from "pino";
 
 import { syncGraphFromIndexedItem } from "./graph-populator.ts";
 import { isItemLinkedGraphType } from "./relationship-graph.ts";
@@ -6,6 +7,18 @@ import { isItemLinkedGraphType } from "./relationship-graph.ts";
 export type RegraphResult = {
   scanned: number;
   graphed: number;
+  skipped: number;
+};
+
+export type RegraphOptions = {
+  batchSize?: number;
+  logger?: Logger;
+  /**
+   * @internal test seam: override the sync function so a test can force a
+   * deterministic per-item failure without touching graph-populator.ts or
+   * mocking the DB layer. Production callers must never set this.
+   */
+  _syncItem?: typeof syncGraphFromIndexedItem;
 };
 
 type ItemRow = {
@@ -47,31 +60,73 @@ const REGRAPH_TYPE_ORDER: readonly string[] = Object.freeze([
   "message",
 ]);
 
-function graphOneRow(db: Database, r: ItemRow): boolean {
-  if (!isItemLinkedGraphType(r.type)) return false;
-  syncGraphFromIndexedItem(db, {
-    id: r.id,
-    service: r.service,
-    type: r.type,
-    title: r.title,
-    bodyPreview: r.body_preview,
-    authorId: r.author_id,
-    metadata: parseMetadata(r.metadata),
-  });
-  return true;
+function totalChanges(db: Database): number {
+  return (db.query("SELECT total_changes() AS n").get() as { n: number }).n;
 }
+
+/**
+ * Graph one row inside its own nested transaction. This always runs nested
+ * inside `regraphSlice`'s per-batch transaction, so `bun:sqlite` implements
+ * it as a SAVEPOINT: if `syncItem` throws, only this row's writes roll back —
+ * the enclosing batch (and any sibling rows already committed within it) is
+ * unaffected. That is what keeps a bad row from ever leaving the graph
+ * half-cleared: either every write the attempt made lands, or none of them
+ * do.
+ *
+ * `graphed` is derived from the connection's cumulative `total_changes()`
+ * rather than from `isItemLinkedGraphType` alone, because that predicate is
+ * broader than `syncGraphFromIndexedItem`'s actual dispatch — e.g.
+ * `ci_run`/`alert`/`error_issue` satisfy it but have no dispatch branch, so
+ * nothing is ever written for them. Measuring the row-change counter directly
+ * can't drift out of sync with the populator the way a second hand-maintained
+ * type list would.
+ */
+function graphOneRow(db: Database, r: ItemRow, syncItem: typeof syncGraphFromIndexedItem): boolean {
+  if (!isItemLinkedGraphType(r.type)) return false;
+  let graphed = false;
+  db.transaction(() => {
+    const before = totalChanges(db);
+    syncItem(db, {
+      id: r.id,
+      service: r.service,
+      type: r.type,
+      title: r.title,
+      bodyPreview: r.body_preview,
+      authorId: r.author_id,
+      metadata: parseMetadata(r.metadata),
+    });
+    graphed = totalChanges(db) > before;
+  })();
+  return graphed;
+}
+
+type RegraphRunConfig = {
+  batchSize: number;
+  syncItem: typeof syncGraphFromIndexedItem;
+  logger: Logger | undefined;
+};
 
 /**
  * Page through one slice of the item table by keyset (`id > lastId`) rather
  * than OFFSET. OFFSET makes SQLite re-walk every skipped row on each page,
  * which turns a large backfill quadratic.
+ *
+ * Each page is applied in a single `db.transaction`, so a page either fully
+ * commits or fully rolls back — an interruption (kill, crash, or an
+ * unguarded throw) leaves the graph consistent at a page boundary instead of
+ * mid-item, and batching removes most of the per-statement autocommit
+ * overhead that dominates a large backfill.
+ *
+ * A single row's sync failure is caught per-item (see `graphOneRow`'s
+ * savepoint) so it never aborts the rest of the page or the pass; it is
+ * counted in `skipped` and logged rather than swallowed silently.
  */
 function regraphSlice(
   db: Database,
   where: string,
   params: readonly string[],
-  batchSize: number,
-  counters: { scanned: number; graphed: number },
+  cfg: RegraphRunConfig,
+  counters: { scanned: number; graphed: number; skipped: number },
 ): void {
   let lastId = "";
   for (;;) {
@@ -83,13 +138,24 @@ function regraphSlice(
           ORDER BY id ASC
           LIMIT ?`,
       )
-      .all(...params, lastId, batchSize) as ItemRow[];
+      .all(...params, lastId, cfg.batchSize) as ItemRow[];
     if (rows.length === 0) return;
 
-    for (const r of rows) {
-      counters.scanned += 1;
-      if (graphOneRow(db, r)) counters.graphed += 1;
-    }
+    const runBatch = db.transaction((batchRows: ItemRow[]) => {
+      for (const r of batchRows) {
+        counters.scanned += 1;
+        try {
+          if (graphOneRow(db, r, cfg.syncItem)) counters.graphed += 1;
+        } catch (err) {
+          counters.skipped += 1;
+          cfg.logger?.warn(
+            { err, itemId: r.id, itemType: r.type },
+            "regraph: skipped item after sync failure",
+          );
+        }
+      }
+    });
+    runBatch(rows);
 
     const last = rows.at(-1);
     if (last === undefined) return;
@@ -107,19 +173,27 @@ function regraphSlice(
  * the items that reference them; every edge this plan emits therefore settles
  * in a single pass. Idempotent regardless — each sync function clears and
  * rebuilds the edges it owns — so re-running is always safe.
+ *
+ * A row whose sync throws is skipped (not fatal to the pass) and counted in
+ * `skipped`; `graphed` counts only items that actually produced graph writes.
  */
-export function regraphAllItems(db: Database, opts?: { batchSize?: number }): RegraphResult {
-  const batchSize = opts?.batchSize ?? 500;
-  const counters = { scanned: 0, graphed: 0 };
+export function regraphAllItems(db: Database, opts?: RegraphOptions): RegraphResult {
+  const cfg: RegraphRunConfig = {
+    batchSize: opts?.batchSize ?? 500,
+    syncItem: opts?._syncItem ?? syncGraphFromIndexedItem,
+    logger: opts?.logger,
+  };
+  const counters = { scanned: 0, graphed: 0, skipped: 0 };
 
   for (const type of REGRAPH_TYPE_ORDER) {
-    regraphSlice(db, "type = ?", [type], batchSize, counters);
+    regraphSlice(db, "type = ?", [type], cfg, counters);
   }
 
   // Everything else: graph-participating types with no ordering constraint,
-  // plus non-participating types, which are counted as scanned but skipped.
+  // plus non-participating types, which are counted as scanned but not
+  // graphed.
   const placeholders = REGRAPH_TYPE_ORDER.map(() => "?").join(", ");
-  regraphSlice(db, `type NOT IN (${placeholders})`, REGRAPH_TYPE_ORDER, batchSize, counters);
+  regraphSlice(db, `type NOT IN (${placeholders})`, REGRAPH_TYPE_ORDER, cfg, counters);
 
   return counters;
 }

--- a/packages/gateway/src/graph/regraph.ts
+++ b/packages/gateway/src/graph/regraph.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
 import type { Logger } from "pino";
 
-import { syncGraphFromIndexedItem } from "./graph-populator.ts";
+import { type ResolveServiceId, syncGraphFromIndexedItem } from "./graph-populator.ts";
 import { isItemLinkedGraphType } from "./relationship-graph.ts";
 
 export type RegraphResult = {
@@ -13,6 +13,20 @@ export type RegraphResult = {
 export type RegraphOptions = {
   batchSize?: number;
   logger?: Logger;
+  /**
+   * Threaded through to `syncGraphFromIndexedItem`'s third argument on every
+   * row. Without it, `syncTimelineEventGraph` binds `affectedService` from
+   * `metadata.service` alone — so a `deployment`/`incident` pair that only
+   * correlates via a `[metrics.dora.<id>]`/`[ci.service.<id>]` binding (e.g.
+   * PagerDuty's `pagerduty_service_id` or a repo URN, never a plain
+   * `metadata.service`) has its `correlates_with` edge unconditionally
+   * cleared and NOT re-emitted, and `affectedService` gets rewritten to
+   * `null` in the entity's stored metadata. Production callers must supply
+   * the same resolver assembled for the live `SyncContext`
+   * (`platform/assemble.ts`) or this backfill is destructive for that class
+   * of edge.
+   */
+  resolveServiceId?: ResolveServiceId;
   /**
    * @internal test seam: override the sync function so a test can force a
    * deterministic per-item failure without touching graph-populator.ts or
@@ -81,20 +95,29 @@ function totalChanges(db: Database): number {
  * can't drift out of sync with the populator the way a second hand-maintained
  * type list would.
  */
-function graphOneRow(db: Database, r: ItemRow, syncItem: typeof syncGraphFromIndexedItem): boolean {
+function graphOneRow(
+  db: Database,
+  r: ItemRow,
+  syncItem: typeof syncGraphFromIndexedItem,
+  resolveServiceId: ResolveServiceId | undefined,
+): boolean {
   if (!isItemLinkedGraphType(r.type)) return false;
   let graphed = false;
   db.transaction(() => {
     const before = totalChanges(db);
-    syncItem(db, {
-      id: r.id,
-      service: r.service,
-      type: r.type,
-      title: r.title,
-      bodyPreview: r.body_preview,
-      authorId: r.author_id,
-      metadata: parseMetadata(r.metadata),
-    });
+    syncItem(
+      db,
+      {
+        id: r.id,
+        service: r.service,
+        type: r.type,
+        title: r.title,
+        bodyPreview: r.body_preview,
+        authorId: r.author_id,
+        metadata: parseMetadata(r.metadata),
+      },
+      resolveServiceId,
+    );
     graphed = totalChanges(db) > before;
   })();
   return graphed;
@@ -104,6 +127,7 @@ type RegraphRunConfig = {
   batchSize: number;
   syncItem: typeof syncGraphFromIndexedItem;
   logger: Logger | undefined;
+  resolveServiceId: ResolveServiceId | undefined;
 };
 
 /**
@@ -145,7 +169,7 @@ function regraphSlice(
       for (const r of batchRows) {
         counters.scanned += 1;
         try {
-          if (graphOneRow(db, r, cfg.syncItem)) counters.graphed += 1;
+          if (graphOneRow(db, r, cfg.syncItem, cfg.resolveServiceId)) counters.graphed += 1;
         } catch (err) {
           counters.skipped += 1;
           cfg.logger?.warn(
@@ -182,6 +206,7 @@ export function regraphAllItems(db: Database, opts?: RegraphOptions): RegraphRes
     batchSize: opts?.batchSize ?? 500,
     syncItem: opts?._syncItem ?? syncGraphFromIndexedItem,
     logger: opts?.logger,
+    resolveServiceId: opts?.resolveServiceId,
   };
   const counters = { scanned: 0, graphed: 0, skipped: 0 };
 

--- a/packages/gateway/src/graph/regraph.ts
+++ b/packages/gateway/src/graph/regraph.ts
@@ -1,0 +1,125 @@
+import type { Database } from "bun:sqlite";
+
+import { syncGraphFromIndexedItem } from "./graph-populator.ts";
+import { isItemLinkedGraphType } from "./relationship-graph.ts";
+
+export type RegraphResult = {
+  scanned: number;
+  graphed: number;
+};
+
+type ItemRow = {
+  id: string;
+  service: string;
+  type: string;
+  title: string;
+  body_preview: string | null;
+  author_id: string | null;
+  metadata: string | null;
+};
+
+function parseMetadata(raw: string | null): Record<string, unknown> {
+  if (raw === null || raw === "") return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Item types graphed in dependency order. An entity that is only ever a
+ * reference *target* must already exist when the item referencing it is
+ * processed, or the edge is silently skipped: `findIssueEntityIds` and
+ * `findCommitEntityIds` resolve against `graph_entity`, not `item`.
+ *
+ * `deployment` / `incident` correlate symmetrically (either side emits the
+ * edge), so their relative order is free — they are listed only to keep the
+ * whole dependency story in one place.
+ */
+const REGRAPH_TYPE_ORDER: readonly string[] = Object.freeze([
+  "issue",
+  "git_commit",
+  "deployment",
+  "incident",
+  "pr",
+  "message",
+]);
+
+function graphOneRow(db: Database, r: ItemRow): boolean {
+  if (!isItemLinkedGraphType(r.type)) return false;
+  syncGraphFromIndexedItem(db, {
+    id: r.id,
+    service: r.service,
+    type: r.type,
+    title: r.title,
+    bodyPreview: r.body_preview,
+    authorId: r.author_id,
+    metadata: parseMetadata(r.metadata),
+  });
+  return true;
+}
+
+/**
+ * Page through one slice of the item table by keyset (`id > lastId`) rather
+ * than OFFSET. OFFSET makes SQLite re-walk every skipped row on each page,
+ * which turns a large backfill quadratic.
+ */
+function regraphSlice(
+  db: Database,
+  where: string,
+  params: readonly string[],
+  batchSize: number,
+  counters: { scanned: number; graphed: number },
+): void {
+  let lastId = "";
+  for (;;) {
+    const rows = db
+      .query(
+        `SELECT id, service, type, title, body_preview, author_id, metadata
+           FROM item
+          WHERE ${where} AND id > ?
+          ORDER BY id ASC
+          LIMIT ?`,
+      )
+      .all(...params, lastId, batchSize) as ItemRow[];
+    if (rows.length === 0) return;
+
+    for (const r of rows) {
+      counters.scanned += 1;
+      if (graphOneRow(db, r)) counters.graphed += 1;
+    }
+
+    const last = rows.at(-1);
+    if (last === undefined) return;
+    lastId = last.id;
+  }
+}
+
+/**
+ * Re-run the graph populator over every indexed item.
+ *
+ * Needed because a populator change only reaches existing rows when they next
+ * re-sync — and historical items may never re-sync.
+ *
+ * Processed in `REGRAPH_TYPE_ORDER` so reference targets are graphed before
+ * the items that reference them; every edge this plan emits therefore settles
+ * in a single pass. Idempotent regardless — each sync function clears and
+ * rebuilds the edges it owns — so re-running is always safe.
+ */
+export function regraphAllItems(db: Database, opts?: { batchSize?: number }): RegraphResult {
+  const batchSize = opts?.batchSize ?? 500;
+  const counters = { scanned: 0, graphed: 0 };
+
+  for (const type of REGRAPH_TYPE_ORDER) {
+    regraphSlice(db, "type = ?", [type], batchSize, counters);
+  }
+
+  // Everything else: graph-participating types with no ordering constraint,
+  // plus non-participating types, which are counted as scanned but skipped.
+  const placeholders = REGRAPH_TYPE_ORDER.map(() => "?").join(", ");
+  regraphSlice(db, `type NOT IN (${placeholders})`, REGRAPH_TYPE_ORDER, batchSize, counters);
+
+  return counters;
+}

--- a/packages/gateway/src/index/item-key.ts
+++ b/packages/gateway/src/index/item-key.ts
@@ -1,0 +1,13 @@
+/**
+ * The `<service>:<externalId>` primary key shared by the item table and the
+ * graph populator. Lives in its own dependency-free module because
+ * `item-store.ts` imports the populator — importing the key helper back out
+ * of `item-store` would close a cycle.
+ */
+export function itemPrimaryKey(service: string, externalId: string): string {
+  const prefix = `${service}:`;
+  if (externalId.startsWith(prefix)) {
+    return externalId;
+  }
+  return `${service}:${externalId}`;
+}

--- a/packages/gateway/src/index/item-store.ts
+++ b/packages/gateway/src/index/item-store.ts
@@ -6,6 +6,9 @@ import { syncGraphFromIndexedItem } from "../graph/graph-populator.ts";
 import { deleteGraphEntitiesForItemKeys } from "../graph/relationship-graph.ts";
 import type { SyncContext } from "../sync/types.ts";
 import { RAW_META_MAX_BYTES } from "./constants.ts";
+import { itemPrimaryKey } from "./item-key.ts";
+
+export { itemPrimaryKey } from "./item-key.ts";
 
 export type IndexedItemRow = {
   id: string;
@@ -22,14 +25,6 @@ export type IndexedItemRow = {
   synced_at: number;
   pinned: number;
 };
-
-export function itemPrimaryKey(service: string, externalId: string): string {
-  const prefix = `${service}:`;
-  if (externalId.startsWith(prefix)) {
-    return externalId;
-  }
-  return `${service}:${externalId}`;
-}
 
 export function itemExternalIdFromInput(service: string, idOrExternal: string): string {
   const prefix = `${service}:`;

--- a/packages/gateway/src/index/item-store.ts
+++ b/packages/gateway/src/index/item-store.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import type { NimbusItem } from "@nimbus-dev/sdk";
 
 import { dbRun } from "../db/write.ts";
-import { syncGraphFromIndexedItem } from "../graph/graph-populator.ts";
+import { type ResolveServiceId, syncGraphFromIndexedItem } from "../graph/graph-populator.ts";
 import { deleteGraphEntitiesForItemKeys } from "../graph/relationship-graph.ts";
 import type { SyncContext } from "../sync/types.ts";
 import { RAW_META_MAX_BYTES } from "./constants.ts";
@@ -54,6 +54,7 @@ export function upsertIndexedItem(
     pinned?: boolean;
     syncedAt: number;
   },
+  resolveServiceId?: ResolveServiceId,
 ): void {
   const id = itemPrimaryKey(row.service, row.externalId);
   const meta = JSON.stringify(row.metadata ?? {});
@@ -96,22 +97,26 @@ export function upsertIndexedItem(
       row.pinned === true ? 1 : 0,
     ],
   );
-  syncGraphFromIndexedItem(db, {
-    id,
-    service: row.service,
-    type: row.type,
-    title: row.title,
-    bodyPreview: preview,
-    authorId: row.authorId ?? null,
-    metadata: row.metadata ?? {},
-  });
+  syncGraphFromIndexedItem(
+    db,
+    {
+      id,
+      service: row.service,
+      type: row.type,
+      title: row.title,
+      bodyPreview: preview,
+      authorId: row.authorId ?? null,
+      metadata: row.metadata ?? {},
+    },
+    resolveServiceId,
+  );
 }
 
 export function upsertIndexedItemForSync(
   ctx: SyncContext,
   row: Parameters<typeof upsertIndexedItem>[1],
 ): void {
-  upsertIndexedItem(ctx.db, row);
+  upsertIndexedItem(ctx.db, row, ctx.resolveServiceId);
   const id = itemPrimaryKey(row.service, row.externalId);
   ctx.scheduleItemEmbedding?.(id);
 }

--- a/packages/gateway/src/index/item-store.ts
+++ b/packages/gateway/src/index/item-store.ts
@@ -106,6 +106,7 @@ export function upsertIndexedItem(
     service: row.service,
     type: row.type,
     title: row.title,
+    bodyPreview: preview,
     authorId: row.authorId ?? null,
     metadata: row.metadata ?? {},
   });

--- a/packages/gateway/src/metrics/service-identity.test.ts
+++ b/packages/gateway/src/metrics/service-identity.test.ts
@@ -198,6 +198,144 @@ describe("buildServiceIdentityResolver", () => {
     });
   });
 
+  describe("I-1: deployment environment gating", () => {
+    it("binds a deployment whose metadata.target matches deployEnvironments (after the production→prod alias)", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["prod"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { repo: "acme/checkout", target: "production" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("does not bind a deployment whose metadata.target is excluded by deployEnvironments", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["prod"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { repo: "acme/checkout", target: "preview" },
+        }),
+      ).toBeUndefined();
+    });
+
+    it("prefers the canonical metadata.environment over metadata.target when both are present", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["staging"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { repo: "acme/checkout", environment: "staging", target: "preview" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("binds a deployment with no environment signal at all (fail-open)", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["prod"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { repo: "acme/checkout" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("does not gate a non-deployment item type even when it carries a non-matching target", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["prod"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "incident",
+          metadata: { repo: "acme/checkout", target: "preview" },
+        }),
+      ).toBe("checkout");
+    });
+  });
+
+  describe("M-2: ambiguous binding warning", () => {
+    it("warns when two ServiceConfigs claim the same pagerdutyServices entry, and still resolves deterministically (first by config-map order)", () => {
+      const warnings: unknown[] = [];
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({ serviceId: "checkout", pagerdutyServices: ["PSVC1"] }),
+          baseConfig({ serviceId: "checkout-mono", pagerdutyServices: ["PSVC1"], repos: [] }),
+        ),
+        (w) => warnings.push(w),
+      );
+      const result = resolve({
+        service: "pagerduty",
+        type: "incident",
+        metadata: { pagerduty_service_id: "PSVC1" },
+      });
+      expect(result).toBe("checkout");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        bindingKind: "pagerduty_service_id",
+        key: "PSVC1",
+        chosenServiceId: "checkout",
+        candidateServiceIds: ["checkout", "checkout-mono"],
+      });
+    });
+
+    it("warns when two ServiceConfigs claim the same repo URN (a monorepo)", () => {
+      const warnings: unknown[] = [];
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            pagerdutyServices: [],
+            repos: [{ provider: "github", providerId: "acme/mono" }],
+          }),
+          baseConfig({
+            serviceId: "billing",
+            pagerdutyServices: [],
+            repos: [{ provider: "github", providerId: "acme/mono" }],
+          }),
+        ),
+        (w) => warnings.push(w),
+      );
+      const result = resolve({
+        service: "github",
+        type: "pr",
+        metadata: { repo: "acme/mono" },
+      });
+      expect(result).toBe("checkout");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        bindingKind: "repo_urn",
+        chosenServiceId: "checkout",
+        candidateServiceIds: ["checkout", "billing"],
+      });
+    });
+
+    it("does not warn when only one ServiceConfig claims the key", () => {
+      const warnings: unknown[] = [];
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ serviceId: "checkout", pagerdutyServices: ["PSVC1"] })),
+        (w) => warnings.push(w),
+      );
+      resolve({
+        service: "pagerduty",
+        type: "incident",
+        metadata: { pagerduty_service_id: "PSVC1" },
+      });
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
   describe("no match anywhere", () => {
     it("returns undefined for an item with none of the bound fields", () => {
       const resolve = buildServiceIdentityResolver(configs(baseConfig()));

--- a/packages/gateway/src/metrics/service-identity.test.ts
+++ b/packages/gateway/src/metrics/service-identity.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test";
+import type { ServiceConfig } from "./dora-config.ts";
+import { buildServiceIdentityResolver } from "./service-identity.ts";
+
+function baseConfig(overrides?: Partial<ServiceConfig>): ServiceConfig {
+  return {
+    serviceId: "checkout",
+    repos: [{ provider: "github", providerId: "acme/checkout" }],
+    pagerdutyServices: ["PSVC1"],
+    deployWorkflowPattern: /^Deploy/,
+    incidentWindowMinutes: 60,
+    excludePrLabels: ["revert"],
+    deployEnvironments: ["prod"],
+    severityP1Aliases: ["P1"],
+    ...overrides,
+  };
+}
+
+function configs(...cfgs: ServiceConfig[]): Map<string, ServiceConfig> {
+  return new Map(cfgs.map((c) => [c.serviceId, c]));
+}
+
+describe("buildServiceIdentityResolver", () => {
+  describe("path 1: metadata.nimbus_service_id", () => {
+    it("resolves directly when the id names a known service", () => {
+      const resolve = buildServiceIdentityResolver(configs(baseConfig()));
+      expect(
+        resolve({
+          service: "deploy-annotate",
+          type: "deployment",
+          metadata: { nimbus_service_id: "checkout" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("falls through when the id does not name a known service", () => {
+      const resolve = buildServiceIdentityResolver(configs(baseConfig()));
+      expect(
+        resolve({
+          service: "deploy-annotate",
+          type: "deployment",
+          metadata: { nimbus_service_id: "unknown-svc" },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("path 2: metadata.pagerduty_service_id", () => {
+    it("resolves via the ServiceConfig whose pagerdutyServices contains it", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ serviceId: "checkout", pagerdutyServices: ["PSVC1", "PSVC2"] })),
+      );
+      expect(
+        resolve({
+          service: "pagerduty",
+          type: "incident",
+          metadata: { pagerduty_service_id: "PSVC2" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("returns undefined when no ServiceConfig claims the pagerduty service id", () => {
+      const resolve = buildServiceIdentityResolver(configs(baseConfig()));
+      expect(
+        resolve({
+          service: "pagerduty",
+          type: "incident",
+          metadata: { pagerduty_service_id: "PSVC-UNMAPPED" },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("path 3: repo-bearing metadata", () => {
+    it("resolves a github repo URN via metadata.repo", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            repos: [{ provider: "github", providerId: "acme/checkout" }],
+          }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "github",
+          type: "pr",
+          metadata: { repo: "acme/checkout" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("resolves a gitlab repo URN via metadata.project", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            repos: [{ provider: "gitlab", providerId: "group/checkout" }],
+          }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "gitlab",
+          type: "pr",
+          metadata: { project: "group/checkout" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("resolves a jenkins URN via metadata.jobName", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            repos: [{ provider: "jenkins", providerId: "checkout-pipeline" }],
+          }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "jenkins",
+          type: "ci_run",
+          metadata: { jobName: "checkout-pipeline" },
+        }),
+      ).toBe("checkout");
+    });
+
+    it("never matches a circleci URN (no external id in this item shape)", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            repos: [{ provider: "circleci", providerId: "gh/acme/checkout" }],
+          }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "circleci",
+          type: "ci_run",
+          metadata: {},
+        }),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when no repo matches", () => {
+      const resolve = buildServiceIdentityResolver(configs(baseConfig()));
+      expect(
+        resolve({
+          service: "github",
+          type: "pr",
+          metadata: { repo: "acme/some-other-repo" },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("precedence", () => {
+    it("prefers nimbus_service_id over pagerduty_service_id", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({ serviceId: "checkout", pagerdutyServices: ["PSVC1"] }),
+          baseConfig({ serviceId: "search", pagerdutyServices: [], repos: [] }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "pagerduty",
+          type: "incident",
+          metadata: { nimbus_service_id: "search", pagerduty_service_id: "PSVC1" },
+        }),
+      ).toBe("search");
+    });
+
+    it("prefers pagerduty_service_id over a repo match", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            pagerdutyServices: ["PSVC1"],
+            repos: [{ provider: "github", providerId: "acme/other" }],
+          }),
+          baseConfig({
+            serviceId: "other",
+            pagerdutyServices: [],
+            repos: [{ provider: "github", providerId: "acme/other" }],
+          }),
+        ),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { pagerduty_service_id: "PSVC1", repo: "acme/other" },
+        }),
+      ).toBe("checkout");
+    });
+  });
+
+  describe("no match anywhere", () => {
+    it("returns undefined for an item with none of the bound fields", () => {
+      const resolve = buildServiceIdentityResolver(configs(baseConfig()));
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { uid: "dpl_123", state: "READY" },
+        }),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined against an empty config map", () => {
+      const resolve = buildServiceIdentityResolver(new Map());
+      expect(
+        resolve({
+          service: "pagerduty",
+          type: "incident",
+          metadata: { pagerduty_service_id: "PSVC1" },
+        }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/packages/gateway/src/metrics/service-identity.test.ts
+++ b/packages/gateway/src/metrics/service-identity.test.ts
@@ -28,9 +28,9 @@ describe("buildServiceIdentityResolver", () => {
         resolve({
           service: "deploy-annotate",
           type: "deployment",
-          metadata: { nimbus_service_id: "checkout" },
+          metadata: { nimbus_service_id: "checkout", environment: "prod" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
     it("falls through when the id does not name a known service", () => {
@@ -41,7 +41,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { nimbus_service_id: "unknown-svc" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
   });
 
@@ -56,10 +56,10 @@ describe("buildServiceIdentityResolver", () => {
           type: "incident",
           metadata: { pagerduty_service_id: "PSVC2" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
-    it("returns undefined when no ServiceConfig claims the pagerduty service id", () => {
+    it("returns unknown when no ServiceConfig claims the pagerduty service id", () => {
       const resolve = buildServiceIdentityResolver(configs(baseConfig()));
       expect(
         resolve({
@@ -67,7 +67,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "incident",
           metadata: { pagerduty_service_id: "PSVC-UNMAPPED" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
   });
 
@@ -87,7 +87,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "pr",
           metadata: { repo: "acme/checkout" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
     it("resolves a gitlab repo URN via metadata.project", () => {
@@ -105,7 +105,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "pr",
           metadata: { project: "group/checkout" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
     it("resolves a jenkins URN via metadata.jobName", () => {
@@ -123,7 +123,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "ci_run",
           metadata: { jobName: "checkout-pipeline" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
     it("never matches a circleci URN (no external id in this item shape)", () => {
@@ -141,10 +141,10 @@ describe("buildServiceIdentityResolver", () => {
           type: "ci_run",
           metadata: {},
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
 
-    it("returns undefined when no repo matches", () => {
+    it("returns unknown when no repo matches", () => {
       const resolve = buildServiceIdentityResolver(configs(baseConfig()));
       expect(
         resolve({
@@ -152,7 +152,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "pr",
           metadata: { repo: "acme/some-other-repo" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
   });
 
@@ -170,7 +170,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "incident",
           metadata: { nimbus_service_id: "search", pagerduty_service_id: "PSVC1" },
         }),
-      ).toBe("search");
+      ).toEqual({ kind: "bound", serviceId: "search" });
     });
 
     it("prefers pagerduty_service_id over a repo match", () => {
@@ -192,9 +192,9 @@ describe("buildServiceIdentityResolver", () => {
         resolve({
           service: "vercel",
           type: "deployment",
-          metadata: { pagerduty_service_id: "PSVC1", repo: "acme/other" },
+          metadata: { pagerduty_service_id: "PSVC1", repo: "acme/other", environment: "prod" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
   });
 
@@ -209,10 +209,10 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { repo: "acme/checkout", target: "production" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
-    it("does not bind a deployment whose metadata.target is excluded by deployEnvironments", () => {
+    it("excludes a deployment whose metadata.target is excluded by deployEnvironments", () => {
       const resolve = buildServiceIdentityResolver(
         configs(baseConfig({ deployEnvironments: ["prod"] })),
       );
@@ -222,7 +222,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { repo: "acme/checkout", target: "preview" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "excluded" });
     });
 
     it("prefers the canonical metadata.environment over metadata.target when both are present", () => {
@@ -235,10 +235,15 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { repo: "acme/checkout", environment: "staging", target: "preview" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
-    it("binds a deployment with no environment signal at all (fail-open)", () => {
+    // F2: a deployment with no environment signal at all now resolves
+    // `excluded` (fail CLOSED) — the prior fail-open behavior is exactly
+    // what this test used to assert; see service-identity.ts's F2 doc for
+    // why an unverified "Vercel always writes target" assumption is not
+    // trustworthy enough to bind on.
+    it("F2: excludes (fails closed) a deployment with no environment signal at all", () => {
       const resolve = buildServiceIdentityResolver(
         configs(baseConfig({ deployEnvironments: ["prod"] })),
       );
@@ -248,7 +253,20 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { repo: "acme/checkout" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "excluded" });
+    });
+
+    it("F2: still binds a deployment whose metadata.target is production", () => {
+      const resolve = buildServiceIdentityResolver(
+        configs(baseConfig({ deployEnvironments: ["prod"] })),
+      );
+      expect(
+        resolve({
+          service: "vercel",
+          type: "deployment",
+          metadata: { repo: "acme/checkout", target: "production" },
+        }),
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
 
     it("does not gate a non-deployment item type even when it carries a non-matching target", () => {
@@ -261,7 +279,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "incident",
           metadata: { repo: "acme/checkout", target: "preview" },
         }),
-      ).toBe("checkout");
+      ).toEqual({ kind: "bound", serviceId: "checkout" });
     });
   });
 
@@ -280,7 +298,7 @@ describe("buildServiceIdentityResolver", () => {
         type: "incident",
         metadata: { pagerduty_service_id: "PSVC1" },
       });
-      expect(result).toBe("checkout");
+      expect(result).toEqual({ kind: "bound", serviceId: "checkout" });
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toMatchObject({
         bindingKind: "pagerduty_service_id",
@@ -312,7 +330,7 @@ describe("buildServiceIdentityResolver", () => {
         type: "pr",
         metadata: { repo: "acme/mono" },
       });
-      expect(result).toBe("checkout");
+      expect(result).toEqual({ kind: "bound", serviceId: "checkout" });
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toMatchObject({
         bindingKind: "repo_urn",
@@ -334,10 +352,81 @@ describe("buildServiceIdentityResolver", () => {
       });
       expect(warnings).toHaveLength(0);
     });
+
+    // F3: the resolver is built once and then called for every synced item —
+    // an ambiguous key hit by many items must still warn only once, not once
+    // per item.
+    it("F3: warns only once total across many items that all hit the same ambiguous key, not once per item", () => {
+      const warnings: unknown[] = [];
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({ serviceId: "checkout", pagerdutyServices: ["PSVC1"] }),
+          baseConfig({ serviceId: "checkout-mono", pagerdutyServices: ["PSVC1"], repos: [] }),
+        ),
+        (w) => warnings.push(w),
+      );
+
+      for (let i = 0; i < 50; i++) {
+        resolve({
+          service: "pagerduty",
+          type: "incident",
+          metadata: { pagerduty_service_id: "PSVC1" },
+        });
+      }
+
+      expect(warnings).toHaveLength(1);
+    });
+
+    // F4: an ambiguous binding behind a deployment that the I-1/F2
+    // environment gate excludes must not be reported — the log would
+    // otherwise assert a `chosenServiceId` for a resolve that returned
+    // nothing. Once the SAME key later actually binds, it warns exactly
+    // once, for that bound resolution only.
+    it("F4: does not warn for an ambiguous binding the environment gate excluded; warns once it actually binds", () => {
+      const warnings: unknown[] = [];
+      const resolve = buildServiceIdentityResolver(
+        configs(
+          baseConfig({
+            serviceId: "checkout",
+            pagerdutyServices: [],
+            repos: [{ provider: "github", providerId: "acme/mono" }],
+            deployEnvironments: ["prod"],
+          }),
+          baseConfig({
+            serviceId: "billing",
+            pagerdutyServices: [],
+            repos: [{ provider: "github", providerId: "acme/mono" }],
+            deployEnvironments: ["prod"],
+          }),
+        ),
+        (w) => warnings.push(w),
+      );
+
+      const excluded = resolve({
+        service: "vercel",
+        type: "deployment",
+        metadata: { repo: "acme/mono", target: "preview" },
+      });
+      expect(excluded).toEqual({ kind: "excluded" });
+      expect(warnings).toHaveLength(0);
+
+      const bound = resolve({
+        service: "vercel",
+        type: "deployment",
+        metadata: { repo: "acme/mono", target: "production" },
+      });
+      expect(bound).toEqual({ kind: "bound", serviceId: "checkout" });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        bindingKind: "repo_urn",
+        chosenServiceId: "checkout",
+        candidateServiceIds: ["checkout", "billing"],
+      });
+    });
   });
 
   describe("no match anywhere", () => {
-    it("returns undefined for an item with none of the bound fields", () => {
+    it("returns unknown for an item with none of the bound fields", () => {
       const resolve = buildServiceIdentityResolver(configs(baseConfig()));
       expect(
         resolve({
@@ -345,10 +434,10 @@ describe("buildServiceIdentityResolver", () => {
           type: "deployment",
           metadata: { uid: "dpl_123", state: "READY" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
 
-    it("returns undefined against an empty config map", () => {
+    it("returns unknown against an empty config map", () => {
       const resolve = buildServiceIdentityResolver(new Map());
       expect(
         resolve({
@@ -356,7 +445,7 @@ describe("buildServiceIdentityResolver", () => {
           type: "incident",
           metadata: { pagerduty_service_id: "PSVC1" },
         }),
-      ).toBeUndefined();
+      ).toEqual({ kind: "unknown" });
     });
   });
 });

--- a/packages/gateway/src/metrics/service-identity.ts
+++ b/packages/gateway/src/metrics/service-identity.ts
@@ -12,7 +12,27 @@ export type ServiceIdentityItem = {
   readonly metadata: Record<string, unknown>;
 };
 
-export type ServiceIdentityResolver = (item: ServiceIdentityItem) => string | undefined;
+/**
+ * F1: a bare `undefined` cannot distinguish "the deploy-environment gate
+ * explicitly excluded this item" from "nothing in the config map claims it
+ * at all" — and that ambiguity is exactly what let a gate-excluded preview
+ * deployment's `undefined` get silently re-bound by the graph populator's
+ * `?? stringField(row.metadata, "service")` fallback. The three cases are
+ * now distinguishable:
+ *   - `bound`    — a `ServiceConfig` claimed this item and it passed I-1's
+ *                  deploy-environment gate (or the gate doesn't apply).
+ *   - `excluded` — a `ServiceConfig` claimed this item but I-1 excluded it
+ *                  (non-prod environment, or F2's no-signal fail-closed
+ *                  case). The caller MUST bind nothing — never fall back.
+ *   - `unknown`  — nothing in the config map claims this item. The caller
+ *                  may still fall back to `metadata.service`, unchanged.
+ */
+export type ServiceIdentityResolution =
+  | { readonly kind: "bound"; readonly serviceId: string }
+  | { readonly kind: "excluded" }
+  | { readonly kind: "unknown" };
+
+export type ServiceIdentityResolver = (item: ServiceIdentityItem) => ServiceIdentityResolution;
 
 /** M-2: reported when two `ServiceConfig`s both claim the same binding key —
  * the resolver still picks deterministically (first by config-map iteration
@@ -94,31 +114,121 @@ function deploymentEnvironment(meta: Record<string, unknown>): string | undefine
  *
  * Only `deployment`-typed items are gated — an `incident` (or any other
  * item type) carrying `metadata.target`/`metadata.environment` by
- * coincidence is unaffected.
+ * coincidence is unaffected, and always resolves `bound` once a
+ * `ServiceConfig` claims it.
  *
- * DECISION (I-1, no-signal case): a deployment with NEITHER
- * `metadata.environment` NOR `metadata.target` is bound anyway (fail-open),
- * not excluded. Today's only two deployment sources are
- * `deployment/annotate.ts` (which always sets `metadata.environment`, and is
- * itself already DORA-gated by `deployEnvironments` before annotation) and
- * Vercel (`metadata.target`, always present in the git-integration payload
- * `mapVercelDeploymentToItem` maps). A future deployment connector that
- * emits neither key is genuinely unknown, not known-and-excluded — treating
- * "no signal" the same as "excluded" would silently drop ALL correlation for
- * that connector's deploys, a strictly worse failure mode than the narrow,
- * fixable over-emission this filter targets.
+ * F2 DECISION (no-signal case, REVISED — was fail-open): a deployment with
+ * NEITHER `metadata.environment` NOR `metadata.target` now resolves
+ * `excluded`, not `bound`. The prior fail-open reasoning leaned on Vercel
+ * "always" writing `target` — but this repo's own connector description
+ * (`packages/mcp-connectors/vercel/nimbus.extension.json`) documents
+ * `target` as `production/staging` only (no "always present" guarantee),
+ * and `vercel-deployment-mapping.ts` already treats it as possibly absent
+ * (`stringField(row, "target") ?? null`). If the Vercel API ever returns
+ * `target: null` for a preview deploy, fail-open would filter nothing while
+ * a passing test claimed it did. An unknown environment cannot be shown to
+ * be production, and a false "this deploy caused that incident" edge is
+ * worse than a missing one — so no signal now means no binding. This costs
+ * nothing real: `deployment/annotate.ts` (the CI path) already *requires*
+ * `environment` and throws without it, and Prefect's mapper
+ * (`prefect-deployment-mapping.ts`) writes no key this resolver binds on at
+ * all (no `repo`/`pagerduty_service_id`/`nimbus_service_id`), so its
+ * deployments never reached this function either before or after.
  */
-function deploymentEnvironmentAllowed(item: ServiceIdentityItem, cfg: ServiceConfig): boolean {
-  if (item.type !== "deployment") return true;
+function deploymentBindingResolution(
+  item: ServiceIdentityItem,
+  cfg: ServiceConfig,
+): ServiceIdentityResolution {
+  if (item.type !== "deployment") {
+    return { kind: "bound", serviceId: cfg.serviceId };
+  }
   const env = deploymentEnvironment(item.metadata);
-  if (env === undefined) return true;
-  return cfg.deployEnvironments.includes(env);
+  if (env === undefined) {
+    return { kind: "excluded" };
+  }
+  return cfg.deployEnvironments.includes(env)
+    ? { kind: "bound", serviceId: cfg.serviceId }
+    : { kind: "excluded" };
 }
 
 /** M-2: URN this candidate `ServiceConfig` matched, for the ambiguity warning. */
 function matchingRepoUrnKey(metadata: Record<string, unknown>, cfg: ServiceConfig): string {
   const urn = cfg.repos.find((u) => repoMetadataMatchesUrn(metadata, u));
   return urn === undefined ? "?" : `${urn.provider}:${urn.providerId}`;
+}
+
+/**
+ * F3: one entry per binding key that more than one `ServiceConfig` claims.
+ * `winner` mirrors the deterministic pick the resolution loop below makes
+ * (first by `configs` iteration order). `warned` is mutated at most once —
+ * ambiguity is a static property of the config map, so the decision to
+ * report it is made once per key for the resolver's whole lifetime, not
+ * once per item that happens to hit it (see F3 at the call sites below).
+ */
+type AmbiguousBindingCandidate = {
+  readonly warning: AmbiguousBindingWarning;
+  warned: boolean;
+};
+
+/**
+ * F3: precomputes which binding keys are ambiguous, once, from `configs`
+ * alone — independent of any item. `keysFor` extracts every key a given
+ * `ServiceConfig` claims (its `pagerdutyServices` list, or its `repos`
+ * rendered as `${provider}:${providerId}` strings); a key claimed by more
+ * than one config is ambiguous.
+ */
+function indexAmbiguousBindings(
+  configs: ReadonlyMap<string, ServiceConfig>,
+  bindingKind: AmbiguousBindingWarning["bindingKind"],
+  keysFor: (cfg: ServiceConfig) => Iterable<string>,
+): Map<string, AmbiguousBindingCandidate> {
+  const claimantsByKey = new Map<string, ServiceConfig[]>();
+  for (const cfg of configs.values()) {
+    for (const key of keysFor(cfg)) {
+      const claimants = claimantsByKey.get(key);
+      if (claimants === undefined) {
+        claimantsByKey.set(key, [cfg]);
+      } else {
+        claimants.push(cfg);
+      }
+    }
+  }
+
+  const ambiguous = new Map<string, AmbiguousBindingCandidate>();
+  for (const [key, claimants] of claimantsByKey) {
+    if (claimants.length > 1) {
+      const winner = claimants[0] as ServiceConfig;
+      ambiguous.set(key, {
+        warning: {
+          bindingKind,
+          key,
+          chosenServiceId: winner.serviceId,
+          candidateServiceIds: claimants.map((c) => c.serviceId),
+        },
+        warned: false,
+      });
+    }
+  }
+  return ambiguous;
+}
+
+/**
+ * F4: reports `candidate`'s ambiguity at most once (F3), and only for a
+ * `resolution` that actually bound — an ambiguity behind a deployment that
+ * I-1 excluded never produced the binding the warning would claim, so it
+ * must not be reported at all (the log would otherwise assert a
+ * `chosenServiceId` for a resolve that returned nothing).
+ */
+function reportAmbiguityIfBound(
+  candidate: AmbiguousBindingCandidate | undefined,
+  resolution: ServiceIdentityResolution,
+  onAmbiguousBinding: AmbiguousBindingWarner | undefined,
+): void {
+  if (candidate === undefined || candidate.warned || resolution.kind !== "bound") {
+    return;
+  }
+  candidate.warned = true;
+  onAmbiguousBinding?.(candidate.warning);
 }
 
 /**
@@ -134,27 +244,44 @@ function matchingRepoUrnKey(metadata: Record<string, unknown>, cfg: ServiceConfi
  *   3. `metadata.repo` / `metadata.project` — matched against the
  *      `ServiceConfig` whose `repos` contains a matching URN.
  *
- * A `deployment`-typed item additionally passes `deploymentEnvironmentAllowed`
- * against whichever `ServiceConfig` matched (I-1) — a non-prod deployment
- * resolves to `undefined` even though a config claims it, on every path.
+ * A `deployment`-typed item additionally passes `deploymentBindingResolution`
+ * against whichever `ServiceConfig` matched (I-1/F2) — a non-prod (or,
+ * since F2, environment-signal-less) deployment resolves `excluded` even
+ * though a config claims it, on every path.
  *
- * `onAmbiguousBinding` (M-2) fires when path 2 or 3 has more than one
- * candidate `ServiceConfig` claiming the same key; the resolution itself
- * stays deterministic (first by `configs` iteration order, unchanged).
+ * `onAmbiguousBinding` (M-2) fires when path 2 or 3's binding key has more
+ * than one candidate `ServiceConfig` claiming it; the resolution itself
+ * stays deterministic (first by `configs` iteration order, unchanged). F3:
+ * the ambiguity set is computed once, in this function body, not per item —
+ * so the callback fires at most once per ambiguous key for the resolver's
+ * lifetime, not once per item that resolves through it. F4: it only fires
+ * for a resolution that actually returned `bound`.
  *
- * Returns `undefined` when nothing binds, so the graph populator falls back
- * to `metadata.service` (today's behaviour, unchanged).
+ * Returns `{ kind: "unknown" }` when nothing in the config map claims the
+ * item — the graph populator falls back to `metadata.service` for that case
+ * only (today's behaviour, unchanged). `{ kind: "excluded" }` means a config
+ * claimed the item but I-1/F2 excluded it: the caller must bind nothing.
  */
 export function buildServiceIdentityResolver(
   configs: ReadonlyMap<string, ServiceConfig>,
   onAmbiguousBinding?: AmbiguousBindingWarner,
 ): ServiceIdentityResolver {
+  // F3: computed once here, from `configs` alone — see `indexAmbiguousBindings`.
+  const pagerdutyAmbiguity = indexAmbiguousBindings(
+    configs,
+    "pagerduty_service_id",
+    (cfg) => cfg.pagerdutyServices,
+  );
+  const repoUrnAmbiguity = indexAmbiguousBindings(configs, "repo_urn", (cfg) =>
+    cfg.repos.map((urn) => `${urn.provider}:${urn.providerId}`),
+  );
+
   return (item) => {
     const nimbusServiceId = stringField(item.metadata, "nimbus_service_id");
     if (nimbusServiceId !== undefined) {
       const cfg = configs.get(nimbusServiceId);
       if (cfg !== undefined) {
-        return deploymentEnvironmentAllowed(item, cfg) ? nimbusServiceId : undefined;
+        return deploymentBindingResolution(item, cfg);
       }
     }
 
@@ -165,15 +292,13 @@ export function buildServiceIdentityResolver(
       );
       if (claimants.length > 0) {
         const winner = claimants[0] as ServiceConfig;
-        if (claimants.length > 1) {
-          onAmbiguousBinding?.({
-            bindingKind: "pagerduty_service_id",
-            key: pagerdutyServiceId,
-            chosenServiceId: winner.serviceId,
-            candidateServiceIds: claimants.map((c) => c.serviceId),
-          });
-        }
-        return deploymentEnvironmentAllowed(item, winner) ? winner.serviceId : undefined;
+        const resolution = deploymentBindingResolution(item, winner);
+        reportAmbiguityIfBound(
+          pagerdutyAmbiguity.get(pagerdutyServiceId),
+          resolution,
+          onAmbiguousBinding,
+        );
+        return resolution;
       }
     }
 
@@ -182,17 +307,12 @@ export function buildServiceIdentityResolver(
     );
     if (repoClaimants.length > 0) {
       const winner = repoClaimants[0] as ServiceConfig;
-      if (repoClaimants.length > 1) {
-        onAmbiguousBinding?.({
-          bindingKind: "repo_urn",
-          key: matchingRepoUrnKey(item.metadata, winner),
-          chosenServiceId: winner.serviceId,
-          candidateServiceIds: repoClaimants.map((c) => c.serviceId),
-        });
-      }
-      return deploymentEnvironmentAllowed(item, winner) ? winner.serviceId : undefined;
+      const resolution = deploymentBindingResolution(item, winner);
+      const urnKey = matchingRepoUrnKey(item.metadata, winner);
+      reportAmbiguityIfBound(repoUrnAmbiguity.get(urnKey), resolution, onAmbiguousBinding);
+      return resolution;
     }
 
-    return undefined;
+    return { kind: "unknown" };
   };
 }

--- a/packages/gateway/src/metrics/service-identity.ts
+++ b/packages/gateway/src/metrics/service-identity.ts
@@ -14,6 +14,18 @@ export type ServiceIdentityItem = {
 
 export type ServiceIdentityResolver = (item: ServiceIdentityItem) => string | undefined;
 
+/** M-2: reported when two `ServiceConfig`s both claim the same binding key —
+ * the resolver still picks deterministically (first by config-map iteration
+ * order, same as before), this only makes the ambiguity observable. */
+export type AmbiguousBindingWarning = {
+  readonly bindingKind: "pagerduty_service_id" | "repo_urn";
+  readonly key: string;
+  readonly chosenServiceId: string;
+  readonly candidateServiceIds: readonly string[];
+};
+
+export type AmbiguousBindingWarner = (warning: AmbiguousBindingWarning) => void;
+
 function stringField(meta: Record<string, unknown>, key: string): string | undefined {
   const v = meta[key];
   return typeof v === "string" && v.trim() !== "" ? v : undefined;
@@ -44,6 +56,72 @@ function repoMetadataMatchesUrn(
 }
 
 /**
+ * Vercel's git-integration deployments write `target: "production" | "preview"`
+ * (`connectors/vercel-deployment-mapping.ts`). Everywhere else that speaks an
+ * environment name — `ServiceConfig.deployEnvironments`, and the explicit
+ * `metadata.environment` `deployment/annotate.ts` writes — uses the canonical
+ * `deployEnvironments` vocabulary (default `["prod"]`). This is the one alias
+ * needed to bridge the two.
+ */
+const DEPLOY_TARGET_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  production: "prod",
+});
+
+function normalizeDeployEnvironment(raw: string): string {
+  return DEPLOY_TARGET_ALIASES[raw] ?? raw;
+}
+
+/**
+ * Best-effort environment signal for a deployment item: the canonical
+ * `metadata.environment` (`deployment/annotate.ts`) takes precedence,
+ * falling back to Vercel's `metadata.target`. `undefined` means the item
+ * carries no environment signal at all.
+ */
+function deploymentEnvironment(meta: Record<string, unknown>): string | undefined {
+  const raw = stringField(meta, "environment") ?? stringField(meta, "target");
+  return raw === undefined ? undefined : normalizeDeployEnvironment(raw);
+}
+
+/**
+ * I-1: a deployment with an explicit non-prod environment signal (e.g. a
+ * Vercel preview, created on every push for a git-integrated project) must
+ * not bind to a service identity at all — binding it would let
+ * `syncTimelineEventGraph` correlate it against every incident in the
+ * 2-hour window, asserting a causal "this deploy caused that incident" edge
+ * for a deploy that never reached the target environment. Previews
+ * numerically dominate prod deploys, so left unfiltered they drown out the
+ * correlations that matter.
+ *
+ * Only `deployment`-typed items are gated — an `incident` (or any other
+ * item type) carrying `metadata.target`/`metadata.environment` by
+ * coincidence is unaffected.
+ *
+ * DECISION (I-1, no-signal case): a deployment with NEITHER
+ * `metadata.environment` NOR `metadata.target` is bound anyway (fail-open),
+ * not excluded. Today's only two deployment sources are
+ * `deployment/annotate.ts` (which always sets `metadata.environment`, and is
+ * itself already DORA-gated by `deployEnvironments` before annotation) and
+ * Vercel (`metadata.target`, always present in the git-integration payload
+ * `mapVercelDeploymentToItem` maps). A future deployment connector that
+ * emits neither key is genuinely unknown, not known-and-excluded — treating
+ * "no signal" the same as "excluded" would silently drop ALL correlation for
+ * that connector's deploys, a strictly worse failure mode than the narrow,
+ * fixable over-emission this filter targets.
+ */
+function deploymentEnvironmentAllowed(item: ServiceIdentityItem, cfg: ServiceConfig): boolean {
+  if (item.type !== "deployment") return true;
+  const env = deploymentEnvironment(item.metadata);
+  if (env === undefined) return true;
+  return cfg.deployEnvironments.includes(env);
+}
+
+/** M-2: URN this candidate `ServiceConfig` matched, for the ambiguity warning. */
+function matchingRepoUrnKey(metadata: Record<string, unknown>, cfg: ServiceConfig): string {
+  const urn = cfg.repos.find((u) => repoMetadataMatchesUrn(metadata, u));
+  return urn === undefined ? "?" : `${urn.provider}:${urn.providerId}`;
+}
+
+/**
  * Builds a `SyncContext.resolveServiceId` resolver from the
  * `[metrics.dora.<id>]` / `[ci.service.<id>]` service-identity bindings
  * (`loadNimbusServiceConfigsFromConfigDir`, `config/nimbus-toml.ts`).
@@ -56,31 +134,63 @@ function repoMetadataMatchesUrn(
  *   3. `metadata.repo` / `metadata.project` — matched against the
  *      `ServiceConfig` whose `repos` contains a matching URN.
  *
+ * A `deployment`-typed item additionally passes `deploymentEnvironmentAllowed`
+ * against whichever `ServiceConfig` matched (I-1) — a non-prod deployment
+ * resolves to `undefined` even though a config claims it, on every path.
+ *
+ * `onAmbiguousBinding` (M-2) fires when path 2 or 3 has more than one
+ * candidate `ServiceConfig` claiming the same key; the resolution itself
+ * stays deterministic (first by `configs` iteration order, unchanged).
+ *
  * Returns `undefined` when nothing binds, so the graph populator falls back
  * to `metadata.service` (today's behaviour, unchanged).
  */
 export function buildServiceIdentityResolver(
   configs: ReadonlyMap<string, ServiceConfig>,
+  onAmbiguousBinding?: AmbiguousBindingWarner,
 ): ServiceIdentityResolver {
   return (item) => {
     const nimbusServiceId = stringField(item.metadata, "nimbus_service_id");
-    if (nimbusServiceId !== undefined && configs.has(nimbusServiceId)) {
-      return nimbusServiceId;
+    if (nimbusServiceId !== undefined) {
+      const cfg = configs.get(nimbusServiceId);
+      if (cfg !== undefined) {
+        return deploymentEnvironmentAllowed(item, cfg) ? nimbusServiceId : undefined;
+      }
     }
 
     const pagerdutyServiceId = stringField(item.metadata, "pagerduty_service_id");
     if (pagerdutyServiceId !== undefined) {
-      for (const cfg of configs.values()) {
-        if (cfg.pagerdutyServices.includes(pagerdutyServiceId)) {
-          return cfg.serviceId;
+      const claimants = [...configs.values()].filter((cfg) =>
+        cfg.pagerdutyServices.includes(pagerdutyServiceId),
+      );
+      if (claimants.length > 0) {
+        const winner = claimants[0] as ServiceConfig;
+        if (claimants.length > 1) {
+          onAmbiguousBinding?.({
+            bindingKind: "pagerduty_service_id",
+            key: pagerdutyServiceId,
+            chosenServiceId: winner.serviceId,
+            candidateServiceIds: claimants.map((c) => c.serviceId),
+          });
         }
+        return deploymentEnvironmentAllowed(item, winner) ? winner.serviceId : undefined;
       }
     }
 
-    for (const cfg of configs.values()) {
-      if (cfg.repos.some((urn) => repoMetadataMatchesUrn(item.metadata, urn))) {
-        return cfg.serviceId;
+    const repoClaimants = [...configs.values()].filter((cfg) =>
+      cfg.repos.some((urn) => repoMetadataMatchesUrn(item.metadata, urn)),
+    );
+    if (repoClaimants.length > 0) {
+      const winner = repoClaimants[0] as ServiceConfig;
+      if (repoClaimants.length > 1) {
+        onAmbiguousBinding?.({
+          bindingKind: "repo_urn",
+          key: matchingRepoUrnKey(item.metadata, winner),
+          chosenServiceId: winner.serviceId,
+          candidateServiceIds: repoClaimants.map((c) => c.serviceId),
+        });
       }
+      return deploymentEnvironmentAllowed(item, winner) ? winner.serviceId : undefined;
     }
 
     return undefined;

--- a/packages/gateway/src/metrics/service-identity.ts
+++ b/packages/gateway/src/metrics/service-identity.ts
@@ -1,0 +1,88 @@
+import type { ParsedDoraRepoUrn, ServiceConfig } from "./dora-config.ts";
+
+/**
+ * The subset of an indexed item the resolver needs. Mirrors
+ * `SyncContext["resolveServiceId"]`'s parameter shape (`sync/types.ts`) —
+ * kept as a local type here so this module stays dependency-light and
+ * trivially unit-testable in isolation from the sync layer.
+ */
+export type ServiceIdentityItem = {
+  readonly service: string;
+  readonly type: string;
+  readonly metadata: Record<string, unknown>;
+};
+
+export type ServiceIdentityResolver = (item: ServiceIdentityItem) => string | undefined;
+
+function stringField(meta: Record<string, unknown>, key: string): string | undefined {
+  const v = meta[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+/**
+ * Matches an item's repo-shaped metadata against a `[metrics.dora.<id>]` /
+ * `[ci.service.<id>]` repo URN. Mirrors `repoLikeMatchesUrn` in
+ * `metrics/dora.ts`, minus its `circleci` external-id branch: this
+ * resolver's item shape (`SyncContext.resolveServiceId`) carries no
+ * external id, only metadata, so a circleci URN never matches here.
+ */
+function repoMetadataMatchesUrn(
+  metadata: Record<string, unknown>,
+  urn: ParsedDoraRepoUrn,
+): boolean {
+  switch (urn.provider) {
+    case "github":
+    case "bitbucket":
+      return metadata["repo"] === urn.providerId;
+    case "gitlab":
+      return metadata["project"] === urn.providerId || metadata["repo"] === urn.providerId;
+    case "jenkins":
+      return metadata["jobName"] === urn.providerId;
+    case "circleci":
+      return false;
+  }
+}
+
+/**
+ * Builds a `SyncContext.resolveServiceId` resolver from the
+ * `[metrics.dora.<id>]` / `[ci.service.<id>]` service-identity bindings
+ * (`loadNimbusServiceConfigsFromConfigDir`, `config/nimbus-toml.ts`).
+ *
+ * Resolution order, first match wins:
+ *   1. `metadata.nimbus_service_id` — used directly only if it names a
+ *      known service (guards against a stale/foreign id passing through).
+ *   2. `metadata.pagerduty_service_id` — matched against the `ServiceConfig`
+ *      whose `pagerdutyServices` contains it.
+ *   3. `metadata.repo` / `metadata.project` — matched against the
+ *      `ServiceConfig` whose `repos` contains a matching URN.
+ *
+ * Returns `undefined` when nothing binds, so the graph populator falls back
+ * to `metadata.service` (today's behaviour, unchanged).
+ */
+export function buildServiceIdentityResolver(
+  configs: ReadonlyMap<string, ServiceConfig>,
+): ServiceIdentityResolver {
+  return (item) => {
+    const nimbusServiceId = stringField(item.metadata, "nimbus_service_id");
+    if (nimbusServiceId !== undefined && configs.has(nimbusServiceId)) {
+      return nimbusServiceId;
+    }
+
+    const pagerdutyServiceId = stringField(item.metadata, "pagerduty_service_id");
+    if (pagerdutyServiceId !== undefined) {
+      for (const cfg of configs.values()) {
+        if (cfg.pagerdutyServices.includes(pagerdutyServiceId)) {
+          return cfg.serviceId;
+        }
+      }
+    }
+
+    for (const cfg of configs.values()) {
+      if (cfg.repos.some((urn) => repoMetadataMatchesUrn(item.metadata, urn))) {
+        return cfg.serviceId;
+      }
+    }
+
+    return undefined;
+  };
+}

--- a/packages/gateway/src/platform/assemble.test.ts
+++ b/packages/gateway/src/platform/assemble.test.ts
@@ -201,4 +201,28 @@ describe("assemblePlatformServices — in-process assembly", () => {
     services = await assemblePlatformServices(paths);
     expect(services.chatops).toBeUndefined();
   }, 30000);
+
+  // M-1: `loadNimbusServiceConfigsFromConfigDir` throws on a malformed
+  // [metrics.dora.*]/[ci.service.*] block. Before the fix, this call was
+  // unguarded at boot — a config typo aborted gateway startup entirely
+  // instead of degrading the one feature (timeline correlation) that reads it.
+  it("M-1: boots successfully despite a malformed [metrics.dora.*] block (missing required 'repos')", async () => {
+    const paths = makePaths();
+    const tomlPath = join(paths.configDir, "nimbus.toml");
+    rmSync(paths.configDir, { recursive: true, force: true });
+    mkdirSync(paths.configDir, { recursive: true });
+    writeFileSync(
+      tomlPath,
+      [
+        "[metrics.dora.checkout]",
+        // 'repos' deliberately omitted — materializeOneServiceConfig throws
+        // "missing required 'repos'" (config/service-config-toml.ts).
+        'pagerduty_services = ["PSVC1"]',
+      ].join("\n"),
+    );
+
+    services = await assemblePlatformServices(paths);
+    expect(services).toBeDefined();
+    expect(typeof services.ipc.stop).toBe("function");
+  }, 30000);
 });

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -41,6 +41,7 @@ import {
   loadNimbusPreflightFromConfigDir,
   loadNimbusQuorumFromConfigDir,
   loadNimbusScimFromConfigDir,
+  loadNimbusServiceConfigsFromConfigDir,
   loadNimbusShareHttpSink,
   loadNimbusTribalFromConfigDir,
   loadNimbusUpdaterFromConfigDir,
@@ -134,6 +135,7 @@ import { LlamaCppProvider } from "../llm/llamacpp-provider.ts";
 import { OllamaProvider } from "../llm/ollama-provider.ts";
 import { LlmRegistry } from "../llm/registry.ts";
 import { SessionMemoryStore } from "../memory/session-memory-store.ts";
+import { buildServiceIdentityResolver } from "../metrics/service-identity.ts";
 import { ensureAnchorKeypair } from "../policy/anchor-keypair.ts";
 import { partitionByAllowlist } from "../policy/connector-allowlist.ts";
 import { startPurge } from "../policy/gdpr-purge.ts";
@@ -1584,11 +1586,20 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
     identityBootRefHolder,
   });
 
+  // Timeline correlation (deployment <-> incident, `correlates_with`): binds an item's
+  // PagerDuty/repo metadata to a nimbus service id via the [metrics.dora.<id>] /
+  // [ci.service.<id>] config, so cross-provider service identifiers (PagerDuty's
+  // "PSVC1" vs. a forge's "checkout-web") resolve to the same `ServiceConfig.serviceId`.
+  const resolveServiceId = buildServiceIdentityResolver(
+    loadNimbusServiceConfigsFromConfigDir(paths.configDir),
+  );
+
   const syncBase: SyncContext = {
     vault,
     db,
     logger: syncLogger,
     rateLimiter,
+    resolveServiceId,
     ...teamCredentialExtras,
   };
   const syncContext: SyncContext = scheduleItemEmbedding

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -1590,9 +1590,34 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   // PagerDuty/repo metadata to a nimbus service id via the [metrics.dora.<id>] /
   // [ci.service.<id>] config, so cross-provider service identifiers (PagerDuty's
   // "PSVC1" vs. a forge's "checkout-web") resolve to the same `ServiceConfig.serviceId`.
-  const resolveServiceId = buildServiceIdentityResolver(
-    loadNimbusServiceConfigsFromConfigDir(paths.configDir),
-  );
+  //
+  // M-1: `loadNimbusServiceConfigsFromConfigDir` throws on any malformed
+  // `[metrics.dora.*]`/`[ci.service.*]` block (missing `repos`, unknown key, bad
+  // URN/regex, out-of-range window, invalid env name). This is the only call site
+  // reached unconditionally at boot — degrade to no service-identity bindings
+  // (timeline correlation falls back to plain `metadata.service`, as before this
+  // feature existed) rather than aborting gateway startup over a config typo.
+  let serviceConfigs: ReturnType<typeof loadNimbusServiceConfigsFromConfigDir>;
+  try {
+    serviceConfigs = loadNimbusServiceConfigsFromConfigDir(paths.configDir);
+  } catch (err) {
+    syncLogger.warn(
+      { err },
+      "failed to load [metrics.dora.*]/[ci.service.*] service configs — timeline " +
+        "correlation will fall back to metadata.service only until this is fixed",
+    );
+    serviceConfigs = new Map();
+  }
+  // M-2: two ServiceConfigs claiming the same pagerdutyServices entry or repo URN
+  // (a monorepo) resolve deterministically but silently otherwise; surface it the
+  // same way `loadNimbusServiceConfigsFromConfigDir` already warns on duplicate ids.
+  const resolveServiceId = buildServiceIdentityResolver(serviceConfigs, (w) => {
+    syncLogger.warn(
+      { ...w },
+      "ambiguous service-identity binding — multiple [metrics.dora.*]/[ci.service.*] " +
+        "configs claim the same key; picked the first by config order",
+    );
+  });
 
   const syncBase: SyncContext = {
     vault,

--- a/packages/gateway/src/sync/types.ts
+++ b/packages/gateway/src/sync/types.ts
@@ -21,12 +21,23 @@ export interface SyncContext {
    * [metrics.dora.<id>] / [ci.service.<id>] bindings. Optional: when absent
    * the graph populator falls back to `metadata.service`, so connectors and
    * tests that predate this compile and behave unchanged.
+   *
+   * F1: the return shape mirrors `metrics/service-identity.ts`'s
+   * `ServiceIdentityResolution` / `graph/graph-populator.ts`'s
+   * `ResolveServiceIdResult` — declared structurally here too rather than
+   * imported, keeping this module dependency-light. `excluded` (a config
+   * claimed the item but the I-1/F2 deploy-environment gate rejected it)
+   * must bind nothing; only `unknown` (nothing claims the item) falls back
+   * to `metadata.service`.
    */
   resolveServiceId?: (item: {
     readonly service: string;
     readonly type: string;
     readonly metadata: Record<string, unknown>;
-  }) => string | undefined;
+  }) =>
+    | { readonly kind: "bound"; readonly serviceId: string }
+    | { readonly kind: "excluded" }
+    | { readonly kind: "unknown" };
 }
 
 export interface Syncable {

--- a/packages/gateway/src/sync/types.ts
+++ b/packages/gateway/src/sync/types.ts
@@ -16,6 +16,17 @@ export interface SyncContext {
   credentialFor: (service: string) => { credential: "personal" | "team"; teamEntry?: string };
   /** Gate-routed localOperator team list drain (I19). Returns raw items or throws an actionable error. */
   runTeamList: (req: { entry: string; service: string; listToolId: string }) => Promise<unknown[]>;
+  /**
+   * Resolves an indexed item to its nimbus service id using the
+   * [metrics.dora.<id>] / [ci.service.<id>] bindings. Optional: when absent
+   * the graph populator falls back to `metadata.service`, so connectors and
+   * tests that predate this compile and behave unchanged.
+   */
+  resolveServiceId?: (item: {
+    readonly service: string;
+    readonly type: string;
+    readonly metadata: Record<string, unknown>;
+  }) => string | undefined;
 }
 
 export interface Syncable {

--- a/packages/gateway/test/integration/graph/pr-commit-edge.test.ts
+++ b/packages/gateway/test/integration/graph/pr-commit-edge.test.ts
@@ -13,6 +13,7 @@ describe("graph-populator: pr → commit merged_as edge", () => {
       service: "github",
       type: "pr",
       title: "Add retry logic",
+      bodyPreview: null,
       authorId: null,
       metadata: {
         repo: "nimbus-agent/payments",
@@ -41,6 +42,7 @@ describe("graph-populator: pr → commit merged_as edge", () => {
       service: "github",
       type: "pr",
       title: "WIP",
+      bodyPreview: null,
       authorId: null,
       metadata: { repo: "nimbus-agent/payments", merged: false },
     });
@@ -62,6 +64,7 @@ describe("graph-populator: pr → commit merged_as edge", () => {
       service: "github",
       type: "pr",
       title: "Squash-merge with no SHA echoed back",
+      bodyPreview: null,
       authorId: null,
       metadata: { repo: "nimbus-agent/payments", merged: true },
     });

--- a/packages/mcp-connectors/vercel/README.md
+++ b/packages/mcp-connectors/vercel/README.md
@@ -25,8 +25,8 @@ touches the vault. The gateway-side syncable
 (`packages/gateway/src/connectors/vercel-sync.ts`) walks
 `GET /v6/deployments?limit=100` (paginated via `pagination.next`, capped 20
 pages) and upserts each deployment with metadata `{ uid, name, state, target,
-url, inspector_url, commit_sha, commit_message, commit_ref, pr_id, creator,
-created_at, canonical_url }`.
+url, inspector_url, commit_sha, commit_message, commit_ref, pr_id, repo,
+creator, created_at, canonical_url }`.
 
 Vault keys:
 


### PR DESCRIPTION
## What this does

Three graph relation types — `resolves`, `mentions`, `correlates_with` — were declared in the SQLite schema but written by **no populator**. Any query traversing them returned zero rows on every index, forever. This makes them real, so the upcoming `nimbus why <file>:<line>` agent (step 1b) can answer "who wrote this, why, what drove it, what depends on it" from the local index.

| Edge | Traversal |
| --- | --- |
| `resolves` | PR title+body → issue (numeric refs and ticket keys, both forges) |
| `mentions` | chat message → issue / commit |
| `correlates_with` | deployment → incident, 2h same-service window |

Also lands: `incident` and `deployment` graph entities (which had **never** existed, despite both being indexed as items and listed in `ITEM_LINKED_ENTITY_TYPES`), a service-identity binding so cross-provider identifiers resolve to one nimbus service, and a transactional backfill so the new edges reach already-indexed history rather than only newly-synced data.

Spec: `docs/superpowers/specs/2026-07-23-nimbus-why-lens-design.md`
Plan: `docs/superpowers/plans/2026-07-23-why-lens-1a-populator-edges.md`

## Scope

No new migration, no new table, no new invariant, no new HITL action type, no CLI/IPC surface. Every relation type and table already existed — this is populator work.

## The reason this is larger than "emit three edges"

Every per-task suite passed against **fixtures that no connector emits**. Whole-branch review caught that two of the three edge types were correct in code and unreachable against real connector data:

- `correlates_with` keyed on `metadata.service`, which **no connector writes** — PagerDuty writes `pagerduty_service_id`, Vercel writes `name`, the CI path writes `nimbus_service_id` and bypassed the populator entirely.
- The `resolves` numeric path built `${repo}#${n}` (the **PR** externalId shape) while GitHub indexes issues as `${repo}#issue-${n}`.

Both are fixed and verified end-to-end against metadata copied verbatim from connector source. A standing rule is now recorded in the plan: **regression tests are seeded from the connector's own `externalId`/metadata builders, never hand-written shapes.**

Three further defects were each correct in isolation and defeated by another part of this same branch — the backfill deleted the edges the resolver created; the `expert.ts` gap-note probe was satisfied by this branch's own `resolves` edges; the environment gate was undone by a `?? metadata.service` fallback. All three passed their own tests.

## Correctness choices worth review

- **`occurredAtForItem` throws** rather than defaulting to `Date.now()`. A fabricated timestamp would feed the correlation window and produce a *confidently wrong* causal claim; an exception is loud and local. Unreachable on the production path (`upsertIndexedItem` writes the row first, synchronously, on the same handle).
- **The deployment environment gate fails closed.** A deployment with no derivable environment does not correlate. The alternative rested on "Vercel always writes `target`", which this repo's own connector description contradicts (`target (production/staging)`). Fail-closed costs nothing real — the CI path *requires* `environment`, and Prefect can't bind on any key anyway — and removes a dependency on an unverified API vocabulary.
- **No `LIMIT` on counterpart lookup.** Each side clears its whole direction before re-emitting, so a cap made `clear` and `emit` asymmetric and silently destroyed edges the other side created (reproduced: 30 → 20 after a re-sync). The 2h same-service window already bounds the result.
- **`${order}` interpolation** in `timelineCounterparts` is the sole exception to the bound-parameter rule — SQL keywords cannot be bound, and it is re-derived through a ternary from an `"ASC" | "DESC"` union, so it holds even if the parameter type widens.
- **`SyncContext.resolveServiceId` is optional.** ~80 connectors construct `SyncContext`; absence preserves prior behaviour exactly.

## Verification

`tsc --noEmit` clean · **762 tests, 0 fail** · `biome` clean over 2920 files · `audit:boundaries`, `audit:invariants`, `audit:any`, `audit:cross-platform`, `audit:doc-refs`, `audit:status-drift`, `audit:readme-cli`, `lint:markdown` all pass.

Every retirement guard was mutation-tested: reverting it fails exactly its own test and no other.

Rebased onto `main` with zero conflicts; the code diff is byte-identical pre- and post-rebase.

## Known-deferred (recorded for step 1b)

- `annotateDeployment`'s DORA eligibility uses a raw `includes()` with no `production → prod` alias, so it now disagrees with correlation about "production".
- `subIncidentResolved` still has no query of its own; it goes silent the day something emits `resolves → incident`. Pre-existing structure, unchanged here.
- Ticket-key extraction matches prose (`UTF-8`, `RFC-2119`, `SHA-256`) — a precision issue, each costing one unindexed scan.
- `REGRAPH_TYPE_ORDER` omits `obsidian_note` (near-zero risk: ordering only matters when the target entity does not yet exist).
- `regraphAllItems` has no CLI surface yet — `nimbus index regraph` is step 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Graph relationships now capture issue resolutions, message mentions, and incident–deployment correlations.
  - Added configurable service identity matching for more accurate deployment and incident associations.
  - Added graph backfill support for existing indexed data.
  - Vercel deployment records now include repository information.

- **Bug Fixes**
  - Resynchronizing items no longer removes unrelated relationships.
  - Malformed metrics configuration no longer prevents gateway startup.

- **Documentation**
  - Added design and implementation plans for the Why Lens and `nimbus why` experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->