### PR TITLE
feat(github): enrich fallback 'PR #N' titles via pull-detail fetch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-23 — GitHub connector PR-title enrichment.** GitHub connector now enriches indexed PR
+  titles via a pull-detail fetch, replacing id-only `PR #N` fallbacks.
+
 - **2026-07-23 — Ecosystem Stage 1 complete: the client surface goes 15 → 52 methods.** The gateway
   dispatches ~212 JSON-RPC methods; `@nimbus-dev/client` exposed 15 of them, so entire namespaces
   were built, dispatch-wired and Tauri-allowlisted yet unreachable from any npm client. All eight

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
-- **2026-07-23 — GitHub connector PR-title enrichment.** GitHub connector now enriches indexed PR
+- **2026-07-24 — GitHub connector PR-title enrichment.** GitHub connector now enriches indexed PR
   titles via a pull-detail fetch, replacing id-only `PR #N` fallbacks.
 
 - **2026-07-23 — Ecosystem Stage 1 complete: the client surface goes 15 → 52 methods.** The gateway

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -143,6 +143,23 @@ describe("enrichFallbackPrTitles", () => {
     expect(titleOf(db, "acme/app#7")).toBe("PR #7");
   });
 
+  test("a real title that merely starts with the fallback shape is not clobbered", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 1, "PR #1 revert", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ number: 1, title: "Fix the retry loop" }), {
+          status: 200,
+        }),
+      )) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+
+    expect(n).toBe(0);
+    expect(titleOf(db, "acme/app#1")).toBe("PR #1 revert");
+  });
+
   test("a malformed JSON response is skipped, not enriched", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);
