### PR TITLE
docs: Stage 2a spike findings — don't build the why lens yet

### DIFF
--- a/docs/superpowers/specs/2026-07-23-stage-2a-data-spike-findings.md
+++ b/docs/superpowers/specs/2026-07-23-stage-2a-data-spike-findings.md
@@ -1,0 +1,45 @@
+# Stage 2a spike — `why` lens data quality (findings)
+
+**Date:** 2026-07-23 · **Method:** read-only SQLite queries against the live local index
+(`nimbus.db`, 26 MB, schema V44) on the primary dev machine. · **Question:** does the data
+support building the hover `why` lens now?
+
+## Recommendation: **don't build yet.**
+
+The lens's foundational lane is empty and its enrichment lanes are absent on a real,
+actively-used machine. Built today, the hover would render blank almost everywhere — the
+exact "correlation quality is data-dependent" failure the roadmap flagged, and strong
+support for Open Decision #3's doubt that the editor is even the right first surface.
+
+## Measurements
+
+| Lane | Live value | Lens impact |
+| --- | --- | --- |
+| `git_blame_line` (V32) | **0 rows, 0 files** | The blame → commit → author chain — the lens's first hop — has no data at all. |
+| Index items | 546: gmail 228, `ci_run` 214, `pr` 79, `file` 13, `folder` 5, `issue` 5, `web_clip` 2 | Only 5 services carry data out of ~95 registered connectors. |
+| Graph | 86 entities / 89 relations: `targets` 79, `opened` 5, `belongs_to` 5 | PR→issue joins exist for **5 issues total**; 1 person entity (vs 65 rows in `person`). |
+| PR titles | Literally `"PR #220"` | Even a working hover would display id-only titles — no human-readable summary lane. |
+| Slack / incident / ticket lanes | No Slack, PagerDuty, or Jira items | The "the Slack thread, the incident that drove the change" hover rows have zero sources. |
+
+## What would have to be true first
+
+1. **`git_blame_line` populated** — find out why it is empty on a machine with active git
+   repos (unconfigured `[[filesystem.roots]]`? blame indexing gated behind a setting or
+   never scheduled?) and fix the pipeline. Without this the lens cannot take its first hop.
+2. **PR title enrichment** — `"PR #220"` titles make every downstream hover row unreadable;
+   the GitHub connector needs to carry real titles before any UI consumes them.
+3. **At least one conversation/incident lane live** (Slack or Jira or PagerDuty credentials
+   on the machine) so "degrades gracefully" degrades to something rather than nothing.
+4. Re-run this spike; build when blame coverage on an active repo is non-trivial and the
+   blame→PR join rate on recent lines clears a bar worth demoing (suggest: ≥60% of lines in
+   a recently-active repo resolve to a PR).
+
+## Notes
+
+- The graph lanes that DO exist (`pr --targets--> repo`, `issue` links) came from the
+  GitHub connector alone, which reinforces the roadmap's degradation story — git + GitHub
+  is the base lane — but the base lane's own first link (blame) is the missing piece.
+- This finding feeds [roadmap Open Decision #3](../../ecosystem-roadmap.md#open-decisions):
+  nothing measured here argues the editor must own the lens; the *before* (blast radius,
+  shipped as `/blast` in Stage 2b) and *after* (postmortem) jobs are already served by the
+  brief agents at current data quality.

--- a/docs/superpowers/specs/2026-07-23-stage-2a-data-spike-findings.md
+++ b/docs/superpowers/specs/2026-07-23-stage-2a-data-spike-findings.md
@@ -6,16 +6,20 @@ support building the hover `why` lens now?
 
 ## Recommendation: **don't build yet.**
 
-The lens's foundational lane is empty and its enrichment lanes are absent on a real,
-actively-used machine. Built today, the hover would render blank almost everywhere — the
-exact "correlation quality is data-dependent" failure the roadmap flagged, and strong
-support for Open Decision #3's doubt that the editor is even the right first surface.
+The lens's **precomputed** foundational lane is empty and its enrichment lanes are absent
+on a real, actively-used machine. This spike measured persisted index data only; whether an
+on-demand local `git blame` fallback could paper over the empty table was out of scope —
+but even a perfect fallback still lands on id-only PR titles, 5 issue joins, and zero
+conversation/incident sources, so the hover would carry almost nothing worth showing. That
+is the exact "correlation quality is data-dependent" failure the roadmap flagged, and
+strong support for Open Decision #3's doubt that the editor is even the right first
+surface.
 
 ## Measurements
 
 | Lane | Live value | Lens impact |
 | --- | --- | --- |
-| `git_blame_line` (V32) | **0 rows, 0 files** | The blame → commit → author chain — the lens's first hop — has no data at all. |
+| `git_blame_line` (V32) | **0 rows, 0 files** | The precomputed blame → commit → author lane has no data; any hover would depend entirely on on-demand blame (unmeasured here). |
 | Index items | 546: gmail 228, `ci_run` 214, `pr` 79, `file` 13, `folder` 5, `issue` 5, `web_clip` 2 | Only 5 services carry data out of ~95 registered connectors. |
 | Graph | 86 entities / 89 relations: `targets` 79, `opened` 5, `belongs_to` 5 | PR→issue joins exist for **5 issues total**; 1 person entity (vs 65 rows in `person`). |
 | PR titles | Literally `"PR #220"` | Even a working hover would display id-only titles — no human-readable summary lane. |
@@ -28,11 +32,15 @@ support for Open Decision #3's doubt that the editor is even the right first sur
    never scheduled?) and fix the pipeline. Without this the lens cannot take its first hop.
 2. **PR title enrichment** — `"PR #220"` titles make every downstream hover row unreadable;
    the GitHub connector needs to carry real titles before any UI consumes them.
