### PR TITLE
docs: Stage 2 re-cut design + PR 1 consumption plan

### DIFF
--- a/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
@@ -22,10 +22,12 @@
 ### Task 0: Worktree + dependency bump
 
 **Files:**
+
 - Modify: `package.json` (devDependencies)
 - Modify: `bun.lock` (via `bun install`)
 
 **Interfaces:**
+
 - Produces: a workspace where `client.sessionList`, `client.connectorListStatus`, `client.gatewayPing` typecheck.
 
 - [ ] **Step 1: Create the worktree and install**
@@ -60,6 +62,7 @@ git commit -m "build: bump @nimbus-dev/client to ^0.11.0 (Stage 1 surface)"
 ### Task 1: Sessions via `sessionList()` + querySql guard
 
 **Files:**
+
 - Modify: `src/extension.ts` (delete `SESSIONS_SQL` at :70-74, rewrite `loadSessions` at :436-453, drop the `parseSessionRow` import at :52)
 - Modify: `src/sidebar/sessions.ts` (delete `parseSessionRow`; keep `SessionSummary`, `sessionToItem`)
 - Modify: `test/unit/sessions.test.ts` (drop `parseSessionRow` describe-block)
@@ -67,6 +70,7 @@ git commit -m "build: bump @nimbus-dev/client to ^0.11.0 (Stage 1 surface)"
 - Create: `test/unit/no-raw-sql-guard.test.ts`
 
 **Interfaces:**
+
 - Consumes: `client.sessionList(): Promise<{ sessions: SessionListEntry[] }>` where `SessionListEntry` is structurally identical to the local `SessionSummary`.
 - Produces: `loadSessions(): Promise<SessionSummary[]>` unchanged in signature — `createSessionsView` needs no change.
 
@@ -183,12 +187,14 @@ git commit -m "feat(sessions): consume session.list; delete the querySql hack + 
 ### Task 2: Connector health in the status bar
 
 **Files:**
+
 - Create: `src/status-bar/connector-health.ts`
 - Create: `test/unit/connector-health.test.ts`
 - Modify: `src/extension.ts` (poll + feed `renderStatusBar`)
 - Modify: `test/unit/extension.test.ts` (one new integration test)
 
 **Interfaces:**
+
 - Consumes: `client.connectorListStatus(): Promise<ConnectorSyncStatus[]>` (`status: "ok" | "syncing" | "paused" | "backoff" | "error"`, `enabled: boolean`, `serviceId: string`).
 - Produces: `summarizeConnectorHealth(statuses: ConnectorSyncStatus[]): { count: number; names: string[] }` — degraded = `enabled && (status === "error" || status === "backoff")`, names sorted for deterministic rendering. Feeds the existing `StatusBarInputs.degradedConnectorCount/-Names` (`src/status-bar/status-bar-item.ts:7-8`), currently hardwired to `0`/`[]` at `src/extension.ts:211-212`.
 
@@ -370,11 +376,13 @@ git commit -m "feat(status-bar): live degraded-connector count via connector.lis
 ### Task 3: `gatewayPing` in the Troubleshoot report
 
 **Files:**
+
 - Modify: `src/connection/troubleshooter.ts` (optional `ping` input, connected-state message)
 - Modify: `test/unit/troubleshooter.test.ts` (confirm exact name with `ls test/unit | grep trouble`)
 - Modify: `src/extension.ts:828-846` (`nimbus.troubleshootConnection` handler)
 
 **Interfaces:**