@@ -154,5 +171,18 @@ describe("enrichFallbackPrTitles", () => {
 
     expect(n).toBe(0);
     expect(titleOf(db, "acme/app#8")).toBe("PR #8");
+  });
+
+  test("valid JSON that is not an object (e.g. an array) is skipped, not enriched", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 10, "PR #10", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("[1,2,3]", { status: 200 }))) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+
+    expect(n).toBe(0);
+    expect(titleOf(db, "acme/app#10")).toBe("PR #10");
   });
 });

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import type { SyncContext } from "../sync/types.ts";
+import {
+  createMemoryIndexDb,
+  createStubVault,
+  syncTestContext,
+} from "./connector-sync-test-helpers.ts";
+import { enrichFallbackPrTitles } from "./github-sync.ts";
+
+function seedPrRow(
+  db: ReturnType<typeof createMemoryIndexDb>,
+  repoFull: string,
+  num: number,
+  title: string,
+  modifiedAt: number,
+): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: `${repoFull}#${String(num)}`,
+    title,
+    bodyPreview: "",
+    url: null,
+    canonicalUrl: null,
+    modifiedAt,
+    metadata: { number: num, repo: repoFull },
+    syncedAt: modifiedAt,
+  });
+}
+
+function ctxFor(db: ReturnType<typeof createMemoryIndexDb>): SyncContext {
+  return syncTestContext(db, createStubVault({}));
+}
+
+function titleOf(db: ReturnType<typeof createMemoryIndexDb>, externalId: string): string {
+  const row = db.query("SELECT title FROM item WHERE external_id = ?").get(externalId) as {
+    title: string;
+  };
+  return row.title;
+}
+
+describe("enrichFallbackPrTitles", () => {
+  test("enriches only fallback-titled PRs, newest-first, capped at 10", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 1, "PR #1", 1000); // fallback -> enrich
+    seedPrRow(db, "acme/app", 2, "Real title", 2000); // not fallback -> skip
+    const fetchImpl = ((): Promise<Response> =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ number: 1, title: "Fix the retry loop", html_url: "https://x/pr/1" }),
+          { status: 200 },
+        ),
+      )) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 3000, fetchImpl);
+
+    expect(n).toBe(1);
+    expect(titleOf(db, "acme/app#1")).toBe("Fix the retry loop");
+    expect(titleOf(db, "acme/app#2")).toBe("Real title");
+  });
+
+  test("a failed detail fetch leaves the fallback untouched", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 9, "PR #9", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("nope", { status: 404 }))) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+
+    expect(n).toBe(0);
+    expect(titleOf(db, "acme/app#9")).toBe("PR #9");
+  });
+
+  test("returns 0 when there are no fallback-titled rows", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 3, "Add retry backoff", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("{}", { status: 200 }))) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+
+    expect(n).toBe(0);
+  });
+
+  test("caps at 10 and processes newest-first", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    for (let i = 1; i <= 12; i += 1) {
+      seedPrRow(db, "acme/app", i, `PR #${String(i)}`, i * 1000);
+    }
+    const fetched: number[] = [];
+    const fetchImpl = ((url: string) => {
+      const match = /\/pulls\/(\d+)$/.exec(url);
+      const num = match ? Number.parseInt(match[1] ?? "0", 10) : 0;
+      fetched.push(num);
+      return Promise.resolve(
+        new Response(JSON.stringify({ number: num, title: `Real ${String(num)}` }), {
+          status: 200,
+        }),
+      );
+    }) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 20000, fetchImpl);
+
+    expect(n).toBe(10);
+    expect(fetched).toHaveLength(10);
+    // newest-first: PR #12 down to PR #3 (modified_at DESC), #1 and #2 left for next tick.
+    expect(fetched).toEqual([12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
+    expect(titleOf(db, "acme/app#1")).toBe("PR #1");
+    expect(titleOf(db, "acme/app#2")).toBe("PR #2");
+  });
+
+  test("a 401 response throws UnauthenticatedError", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 5, "PR #5", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("nope", { status: 401 }))) as unknown as typeof fetch;
+
+    await expect(enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl)).rejects.toThrow(
+      /unauthorized/,
+    );
+  });
+
+  test("a rate-limited (403, no remaining) response propagates and aborts the tick", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 6, "PR #6", 1000);
+    seedPrRow(db, "acme/app", 7, "PR #7", 2000);
+    const fetchImpl = (() =>
+      Promise.resolve(
+        new Response("nope", { status: 403, headers: { "x-ratelimit-remaining": "0" } }),
+      )) as unknown as typeof fetch;
+
+    await expect(enrichFallbackPrTitles(ctx, "pat", 3000, fetchImpl)).rejects.toThrow(
+      /rate limited/,
+    );
+    expect(titleOf(db, "acme/app#7")).toBe("PR #7");
+  });
+
+  test("a malformed JSON response is skipped, not enriched", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxFor(db);
+    seedPrRow(db, "acme/app", 8, "PR #8", 1000);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("not json", { status: 200 }))) as unknown as typeof fetch;
+
+    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+
+    expect(n).toBe(0);
+    expect(titleOf(db, "acme/app#8")).toBe("PR #8");
+  });
+});

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -357,6 +357,78 @@ function throwGithubRateLimitErrorIfApplicable(
   }
 }
 