-3. **At least one conversation/incident lane live** (Slack or Jira or PagerDuty credentials
-   on the machine) so "degrades gracefully" degrades to something rather than nothing.
-4. Re-run this spike; build when blame coverage on an active repo is non-trivial and the
-   blame→PR join rate on recent lines clears a bar worth demoing (suggest: ≥60% of lines in
-   a recently-active repo resolve to a PR).
+3. **At least one conversation lane (Slack/Teams) or incident-driver lane (PagerDuty,
+   Sentry, or another alerting source) live** on the machine, so "degrades gracefully"
+   degrades to something rather than nothing. Jira is the *ticket* lane — useful, but it
+   substitutes for neither the discussion thread nor the incident driver.
+4. Re-run this spike; build when the precompute lane clears a reproducible bar. Suggested
+   bar: sample the `git_blame_line` rows for files modified in the last 90 days in one
+   actively-developed indexed repo; **≥60% of those sampled rows must resolve to a PR**
+   (numerator: rows whose `commit_sha` joins to a `pr` item; denominator: the sampled
+   rows). If the blame table is still empty, the bar is unmet by definition.
 
 ## Notes
 


### PR DESCRIPTION
Docs-only: the read-only data-quality spike the approved Stage 2 design called for (spec merged in #814), run against the live local index (nimbus.db, schema V44).

**Recommendation: don't build the hover `why` lens yet.** Measured on a real, actively-used machine:

- `git_blame_line` (V32): **0 rows** — the lens's first hop has no data at all.
- 546 items across only 5 services; PR→issue graph joins exist for 5 issues; **1** person entity.
- PR titles are literally `"PR #220"` — nothing human-readable to hover.
- No Slack/PagerDuty/Jira lane has any data.

The report records the prerequisites (blame pipeline populated + investigated, PR title enrichment, at least one conversation/incident lane live) and a re-run bar (≥60% blame→PR resolution on a recently-active repo) before the lens is worth building. Feeds roadmap Open Decision #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Stage 2a data-quality findings page based on read-only checks against the live local index.
  * Documented current coverage across graph entities/relations, including lane-by-lane impact and why the hover “why” lens can’t be reliably built yet.
  * Listed the prerequisites and coverage thresholds required to revisit the investigation, including fixes needed for missing blame and conversation/incident context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->