+
 - Consumes: `client.gatewayPing(): Promise<{ version: string; uptime: number }>` (extra fields ignored).
 - Produces: `buildTroubleshooter(state, opts)` where `opts` gains `ping?: { ok: true; version: string; uptime: number } | { ok: false; error: string }`. Absent `ping` keeps today's exact output (all existing tests must pass unmodified).
 

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
@@ -1,0 +1,535 @@
+# Stage 2 PR 1 — Consume the Stage 1 client surface in nimbus-vscode
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump `@nimbus-dev/client` to `^0.11.0` and consume it: sessions via `sessionList()` (deleting the `querySql` hack), connector health in the status bar via `connectorListStatus()`, and a live `gatewayPing()` in the Troubleshoot report.
+
+**Architecture:** All changes live in `nimbus-vscode` (repo `C:\gitrep\nimbus-vscode`). The extension's `activateWithDeps(ctx, deps)` is fully dependency-injected and tested through fake deps in `test/unit/extension.test.ts` (`makeFakeClient`). Pure logic goes in small modules (`src/status-bar/`, `src/connection/`) with their own unit tests; `extension.ts` only wires.
+
+**Tech Stack:** TypeScript strict, esbuild bundle, vitest (run via `bunx vitest run`), Biome. Client: `@nimbus-dev/client` 0.11.0 (`sessionList(): Promise<{sessions: {sessionId; lastWriteAt; chunkCount}[]}>`, `connectorListStatus(): Promise<ConnectorSyncStatus[]>`, `gatewayPing(): Promise<{version; uptime; ...}>`).
+
+## Global Constraints
+
+- Repo: `C:\gitrep\nimbus-vscode`; branch `dev/asafgolombek/stage2-pr1-consume-011` in a worktree under `.claude/worktrees/`. Never commit on `main`.
+- Fresh worktree ⇒ `bun install` FIRST (phantom type errors otherwise).
+- `bun run lint` misreports in `.claude/worktrees` in the Nimbus repo; in nimbus-vscode `bunx biome check .` is the safe form.
+- Full local gate set before the first push: `bun run typecheck && bunx biome check . && bun run test && bun run build && bun run check-bundle && bun run check-settings-docs`.
+- No `any`; `exactOptionalPropertyTypes` is on (use conditional spreads, see `src/sidebar/agents.ts:56`).
+- The user merges the PR; the agent opens it.
+
+---
+
+### Task 0: Worktree + dependency bump
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+- Modify: `bun.lock` (via `bun install`)
+
+**Interfaces:**
+- Produces: a workspace where `client.sessionList`, `client.connectorListStatus`, `client.gatewayPing` typecheck.
+
+- [ ] **Step 1: Create the worktree and install**
+
+```bash
+cd /c/gitrep/nimbus-vscode
+git worktree add .claude/worktrees/stage2-pr1 -b dev/asafgolombek/stage2-pr1-consume-011
+cd .claude/worktrees/stage2-pr1
+bun install
+```
+
+- [ ] **Step 2: Bump the client**
+
+In `package.json` devDependencies change `"@nimbus-dev/client": "^0.6.0"` → `"^0.11.0"`, then:
+
+```bash
+bun install
+bun run typecheck
+```
+
+Expected: typecheck PASS (0.11.0 is additive over 0.6.0).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "build: bump @nimbus-dev/client to ^0.11.0 (Stage 1 surface)"
+```
+
+---
+
+### Task 1: Sessions via `sessionList()` + querySql guard
+
+**Files:**
+- Modify: `src/extension.ts` (delete `SESSIONS_SQL` at :70-74, rewrite `loadSessions` at :436-453, drop the `parseSessionRow` import at :52)
+- Modify: `src/sidebar/sessions.ts` (delete `parseSessionRow`; keep `SessionSummary`, `sessionToItem`)
+- Modify: `test/unit/sessions.test.ts` (drop `parseSessionRow` describe-block)
+- Modify: `test/unit/extension.test.ts:671-700` (fake `sessionList` instead of `querySql`)
+- Create: `test/unit/no-raw-sql-guard.test.ts`
+
+**Interfaces:**
+- Consumes: `client.sessionList(): Promise<{ sessions: SessionListEntry[] }>` where `SessionListEntry` is structurally identical to the local `SessionSummary`.
+- Produces: `loadSessions(): Promise<SessionSummary[]>` unchanged in signature — `createSessionsView` needs no change.
+
+- [ ] **Step 1: Write the failing guard test**
+
+`test/unit/no-raw-sql-guard.test.ts`:
+
+```ts
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+// Stage 1 exposed typed methods for what the extension used to reach via raw
+// SQL. Guard the call shape (`querySql(`), not the bare identifier, so a
+// leftover import alone cannot satisfy the test in reverse.
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listTsFiles(p));
+    else if (entry.name.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+describe("no raw-SQL client calls in src/", () => {
+  test("querySql( appears nowhere in src/", () => {
+    const offenders = listTsFiles(join(__dirname, "..", "..", "src")).filter((f) =>
+      readFileSync(f, "utf8").includes("querySql("),
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+bunx vitest run test/unit/no-raw-sql-guard.test.ts
+```
+
+Expected: FAIL — offenders contains `src/extension.ts` (the `client.querySql(SESSIONS_SQL)` call).
+
+- [ ] **Step 3: Rewrite the two extension tests to the new surface**
+
+In `test/unit/extension.test.ts` replace the `querySql` fakes (lines ~671-700):
+
+```ts
+test("the registered sessions provider lists sessions via sessionList", async () => {
+  const sessionList = vi.fn(async () => ({
+    sessions: [{ sessionId: "abc-123", lastWriteAt: 1_700_000_000_000, chunkCount: 3 }],
+  }));
+  const h = await activateConnected({
+    openClient: makeFakeClient({ sessionList } as unknown as Partial<ClientLike>),
+  });
+  // ...same provider-lookup + getChildren assertions as the current test body,
+  // asserting one row labelled "Session abc-123".slice-style short id...
+  expect(sessionList).toHaveBeenCalled();
+});
+
+test("the sessions provider shows an error row when sessionList fails", async () => {
+  const sessionList = vi.fn(async () => {
+    throw new Error("boom");
+  });
+  // ...same error-row assertion as the current querySql-failure test...
+  expect(sessionList).toHaveBeenCalled();
+});
+```
+
+(Keep the existing surrounding harness code — only the faked method changes. Mirror the current test bodies exactly; they already assert the provider rows.)
+
+- [ ] **Step 4: Implement**
+
+`src/extension.ts` — delete the `SESSIONS_SQL` const (lines 70-74) and rewrite `loadSessions`:
+
+```ts
+const loadSessions = async (): Promise<SessionSummary[]> => {
+  const client = nimbus();
+  if (client === undefined) return [];
+  try {
+    const { sessions } = await client.sessionList();
+    return sessions;
+  } catch (e) {
+    // e.g. an older Gateway without session.list. Log a trail, then rethrow
+    // so the view renders its "Failed to load sessions" row.
+    log.warn(`loadSessions sessionList failed: ${errMsg(e)}`);
+    throw e;
+  }
+};
+```
+
+Update the import at :52 to `import type { SessionSummary } from "./sidebar/sessions.js";` and drop the now-stale comment block above `createSessionsView` (the "swap for a typed client.listSessions()" note — it happened).
+
+`src/sidebar/sessions.ts` — delete `parseSessionRow` and its `asFiniteNumber, asRecord` import (keep `formatRelativeTime`); `test/unit/sessions.test.ts` — delete the `parseSessionRow` describe-block.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+bunx vitest run test/unit/no-raw-sql-guard.test.ts test/unit/sessions.test.ts test/unit/extension.test.ts
+bun run typecheck
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u test/unit/no-raw-sql-guard.test.ts
+git commit -m "feat(sessions): consume session.list; delete the querySql hack + guard"
+```
+
+---
+
+### Task 2: Connector health in the status bar
+
+**Files:**
+- Create: `src/status-bar/connector-health.ts`
+- Create: `test/unit/connector-health.test.ts`
+- Modify: `src/extension.ts` (poll + feed `renderStatusBar`)
+- Modify: `test/unit/extension.test.ts` (one new integration test)
+
+**Interfaces:**
+- Consumes: `client.connectorListStatus(): Promise<ConnectorSyncStatus[]>` (`status: "ok" | "syncing" | "paused" | "backoff" | "error"`, `enabled: boolean`, `serviceId: string`).
+- Produces: `summarizeConnectorHealth(statuses: ConnectorSyncStatus[]): { count: number; names: string[] }` — degraded = `enabled && (status === "error" || status === "backoff")`, names sorted for deterministic rendering. Feeds the existing `StatusBarInputs.degradedConnectorCount/-Names` (`src/status-bar/status-bar-item.ts:7-8`), currently hardwired to `0`/`[]` at `src/extension.ts:211-212`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+`test/unit/connector-health.test.ts`:
+
+```ts
+import type { ConnectorSyncStatus } from "@nimbus-dev/client";
+import { describe, expect, test } from "vitest";
+import { summarizeConnectorHealth } from "../../src/status-bar/connector-health.js";
+
+function status(over: Partial<ConnectorSyncStatus>): ConnectorSyncStatus {
+  return {
+    serviceId: "github",
+    status: "ok",
+    lastSyncAt: null,
+    nextSyncAt: null,
+    intervalMs: 60000,
+    itemCount: 0,
+    lastError: null,
+    consecutiveFailures: 0,
+    depth: "summary",
+    enabled: true,
+    ...over,
+  };
+}
+
+describe("summarizeConnectorHealth", () => {
+  test("error and backoff count as degraded, sorted by serviceId", () => {
+    const r = summarizeConnectorHealth([
+      status({ serviceId: "slack", status: "error" }),
+      status({ serviceId: "github", status: "backoff" }),
+      status({ serviceId: "jira", status: "ok" }),
+    ]);
+    expect(r).toEqual({ count: 2, names: ["github", "slack"] });
+  });
+
+  test("disabled connectors never count", () => {
+    const r = summarizeConnectorHealth([status({ status: "error", enabled: false })]);
+    expect(r).toEqual({ count: 0, names: [] });
+  });
+
+  test("paused and syncing are not degraded", () => {
+    const r = summarizeConnectorHealth([
+      status({ status: "paused" }),
+      status({ serviceId: "gitlab", status: "syncing" }),
+    ]);
+    expect(r).toEqual({ count: 0, names: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+bunx vitest run test/unit/connector-health.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the pure helper**
+
+`src/status-bar/connector-health.ts`:
+
+```ts
+import type { ConnectorSyncStatus } from "@nimbus-dev/client";
+
+// A connector is degraded when it is enabled but its scheduler has given up or
+// is backing off. paused/syncing are user-intended or transient, not degraded.
+export function summarizeConnectorHealth(statuses: readonly ConnectorSyncStatus[]): {
+  count: number;
+  names: string[];
+} {
+  const names = statuses
+    .filter((s) => s.enabled && (s.status === "error" || s.status === "backoff"))
+    .map((s) => s.serviceId)
+    .sort();
+  return { count: names.length, names };
+}
+```
+
+- [ ] **Step 4: Run unit test to verify it passes**
+
+```bash
+bunx vitest run test/unit/connector-health.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire the poll in `extension.ts` (test-first)**
+
+Add to `test/unit/extension.test.ts`, next to the existing status-bar tests:
+
+```ts
+test("degraded connectors reach the status bar text", async () => {
+  const connectorListStatus = vi.fn(async () => [
+    // one enabled error connector — same literal shape as ConnectorSyncStatus
+    {
+      serviceId: "slack", status: "error", lastSyncAt: null, nextSyncAt: null,
+      intervalMs: 60000, itemCount: 0, lastError: "401", consecutiveFailures: 3,
+      depth: "summary", enabled: true,
+    },
+  ]);
+  const h = await activateConnected({
+    openClient: makeFakeClient({ connectorListStatus } as unknown as Partial<ClientLike>),
+  });
+  await flushAsync(); // however the file settles promises (see egress badge tests)
+  expect(connectorListStatus).toHaveBeenCalled();
+  expect(statusItemOf(h).text).toContain("1 degraded");
+});
+```
+
+(Reuse the file's existing helpers for activation, promise settling, and reading the status item — mirror the egress-badge test immediately above it.)
+
+Then in `src/extension.ts`, next to the egress poll (after line ~204):
+
+```ts
+let connectorHealth = { count: 0, names: [] as string[] };
+let connectorPollSeq = 0;
+const pollConnectorHealth = async (): Promise<void> => {
+  const mine = ++connectorPollSeq;
+  const client = nimbus();
+  if (connection.current().kind !== "connected" || client === undefined) {
+    connectorHealth = { count: 0, names: [] };
+    return;
+  }
+  try {
+    const statuses = await client.connectorListStatus();
+    if (mine !== connectorPollSeq) return;
+    connectorHealth = summarizeConnectorHealth(statuses);
+  } catch (e) {
+    if (mine !== connectorPollSeq) return;
+    log.warn(`connectorListStatus poll failed: ${errMsg(e)}`);
+    connectorHealth = { count: 0, names: [] };
+  }
+  statusBar.update(currentStatusInputs());
+};
+```
+
+Refactor `renderStatusBar` so both paths share one input builder:
+
+```ts
+const currentStatusInputs = (): StatusBarInputs => ({
+  connection: connection.current(),
+  profile: "",
+  degradedConnectorCount: connectorHealth.count,
+  degradedConnectorNames: connectorHealth.names,
+  pendingHitlCount,
+  autoStartGateway: settings.autoStartGateway(),
+});
+const renderStatusBar = (_s: ConnectionState): void => {
+  statusBar.update(currentStatusInputs());
+  void pollEgressBadge();
+  void pollConnectorHealth();
+};
+```
+
+(`StatusBarInputs` is exported from `src/status-bar/status-bar-item.ts`; import it as a type. `renderStatusBar` keeps its `(s)` parameter shape at call sites — use `connection.current()` internally.) Add `void pollConnectorHealth()` inside the existing `setInterval` callback alongside `pollEgressBadge` (both intervals: initial call at :204 and the `statusBarPollMs` re-create at :416).
+
+- [ ] **Step 6: Run tests**
+
+```bash
+bunx vitest run test/unit/connector-health.test.ts test/unit/extension.test.ts test/unit/status-bar.test.ts
+bun run typecheck
+```
+
+Expected: PASS (also run `test/unit/status-bar-item.test.ts` if that is the actual filename — check `ls test/unit | grep status`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -u src/status-bar/connector-health.ts test/unit/connector-health.test.ts
+git commit -m "feat(status-bar): live degraded-connector count via connector.listStatus"
+```
+
+---
+
+### Task 3: `gatewayPing` in the Troubleshoot report
+
+**Files:**
+- Modify: `src/connection/troubleshooter.ts` (optional `ping` input, connected-state message)
+- Modify: `test/unit/troubleshooter.test.ts` (confirm exact name with `ls test/unit | grep trouble`)
+- Modify: `src/extension.ts:828-846` (`nimbus.troubleshootConnection` handler)
+
+**Interfaces:**
+- Consumes: `client.gatewayPing(): Promise<{ version: string; uptime: number }>` (extra fields ignored).
+- Produces: `buildTroubleshooter(state, opts)` where `opts` gains `ping?: { ok: true; version: string; uptime: number } | { ok: false; error: string }`. Absent `ping` keeps today's exact output (all existing tests must pass unmodified).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the troubleshooter test file:
+
+```ts
+const CONNECTED = { kind: "connected", socketPath: "/tmp/nimbus.sock" } as const;
+const BASE = { autoStartGateway: false, platform: "linux" as NodeJS.Platform };
+
+test("connected + ping ok reports gateway version and uptime", () => {
+  const r = buildTroubleshooter(CONNECTED, {
+    ...BASE,
+    ping: { ok: true, version: "0.24.0", uptime: 5 * 60_000 },
+  });
+  expect(r.level).toBe("info");
+  expect(r.message).toContain("v0.24.0");
+  expect(r.message).toContain("5 min");
+});
+
+test("connected + ping failure warns: socket up, gateway unresponsive", () => {
+  const r = buildTroubleshooter(CONNECTED, {
+    ...BASE,
+    ping: { ok: false, error: "timeout" },
+  });
+  expect(r.level).toBe("warn");
+  expect(r.message).toContain("not responding");
+  expect(r.message).toContain("timeout");
+  expect(r.actions.map((a) => a.label)).toContain("Reconnect Now");
+});
+
+test("connected without ping input keeps the legacy message", () => {
+  const r = buildTroubleshooter(CONNECTED, BASE);
+  expect(r.message).toBe("Connected to the Gateway at /tmp/nimbus.sock.");
+});
+```
+
+- [ ] **Step 2: Run to verify the two new tests fail**
+
+```bash
+bunx vitest run test/unit/troubleshooter.test.ts
+```
+
+Expected: 2 FAIL (unknown `ping` option / unchanged message), legacy test PASS.
+
+- [ ] **Step 3: Implement**
+
+In `src/connection/troubleshooter.ts`:
+
+```ts
+export type PingOutcome =
+  | { ok: true; version: string; uptime: number }
+  | { ok: false; error: string };
+
+export function buildTroubleshooter(
+  state: ConnectionState,
+  opts: { autoStartGateway: boolean; platform: NodeJS.Platform; ping?: PingOutcome },
+): TroubleshootReport {
+  switch (state.kind) {
+    case "connected": {
+      const ping = opts.ping;
+      if (ping !== undefined && !ping.ok) {
+        return {
+          level: "warn",
+          message: `Socket ${state.socketPath} is connected, but the Gateway is not responding to ping: ${ping.error}.`,
+          actions: [RECONNECT, OPEN_LOGS],
+        };
+      }
+      if (ping !== undefined) {
+        const min = Math.round(ping.uptime / 60_000);
+        return {
+          level: "info",
+          message: `Connected to the Gateway at ${state.socketPath} — v${ping.version}, up ${min} min.`,
+          actions: [OPEN_LOGS],
+        };
+      }
+      return {
+        level: "info",
+        message: `Connected to the Gateway at ${state.socketPath}.`,
+        actions: [OPEN_LOGS],
+      };
+    }
+    // ...remaining cases unchanged...
+  }
+}
+```
+
+In `src/extension.ts` `nimbus.troubleshootConnection` (:828), before `buildTroubleshooter`:
+
+```ts
+const state = connection.current();
+let ping: PingOutcome | undefined;
+const client = nimbus();
+if (state.kind === "connected" && client !== undefined) {
+  try {
+    const p = await client.gatewayPing();
+    ping = { ok: true, version: p.version, uptime: p.uptime };
+  } catch (e) {
+    ping = { ok: false, error: errMsg(e) };
+  }
+}
+const report = buildTroubleshooter(state, {
+  autoStartGateway: settings.autoStartGateway(),
+  platform: process.platform,
+  ...(ping !== undefined ? { ping } : {}),
+});
+```
+
+(Import `PingOutcome` as a type. The conditional spread keeps `exactOptionalPropertyTypes` happy.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bunx vitest run test/unit/troubleshooter.test.ts test/unit/extension.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(troubleshoot): live gateway.ping health in the connection report"
+```
+
+---
+
+### Task 4: Full gates, push, PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full local gate set**
+
+```bash
+bun run typecheck && bunx biome check . && bun run test && bun run build && bun run check-bundle && bun run check-settings-docs
+```
+
+Expected: every gate PASS. Fix locally before any push — never push-and-see.
+
+- [ ] **Step 2: Whole-branch review**
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+Confirm: 4-5 commits, no stray files (never `git add -A`), no `settings.local.json`.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin dev/asafgolombek/stage2-pr1-consume-011
+gh pr create --repo nimbus-agent/nimbus-vscode --title "feat: consume the Stage 1 client surface (client ^0.11.0)" --body "..."
+```
+
+PR body covers: the ^0.6.0 caret pin meant zero Stage 1 methods were visible; sessions now use \`session.list\` (querySql hack deleted + guard test); status bar shows live degraded-connector state via \`connector.listStatus\` (making the \`statusBarPollMs\` description true); Troubleshoot includes a live \`gateway.ping\`. Reference the ecosystem roadmap Stage 2 and the spec. End with the 🤖 Generated-with-Claude-Code footer. The user merges.

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md
@@ -178,7 +178,7 @@ Expected: all PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add -u test/unit/no-raw-sql-guard.test.ts
+git add -u && git add test/unit/no-raw-sql-guard.test.ts
 git commit -m "feat(sessions): consume session.list; delete the querySql hack + guard"
 ```
 

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr2-2e-core.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr2-2e-core.md
@@ -1,0 +1,128 @@
+# Stage 2 PR 2 — 2e-core: Restricted-Mode fix + native welcome views
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare `capabilities.untrustedWorkspaces` and `extensionKind` (today VS Code silently disables the extension in Restricted Mode), and replace the lone "Not connected" tree row with native `viewsWelcome` content across the five sidebar views.
+
+**Architecture:** Manifest-first: the fix is mostly `package.json` `contributes`/top-level fields, pinned by a manifest-contract unit test so a future edit can't silently drop them. One behavior change in `src/sidebar/tree-view.ts`: `connectionPlaceholder` returns `[]` for `disconnected`/`idle` so VS Code renders the `viewsWelcome` content (welcome only shows for an empty tree); `connecting`/`permission-denied` keep their informative rows, which deliberately suppress the generic welcome.
+
+**Tech Stack:** as PR 1 (repo `C:\gitrep\nimbus-vscode`, vitest, Biome, esbuild).
+
+## Global Constraints
+
+- Branch `dev/asafgolombek/stage2-pr2-2e-core` in a worktree under `.claude/worktrees/`; `bun install` first; never commit on `main`.
+- Full gate set before first push: `typecheck`, `bunx biome check .`, `test`, `build`, `check-bundle`, `check-settings-docs`, `package` + `check-vsix-contents`.
+- The existing `nimbus.connected` context key (`src/extension.ts` `setContext`) is the `viewsWelcome` `when`-clause source — do not invent a new key.
+
+---
+
+### Task 1: Manifest declarations (test-first)
+
+**Files:**
+
+- Create: `test/unit/manifest-capabilities.test.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces: top-level `extensionKind: ["ui"]`; `capabilities.untrustedWorkspaces = { supported: "limited", description, restrictedConfigurations: ["nimbus.socketPath", "nimbus.autoStartGateway"] }`; `contributes.viewsWelcome` with one entry per sidebar view id (`nimbus.auditView`, `nimbus.egressView`, `nimbus.agentsView`, `nimbus.indexView`, `nimbus.sessionsView`), each `when: "!nimbus.connected"` and contents linking `command:nimbus.startGateway` + `command:nimbus.troubleshootConnection`.
+
+- [ ] **Step 1: Write the failing manifest-contract test**
+
+```ts
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const VIEW_IDS = [
+  "nimbus.auditView",
+  "nimbus.egressView",
+  "nimbus.agentsView",
+  "nimbus.indexView",
+  "nimbus.sessionsView",
+];
+
+const manifest = JSON.parse(readFileSync(join(__dirname, "..", "..", "package.json"), "utf8"));
+
+describe("extension manifest: restricted-mode + remote + welcome declarations", () => {
+  test("untrustedWorkspaces is declared as limited with the dangerous settings restricted", () => {
+    const uw = manifest.capabilities?.untrustedWorkspaces;
+    expect(uw?.supported).toBe("limited");
+    expect(uw?.restrictedConfigurations).toEqual(
+      expect.arrayContaining(["nimbus.socketPath", "nimbus.autoStartGateway"]),
+    );
+    expect(typeof uw?.description).toBe("string");
+  });
+
+  test("extensionKind pins the extension to the UI host (the gateway is local)", () => {
+    expect(manifest.extensionKind).toEqual(["ui"]);
+  });
+
+  test("every sidebar view has a not-connected welcome with start/troubleshoot actions", () => {
+    const entries = manifest.contributes?.viewsWelcome ?? [];
+    for (const id of VIEW_IDS) {
+      const entry = entries.find((e: { view: string }) => e.view === id);
+      expect(entry, `viewsWelcome missing for ${id}`).toBeDefined();
+      expect(entry.when).toBe("!nimbus.connected");
+      expect(entry.contents).toContain("command:nimbus.startGateway");
+      expect(entry.contents).toContain("command:nimbus.troubleshootConnection");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** (`bunx vitest run test/unit/manifest-capabilities.test.ts` → 3 FAIL)
+
+- [ ] **Step 3: Add the manifest fields**
+
+Top-level (after `"engines"`): `"extensionKind": ["ui"]` and
+
+```json
+"capabilities": {
+  "untrustedWorkspaces": {
+    "supported": "limited",
+    "description": "In Restricted Mode the workspace-level socketPath and autoStartGateway settings are ignored (a workspace could otherwise redirect the IPC socket or spawn a process). Everything else works.",
+    "restrictedConfigurations": ["nimbus.socketPath", "nimbus.autoStartGateway"]
+  }
+}
+```
+
+`contributes.viewsWelcome`: five entries, one per view id, each:
+
+```json
+{
+  "view": "nimbus.auditView",
+  "contents": "The Nimbus Gateway is not connected.\n[Start Gateway](command:nimbus.startGateway)\n[Troubleshoot](command:nimbus.troubleshootConnection)\nLocal-first: your data never leaves this machine.",
+  "when": "!nimbus.connected"
+}
+```
+
+- [ ] **Step 4: Run to verify it passes; commit** (`feat(manifest): declare untrustedWorkspaces, extensionKind, viewsWelcome`)
+
+---
+
+### Task 2: Empty tree on disconnected/idle so the welcome renders
+
+**Files:**
+
+- Modify: `src/sidebar/tree-view.ts` (`connectionPlaceholder`)
+- Modify: `test/unit/sidebar-views.test.ts` (pins the old row)
+- Modify: `test/unit/extension.test.ts` if any test asserts the "Not connected — click to reconnect" row
+
+**Interfaces:**
+
+- `connectionPlaceholder(state)` now returns `[]` for `kind === "disconnected"` and `"idle"` (welcome takes over), keeps the `connecting`/`starting-gateway` row and the `permission-denied` row, still `undefined` when connected.
+
+- [ ] **Step 1: Update the pinning tests** — in `test/unit/sidebar-views.test.ts` change the disconnected/idle expectations from the "Not connected — click to reconnect" row to `[]`, with a comment that the empty tree is load-bearing: it is what makes VS Code show the `viewsWelcome` content. Keep (or add) assertions that `connecting` and `permission-denied` still render rows.
+
+- [ ] **Step 2: Run to verify the changed tests fail** against the current implementation.
+
+- [ ] **Step 3: Implement** — in `connectionPlaceholder`, `disconnected` and `idle` return `[]`; add the comment: "Empty (not a row): an empty tree is what lets VS Code render the viewsWelcome content for `!nimbus.connected`, which carries the start/troubleshoot buttons."
+
+- [ ] **Step 4: Full unit suite + typecheck; commit** (`feat(sidebar): empty tree when down so viewsWelcome renders`)
+
+---
+
+### Task 3: Full gates, push, PR
+
+As PR 1's Task 4 (all gates incl. `package` + `check-vsix-contents`, whole-branch review, push, `gh pr create`). PR body: the silent Restricted-Mode disablement fix is the headline; note `extensionKind: ["ui"]` rationale (gateway is machine-local) and the welcome-view swap with its empty-tree mechanism.

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr3-2d-lm-tools.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr3-2d-lm-tools.md
@@ -1,0 +1,103 @@
+# Stage 2 PR 3 — 2d: Language Model tool registration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Register `nimbus_search` and `nimbus_ask` as Language Model tools (`contributes.languageModelTools` + `vscode.lm.registerTool`) so Copilot (and any LM extension) can pull the user's private local-index context. Zero new RPCs; stable API at the existing `^1.95.0` engines floor.
+
+**Architecture:** Mirror the chat-participant split: a **pure** module `src/lm-tools/lm-tools.ts` (input validation, client calls through a minimal `LmToolsClientLike`, plain-string results — unit-testable, no `vscode` import) and a **real** adapter `src/lm-tools/real-lm-tools.ts` (`vscode.lm.registerTool`, wraps strings in `LanguageModelToolResult`/`LanguageModelTextPart`). `ActivateDeps` gains `registerLmTools?` defaulting to the real adapter, invoked once at activation with a lazy `() => client` — tools answer "Gateway not connected" text when down.
+
+**Tech Stack:** as PR 1/2. Client calls: `searchRanked({ name, limit })`, `agentInvoke(input, { stream: false, agent? })` → `{ reply?: string }`.
+
+## Global Constraints
+
+- Branch `dev/asafgolombek/stage2-pr3-2d-lm-tools` in a worktree; `bun install` first; never commit on `main`; full gate set (incl. `package` + `check-vsix-contents`) before first push.
+- Tool `modelDescription`s are written in the ICP's vocabulary: private incident/CI/PR context, local machine, invisible to cloud assistants.
+- The pure module must not import `vscode` (vitest runs without the vscode host).
+
+---
+
+### Task 1: Manifest entries (test-first)
+
+**Files:**
+
+- Modify: `test/unit/manifest-capabilities.test.ts` (new describe-block) — or extend in place if PR 2 merged; if PR 2 is unmerged, base off its branch is NOT allowed — create the equivalent standalone test file `test/unit/manifest-lm-tools.test.ts` instead.
+- Modify: `package.json` (`contributes.languageModelTools`)
+
+**Interfaces:**
+
+- Produces: two `languageModelTools` entries named `nimbus_search` / `nimbus_ask`, each with `displayName`, `modelDescription`, `userDescription`, `canBeReferencedInPrompt: true`, `toolReferenceName` (`nimbusSearch` / `nimbusAsk`), `tags`, and an `inputSchema` (`query: string` required + optional `limit: number` for search; `question: string` required for ask).
+
+- [ ] **Step 1: failing test** — assert both entries exist by `name`, `inputSchema.required` matches, `modelDescription` contains "local" and "private", `canBeReferencedInPrompt === true`.
+- [ ] **Step 2: run to fail.**
+- [ ] **Step 3: add the manifest entries** (schema per Interfaces; search `limit` described as "max results, default 8, clamped 1–20").
+- [ ] **Step 4: run to pass; commit** (`feat(manifest): declare nimbus_search + nimbus_ask LM tools`).
+
+---
+
+### Task 2: Pure tool handlers (TDD)
+
+**Files:**
+
+- Create: `src/lm-tools/lm-tools.ts`
+- Create: `test/unit/lm-tools.test.ts`
+
+**Interfaces:**
+
+```ts
+export interface LmToolsClientLike {
+  searchRanked(params: { name: string; limit?: number }): Promise<unknown[]>;
+  agentInvoke(
+    input: string,
+    options?: { stream?: boolean; agent?: string },
+  ): Promise<{ reply?: string } & Record<string, unknown>>;
+}
+export interface LmToolsDeps {
+  client: () => LmToolsClientLike | undefined;
+  askAgent: () => string; // settings.askAgent(); "" = gateway default
+  log: { warn(msg: string): void };
+}
+export function runNimbusSearchTool(deps: LmToolsDeps, input: unknown): Promise<string>;
+export function runNimbusAskTool(deps: LmToolsDeps, input: unknown): Promise<string>;
+```
+
+Behavior:
+
+- Invalid input (non-object / missing-empty `query`/`question`) → a one-line error string naming the expected field (LM tools should return text, not throw).
+- No client → `"The Nimbus Gateway is not connected on this machine, so the private local index is unavailable. The user can run \"Nimbus: Start Gateway\"."`
+- Search: clamp `limit` to 1–20 (default 8), call `searchRanked({ name: query, limit })`, format each row via the existing row-shape used by `src/search.ts` (`normalizeInline` / fields `name`, `service`, `snippet`) as `- <name> (<service>): <snippet>`; empty results → `"No matches in the local index for \"<query>\"."`
+- Ask: `agentInvoke(question, { stream: false, agent })` passing `agent` only when `askAgent()` is non-empty; return `reply ?? "(the agent returned no reply)"`.
+- Client call throws → `"Nimbus lookup failed: <errMsg>"` + `log.warn`.
+
+- [ ] **Step 1: failing tests** covering each behavior bullet (fake client objects; no vscode).
+- [ ] **Step 2: run to fail. Step 3: implement. Step 4: run to pass; typecheck. Step 5: commit** (`feat(lm-tools): pure nimbus_search / nimbus_ask handlers`).
+
+---
+
+### Task 3: Real registration + activation wiring
+
+**Files:**
+
+- Create: `src/lm-tools/real-lm-tools.ts`
+- Modify: `src/extension.ts` (ActivateDeps + wiring next to `registerParticipant`, `src/extension.ts:1001`)
+- Modify: `test/unit/extension.test.ts` (one test: activation calls `registerLmTools` once with working deps)
+
+**Interfaces:**
+
+```ts
+// real-lm-tools.ts
+export function registerNimbusLmTools(opts: { deps: LmToolsDeps }): DisposableLike;
+// extension.ts
+registerLmTools?: (opts: { deps: LmToolsDeps }) => DisposableLike;
+```
+
+`registerNimbusLmTools` calls `vscode.lm.registerTool("nimbus_search", …)` / `("nimbus_ask", …)`; each `invoke` awaits the pure handler and returns `new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(text)])`; returns a disposable disposing both. Wire in `extension.ts`: `const registerLm = deps.registerLmTools ?? registerNimbusLmTools; ctx.subscriptions.push(registerLm({ deps: { client: () => nimbus(), askAgent: () => settings.askAgent(), log } }));`
+
+- [ ] **Step 1: failing extension test** — fake `registerLmTools` captures deps; assert called once, and `deps.client()` resolves to the fake client after connect.
+- [ ] **Step 2-4: implement, pass, typecheck.**
+- [ ] **Step 5: commit** (`feat(lm-tools): register nimbus_search + nimbus_ask with vscode.lm`).
+
+---
+
+### Task 4: Full gates, push, PR
+
+As PR 1 Task 4. PR body leads with: Copilot can now call Nimbus for private local context (the "value per install" multiplier); note the accepted trade (roadmap: hands the relationship to Microsoft; Stage 3 owns installs); README gets a short "Copilot integration" section only if `check-settings-docs`/docs gates require nothing else — otherwise defer README copy to Stage 3's re-cut.

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr4-2b-ops-vocabulary.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr4-2b-ops-vocabulary.md
@@ -1,0 +1,71 @@
+# Stage 2 PR 4 — 2b: ops vocabulary
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Copilot-three slash commands (`/explain` `/fix` `/test`) with the ops four — `/incident`, `/deploys`, `/owns`, `/blast` — backed by the built-in brief agents and DORA metrics, plus file-type-keyed quick-ask presets for infra files.
+
+**Architecture:** **Stacked on PR 1's branch** (`dev/asafgolombek/stage2-pr1-consume-011`, PR base set to it) — the brief methods and `metricsDora` exist only on client 0.11.0. Ops turns bypass `askStream` entirely: `runParticipantTurn` routes `req.command` to a new pure module `src/chat-participant/ops-commands.ts` that calls the typed client methods and renders structured briefs as markdown. The old three survive as quick-ask presets (Explain/Fix already are; add "Write tests").
+
+**Verified client/SDK shapes** (sdk 1.5.x `brief-composites.ts`): `ExpertBrief.ranked: ExpertFinding[]` (`displayName`, `confidence`, `evidence[]`, `score`); `ImpactBrief.affected: ImpactFinding[]` (`category`, `affectedTitle`, `serviceId`, `hops`, `pathSummary`); `CatchupBrief.sections: CatchupSection[]` (`serviceId`, `totalItemsInWindow`, `items[]: {title, modifiedAt, relevanceReasons}`); all `AgentBriefBase & {gaps: GapNote[]}`. `DoraMetricsResult.metrics.{deployment_frequency,lead_time_for_changes,change_failure_rate,mttr}: {value: number|null, unit, sample, gap}`. Client methods: `agentsExpert({topicOrFile, limit?})`, `agentsImpact({fileOrPrUrl, depth?})`, `agentsCatchup({sinceMs?, service?})` (each `o?: {timeoutMs?}`), `metricsDora({service, since?})` — the brief methods already handle briefReady/briefError correlation internally.
+
+## Global Constraints
+
+- Branch `dev/asafgolombek/stage2-pr4-2b-ops` in a worktree, created **from `dev/asafgolombek/stage2-pr1-consume-011`**; `gh pr create --base dev/asafgolombek/stage2-pr1-consume-011`; GitHub retargets to main when PR 1 merges.
+- `bun install` first; full gate set before first push; never commit on `main`.
+- Commands degrade honestly: a brief with zero findings says so and surfaces `gaps[].detail`; a thrown `AgentBriefError`/timeout renders its message.
+
+---
+
+### Task 1: Vocabulary swap in types, manifest, adapter (test-first)
+
+**Files:**
+
+- Modify: `src/chat-participant/participant-types.ts` — `ParticipantCommand = "incident" | "deploys" | "owns" | "blast"`; `ParticipantClientLike` gains `agentsExpert`, `agentsImpact`, `agentsCatchup`, `metricsDora` (signatures above).
+- Modify: `src/chat-participant/prompt.ts` — delete `COMMAND_TEMPLATES` + the `req.command` branch (ops turns never build a prompt); `buildParticipantPrompt` keeps only the free-form path.
+- Modify: `src/chat-participant/real-participant.ts` — `normalizeCommand` accepts the four new commands.
+- Modify: `package.json` `chatParticipants[0].commands` — four entries: incident ("What changed around the current incident window?"), deploys ("DORA metrics for a service: /deploys <service> [7d|24h]"), owns ("Who owns this file, service, or topic?"), blast ("Blast radius of changing the current file or a PR").
+- Modify: `src/extension.ts` participant-deps block — proxy the four new client methods.
+- Tests: update `test/unit/participant-prompt.test.ts` (command-prompt cases deleted), `participant-registration.test.ts` (normalizeCommand), add manifest pin `test/unit/manifest-participant-commands.test.ts` (four names, no explain/fix/test).
+
+- [ ] Steps: failing manifest+normalize tests → run red → implement all listed edits → suite green → commit (`feat(participant): ops slash-command vocabulary`).
+
+### Task 2: `ops-commands.ts` pure module (TDD)
+
+**Files:** Create `src/chat-participant/ops-commands.ts` + `test/unit/ops-commands.test.ts`.
+
+**Interface:**
+
+```ts
+export async function runOpsCommand(
+  client: ParticipantClientLike,
+  req: ParticipantRequest,
+  sink: ChatResponseSink,
+  log: { warn(m: string): void },
+): Promise<void>;
+```
+
+Routing (arg = `req.prompt.trim()`):
+
+- `blast`: target = arg, else `req.selection?.path`; none → usage line. `agentsImpact({ fileOrPrUrl: target })` → heading + one line per finding: `- **<affectedTitle>** (<serviceId>, <category>, <hops> hop(s)) — <pathSummary>`; empty → "No downstream dependents found." + gaps.
+- `owns`: topic = arg, else `req.selection?.path`; none → usage. `agentsExpert({ topicOrFile: topic, limit: 5 })` → `- **<displayName>** — <confidence> confidence, <evidence.length> signals` (top 5 of `ranked`); empty → honest none + gaps.
+- `incident`: `agentsCatchup({ sinceMs: 24*60*60*1000, ...(arg ? { service: arg } : {}) })` → per section `### <serviceId> (<totalItemsInWindow> in window)` + top 5 items `- <title> — <relevanceReasons.join(", ")>`.
+- `deploys`: parse `<service> [since]` (`since` matches `/^\d+(d|h)$/`, default `"7d"`); no service → usage. `metricsDora({ service, since })` → four lines `- Deployment frequency: <value> <unit> (n=<sample>)`, `value === null` → `no data (<gap>)`.
+- Every call in try/catch → `sink.markdown("Nimbus could not build that brief: <errMsg>")` + `log.warn`.
+- Gaps: when `gaps.length > 0`, append `_Data gaps: <detail; joined>_`.
+
+- [ ] Steps: failing tests per route (happy, empty, error, usage) → red → implement → green → commit (`feat(participant): brief-backed ops command handlers`).
+
+### Task 3: Route in `runParticipantTurn` + presets
+
+**Files:**
+
+- Modify: `src/chat-participant/participant.ts` — after the connected/empty checks: `if (req.command !== undefined) { await runOpsCommand(client, req, deps, sink); return {}; }` (bare-turn hint text updated to name the new commands). Note the empty-prompt guard must not swallow bare `/incident` (prompt may be empty when a command is set — reorder the checks).
+- Modify: `src/quick-ask-presets.ts` — add `{ label: "Write tests", prompt: "Write focused unit tests for this code, following the project's existing test framework and conventions." }` to defaults; add `export function filePresetsFor(fileName: string, languageId: string): QuickAskPreset[]` returning ops presets for `*.tf` / k8s-helm YAML (languageId yaml) / `Dockerfile*` / `.github/workflows/*`: "What breaks if I apply this?", "Who owns this service?", "What changed here recently?".
+- Modify: `src/extension.ts` quick-ask picker — prepend `filePresetsFor(...)` of the active editor to the resolved presets.
+- Tests: `participant.test.ts` (command routes to ops, not askStream), `quick-ask-presets.test.ts` (new default + per-file-type cases).
+
+- [ ] Steps: red → implement → full suite + typecheck → commit (`feat(quick-ask): ops presets keyed to infra file types`).
+
+### Task 4: Full gates, push, PR (base = PR 1's branch)
+
+Full gate set incl. package/check-vsix; whole-branch review (`git log stage2-pr1-consume-011..HEAD`); `gh pr create --base dev/asafgolombek/stage2-pr1-consume-011`. PR body: the vocabulary re-cut rationale (stop adjudicating on model quality), the honest-degradation contract, and the stacking note.

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr5-2c-egress-receipts.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr5-2c-egress-receipts.md
@@ -1,0 +1,42 @@
+# Stage 2 PR 5 — 2c: egress receipts
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the egress ledger visible at the moment of use: a per-answer ledger-delta footer in the chat participant, a readable self-contained proof artifact for "Prove window", an opt-in signed `Nimbus-Egress-Proof` commit trailer, and blocked rows rendered as first-class proof-of-denial.
+
+**Scope decisions (deliberate):**
+
+- **Footer is participant-only.** The webview chat panel already sits next to the live egress status-bar badge; the participant (the Copilot-side surface) is where an answer can trigger egress with no Nimbus chrome in sight.
+- **The proof artifact is an HTML report embedding the machine-verifiable JSON**, with verification instructions pointing at `nimbus egress verify` / `nimbus prove`. True in-file BLAKE3+Ed25519 verification would require embedding crypto implementations — out of scope; the JSON inside stays byte-identical to the RPC result.
+
+**Branch:** `dev/asafgolombek/stage2-pr5-2c-receipts` off main (all egress methods exist since client 0.4.0; main now has 0.11.0 anyway).
+
+## Tasks
+
+### Task 1: Per-answer ledger delta in the participant (TDD)
+
+- `participant-types.ts`: `ParticipantClientLike` += `egressHead(): Promise<{ head: string; count: number }>`.
+- `participant.ts` free-form path: `head0 = await client.egressHead()` (try/catch → undefined) before the stream; after the stream completes, `head1`; when both resolved: footer `sink.markdown("\n\n---\n_Egress: N row(s) appended to the local ledger during this answer._")` (0 → "no rows appended — nothing left this machine"). Any head error → no footer, `log.warn`.
+- Ops commands (read-only briefs) get the same footer via the shared helper — extract `emitEgressDelta(client, sink, log, head0)`.
+- Tests: delta rendered for 2-row growth; zero-delta wording; head failure → silent; fakeClient gains `egressHead`.
+
+### Task 2: Proof artifact as self-contained HTML (TDD)
+
+- `sidebar/egress.ts` `buildProofDocument(result, now)` → `{ filename: "egress-proof-<now>.html", content }`: an HTML page (inline CSS only, no external requests) rendering completeness tier + row count, verify status, receipt (digest/pubkey/sig) when present, a rows table (timestamp ISO, destination.method, result, consent), a "How to verify" section naming `nimbus egress verify` and `nimbus prove`, and the raw JSON in a `<script type="application/json" id="nimbus-egress-proof">` block byte-identical to the RPC result.
+- `extension.ts` `proveEgressWindow` flow: pass `sign: true` so the receipt is attached; save dialog default name switches to the `.html` filename.
+- Tests: filename/extension; content contains tier, verify ok/failed marker, digest when receipt present, embedded JSON parses back to the input.
+
+### Task 3: `Nimbus-Egress-Proof` commit trailer (TDD)
+
+- New setting `nimbus.scm.egressProofTrailer` (boolean, default false) + README settings row (`check-settings-docs` gates this).
+- `scm/commands.ts` `generateCommitMessage`: when the setting is on and the client exposes `egressProveWindow`, call `egressProveWindow({ since: now - 24h, sign: true })`; when `receipt` is present append `\n\nNimbus-Egress-Proof: <digest> sig=<sigB64> pubkey=<pubkeyB64>`; missing receipt or error → no trailer + `log.warn` (never block the commit message).
+- Tests: trailer appended when enabled+receipt; absent when disabled; absent+warn on error.
+
+### Task 4: Proof-of-denial rendering (TDD)
+
+- `sidebar/egress.ts` `egressRowToItem`: blocked rows get `label` prefixed `⛔ `, `description` `blocked · <relative-time>`, tooltip gains "proof of denial — stopped before dispatch"; `contextValue: "nimbusEgressDenial"` for future menu wiring.
+- Tests: blocked vs authorized rendering.
+
+### Task 5: Full gates, push, PR
+
+Standard gate set incl. `package`+`check-vsix-contents`; whole-branch review; PR to main referencing the spec and the M7/Provable-Locality alignment.

--- a/docs/superpowers/plans/2026-07-23-stage-2-pr5-2c-egress-receipts.md
+++ b/docs/superpowers/plans/2026-07-23-stage-2-pr5-2c-egress-receipts.md
@@ -34,7 +34,7 @@
 
 ### Task 4: Proof-of-denial rendering (TDD)
 
-- `sidebar/egress.ts` `egressRowToItem`: blocked rows get `label` prefixed `⛔ `, `description` `blocked · <relative-time>`, tooltip gains "proof of denial — stopped before dispatch"; `contextValue: "nimbusEgressDenial"` for future menu wiring.
+- `sidebar/egress.ts` `egressRowToItem`: blocked rows get a `⛔` label prefix (with a trailing space), `description` `blocked · <relative-time>`, tooltip gains "proof of denial — stopped before dispatch"; `contextValue: "nimbusEgressDenial"` for future menu wiring.
 - Tests: blocked vs authorized rendering.
 
 ### Task 5: Full gates, push, PR

--- a/docs/superpowers/specs/2026-07-23-stage-2-recut-design.md
+++ b/docs/superpowers/specs/2026-07-23-stage-2-recut-design.md
@@ -1,0 +1,115 @@
+# Stage 2 — Re-cut the VS Code surface for the ICP (design)
+
+**Date:** 2026-07-23 · **Status:** approved · **Owner repo for the work:** `nimbus-vscode` (plus a read-only spike against the gateway index)
+
+Authoritative context: [`docs/ecosystem-roadmap.md`](../../ecosystem-roadmap.md) Stage 2. Stage 1 is
+complete (2026-07-23): `@nimbus-dev/client` 0.11.0 exposes 52 methods. This spec covers consuming
+that surface in `nimbus-vscode` and the deliberately-selected Stage 2 items: **2e-core, 2d, 2c, 2b
+in full, plus a de-risk spike for 2a**. Scope was chosen against the roadmap's own framing: 2e
+fixes a silent bug, 2d is a large multiplier for ~zero new RPCs, and 2a's headline value is
+data-dependent and unproven (roadmap Open Decision #3).
+
+## Verified starting facts
+
+- `nimbus-vscode/package.json` pins `"@nimbus-dev/client": "^0.6.0"`. On 0.x a caret does not
+  cross minors, so the extension sees **none** of Stage 1 today. The bump is the unblock.
+- The extension calls 13 client methods. Two are the hacks Stage 1 exists to delete:
+  `client.querySql(SESSIONS_SQL)` (`src/extension.ts:440`) and a local `listSessions` wrapper
+  (`src/extension.ts:457`) — the code comment itself says *"switch to client.listSessions() once
+  the client exposes one"*. Wave 1d shipped `session.*`; the client method is `sessionList()`.
+- `capabilities.untrustedWorkspaces` and `extensionKind` are **undeclared**, so VS Code disables
+  the extension entirely in a Restricted-Mode workspace, with no explanation.
+- The `nimbus.statusBarPollMs` setting description says it polls *connector health*, but the poll
+  only drives the egress badge (`egressHead`). The description is currently a lie.
+- Open gateway issues [#809] (`connector.configChanged` unexposed), [#810] (`workflow.run` stream
+  chunks unconsumable), [#812] (ipc test flake) do **not** block any selected item.
+
+## Deliverables (5 PRs + 1 spike)
+
+### PR 1 — Consumption (`nimbus-vscode`)
+
+The mandatory unblock, scoped opportunistically:
+
+- Bump `@nimbus-dev/client` to `^0.11.0`.
+- Sessions view: replace `querySql(SESSIONS_SQL)` + the local `listSessions` wrapper with
+  `sessionList()`; delete `SESSIONS_SQL`.
+- Wire `gatewayPing()` into connection health and the Troubleshoot Connection command.
+- Status bar: add a connector-health segment fed by `connectorListStatus()` on the existing
+  `statusBarPollMs` cadence — making the setting's description true.
+- Guard test: assert `querySql(` appears nowhere in `src/` so the hack cannot return
+  (assert on the call shape, not the bare identifier).
+
+Explicitly **not** here: built-in brief agents in the sidebar — they land with 2b, where they are
+the engine.
+
+### PR 2 — 2e-core: native-feel correctness (`nimbus-vscode`)
+
+- `capabilities.untrustedWorkspaces: { supported: "limited" }` with `restrictedConfigurations`
+  for the two dangerous settings: `nimbus.socketPath` (redirects the IPC target) and
+  `nimbus.autoStartGateway` (spawns a process).
+- `extensionKind: ["ui"]` — the gateway daemon lives on the user's local machine, so in
+  SSH/remote/container scenarios the extension must run on the client side.
+- `viewsWelcome` for all five sidebar views: the gateway-down state renders "Start Gateway" /
+  "Troubleshoot" buttons instead of blank boxes.
+
+Deferred from 2e (deliberately): `TreeView.badge`, `FileDecorationProvider`, chat participant
+`followupProvider` / `onDidReceiveFeedback` / `disambiguation`.
+
+### PR 3 — 2d: Language Model tool registration (`nimbus-vscode`)
+
+- `contributes.languageModelTools` + `vscode.lm.registerTool` — both in stable `@types/vscode`
+  at the existing `^1.95.0` engines floor: no engines bump, no proposed-API flag.
+- Two tools to start:
+  - `nimbus_search` — ranked local-index search via `searchRanked`.
+  - `nimbus_ask` — one-shot grounded answer via `askStream`, collected to a string.
+- Tool descriptions written in the ICP's vocabulary (private incident / CI / PR context the
+  cloud assistant cannot see). More tools follow demand, not speculation.
+
+### PR 4 — 2b: ops vocabulary (`nimbus-vscode`)
+
+- Chat participant commands: **replace** `/explain` `/fix` `/test` with `/incident`, `/deploys`,
+  `/owns`, `/blast` (roadmap-intended; the old three survive as quick-ask presets).
+- Where a built-in brief agent is the right engine, use it: `/blast` → `agentsImpact`,
+  `/owns` → `agentsExpert`, `/incident` → `agentsCatchup`; `/deploys` → `metricsDora` plus recent
+  deploy/`ci_run` items from the index.
+- Quick-ask presets keyed to file type: `*.tf`, k8s/helm YAML, `Dockerfile`,
+  `.github/workflows/*` — e.g. *"What breaks if I apply this?"*, *"Who owns this service?"*.
+
+### PR 5 — 2c: egress receipts (`nimbus-vscode`)
+
+- Per-answer footer in chat: `egressHead` before/after each answer → ledger-delta line
+  ("N rows appended · chain verified").
+- "Prove window" exports a **self-contained offline verifier** (single file: verifier + embedded
+  window JSON), not just raw JSON.
+- "Prove this PR": opt-in signed `Nimbus-Egress-Proof` trailer appended by Generate Commit
+  Message (via `egressProveWindow`).
+- Blocked/denied rows rendered distinctly in the Egress view — proof-of-denial as a first-class
+  artifact.
+
+### Spike — 2a data quality (read-only, no PR)
+
+Against the live local index: measure `git_blame_line` (V32) coverage, blame→PR→issue join
+rates, and Slack/incident linkage. Deliverable is a findings report with a build / don't-build
+recommendation for the hover lens, feeding roadmap Open Decision #3. No UI work until the data
+supports the hover experience.
+
+## Sequencing
+
+PR 1 first (everything else assumes 0.11.0) → PR 2 → PR 3 → PR 4 → PR 5. The spike runs in
+parallel at any point. Each PR: worktree branch `dev/asafgolombek/<topic>`, `bun install` first
+in a fresh worktree, full preflight before the first push. The user merges; the agent opens.
+
+## Risks / decisions taken
+
+- **2b replaces the Copilot three** — a user-visible change for existing installs; approved
+  explicitly, and the old prompts remain reachable as quick-ask presets.
+- **`extensionKind: ["ui"]`** is a judgment call: it privileges the local-gateway topology over
+  remote-workspace file access. The extension reads workspace state only through VS Code APIs
+  (selection text, SCM diffs), which work from the UI host.
+- **LM tools hand context to Copilot** — the roadmap names this trade ("hands the relationship
+  to Microsoft; does not create installs"); accepted because it multiplies value per install and
+  Stage 3 owns installs.
+
+[#809]: https://github.com/nimbus-agent/Nimbus/issues/809
+[#810]: https://github.com/nimbus-agent/Nimbus/issues/810
+[#812]: https://github.com/nimbus-agent/Nimbus/issues/812

--- a/docs/superpowers/specs/2026-07-23-stage-2-recut-design.md
+++ b/docs/superpowers/specs/2026-07-23-stage-2-recut-design.md
@@ -33,7 +33,7 @@ The mandatory unblock, scoped opportunistically:
 - Bump `@nimbus-dev/client` to `^0.11.0`.
 - Sessions view: replace `querySql(SESSIONS_SQL)` + the local `listSessions` wrapper with
   `sessionList()`; delete `SESSIONS_SQL`.
-- Wire `gatewayPing()` into connection health and the Troubleshoot Connection command.
+- Wire `gatewayPing()` into the Troubleshoot Connection command (a live "socket up but gateway unresponsive" probe). Ongoing connection health stays with the connection manager; the status bar's live signal is the connector-health poll.
 - Status bar: add a connector-health segment fed by `connectorListStatus()` on the existing
   `statusBarPollMs` cadence — making the setting's description true.
 - Guard test: assert `querySql(` appears nowhere in `src/` so the hack cannot return


### PR DESCRIPTION
Docs-only. Adds the approved Stage 2 design spec (`docs/superpowers/specs/2026-07-23-stage-2-recut-design.md`) and the implementation plan for its first deliverable (`docs/superpowers/plans/2026-07-23-stage-2-pr1-consumption.md`), following the Stage 0/Stage 1 convention of keeping ecosystem specs/plans in this repo.

Scope decided 2026-07-23: mandatory client-consumption PR, then 2e-core, 2d, 2b, 2c in full, plus a build/don't-build data-quality spike for 2a. PR 1 itself is already open as nimbus-vscode#45.

Local verification: lychee (4/4 links OK) + markdownlint (0 errors) on both files.

Note: this is a docs-only PR — the first since #788's `pr-quality-required` fix; it should be mergeable without bypass, which confirms that fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed implementation plan for integrating the Stage 1 client surface into the VS Code extension.
  * Added a design specification outlining the Stage 2 roadmap, deliverables, sequencing, risks, and decisions.
  * Documented planned improvements for session listing, connector health reporting, troubleshooting diagnostics, and restricted-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->