+interface FallbackPrCandidate {
+  readonly externalId: string;
+  readonly repoFull: string;
+  readonly num: number;
+}
+
+const MAX_ENRICH_PER_TICK = 10;
+
+function selectFallbackPrCandidates(db: Database, limit: number): FallbackPrCandidate[] {
+  const rows = db
+    .query(
+      `SELECT external_id, title FROM item
+         WHERE service = 'github' AND type = 'pr' AND title LIKE 'PR #%'
+         ORDER BY modified_at DESC LIMIT ?`,
+    )
+    .all(limit * 3) as { external_id: string; title: string }[]; // over-select; JS filter is exact
+  const out: FallbackPrCandidate[] = [];
+  for (const r of rows) {
+    const hash = r.external_id.lastIndexOf("#");
+    if (hash <= 0) continue;
+    const repoFull = r.external_id.slice(0, hash);
+    const num = Number.parseInt(r.external_id.slice(hash + 1), 10);
+    if (!Number.isFinite(num)) continue;
+    if (r.title !== `PR #${String(num)}`) continue; // exact fallback only
+    out.push({ externalId: r.external_id, repoFull, num });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * Re-fetches pull-request detail for any indexed `pr` row still carrying the
+ * id-only `PR #<num>` fallback title (the GitHub events feed omits `title`
+ * on `PullRequestEvent` payloads). Processes up to `MAX_ENRICH_PER_TICK`
+ * rows, newest-first, sequentially through the shared rate limiter.
+ */
+export async function enrichFallbackPrTitles(
+  ctx: SyncContext,
+  pat: string,
+  now: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+  const candidates = selectFallbackPrCandidates(ctx.db, MAX_ENRICH_PER_TICK);
+  let enriched = 0;
+  for (const c of candidates) {
+    await ctx.rateLimiter.acquire("github");
+    const res = await fetchImpl(pullDetailUrl(c.repoFull, c.num), {
+      headers: buildGithubEventHeaders(pat, null),
+    });
+    if (res.status === 401) {
+      throw new UnauthenticatedError("GitHub pull detail: unauthorized (401)");
+    }
+    throwGithubRateLimitErrorIfApplicable(ctx, res, "pull detail"); // may throw RateLimitError
+    if (!res.ok) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await res.text()) as unknown;
+    } catch {
+      continue;
+    }
+    const pr = asRecord(parsed);
+    if (pr === undefined) {
+      continue;
+    }
+    upsertPr(ctx, c.repoFull, pr, now);
+    enriched += 1;
+  }
+  return enriched;
+}
+
 async function fetchAuthenticatedLogin(ctx: SyncContext, pat: string): Promise<string> {
   await ctx.rateLimiter.acquire("github");
   const res = await fetch(USER_URL, {

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -20,6 +20,10 @@ const SERVICE_ID = "github";
 const CURSOR_PREFIX = "nimbus-ghub1:";
 const USER_URL = "https://api.github.com/user";
 
+export function pullDetailUrl(repoFull: string, num: number): string {
+  return `https://api.github.com/repos/${repoFull}/pulls/${String(num)}`;
+}
+
 function extractLabelNames(raw: unknown): string[] {
   if (!Array.isArray(raw)) {
     return [];
@@ -177,7 +181,7 @@ function modifiedMsFromGithubTimestamps(
   return fallbackMs;
 }
 
-function upsertFromPullRequest(
+export function upsertPr(
   ctx: SyncContext,
   repoFull: string,
   pr: Record<string, unknown>,
@@ -261,7 +265,7 @@ function processPullRequestPayload(
   if (pr === undefined) {
     return false;
   }
-  upsertFromPullRequest(ctx, fullName, pr, now);
+  upsertPr(ctx, fullName, pr, now);
   return true;
 }
 

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -514,6 +514,17 @@ async function syncGithubUserEvents(
     }
   }
 
+  // Best-effort title enrichment for fallback-titled PRs (existing rows + this tick's title-less events).
+  try {
+    await enrichFallbackPrTitles(ctx, pat, now);
+  } catch (err) {
+    if (err instanceof RateLimitError) throw err; // honor backoff
+    ctx.logger.warn(
+      { service: SERVICE_ID, err: String(err) },
+      "PR title enrichment pass failed (non-fatal)",
+    );
+  }
+
   const newEtag = res.headers.get("etag");
   const nextCursor = encodeCursor({ etag: newEtag, login });
 

--- a/packages/gateway/src/graph/graph-populator-resolves.test.ts
+++ b/packages/gateway/src/graph/graph-populator-resolves.test.ts
@@ -159,7 +159,7 @@ test("an incoming resolves edge survives the target issue's own re-sync", () => 
 // Fixtures below are built with the exact expressions github-sync.ts uses
 // to index PRs and issues (`${repoFull}#${num}` / `${repoFull}#issue-${num}`,
 // plus the same `number`/`repo` metadata keys), NOT hand-picked shapes — see
-// `upsertFromPullRequest`/`upsertFromIssue` in connectors/github-sync.ts.
+// `upsertPr`/`upsertFromIssue` in connectors/github-sync.ts.
 function seedGithubIssue(
   db: Database,
   repoFull: string,

--- a/packages/gateway/test/unit/connectors/github-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/github-sync.test.ts
@@ -444,7 +444,7 @@ describe("github-sync — event filtering", () => {
     expect(rows[0].external_id).toBe("acme/app#20");
   });
 
-  test("PR with missing number inside pull_request is dropped at upsertFromPullRequest", async () => {
+  test("PR with missing number inside pull_request is dropped at upsertPr", async () => {
     fixture.fetchMock.respond("GET", USER_URL, { login: "octocat" });
     fixture.fetchMock.respond(
       "GET",


### PR DESCRIPTION
## Stage 2a un-park — PR A of 3 (PR-title enrichment)

**Root cause.** Indexed GitHub PRs showed id-only titles like `PR #220` because the GitHub **events feed** (`PullRequestEvent` → `payload.pull_request`) genuinely delivers no `title`, and the only indexed-`pr` writer falls back to `` `PR #${num}` ``. The rows are not stale-from-old-code — the source data lacked the field. (Root-caused against the live dev-machine index + config + source; see the Stage 2a un-park design/plan on `dev/asafgolombek/stage2a-gateway-unpark`.)

**Fix.** A best-effort, post-sync enrichment pass in the GitHub connector. Each sync tick, up to **10** `pr` rows whose stored title is still the exact `` `PR #${num}` `` fallback (newest-first) are re-fetched via `GET /repos/{owner}/{repo}/pulls/{number}` and re-upserted with their real title. One code path covers both the existing 79 fallback rows and any freshly-ingested title-less event (≤1 sync-tick latency). Source-independent — no new cloud dependency beyond the user's existing PAT.

### Behavior / safety
- **Exact-match only.** `title LIKE 'PR #%'` pre-filter, then a JS `title === \`PR #${num}\`` check — a real title like `"PR #1 revert"` is never clobbered (test included).
- **Best-effort.** Non-OK / 404 / malformed-JSON / non-object-JSON responses skip that row and leave the fallback intact. A `RateLimitError` propagates (honors backoff); any other error is logged non-fatal and the sync tick still succeeds.
- **Bounded.** ≤10 fetches/tick, sequential through the shared rate limiter — no request storm.
- On a `304 Not Modified` events response the tick returns early and enrichment resumes next non-304 tick (backfill is not time-critical).

### Tests
9 unit tests (injected `fetch`): enrich-only-fallback newest-first, cap-at-10 ordering, failed-fetch untouched, no-fallback no-op, `PR #1 revert` not clobbered, 401 → `UnauthenticatedError`, 403/rate-limit propagation, malformed-JSON skip, non-object-JSON skip.

### Verification (local, pre-push)
- `github-sync.ts` coverage: **97.6% line / 90.1% branch / 100% fn** (well above the 85%/80% floor).
- typecheck ✓, biome ✓ (2921 files), static invariant audit ✓, cross-platform audit ✓, lychee ✓ (CHANGELOG links).
- No migration; no IPC/CLI surface change; gateway-only.

Part of the Stage 2a `why`-lens substrate work (PR B = whole-file blame indexer, PR C = root registration follow). Do not merge without the usual CI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub pull requests now receive accurate titles when event data only includes an ID-based placeholder.
  - Recent placeholder-titled pull requests are automatically enriched with details from GitHub.

- **Bug Fixes**
  - Prevents valid pull request titles from being overwritten.
  - Handles unavailable, malformed, unauthorized, and rate-limited responses safely.

- **Documentation**
  - Added a changelog entry describing the GitHub connector enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->