### PR TITLE
ci(infra): P1 org CI foundation — cross-repo drift sweep + declarative rulesets

### DIFF
--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -5,6 +5,7 @@
     "target": "branch",
     "enforcement": "active",
     "conditions_ref_include": ["refs/heads/main"],
+    "conditions_ref_exclude": [],
     "required_rule_types": ["deletion", "non_fast_forward", "pull_request"],
     "pull_request": {
       "allowed_merge_methods": ["squash"],

--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -1,15 +1,25 @@
 {
-  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches here — see docs/infrastructure-roadmap.md.",
-  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"],
-  "name": "General",
-  "target": "branch",
-  "enforcement": "active",
-  "pull_request": {
-    "allowed_merge_methods": ["squash"],
-    "dismiss_stale_reviews_on_push": true,
-    "required_review_thread_resolution": true,
-    "require_code_owner_review": false,
-    "require_last_push_approval": false,
-    "required_approving_review_count": 0
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches in `shared.pull_request`. `required_status_checks` and `code_quality` rules are per-repo CI shape and intentionally NOT diffed here.",
+  "shared": {
+    "name": "General",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions_ref_include": ["refs/heads/main"],
+    "required_rule_types": ["deletion", "non_fast_forward", "pull_request"],
+    "pull_request": {
+      "allowed_merge_methods": ["squash"],
+      "dismiss_stale_reviews_on_push": true,
+      "required_review_thread_resolution": true,
+      "require_code_owner_review": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    }
+  },
+  "repos": {
+    "Nimbus": { "bypass_actor_types": ["OrganizationAdmin"] },
+    "nimbus-client": { "bypass_actor_types": [] },
+    "nimbus-sdk": { "bypass_actor_types": [] },
+    "nimbus-vscode": { "bypass_actor_types": ["OrganizationAdmin"] },
+    "nimbus-web-clipper": { "bypass_actor_types": ["OrganizationAdmin"] }
   }
 }

--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches here — see docs/infrastructure-roadmap.md.",
+  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"],
+  "name": "General",
+  "target": "branch",
+  "enforcement": "active",
+  "pull_request": {
+    "allowed_merge_methods": ["squash"],
+    "dismiss_stale_reviews_on_push": true,
+    "required_review_thread_resolution": true,
+    "require_code_owner_review": false,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 0
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs (cheap, the branch head moved), but NEVER cancel a
+  # push to a protected branch: consecutive merges share this group key, so
+  # `true` here means merge N+1 kills merge N's validation and the commit that
+  # actually ships is never fully tested. Measured at 22 cancelled / 40 runs.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -67,11 +67,16 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
+      - name: Mint App token (Administration:Read on the active repos)
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus,nimbus-client,nimbus-sdk,nimbus-vscode,nimbus-web-clipper
+          permission-administration: read
       - name: Audit ruleset drift across active repos
         env:
-          # Needs a token with administration:read on the 5 active code repos
-          # (GITHUB_TOKEN is scoped to this repo only and cannot read siblings'
-          # rulesets). Provision ORG_RULESET_READ_TOKEN as a repo secret — a
-          # fine-grained PAT or App token with Administration: Read on the org.
-          GH_TOKEN: ${{ secrets.ORG_RULESET_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: bun scripts/structure-audit/check-ruleset-drift.ts

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -1,0 +1,52 @@
+name: Org drift sweep
+
+on:
+  schedule:
+    # 07:00 UTC Mondays — early enough to act on during the week.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: org-drift-sweep
+  cancel-in-progress: false
+
+jobs:
+  sha-pins:
+    name: sha-pins (${{ matrix.repo }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - nimbus-client
+          - nimbus-sdk
+          - nimbus-vscode
+          - nimbus-web-clipper
+          - .github
+          - linux-repo
+          - homebrew-tap
+          - scoop-bucket
+    steps:
+      - name: Checkout Nimbus (for the audit script)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: nimbus-agent/${{ matrix.repo }}
+          path: target
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Audit action pins in ${{ matrix.repo }}
+        run: bun scripts/structure-audit/check-action-sha-pins.ts --root ./target

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -21,6 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # PUBLIC repos only — the default GITHUB_TOKEN checkout works anonymously
+        # for public repos but cannot clone private ones, and a private entry
+        # would fail at checkout indistinguishably from real drift.
         repo:
           - nimbus-client
           - nimbus-sdk
@@ -49,4 +52,26 @@ jobs:
           bun-version: latest
 
       - name: Audit action pins in ${{ matrix.repo }}
-        run: bun scripts/structure-audit/check-action-sha-pins.ts --root ./target
+        run: bun scripts/structure-audit/check-action-sha-pins.ts --root target
+
+  ruleset-drift:
+    name: ruleset-drift
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Audit ruleset drift across active repos
+        env:
+          # Needs a token with administration:read on the 5 active code repos
+          # (GITHUB_TOKEN is scoped to this repo only and cannot read siblings'
+          # rulesets). Provision ORG_RULESET_READ_TOKEN as a repo secret — a
+          # fine-grained PAT or App token with Administration: Read on the org.
+          GH_TOKEN: ${{ secrets.ORG_RULESET_READ_TOKEN }}
+        run: bun scripts/structure-audit/check-ruleset-drift.ts

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -1,0 +1,67 @@
+# Nimbus Infrastructure Roadmap
+
+The delivery machinery for everything the org builds: CI, release automation,
+PR review, and cross-repo coordination.
+
+> **Three roadmaps, three axes.** [`roadmap.md`](./roadmap.md) is authoritative
+> for **what the gateway does** — phases, acceptance criteria.
+> [`ecosystem-roadmap.md`](./ecosystem-roadmap.md) is authoritative for **when
+> capability becomes reachable** — client surface width. This file is
+> authoritative for **how it gets built, reviewed and shipped**.
+>
+> On disagreement about gateway capability, `roadmap.md` wins. On disagreement
+> about client reachability, `ecosystem-roadmap.md` wins. This file yields to
+> both and owns only the machinery.
+
+---
+
+## The pattern this exists to break
+
+**Controls stop where they were written.** Three instances, found across
+unrelated areas of the org:
+
+| Control | Written in | Where the risk is | Propagation |
+| --- | --- | --- | --- |
+| `audit:action-sha-pins` | `Nimbus` | the satellites — pins already drifted | never made |
+| `.coderabbit.yaml` (tuned) | the 4 satellites | `Nimbus` — 30 invariants, reviewed stock | never made |
+| `ci-secrets.md` completeness claim | when authored | `secret-health.yml`'s own credentials | never made |
+
+Two point in opposite directions, so this is not "the periphery lags." A control
+here is scoped to whatever context its author was in, and nothing carries it
+further — not to another repo, not to a later day.
+
+**Operating principle:** every sub-program ends in a gate a machine can check. A
+sub-program is done when its gate is green in CI and would go red if the
+property regressed — not when its code merges. A control that has stopped
+covering the risk looks exactly like one that is passing; only a gate that would
+go red tells them apart.
+
+---
+
+## Sub-programs
+
+Design of record:
+[`superpowers/specs/2026-07-23-org-infrastructure-program-design.md`](./superpowers/specs/2026-07-23-org-infrastructure-program-design.md).
+
+| | Sub-program | Status | Gate |
+| --- | --- | --- | --- |
+| P1 | Org CI Foundation | 🔨 in progress | Org-wide SHA-pin + ruleset drift sweep goes red on any repo |
+| P2 | Release Train | ⬜ not started | A publish that fails to open its downstream PR fails a staleness check |
+| P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
+| P4a | Main-CI concurrency | ⬜ not started | Every commit on `main` has a completed CI run |
+| P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
+| P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
+| P6 | Access & Contribution Model | ⬜ not started | Every repo reachable through a team; contributor-two switches live in checked-in config |
+
+**Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
+land immediately: P4a, `nimbus-client` rulesets, and the DCO decision.
+
+---
+
+## How to update this document
+
+- A sub-program is **done** when its gate is green in CI, not when its code
+  merges.
+- When a gate lands, record the command that runs it, so the claim is checkable.
+- When this file and [`roadmap.md`](./roadmap.md) disagree about gateway
+  capability, `roadmap.md` wins — fix this one.

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -55,7 +55,8 @@ Design of record:
 
 **Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
 land immediately: P4a, `nimbus-client` rulesets, and the contribution-licensing
-decision (CLA).
+decision (resolved 2026-07-24 — **CLA**, see the P1 progress log; implementation
+moves to P6).
 
 ### P1 progress log
 
@@ -66,6 +67,14 @@ decision (CLA).
   `19635616`, active) now protects the narrow-waist repo that had none, matching
   the shape the other active code repos share (squash-only, thread-resolution
   required, zero required approvals in solo mode).
+- **Contribution-licensing decision (2026-07-24)** — resolved to a **CLA** over a
+  DCO. A CLA preserves relicensing optionality for any future commercial
+  dual-licensing of the AGPL-3.0 core; that optionality is the deciding factor,
+  since both mechanisms establish a contributor's right to submit. The P1 plan's
+  Task 7 (a `Signed-off-by` DCO + `dco.yml` check) is therefore **superseded, not
+  amended** — P1 ships with Tasks 1–6 only. The CLA is its own sub-effort (an
+  ICLA/CCLA text + a signature-capture bot) and moves to its natural home in **P6
+  (Access & Contribution Model)**; it is *not* a blocker for the P1 PR.
 - **First org drift sweep (2026-07-23)** — all 8 repos pass `audit:action-sha-pins`
   (run locally as `bun scripts/structure-audit/check-action-sha-pins.ts --root
   <checkout>` against fresh clones, pending the workflow's first post-merge run —

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -45,10 +45,10 @@ Design of record:
 
 | | Sub-program | Status | Gate |
 | --- | --- | --- | --- |
-| P1 | Org CI Foundation | 🔨 in progress | Org-wide SHA-pin + ruleset drift sweep goes red on any repo |
+| P1 | Org CI Foundation | 🔨 in progress | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos |
 | P2 | Release Train | ⬜ not started | A publish that fails to open its downstream PR fails a staleness check |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
-| P4a | Main-CI concurrency | ⬜ not started | Every commit on `main` has a completed CI run |
+| P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
 | P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
 | P6 | Access & Contribution Model | ⬜ not started | Every repo reachable through a team; contributor-two switches live in checked-in config |
@@ -75,6 +75,12 @@ moves to P6).
   amended** — P1 ships with Tasks 1–6 only. The CLA is its own sub-effort (an
   ICLA/CCLA text + a signature-capture bot) and moves to its natural home in **P6
   (Access & Contribution Model)**; it is *not* a blocker for the P1 PR.
+- **Ruleset-drift coverage** — the diff pins name/target/enforcement,
+  `ref_name.include` **and `ref_name.exclude`** (an `exclude` naming the default
+  branch is a silent total-bypass), the required rule types, the bypass **actor
+  type set**, and the pull-request parameters. **Follow-up:** it does not yet pin
+  each bypass actor's `bypass_mode` (`always` vs `pull_request`) — a narrower
+  loosen-in-place vector that needs a richer per-actor declared shape.
 - **First org drift sweep (2026-07-23)** — all 8 repos pass `audit:action-sha-pins`
   (run locally as `bun scripts/structure-audit/check-action-sha-pins.ts --root
   <checkout>` against fresh clones, pending the workflow's first post-merge run —

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -54,7 +54,27 @@ Design of record:
 | P6 | Access & Contribution Model | ⬜ not started | Every repo reachable through a team; contributor-two switches live in checked-in config |
 
 **Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
-land immediately: P4a, `nimbus-client` rulesets, and the DCO decision.
+land immediately: P4a, `nimbus-client` rulesets, and the contribution-licensing
+decision (CLA).
+
+### P1 progress log
+
+- **Main-CI concurrency (P4a)** — shipped: `cancel-in-progress` is now conditional
+  on `github.event_name == 'pull_request'`, so consecutive `main` merges no longer
+  cancel each other's validation.
+- **`nimbus-client` rulesets** — shipped: a `General` branch ruleset (id
+  `19635616`, active) now protects the narrow-waist repo that had none, matching
+  the shape the other active code repos share (squash-only, thread-resolution
+  required, zero required approvals in solo mode).
+- **First org drift sweep (2026-07-23)** — all 8 repos pass `audit:action-sha-pins`
+  (run locally as `bun scripts/structure-audit/check-action-sha-pins.ts --root
+  <checkout>` against fresh clones, pending the workflow's first post-merge run —
+  a net-new `workflow_dispatch` cannot fire on a feature branch). **Finding:** the
+  version drift noted in the design (`harden-runner` v2.20.0 vs v2.19.4,
+  `actions/checkout` v7.0.1 vs v7.0.0) is *staleness*, not *unpinning* — every ref
+  is correctly SHA-pinned, just to older SHAs. The SHA-pin gate is green and
+  structurally cannot detect staleness; a freshness check is a **Plan B**
+  follow-up.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
+++ b/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
@@ -68,8 +68,8 @@ means the consolidation has a gate to land against instead of a hope.
 | `scripts/structure-audit/check-ruleset-drift.test.ts` (create) | Unit tests for the pure diff |
 | `package.json` (modify) | Register `audit:ruleset-drift` |
 | `scripts/lib/preflight-gates.ts` (modify) | Register the new gate so the manifest drift test passes |
-| `docs/CONTRIBUTING.md` (modify) | DCO sign-off terms |
-| `.github/workflows/dco.yml` (create) | Enforce `Signed-off-by` on PR commits |
+| ~~`docs/CONTRIBUTING.md` (modify)~~ | ~~DCO sign-off terms~~ — SUPERSEDED (Task 7): decision resolved to a CLA; not implemented here |
+| ~~`.github/workflows/dco.yml` (create)~~ | ~~Enforce `Signed-off-by` on PR commits~~ — SUPERSEDED (Task 7); the CLA moves to P6 |
 
 ---
 
@@ -191,9 +191,7 @@ gh api --method POST repos/nimbus-agent/nimbus-client/rulesets \
   "target": "branch",
   "enforcement": "active",
   "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
-  "bypass_actors": [
-    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always" }
-  ],
+  "bypass_actors": [],
   "rules": [
     { "type": "deletion" },
     { "type": "non_fast_forward" },
@@ -655,28 +653,35 @@ diff instead of four remembered UI clicks.
 
 - [ ] **Step 1: Write the desired-shape file**
 
-Create `.github/rulesets/general-branch.json`:
+Create `.github/rulesets/general-branch.json`. The file is a `shared` shape plus
+per-repo `overrides` (each repo's expected `bypass_actor_types`), which is what
+`loadDesiredFile()` + `mergeDesired()` consume — not a flat top-level ruleset:
 
 ```json
 {
-  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches here — see docs/infrastructure-roadmap.md.",
-  "repos": [
-    "Nimbus",
-    "nimbus-client",
-    "nimbus-sdk",
-    "nimbus-vscode",
-    "nimbus-web-clipper"
-  ],
-  "name": "General",
-  "target": "branch",
-  "enforcement": "active",
-  "pull_request": {
-    "allowed_merge_methods": ["squash"],
-    "dismiss_stale_reviews_on_push": true,
-    "required_review_thread_resolution": true,
-    "require_code_owner_review": false,
-    "require_last_push_approval": false,
-    "required_approving_review_count": 0
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches in `shared.pull_request`.",
+  "shared": {
+    "name": "General",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions_ref_include": ["refs/heads/main"],
+    "conditions_ref_exclude": [],
+    "required_rule_types": ["deletion", "non_fast_forward", "pull_request"],
+    "pull_request": {
+      "allowed_merge_methods": ["squash"],
+      "dismiss_stale_reviews_on_push": true,
+      "required_review_thread_resolution": true,
+      "require_code_owner_review": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    }
+  },
+  "repos": {
+    "Nimbus": { "bypass_actor_types": ["OrganizationAdmin"] },
+    "nimbus-client": { "bypass_actor_types": [] },
+    "nimbus-sdk": { "bypass_actor_types": [] },
+    "nimbus-vscode": { "bypass_actor_types": ["OrganizationAdmin"] },
+    "nimbus-web-clipper": { "bypass_actor_types": ["OrganizationAdmin"] }
   }
 }
 ```
@@ -895,10 +900,14 @@ Add next to the other `audit:` entries:
 - [ ] **Step 7: Register it in the preflight manifest**
 
 **This is mandatory** — `scripts/lib/preflight-gates.ts` has a drift test that
-fails if a CI gate is missing from the manifest. Add to the `fast` tier array:
+fails if a script is neither a registered gate nor explicitly exempted. This gate
+needs network + `gh` auth + org-read, which local `preflight` and external
+contributors lack, so it does **not** belong in the `fast` tier — it runs only in
+the scheduled `org-drift-sweep.yml` (the `ruleset-drift` job). Register it in the
+`CI_ONLY_GATES` exemption array instead:
 
 ```typescript
-  { name: "audit:ruleset-drift", cmd: ["bun", "run", "audit:ruleset-drift"], tier: "fast" },
+  "audit:ruleset-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml (ruleset-drift job), never the local FAST tier
 ```
 
 - [ ] **Step 8: Run the gate live against the real org**
@@ -1079,7 +1088,9 @@ nothing a contributor agreed to."
 
 Before opening the PR, run the full local gate set — `test:ci` is **not** it:
 
-- [ ] `bun run preflight:fast` — all fast-tier gates including the two new ones
+- [ ] `bun run preflight:fast` — all fast-tier gates (this includes the new
+      `--root` sha-pin change; `audit:ruleset-drift` is **CI-only**, not fast-tier,
+      and is run separately below)
 - [ ] `bun test scripts/structure-audit/` — the new and modified audit tests
 - [ ] `bun run lint:markdown` — expect `0 error(s)`
 - [ ] `bun run audit:doc-refs` — expect **16 docs**

--- a/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
+++ b/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
@@ -938,6 +938,14 @@ becomes one reviewed diff instead of four remembered UI clicks."
 
 ### Task 7: Adopt DCO for inbound contributions
 
+> **SUPERSEDED (2026-07-24).** Open decision 6 was resolved in favour of a **CLA**,
+> not a DCO — a CLA preserves relicensing optionality for a possible future
+> commercial dual-licensing of the AGPL-3.0 core. This task (the `Signed-off-by`
+> DCO + `dco.yml` check) is **replaced, not amended**, per its own note below. P1
+> ships with Tasks 1–6 only; the CLA is a separate sub-effort tracked under **P6
+> (Access & Contribution Model)** in `docs/infrastructure-roadmap.md`. The DCO
+> steps below are retained for the record — **do not implement them.**
+
 **Files:**
 
 - Modify: `docs/CONTRIBUTING.md`

--- a/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
+++ b/docs/superpowers/plans/2026-07-23-p1-org-ci-foundation.md
@@ -1,0 +1,1101 @@
+# P1 — Org CI Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the propagation mechanism that carries a control past the repo it
+was written in, and land the three carve-outs that are currently costing
+something every day.
+
+**Architecture:** Every gate follows the established `scripts/structure-audit/`
+shape — a pure exported function taking a filesystem root or a plain object,
+unit-tested against a temp fixture, plus an `if (import.meta.main)` CLI wrapper
+registered in `package.json` and `scripts/lib/preflight-gates.ts`. Cross-repo
+reach is achieved by checking other repos out in a scheduled workflow and
+pointing the *same tested function* at them — no second parser, no API-shaped
+duplicate of logic that already exists.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6.x strict, `bun:test`, GitHub Actions,
+`gh` CLI.
+
+## Global Constraints
+
+- **No `any`** — use `unknown` for external data. TypeScript strict is
+  non-negotiable.
+- **Never commit on `main`** — this plan's work happens on
+  `dev/asafgolombek/org-infrastructure-program` in the worktree at
+  `.claude/worktrees/org-infra-program`. Read and Edit must use the **worktree
+  absolute path**; a main-repo path silently edits main.
+- **Cross-platform paths** — `path.join()` / `os.tmpdir()`, never hardcoded
+  separators. `bun run audit:cross-platform` flags Windows-separator assertions.
+- **Every new CI gate must be added to `scripts/lib/preflight-gates.ts`** or the
+  manifest drift test fails.
+- **Action refs are SHA-pinned** — every third-party `uses:` needs a full 40-hex
+  SHA. The org rejects tag refs at run time, and `audit:action-sha-pins` will
+  reject your own new workflow.
+- **Conventional Commits** — release-please parses them. Use `ci:`, `docs:`,
+  `feat:`, `fix:`, `test:`, `build:`.
+- **Verify before claiming done** — run the command, read the output. `test:ci`
+  is not the full gate set; `preflight` is.
+
+## Scope
+
+This plan covers **P1's Nimbus-repo foundation plus the three immediate
+carve-outs**. It deliberately excludes the cross-repo reusable-workflow
+consolidation (`_ci-npm-package.yml` / `_ci-extension.yml` in the org `.github`
+repo, plus adoption in four satellites), which touches five repositories and
+five PRs and is its own plan. Splitting here keeps this plan independently
+shippable: everything below lands in the Nimbus repo except two `gh api`
+operations and one licensing decision.
+
+**Prerequisite for Plan B (the consolidation):** Task 4 and Task 5 below build
+the org-wide sweep that will *prove* the consolidation worked. Doing them first
+means the consolidation has a gate to land against instead of a hope.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `.github/workflows/ci.yml` (modify) | Split concurrency so `main` pushes stop cancelling each other |
+| `docs/infrastructure-roadmap.md` (create) | The tracked sibling roadmap; owns "how it gets built, reviewed and shipped" |
+| `scripts/structure-audit/check-doc-references.ts` (modify) | Register the new roadmap in `DOCS_FILES` |
+| `scripts/structure-audit/check-action-sha-pins.ts` (modify) | Add `--root` so the tested function can be aimed at a checkout of another repo |
+| `scripts/structure-audit/check-action-sha-pins.test.ts` (modify) | Cover `--root` argument parsing |
+| `.github/workflows/org-drift-sweep.yml` (create) | Scheduled matrix that checks out each org repo and runs the sweep against it |
+| `.github/rulesets/general-branch.json` (create) | Declarative desired ruleset shape — the source of truth |
+| `scripts/structure-audit/check-ruleset-drift.ts` (create) | Pure diff of desired vs live ruleset; CLI wrapper fetches live via `gh` |
+| `scripts/structure-audit/check-ruleset-drift.test.ts` (create) | Unit tests for the pure diff |
+| `package.json` (modify) | Register `audit:ruleset-drift` |
+| `scripts/lib/preflight-gates.ts` (modify) | Register the new gate so the manifest drift test passes |
+| `docs/CONTRIBUTING.md` (modify) | DCO sign-off terms |
+| `.github/workflows/dco.yml` (create) | Enforce `Signed-off-by` on PR commits |
+
+---
+
+### Task 1: Stop `main` CI from cancelling itself (P4a)
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml:10-12`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks. Independent; ship first.
+
+**Why:** Of the last 40 `ci.yml` runs on `main`, 22 were cancelled. The
+concurrency group is keyed on `${{ github.ref }}`, which is identical for every
+push to `main`, so each merge kills the previous merge's validation. On
+2026-07-21 three PRs merged twelve seconds apart and the only main-branch CI
+failure in 40 runs sits on that batch.
+
+- [ ] **Step 1: Read the current concurrency block**
+
+Run: `sed -n '8,14p' .github/workflows/ci.yml`
+
+Expected output:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+- [ ] **Step 2: Make cancellation conditional on event type**
+
+Replace that block with:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs (cheap, the branch head moved), but NEVER cancel a
+  # push to a protected branch: consecutive merges share this group key, so
+  # `true` here means merge N+1 kills merge N's validation and the commit that
+  # actually ships is never fully tested. Measured at 22 cancelled / 40 runs.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+- [ ] **Step 3: Verify the YAML still parses and the pin gate is clean**
+
+Run: `bun run audit:action-sha-pins`
+Expected: `audit:action-sha-pins: OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: never cancel in-progress CI on main pushes
+
+Concurrency was keyed on github.ref with cancel-in-progress: true, which is
+correct for PR branches and wrong for main — every push to main shares one
+group key, so each merge cancelled the previous merge's validation. 22 of the
+last 40 main-branch ci.yml runs were cancelled, meaning the commit that ships
+frequently has no completed CI behind it.
+
+Cancellation is now conditional on the event being a pull_request."
+```
+
+- [ ] **Step 5: Confirm the fix on the next main push**
+
+After this branch merges, run: `gh run list --workflow=ci.yml --branch main --limit 5 --json conclusion --jq '.[].conclusion'`
+Expected: no `cancelled` entries appear for pushes that were not superseded by a
+force-push. Record the observation — this is the gate for P4a.
+
+---
+
+### Task 2: Give `nimbus-client` branch protection
+
+**Files:**
+
+- No repo files. This is two `gh api` calls against `nimbus-agent/nimbus-client`.
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: a live ruleset that Task 6's drift gate will later assert against.
+
+**Why:** `nimbus-client` is the only active repo with **zero** rulesets, while
+`nimbus-sdk`, `nimbus-vscode` and `nimbus-web-clipper` each have `General` +
+`Protected release tags`. It is the narrow waist both `packages/cli` and the VS
+Code extension consume.
+
+- [ ] **Step 1: Confirm the gap is still real**
+
+Run: `gh api repos/nimbus-agent/nimbus-client/rulesets --jq 'length'`
+Expected: `0`
+
+- [ ] **Step 2: Read the sibling repo's ruleset as the template**
+
+Run: `gh api repos/nimbus-agent/nimbus-sdk/rulesets --jq '.[] | select(.name=="General") | .id'`
+
+Then, with that id: `gh api repos/nimbus-agent/nimbus-sdk/rulesets/<id> > /tmp/sdk-general.json`
+
+Read `/tmp/sdk-general.json`. `nimbus-sdk` is the closest analogue — same
+language, same publish path, same `ci.yml` shape.
+
+- [ ] **Step 3: Create the ruleset on `nimbus-client`**
+
+This deliberately omits a `required_status_checks` rule. Required contexts are
+per-repo job names, they are the most drift-prone part of a ruleset (a skipped
+job never creates its context and the PR waits forever), and Task 6's declarative
+shape does not cover them either. Protection first; required checks are a
+follow-up once `nimbus-client`'s job names are stable under Plan B's
+consolidation.
+
+```bash
+gh api --method POST repos/nimbus-agent/nimbus-client/rulesets \
+  --input - <<'JSON'
+{
+  "name": "General",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [
+    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always" }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["squash"],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}
+JSON
+```
+
+**Note on the review settings:** zero required approvals and no code-owner review
+mirror the rest of the org and are correct for a single-member org. They are the
+solo-mode switches P6 flips; do not set them to contributor values now or you
+will lock yourself out of your own repo.
+
+- [ ] **Step 4: Verify it took effect**
+
+Run: `gh api repos/nimbus-agent/nimbus-client/rulesets --jq '.[] | "\(.name) \(.enforcement)"'`
+Expected: `General active`
+
+- [ ] **Step 5: Record it**
+
+No commit — this is remote state. Note the ruleset id; Task 6 needs it.
+
+---
+
+### Task 3: Create `docs/infrastructure-roadmap.md` and register it
+
+**Files:**
+
+- Create: `docs/infrastructure-roadmap.md`
+- Modify: `scripts/structure-audit/check-doc-references.ts:78-94` (the
+  `DOCS_FILES` array)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: the tracked doc that all later sub-programs update. `DOCS_FILES`
+  grows from 15 to 16 entries, so the `audit:doc-refs` summary line changes from
+  "across 15 docs" to "across 16 docs".
+
+**Note:** Only `audit:doc-refs` needs the registration. `check-status-drift.ts`
+watches four specific surfaces (`CLAUDE.md`, `GEMINI.md`,
+`docs/architecture.md`, `docs/SECURITY-INVARIANTS.md`) for invariant-count and
+version sync; a roadmap doc carrying neither does not belong in it. The design
+spec overstated this as "register in both" — it is wrong and should be corrected
+when the spec is next touched.
+
+- [ ] **Step 1: Write the roadmap doc**
+
+Create `docs/infrastructure-roadmap.md`:
+
+```markdown
+# Nimbus Infrastructure Roadmap
+
+The delivery machinery for everything the org builds: CI, release automation,
+PR review, and cross-repo coordination.
+
+> **Three roadmaps, three axes.** [`roadmap.md`](./roadmap.md) is authoritative
+> for **what the gateway does** — phases, acceptance criteria.
+> [`ecosystem-roadmap.md`](./ecosystem-roadmap.md) is authoritative for **when
+> capability becomes reachable** — client surface width. This file is
+> authoritative for **how it gets built, reviewed and shipped**.
+>
+> On disagreement about gateway capability, `roadmap.md` wins. On disagreement
+> about client reachability, `ecosystem-roadmap.md` wins. This file yields to
+> both and owns only the machinery.
+
+---
+
+## The pattern this exists to break
+
+**Controls stop where they were written.** Three instances, found across
+unrelated areas of the org:
+
+| Control | Written in | Where the risk is | Propagation |
+| --- | --- | --- | --- |
+| `audit:action-sha-pins` | `Nimbus` | the satellites — pins already drifted | never made |
+| `.coderabbit.yaml` (tuned) | the 4 satellites | `Nimbus` — 30 invariants, reviewed stock | never made |
+| `ci-secrets.md` completeness claim | when authored | `secret-health.yml`'s own credentials | never made |
+
+Two point in opposite directions, so this is not "the periphery lags." A control
+here is scoped to whatever context its author was in, and nothing carries it
+further — not to another repo, not to a later day.
+
+**Operating principle:** every sub-program ends in a gate a machine can check. A
+sub-program is done when its gate is green in CI and would go red if the
+property regressed — not when its code merges. A control that has stopped
+covering the risk looks exactly like one that is passing; only a gate that would
+go red tells them apart.
+
+---
+
+## Sub-programs
+
+Design of record:
+[`superpowers/specs/2026-07-23-org-infrastructure-program-design.md`](./superpowers/specs/2026-07-23-org-infrastructure-program-design.md).
+
+| | Sub-program | Status | Gate |
+| --- | --- | --- | --- |
+| P1 | Org CI Foundation | 🔨 in progress | Org-wide SHA-pin + ruleset drift sweep goes red on any repo |
+| P2 | Release Train | ⬜ not started | A publish that fails to open its downstream PR fails a staleness check |
+| P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
+| P4a | Main-CI concurrency | ⬜ not started | Every commit on `main` has a completed CI run |
+| P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
+| P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
+| P6 | Access & Contribution Model | ⬜ not started | Every repo reachable through a team; contributor-two switches live in checked-in config |
+
+**Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
+land immediately: P4a, `nimbus-client` rulesets, and the DCO decision.
+
+---
+
+## How to update this document
+
+- A sub-program is **done** when its gate is green in CI, not when its code
+  merges.
+- When a gate lands, record the command that runs it, so the claim is checkable.
+- When this file and [`roadmap.md`](./roadmap.md) disagree about gateway
+  capability, `roadmap.md` wins — fix this one.
+```
+
+- [ ] **Step 2: Register it in the doc-refs scanned set**
+
+In `scripts/structure-audit/check-doc-references.ts`, add to the `DOCS_FILES`
+array, after the `"docs/architecture.md"` entry:
+
+```typescript
+  "docs/infrastructure-roadmap.md",
+```
+
+- [ ] **Step 3: Verify the doc is now scanned and its links resolve**
+
+Run: `bun run audit:doc-refs`
+Expected: `Doc-reference check: <N> refs across 16 docs — all resolve.`
+
+The **"16 docs"** is the proof the registration took. If it still says 15, the
+array edit did not land.
+
+- [ ] **Step 4: Red-prove the registration**
+
+Temporarily add a broken link to `docs/infrastructure-roadmap.md`:
+
+```markdown
+[broken](./does-not-exist.md)
+```
+
+Run: `bun run audit:doc-refs`
+Expected: **FAIL**, naming `docs/infrastructure-roadmap.md`.
+
+This is the step that proves the gate actually covers the new file rather than
+silently skipping it. Remove the broken link afterwards and re-run to confirm
+green.
+
+- [ ] **Step 5: Lint and link-check**
+
+Run: `bun run lint:markdown`
+Expected: `Summary: 0 error(s)`
+
+Run: `~/.cargo/bin/lychee --config lychee.toml docs/infrastructure-roadmap.md`
+Expected: `0 Errors`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/infrastructure-roadmap.md scripts/structure-audit/check-doc-references.ts
+git commit -m "docs(infra): add infrastructure-roadmap.md as the third roadmap
+
+Sibling to roadmap.md (what the gateway does) and ecosystem-roadmap.md (when
+capability becomes reachable); this one owns how it gets built, reviewed and
+shipped, with an explicit three-way precedence rule.
+
+Registered in check-doc-references.ts DOCS_FILES so its links are gated
+(15 -> 16 docs) rather than rotting silently."
+```
+
+---
+
+### Task 4: Let the SHA-pin audit target any checkout
+
+**Files:**
+
+- Modify: `scripts/structure-audit/check-action-sha-pins.ts:74-82` (the
+  `import.meta.main` block)
+- Modify: `scripts/structure-audit/check-action-sha-pins.test.ts`
+
+**Interfaces:**
+
+- Consumes: the existing `auditActionShaPins(repoRoot: string): AuditResult`
+  export — **unchanged**, do not alter its signature or logic.
+- Produces: `parseRootArg(argv: string[]): string` (exported), and a CLI that
+  accepts `--root <path>`. Task 5's workflow calls
+  `bun scripts/structure-audit/check-action-sha-pins.ts --root ./target`.
+
+**Why:** The pure function already accepts any directory. The only thing pinning
+it to one repo is the CLI hardcoding `process.cwd()`. Adding a flag is a
+four-line change that turns a repo-local gate into an org-wide one, and reuses
+logic that is already tested rather than writing a second parser.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/structure-audit/check-action-sha-pins.test.ts`:
+
+```typescript
+import { parseRootArg } from "./check-action-sha-pins.ts";
+
+describe("parseRootArg", () => {
+  test("defaults to cwd when --root is absent", () => {
+    expect(parseRootArg([])).toBe(process.cwd());
+  });
+
+  test("returns the path following --root", () => {
+    expect(parseRootArg(["--root", "/tmp/other-repo"])).toBe("/tmp/other-repo");
+  });
+
+  test("throws when --root is passed with no value", () => {
+    expect(() => parseRootArg(["--root"])).toThrow("--root requires a path");
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test scripts/structure-audit/check-action-sha-pins.test.ts`
+Expected: FAIL — `parseRootArg` is not exported from the module.
+
+- [ ] **Step 3: Implement it**
+
+In `scripts/structure-audit/check-action-sha-pins.ts`, add above the
+`import.meta.main` block:
+
+```typescript
+/**
+ * Resolves the repository root to audit. Defaults to the process cwd so the
+ * local preflight gate is unchanged; `--root <path>` lets the org-wide sweep
+ * aim the same audited logic at a checkout of another repository.
+ */
+export function parseRootArg(argv: string[]): string {
+  const ix = argv.indexOf("--root");
+  if (ix === -1) return process.cwd();
+  const value = argv[ix + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error("--root requires a path");
+  }
+  return value;
+}
+```
+
+Then change the CLI block to use it:
+
+```typescript
+if (import.meta.main) {
+  const root = parseRootArg(process.argv.slice(2));
+  const result = auditActionShaPins(root);
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`audit:action-sha-pins: ${err}`);
+    process.exit(1);
+  }
+  console.log("audit:action-sha-pins: OK");
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test scripts/structure-audit/check-action-sha-pins.test.ts`
+Expected: PASS, all tests including the three new ones.
+
+- [ ] **Step 5: Verify the default path is unchanged**
+
+Run: `bun run audit:action-sha-pins`
+Expected: `audit:action-sha-pins: OK` — identical to before. The local gate must
+not have changed behaviour.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors. (`scripts/` is typechecked — a `string | undefined` leak
+here will fail.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/structure-audit/check-action-sha-pins.ts scripts/structure-audit/check-action-sha-pins.test.ts
+git commit -m "test(audit): let check-action-sha-pins target any checkout via --root
+
+The pure auditActionShaPins() already accepts any directory; only the CLI
+pinned it to process.cwd(). A --root flag turns a repo-local gate into one the
+org-wide sweep can aim at a checkout of another repository, reusing tested
+logic instead of adding a second parser."
+```
+
+---
+
+### Task 5: Sweep every org repo for stale action pins
+
+**Files:**
+
+- Create: `.github/workflows/org-drift-sweep.yml`
+
+**Interfaces:**
+
+- Consumes: `parseRootArg` / the `--root` CLI from Task 4.
+- Produces: a scheduled workflow named **`Org drift sweep`** with a job named
+  `sha-pins (${{ matrix.repo }})`. P1's gate.
+
+**Why:** `harden-runner` is `v2.20.0` in `nimbus-client`/`nimbus-sdk` and
+`v2.19.4` in `nimbus-web-clipper`; `actions/checkout` is `v7.0.1` versus
+`v7.0.0`. The gate that exists to catch exactly this runs against one repo.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/org-drift-sweep.yml`:
+
+```yaml
+name: Org drift sweep
+
+on:
+  schedule:
+    # 07:00 UTC Mondays — early enough to act on during the week.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: org-drift-sweep
+  cancel-in-progress: false
+
+jobs:
+  sha-pins:
+    name: sha-pins (${{ matrix.repo }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - nimbus-client
+          - nimbus-sdk
+          - nimbus-vscode
+          - nimbus-web-clipper
+          - .github
+          - linux-repo
+          - homebrew-tap
+          - scoop-bucket
+    steps:
+      - name: Checkout Nimbus (for the audit script)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: nimbus-agent/${{ matrix.repo }}
+          path: target
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Audit action pins in ${{ matrix.repo }}
+        run: bun scripts/structure-audit/check-action-sha-pins.ts --root ./target
+```
+
+**Note:** no `bun install` is needed — the audit script imports only `node:fs`
+and `node:path`.
+
+- [ ] **Step 2: Verify the new workflow is itself SHA-pinned**
+
+Run: `bun run audit:action-sha-pins`
+Expected: `audit:action-sha-pins: OK`
+
+If it fails naming `org-drift-sweep.yml`, the SHAs above are stale — resolve
+current ones with
+`gh api repos/actions/checkout/git/ref/tags/v7.0.1 --jq '.object.sha'` and pin
+those.
+
+- [ ] **Step 3: Commit and push the branch**
+
+```bash
+git add .github/workflows/org-drift-sweep.yml
+git commit -m "ci: sweep every org repo for stale action pins
+
+audit:action-sha-pins existed to catch drifted action refs and ran against one
+repo, while harden-runner sat at v2.20.0 in client/sdk and v2.19.4 in
+web-clipper. A scheduled matrix now checks each repo out and points the same
+tested function at it via --root."
+git push -u origin dev/asafgolombek/org-infrastructure-program
+```
+
+- [ ] **Step 4: Prove it live on the branch — do not skip this**
+
+A bare `gh workflow run` executes `main`'s copy of the workflow and fakes a
+pass. The branch **must** be pushed first (Step 3), then:
+
+Run: `gh workflow run org-drift-sweep.yml --ref dev/asafgolombek/org-infrastructure-program`
+
+Then: `gh run list --workflow=org-drift-sweep.yml --limit 1 --json databaseId,status --jq '.[0]'`
+
+Wait for completion, then: `gh run view <databaseId> --json jobs --jq '.jobs[] | "\(.name) \(.conclusion)"'`
+
+- [ ] **Step 5: Read the result — a failure here is the gate working**
+
+Expected: `nimbus-web-clipper` **fails**, reporting `harden-runner` and
+`actions/checkout` refs that are SHA-pinned but to older SHAs than the siblings.
+
+**Important:** the audit checks that refs are *SHA-pinned*, not that they are the
+*newest* SHA. If all eight jobs pass, the sweep is working correctly and the
+version drift found in the diagnosis is a *staleness* problem the SHA gate does
+not detect. Record which it is — that determines whether Plan B needs a separate
+freshness check, and it is a real finding either way.
+
+- [ ] **Step 6: Record the outcome in the roadmap**
+
+Update the P1 row of `docs/infrastructure-roadmap.md` with the observed result
+and the command that produced it. Commit:
+
+```bash
+git add docs/infrastructure-roadmap.md
+git commit -m "docs(infra): record the first org drift sweep result"
+```
+
+---
+
+### Task 6: Make rulesets declarative and drift-checked
+
+**Files:**
+
+- Create: `.github/rulesets/general-branch.json`
+- Create: `scripts/structure-audit/check-ruleset-drift.ts`
+- Create: `scripts/structure-audit/check-ruleset-drift.test.ts`
+- Modify: `package.json` (the `audit:*` script block, near line 162)
+- Modify: `scripts/lib/preflight-gates.ts` (the `fast` tier array)
+
+**Interfaces:**
+
+- Consumes: the live ruleset created in Task 2.
+- Produces: `diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult`
+  and `DesiredRuleset`. P6 will add the contributor-two switches to the JSON
+  file this task creates.
+
+**Why:** Fixing `nimbus-client` by hand fixes one repo once. Checked-in config
+plus a divergence check makes uniform protection a gated property — and gives P6
+somewhere to write the contributor-two switches so the transition is one reviewed
+diff instead of four remembered UI clicks.
+
+- [ ] **Step 1: Write the desired-shape file**
+
+Create `.github/rulesets/general-branch.json`:
+
+```json
+{
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches here — see docs/infrastructure-roadmap.md.",
+  "repos": [
+    "Nimbus",
+    "nimbus-client",
+    "nimbus-sdk",
+    "nimbus-vscode",
+    "nimbus-web-clipper"
+  ],
+  "name": "General",
+  "target": "branch",
+  "enforcement": "active",
+  "pull_request": {
+    "allowed_merge_methods": ["squash"],
+    "dismiss_stale_reviews_on_push": true,
+    "required_review_thread_resolution": true,
+    "require_code_owner_review": false,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 0
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `scripts/structure-audit/check-ruleset-drift.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+
+import { type DesiredRuleset, diffRuleset } from "./check-ruleset-drift.ts";
+
+const DESIRED: DesiredRuleset = {
+  repos: ["nimbus-client"],
+  name: "General",
+  target: "branch",
+  enforcement: "active",
+  pull_request: {
+    allowed_merge_methods: ["squash"],
+    dismiss_stale_reviews_on_push: true,
+    required_review_thread_resolution: true,
+    require_code_owner_review: false,
+    require_last_push_approval: false,
+    required_approving_review_count: 0,
+  },
+};
+
+function liveRuleset(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "General",
+    target: "branch",
+    enforcement: "active",
+    rules: [
+      {
+        type: "pull_request",
+        parameters: {
+          allowed_merge_methods: ["squash"],
+          dismiss_stale_reviews_on_push: true,
+          required_review_thread_resolution: true,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_approving_review_count: 0,
+          ...overrides,
+        },
+      },
+    ],
+  };
+}
+
+describe("diffRuleset", () => {
+  test("passes when live matches desired", () => {
+    const result = diffRuleset(DESIRED, liveRuleset());
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("flags a drifted pull_request parameter", () => {
+    const result = diffRuleset(DESIRED, liveRuleset({ required_approving_review_count: 1 }));
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("required_approving_review_count");
+    expect(result.errors[0]).toContain("expected 0");
+    expect(result.errors[0]).toContain("got 1");
+  });
+
+  test("flags disabled enforcement", () => {
+    const live = { ...liveRuleset(), enforcement: "disabled" };
+    const result = diffRuleset(DESIRED, live);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("enforcement");
+  });
+
+  test("flags a missing ruleset entirely", () => {
+    const result = diffRuleset(DESIRED, null);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("no 'General' ruleset");
+  });
+
+  test("flags a missing pull_request rule", () => {
+    const result = diffRuleset(DESIRED, { name: "General", target: "branch", enforcement: "active", rules: [] });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("pull_request");
+  });
+});
+```
+
+- [ ] **Step 3: Run them and watch them fail**
+
+Run: `bun test scripts/structure-audit/check-ruleset-drift.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the pure diff**
+
+Create `scripts/structure-audit/check-ruleset-drift.ts`:
+
+```typescript
+#!/usr/bin/env bun
+
+/**
+ * audit:ruleset-drift — asserts each active org repo's live `General` branch
+ * ruleset matches the declarative shape in `.github/rulesets/general-branch.json`.
+ *
+ * Manual UI configuration drifts: `nimbus-client` had zero rulesets while its
+ * three sibling repos each had two. Checking the desired shape into the repo and
+ * diffing it turns uniform protection from a one-time task into a gated property.
+ *
+ * The diff is pure and unit-tested; the CLI wrapper fetches live config via `gh`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export interface DesiredRuleset {
+  repos: string[];
+  name: string;
+  target: string;
+  enforcement: string;
+  pull_request: Record<string, unknown>;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Structural equality for the JSON-shaped values a ruleset parameter can hold. */
+function sameValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult {
+  const errors: string[] = [];
+
+  if (!isRecord(live)) {
+    return { ok: false, errors: [`no '${desired.name}' ruleset found (or it is not an object)`] };
+  }
+
+  for (const field of ["name", "target", "enforcement"] as const) {
+    if (live[field] !== desired[field]) {
+      errors.push(`${field}: expected ${String(desired[field])}, got ${String(live[field])}`);
+    }
+  }
+
+  const rules = Array.isArray(live.rules) ? live.rules : [];
+  const prRule = rules.find((r) => isRecord(r) && r.type === "pull_request");
+  if (!isRecord(prRule)) {
+    return { ok: false, errors: [...errors, "no pull_request rule present"] };
+  }
+
+  const params = isRecord(prRule.parameters) ? prRule.parameters : {};
+  for (const [key, want] of Object.entries(desired.pull_request)) {
+    const got = params[key];
+    if (!sameValue(got, want)) {
+      errors.push(
+        `pull_request.${key}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+export function loadDesired(repoRoot: string): DesiredRuleset {
+  const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
+  return JSON.parse(raw) as DesiredRuleset;
+}
+
+if (import.meta.main) {
+  const desired = loadDesired(process.cwd());
+  const allErrors: string[] = [];
+
+  for (const repo of desired.repos) {
+    const proc = Bun.spawnSync([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/rulesets`,
+      "--jq",
+      `.[] | select(.name=="${desired.name}") | .id`,
+    ]);
+    const id = new TextDecoder().decode(proc.stdout).trim();
+    if (id === "") {
+      allErrors.push(`${repo}: no '${desired.name}' ruleset found`);
+      continue;
+    }
+    const detail = Bun.spawnSync(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    const live: unknown = JSON.parse(new TextDecoder().decode(detail.stdout));
+    const result = diffRuleset(desired, live);
+    for (const err of result.errors) allErrors.push(`${repo}: ${err}`);
+  }
+
+  if (allErrors.length > 0) {
+    for (const err of allErrors) console.error(`audit:ruleset-drift: ${err}`);
+    process.exit(1);
+  }
+  console.log(`audit:ruleset-drift: OK (${desired.repos.length} repos)`);
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `bun test scripts/structure-audit/check-ruleset-drift.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Register the gate in `package.json`**
+
+Add next to the other `audit:` entries:
+
+```json
+    "audit:ruleset-drift": "bun scripts/structure-audit/check-ruleset-drift.ts",
+```
+
+- [ ] **Step 7: Register it in the preflight manifest**
+
+**This is mandatory** — `scripts/lib/preflight-gates.ts` has a drift test that
+fails if a CI gate is missing from the manifest. Add to the `fast` tier array:
+
+```typescript
+  { name: "audit:ruleset-drift", cmd: ["bun", "run", "audit:ruleset-drift"], tier: "fast" },
+```
+
+- [ ] **Step 8: Run the gate live against the real org**
+
+Run: `bun run audit:ruleset-drift`
+Expected: `audit:ruleset-drift: OK (5 repos)` — Task 2 created the missing
+`nimbus-client` ruleset, so this should now pass.
+
+If it reports drift, that is a genuine finding: some repo's live config differs
+from the declared shape. Read the diff and decide whether the *file* or the
+*repo* is wrong before changing either.
+
+- [ ] **Step 9: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: both clean. If `lint` reports 0 files in the worktree, validate with
+`bunx biome check packages scripts` instead — that is a known worktree
+false-negative.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add .github/rulesets/general-branch.json scripts/structure-audit/check-ruleset-drift.ts scripts/structure-audit/check-ruleset-drift.test.ts package.json scripts/lib/preflight-gates.ts
+git commit -m "feat(audit): check rulesets into code and gate their drift
+
+nimbus-client had zero rulesets while its three siblings had two each — manual
+UI config drifts. The desired General ruleset shape now lives in
+.github/rulesets/general-branch.json and audit:ruleset-drift diffs it against
+live config for all five active code repos.
+
+The diff is pure and unit-tested; only the CLI wrapper touches the network.
+P6 writes the contributor-two switches into this file, so that transition
+becomes one reviewed diff instead of four remembered UI clicks."
+```
+
+---
+
+### Task 7: Adopt DCO for inbound contributions
+
+**Files:**
+
+- Modify: `docs/CONTRIBUTING.md`
+- Create: `.github/workflows/dco.yml`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: a required-able check named `DCO`.
+
+> **BLOCKED ON A DECISION — do not start without an answer.** Open decision 6 in
+> the design spec: **DCO or CLA?** This task implements **DCO**, the
+> recommendation. If a CLA is chosen instead — which preserves relicensing
+> optionality for any future commercial dual-licensing — this task is replaced,
+> not amended. Ask before implementing.
+
+**Why:** `docs/CONTRIBUTING.md` contains no sign-off or CLA terms and the repo is
+public, so the first outside PR can arrive any day. Retroactive sign-off
+collection is far worse than prospective. The AGPL-3.0 core / MIT SDK split
+sharpens it: a contributor patching the MIT `nimbus-sdk` with work derived from
+reading the AGPL gateway breaks the one-way rule that architecture currently
+enforces but nothing a contributor agrees to.
+
+- [ ] **Step 1: Add the sign-off section to `docs/CONTRIBUTING.md`**
+
+Append:
+
+````markdown
+## Developer Certificate of Origin (DCO)
+
+Every commit must carry a `Signed-off-by` line certifying you wrote the patch or
+otherwise have the right to submit it under the repository's license. See
+[developercertificate.org](https://developercertificate.org/).
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+`git commit -s` adds it automatically. The `DCO` check enforces this on every
+pull request.
+
+**Why this project cares more than most.** Nimbus is dual-licensed: the gateway,
+CLI and connectors are AGPL-3.0, while `@nimbus-dev/sdk` and
+`@nimbus-dev/client` are MIT. Code may flow **MIT → AGPL** but never the
+reverse. If you contribute to the MIT packages, your patch must not be derived
+from AGPL-licensed parts of this repository. If you are unsure which side of the
+line your change sits on, ask in the pull request before pushing.
+````
+
+- [ ] **Step 2: Add the enforcement workflow**
+
+Create `.github/workflows/dco.yml`:
+
+```yaml
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dco-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: DCO
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify every commit is signed off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%B' "$sha" | grep -qiF "Signed-off-by: $author"; then
+              echo "::error::commit $sha is missing 'Signed-off-by: $author'"
+              missing=1
+            fi
+          done < <(git rev-list "$BASE_SHA".."$HEAD_SHA")
+          if [ "$missing" -ne 0 ]; then
+            echo "Add sign-off with: git commit --amend -s   (or: git rebase --signoff $BASE_SHA)"
+            exit 1
+          fi
+          echo "DCO: all commits signed off"
+```
+
+- [ ] **Step 3: Verify pins and markdown**
+
+Run: `bun run audit:action-sha-pins && bun run lint:markdown`
+Expected: both clean.
+
+- [ ] **Step 4: Red-prove the check**
+
+Push a commit **without** `-s` to the branch, then confirm the `DCO` job fails
+naming that SHA. Then amend with `git commit --amend -s`, force-push, and confirm
+it passes.
+
+A gate that has never been observed red is not a gate. This step is the proof.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/CONTRIBUTING.md .github/workflows/dco.yml
+git commit -s -m "feat(ci): require DCO sign-off on contributions
+
+CONTRIBUTING.md carried no sign-off or CLA terms while the repo is public, so
+the first outside PR could arrive with no record of the contributor's right to
+submit. The AGPL-core / MIT-SDK split sharpens it: a patch to the MIT packages
+derived from AGPL code breaks the one-way rule that architecture enforces but
+nothing a contributor agreed to."
+```
+
+---
+
+## Verification
+
+Before opening the PR, run the full local gate set — `test:ci` is **not** it:
+
+- [ ] `bun run preflight:fast` — all fast-tier gates including the two new ones
+- [ ] `bun test scripts/structure-audit/` — the new and modified audit tests
+- [ ] `bun run lint:markdown` — expect `0 error(s)`
+- [ ] `bun run audit:doc-refs` — expect **16 docs**
+- [ ] `~/.cargo/bin/lychee --config lychee.toml docs/*.md docs/superpowers/**/*.md` —
+      match CI's link total for the whole branch, not just edited files. A
+      pre-existing broken link elsewhere still fails your PR.
+- [ ] `bun run audit:ruleset-drift` — expect `OK (5 repos)`
+- [ ] Confirm the `Org drift sweep` run on the branch completed (Task 5 Step 4)
+
+**Known worktree caveats:** full `preflight` is unusable in a worktree; `bun run
+lint` may report 0 files — use `bunx biome check packages scripts`. If anything
+touches coverage, `audit:coverage-floor` is Linux-authoritative and must be run
+under Docker `oven/bun:latest`, not native Windows.
+
+---
+
+## Deferred to Plan B
+
+The cross-repo reusable-workflow consolidation: `_ci-npm-package.yml` and
+`_ci-extension.yml` in the org `.github` repo, plus adoption PRs in
+`nimbus-sdk`, `nimbus-client`, `nimbus-vscode` and `nimbus-web-clipper`. Five
+repos, five PRs, and a dev loop with its own trap — a caller pointed at
+`@dev-branch` for testing must be flipped back to `@main` before merge, or
+production CI is pinned to a branch.
+
+Task 5's sweep is the gate that consolidation lands against, which is why it
+comes first.

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design-review.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design-review.md
@@ -81,7 +81,7 @@ commands are named so the reasoning can be re-checked rather than trusted.
 | 2b | Auto-merge bypasses I2 | **Split** — I2 linkage rejected, merge question adopted | Non-goals + Open decision 4 |
 | 3 | Rulesets as code | **Fixed**, scoped to script + drift gate | P1 |
 | 4 | Cross-repo reusable dev loop | **Fixed** | Design constraints |
-| 5 | Dashboard privacy | **Split** — secret-name framing rejected, private-repo leak accepted | P5 |
+| 5 | Dashboard privacy | **Split** — secret-name framing rejected, private-repo leak accepted, and a follow-up found the inventory itself incomplete | P5 |
 
 ### On item 1 — right conclusion, wrong reasoning
 
@@ -140,19 +140,38 @@ Terraform is rejected as disproportionate — nine repos, no existing state
 backend, solo maintainer, and it breaches the Actions-only infra tier the program
 committed to. A `gh api` script in `.github` reaches the same guarantee.
 
-### On item 5 — wrong risk, real risk underneath
+### On item 5 — wrong risk, real risk underneath, and a third one neither of us saw
 
-Secret **names** are already public by design: `docs/ci-secrets.md` is the
-canonical inventory and lives in a public repo. An expiry countdown against a
-name an attacker can already read leaks nothing, and surfacing it is the point.
-CI pass-rates and durations are likewise already public for public repos via the
-Actions UI.
+Secret **names** are already public regardless of `ci-secrets.md`:
+`grep -rhoE "secrets\.[A-Z_]+" .github/workflows/` yields 22 names, and the
+workflow files are public. So privatizing the doc buys nothing on the thing it
+looks like it protects. CI pass-rates and durations are likewise already public
+for public repos via the Actions UI.
 
-The real exposure the review pointed at without naming: the `.github` repo is
-**public**, and six private scaffolds plus five other private repos would become
-publicly enumerable with commit cadence attached if a dashboard aggregated them
-there. The constraint adopted is therefore about **repo visibility mixing**, not
-about secret names.
+The exposure the review pointed at without naming: the `.github` repo is
+**public**, and the org's **6** private repos would become publicly enumerable
+with commit cadence attached if a dashboard aggregated them there. The adopted
+constraint is therefore about **repo-visibility mixing**, not secret names.
+(Revision 2 of the design miscounted this as "six private scaffolds plus five
+others"; the true split is 12 public / 6 private, corrected in revision 3.)
+
+**A follow-up question — "maybe `ci-secrets.md` is a mistake?" — surfaced the
+real defect, which is neither of the above.** The doc claims to be the canonical
+inventory of *every* Actions secret the workflows consume, and is missing three:
+`SECRET_AUDITOR_CLIENT_ID`, `SECRET_AUDITOR_PRIVATE_KEY` (both
+`secret-health.yml`) and `BENCHER_API_KEY` (`_perf.yml`, `_perf-reference.yml`).
+The two App credentials belong to the workflow that monitors secret health — the
+monitor is absent from the inventory it exists to serve, and
+`nimbus-secret-auditor` is installed org-wide with `all` repo selection.
+
+A completeness claim that is false is worse than a public one, because the claim
+is what people act on. P5 gains an `audit:secret-inventory` gate asserting the
+`grep secrets\.` set equals the documented table. Two narrower trims were also
+adopted (coarsen the one precise expiry date; move the repo-secret-versus-
+`release`-environment mapping off the public page); token type and scope stay,
+as they serve auditors more than attackers. The document is **not** deleted or
+privatized — it is why `secret-health.yml` exists, and obscurity is the weakest
+control in this stack.
 
 ### Not in the review — two gaps found while verifying it
 

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design-review.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design-review.md
@@ -1,0 +1,171 @@
+# Design Review: Org Delivery Infrastructure — Program Design
+
+**Date:** 2026-07-23
+**Target Spec:** [2026-07-23-org-infrastructure-program-design.md](./2026-07-23-org-infrastructure-program-design.md)
+
+---
+
+## 1. Security Boundaries and Secrets in Org-Level Reusable Workflows (P1)
+
+### Reusable Workflows and Secret Leakage (I13/I27/I29)
+
+* **Observation:** Promoting workflows to the org-level `.github` repository using `secrets: inherit` simplifies secrets management.
+* **Potential Issue:** If a repository's write permissions are compromised or if a malicious PR is submitted to a satellite repository, calling a shared workflow with inherited secrets could inadvertently expose organization-level secrets (like NPM tokens, VS Code Marketplace tokens, or release bot credentials) to untrusted code runs.
+* **Suggestion:**
+  * Restrict the use of `secrets: inherit` where possible.
+  * For sensitive workflows (e.g., publishing to npm or VS Code Marketplace), define explicit inputs/secrets requirements instead of blanket inheritance.
+  * Document the exact permission model for workflows running on `pull_request` vs. `push`/`release` events to prevent untrusted PR forks from accessing release-tier secrets.
+
+---
+
+## 2. Downstream Auto-Consumption Cascades and Loops (P2)
+
+### Cascade Control and Circular Dependency Risks
+
+* **Observation:** P2 plans downstream auto-consumption: `sdk` dispatch -> `client` PR, `client` dispatch -> `Nimbus` / `nimbus-vscode` PR.
+* **Potential Issue:** If a cycle is introduced, or if multiple repository dispatches queue up rapid-fire, it can trigger run-away CI loops, wasting runner minutes and polluting the PR queues.
+* **Suggestion:**
+  * Introduce rate-limiting or debounce logic in the dispatch receiver workflows.
+  * Ensure the automated PR creation is idempotent: if a downstream PR for version `X` is already open, do not open a new one; instead, update the existing branch or do nothing.
+  * Define clear termination rules for the release propagation train.
+
+### Automated Merge & HITL Constraints
+
+* **Observation:** The spec notes "There are no human reviewers" and 18 of the last 80 merges were by `nimbus-release-bot`.
+* **Potential Issue:** If the downstream consumption PRs (e.g., bumping client SDK in Nimbus) auto-merge when CI passes, we bypass human gatekeeping entirely. This might conflict with the structural HITL non-negotiables (Invariant I2).
+* **Suggestion:** Explicitly document whether the downstream bumps require manual approval (`asafgolombek`) to merge, or if they are auto-merged by the bot only when passing a specific sub-suite of automated validation gates.
+
+---
+
+## 3. Standardizing and Enforcing Rulesets/Branch Protection (P1)
+
+### Infrastructure-as-Code for Repo Rulesets
+
+* **Observation:** `nimbus-client` has zero rulesets while other repositories have some protected release tags.
+* **Potential Issue:** Manual configuration of rulesets in GitHub's UI leads to setting drift over time.
+* **Suggestion:** Consider managing repository settings and rulesets programmatically (e.g., via GitHub CLI scripts in the `.github` repository or a lightweight Terraform configuration) to guarantee uniform protection across all 9 repositories.
+
+---
+
+## 4. Reusable Workflow Testing and Dev Loop (P1)
+
+### Test Harness/Local Verification for Shared Actions
+
+* **Observation:** "Branch-only workflow changes need live proof."
+* **Potential Issue:** Testing shared workflows in `.github` from satellite repositories before merging to `main` is difficult because GitHub Actions reusable references typically require a hardcoded ref (e.g., `org/.github/.github/workflows/reusable.yml@main` or a specific branch/SHA).
+* **Suggestion:** Document the exact developer loop for testing changes to reusable workflows. Typically, this involves pointing the caller repo's workflow to `org/.github/...@dev-branch` temporarily, triggering the check, and verifying it succeeds before reverting the ref to `@main` for the PR merge.
+
+---
+
+## 5. Org Legibility Dashboard Privacy (P5)
+
+### Public vs. Private Dashboard Legibility
+
+* **Observation:** P5 Tier A plans to write markdown to the `.github` repository profile or a pinned issue showing version status and secret-expiry countdowns.
+* **Potential Issue:** If these repositories are public, publishing a dashboard that surfaces secret names, precise expiration dates, and internal CI pass rates/durations might expose sensitive operations or operational metadata to the public.
+* **Suggestion:** Ensure the dashboard only displays non-sensitive metadata (e.g., names like "VS Code Marketplace Token" with coarse countdowns rather than precise API parameters) and verify that no internal gateway paths or environments are exposed.
+
+---
+
+## Disposition
+
+Recorded 2026-07-23 against design revision 2. Claims above are left **as
+written**; this section records what happened to each and why. Verification
+commands are named so the reasoning can be re-checked rather than trusted.
+
+| # | Item | Disposition | Landed in |
+| --- | --- | --- | --- |
+| 1 | `secrets: inherit` / reusable-workflow leakage | **Fixed, reframed** | Design constraints |
+| 2a | Cascade idempotency | **Fixed** | P2 §3 |
+| 2a | Cycle risk / rate-limiting | **Rejected** | P2 §3 (DAG note) |
+| 2b | Auto-merge bypasses I2 | **Split** — I2 linkage rejected, merge question adopted | Non-goals + Open decision 4 |
+| 3 | Rulesets as code | **Fixed**, scoped to script + drift gate | P1 |
+| 4 | Cross-repo reusable dev loop | **Fixed** | Design constraints |
+| 5 | Dashboard privacy | **Split** — secret-name framing rejected, private-repo leak accepted | P5 |
+
+### On item 1 — right conclusion, wrong reasoning
+
+`grep -rn "secrets: inherit" .github/workflows/` returns nothing: the org does
+not use inheritance anywhere, so the described exposure does not exist today. The
+suggestion is still adopted as a forward constraint, but for a different and
+stronger reason — an explicitly mapped secret that is absent fails **loudly** at
+the call site, while an inherited one that never arrives fails **silently**. That
+silent mode is not hypothetical: it is how `CODECOV_TOKEN` was broken long enough
+to be retired rather than rotated.
+
+The fork half of the concern is largely handled by the platform: `pull_request`
+runs from forks receive no secrets. The genuine sharp edge the review did not
+name is `pull_request_target`, which `labeler.yml` and `pr-title-lint.yml` do
+use, and which runs with base-repo secret access against PR-authored content.
+That is captured as a constraint on what P1 may promote.
+
+**I13, I27 and I29 do not apply.** They govern the gateway's HTTP write
+allowlist, outbound share chokepoint, and egress ledger — runtime properties of a
+binary on a user's machine, not GitHub Actions. See item 2b.
+
+### On item 2b — a category error worth naming
+
+I2 is `HITL_REQUIRED_BACKING` in `engine/executor.ts`: the consent gate an agent
+crosses before a tool call executes on the user's machine. It says nothing about
+GitHub merges. "Human-in-the-loop for an agent action" and "human review before a
+PR lands" share a word and share nothing else; auto-merging a dependency bump
+cannot weaken I2 because I2 is not on that path.
+
+This is recorded in the design's non-goals rather than quietly dropped, because
+invariant names used as generic gravitas is precisely the drift the triple rule
+exists to prevent — and a spec that let it stand would license the next one.
+
+The underlying question is real and was adopted: **open decision 4**, with a
+defensible middle (auto-merge patch bumps only).
+
+### On item 2a — idempotency yes, cycles no
+
+Idempotent PR creation is a genuine requirement and is now specified. Cycle
+detection is rejected: the topology is `sdk → client → {Nimbus, vscode}` and
+nothing downstream publishes anything upstream consumes, so a cycle is not
+reachable by construction. The design states this as a property to *preserve*,
+with the trigger for revisiting it (a future back-edge) named explicitly. Adding
+hop limits against an unreachable state is machinery that would need its own
+tests and would drift.
+
+### On item 3 — the strongest item in the review
+
+Accepted with scope changed. The insight is right and generalizes further than
+stated: `nimbus-client`'s missing rulesets *are* the drift, and the 2026-06-23
+org settings audit already left UI-only items pending. Fixing it by hand fixes
+one repo once. Checked-in ruleset config plus a scheduled divergence check turns
+it into a gated property, which is what the operating principle requires.
+
+Terraform is rejected as disproportionate — nine repos, no existing state
+backend, solo maintainer, and it breaches the Actions-only infra tier the program
+committed to. A `gh api` script in `.github` reaches the same guarantee.
+
+### On item 5 — wrong risk, real risk underneath
+
+Secret **names** are already public by design: `docs/ci-secrets.md` is the
+canonical inventory and lives in a public repo. An expiry countdown against a
+name an attacker can already read leaks nothing, and surfacing it is the point.
+CI pass-rates and durations are likewise already public for public repos via the
+Actions UI.
+
+The real exposure the review pointed at without naming: the `.github` repo is
+**public**, and six private scaffolds plus five other private repos would become
+publicly enumerable with commit cadence attached if a dashboard aggregated them
+there. The constraint adopted is therefore about **repo visibility mixing**, not
+about secret names.
+
+### Not in the review — two gaps found while verifying it
+
+Both are larger than anything above, and both are prior art this program would
+otherwise have re-derived:
+
+* [`2026-07-19-github-app-migration-design.md`](./2026-07-19-github-app-migration-design.md)
+  is the design of record for `nimbus-release-bot` — sub-project 2 of 4 in the
+  org secrets-management program. P2(b) extends it rather than reinventing it,
+  and its finding that an org-installed App can only mint tokens for repos inside
+  that org is exactly why `VSCE_PAT` is unreachable.
+* [`2026-06-20-github-app-design.md`](./2026-06-20-github-app-design.md)
+  specifies a first-party PR-check Action posting preflight + DORA verdicts on
+  pull requests. It is a Phase 12 product deliverable, but it is a fourth
+  reviewer that already exists on paper, and P3 is the natural place to dogfood
+  it. Added as open decision 5.

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -291,6 +291,7 @@ registration and treats it as part of the deliverable.
 | **P4a** | Main-CI concurrency fix | XS | Actions-only | Every commit on `main` has a completed CI run |
 | **P4b** | Latency | S–M | Actions-only | Per-job wall-clock tracked; regressions visible |
 | **P5** | Org Legibility | S | Actions-only | Dashboard regenerates on schedule; stale downstream and expiring secrets surface before they bite; `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
+| **P6** | Access & Contribution Model | S–M | Actions-only | Every repo is reachable through a team; the contributor-two ruleset switches live in the checked-in config P1 drift-checks, so they cannot be flipped in the UI and forgotten |
 
 ### P1 — Org CI Foundation
 
@@ -472,24 +473,94 @@ two trims above, then land the gate that keeps both true.
 P5 precedes P4b because it supplies the measurements P4b must be justified
 against.
 
+### P6 — Access & Contribution Model
+
+The org is public and single-member; the goal is to be ready for contributor two
+*before* they arrive, not to reorganize around a hypothetical team.
+
+**The scaffolding already exists and is well shaped.** Three `closed` teams —
+`maintainers` (maintain on `Nimbus` + the package-manager channels, admin on
+nine others), `connector-authors` (write on the three connector-tooling repos),
+`community-contributors` (triage on `awesome-nimbus` + `nimbus-recipes`). Each
+contains exactly one member. Nothing needs redesigning; four things need
+finishing.
+
+**1. Six repos belong to no team.** `.github`, `linux-repo`, `nimbus-client`,
+`nimbus-sdk`, `nimbus-vscode`, `nimbus-web-clipper` — the entire npm narrow
+waist plus the org's shared-workflow home. Teams were created for the periphery
+and the monorepo and never extended to the publishing chain: the named pattern
+again, in org configuration rather than CI. Grant them before anyone needs
+adding, because there is currently no team to add a contributor *to*.
+
+**2. Four ruleset settings are solo-mode and become wrong silently.** Nimbus's
+`General` ruleset is `active`, and today all four are correct for one person:
+
+| Setting | Now | Breaks how, with contributors |
+| --- | --- | --- |
+| `required_approving_review_count` | `0` | Unreviewed merges |
+| `require_code_owner_review` | `false` | `CODEOWNERS` stays inert |
+| `require_last_push_approval` | `false` | A push can land after approval |
+| Bypass `OrganizationAdmin` | `always` | Invariant protections become advisory for admins |
+
+`CODEOWNERS` is already written, comprehensive, and honest about its own
+status — *"Today they are documentary; they become enforcing the moment a second
+maintainer gains write access."* It maps every invariant-bearing file: the HITL
+gate, the Vault, the sandbox runner, the Tauri allowlist, the HTTP write surface,
+`security-invariants.test.ts` itself. **Flipping `require_code_owner_review` is
+one boolean and the highest-value switch in this program** — a bot can flag an
+I2 violation, a required code-owner review prevents it.
+
+These are not flipped now (they would block a solo maintainer). They are written
+into the checked-in ruleset config P1 creates, commented as the
+contributor-two switch set, so the transition is one reviewed diff rather than
+four remembered UI clicks. **That is P6's gate.**
+
+**3. Inbound contribution licensing is undecided — and this one is urgent.**
+`CONTRIBUTING.md` contains no DCO, sign-off or CLA terms. The repo is public
+*now*, so the first outside PR can arrive any day, and retroactive sign-off
+collection is far worse than prospective. The dual license sharpens it: a
+contributor patching the MIT `nimbus-sdk` with work derived from reading the
+AGPL gateway creates exactly the infection the ecosystem roadmap's one-way rule
+("MIT into AGPL is fine; the reverse would infect") exists to prevent — today
+enforced by architecture, but by nothing a contributor agrees to. DCO is the
+lightweight standard; a CLA is heavier and is what would preserve relicensing
+optionality for any future commercial dual-licensing. **Decide before the first
+outside PR, not after.**
+
+**4. Two org settings and a plan ceiling.** `members_can_create_repositories` is
+`true` (should be `false`); `default_repository_permission` is `read`, which
+grants every future member baseline access to all six private repos (should be
+`none`, with access via teams). And on the **Free** plan, branch protection and
+rulesets do not apply to private repos at all — moot today, not moot with
+contributors. Options: accept, make them public, or move to Team. 2FA is already
+required org-wide.
+
 ---
 
 ## Sequence
 
-**P1 → P4a → P2 → P5 → P3 → P4b**
+**P1 → P6 → P2 → P5 → P3 → P4b**
 
-- **P1 first** — it creates the shared home everything else installs into, and it
-  is the cheapest.
-- **P4a second** — two lines, and until it lands, no other CI improvement can be
-  trusted to have been validated on `main`.
+- **P1 first** — it is the propagation mechanism, and it is the cheapest.
+- **P6 second** — it depends on P1's checked-in ruleset config as the place the
+  contributor-two switches live.
 - **P2 third** — highest toil payoff, and smaller than first estimated
   (Correction 3).
 - **P5 fourth** — small, and it instruments P4b.
-- **P3 fifth** — its first step is cheap; its second step needs evidence P3's
+- **P3 fifth** — its first step is cheap; its second step needs evidence the
   first step generates.
 - **P4b last** — measured, never guessed.
 
-`nimbus-client` rulesets land ahead of all of it, independently.
+**Three items ignore the sequence and should land immediately**, because each is
+tiny and each is currently costing something:
+
+1. **P4a** — the `main` concurrency fix. Two lines. Until it lands, no other CI
+   improvement can be trusted to have been validated on `main` at all.
+2. **`nimbus-client` rulesets** — the only active repo with zero branch
+   protection, and the narrow waist two consumers depend on.
+3. **The DCO/CLA decision** (P6 item 3) — the repo is public, so the first
+   outside PR can arrive before the program reaches P6, and prospective sign-off
+   is far cheaper than retroactive.
 
 ---
 
@@ -543,8 +614,14 @@ against.
   to it and never restates it.
 - **Not a secrets inventory.** [`ci-secrets.md`](../../ci-secrets.md) owns that;
   P2 and P5 link to it.
-- **No human-reviewer workflow** — `CODEOWNERS` routing, review SLAs and
-  round-robin assignment are out of scope; there are no human reviewers.
+- **No human-reviewer *routing* — while the org has one member.** Review SLAs,
+  round-robin assignment and reviewer load-balancing are out of scope, and the
+  **trigger to revisit is a second person holding write access**, not a date.
+  Stated conditionally on purpose: the org is public and actively preparing for
+  contributors (P6), so a flat exclusion here would read in six months as settled
+  policy rather than as a fact about today. `CODEOWNERS` itself is explicitly
+  *not* excluded — it is already authored, and P6 treats enabling it as the
+  cheapest control in the program.
 - **No security invariant applies to this program.** Worth stating, because a
   review of this spec invoked I2, I13, I27 and I29 against it and none of them
   reach. I1–I30 are runtime properties of the **gateway on a user's machine**:
@@ -585,6 +662,15 @@ against.
 5. **Should P3 dogfood the first-party PR-check Action?** Pulling a Phase 12
    product deliverable forward is a roadmap decision;
    [`roadmap.md`](../../roadmap.md) wins on sequencing it.
+6. **DCO or CLA?** DCO is a `Signed-off-by` line plus a bot — near-zero friction,
+   and sufficient to establish that a contributor had the right to submit. A CLA
+   additionally preserves relicensing optionality, which matters only if
+   commercial dual-licensing is ever on the table. DCO is the recommendation
+   absent that intent; the decision is the user's because it is a licensing
+   commitment, not a technical one.
+7. **Free plan, or Team?** Private-repo rulesets require Team ($4/user/month).
+   Six private repos are currently unprotectable. Accept, make them public, or
+   upgrade — deferrable until the first contributor needs private-repo access.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -171,6 +171,16 @@ and `secret-health.yml`.
 P2(b) is therefore **propagation to the satellites**, not invention — a smaller
 job, and the same structural pattern as the CI diagnosis.
 
+**This has a design of record.**
+[`2026-07-19-github-app-migration-design.md`](./2026-07-19-github-app-migration-design.md)
+is sub-project 2 of 4 in the org secrets-management program and is what produced
+`nimbus-release-bot`. It already establishes the App's scope, the three PATs it
+retired (`RELEASE_PAT`, `RELEASE_PLEASE_PAT`, `PACKAGE_MANAGER_PAT`), and the
+two it deliberately did not. **P2(b) extends that design to the satellite repos;
+it does not re-derive it.** Read it before writing P2's plan — in particular its
+finding that an App installed on `nimbus-agent` can mint tokens for repos inside
+that org only, which is exactly why `VSCE_PAT` is out of reach.
+
 Two refinements this forces:
 
 - **`VSCE_PAT` cannot be replaced by a GitHub App.** It is an Azure DevOps token
@@ -259,6 +269,17 @@ rulesets** — no branch protection and no required checks — while `nimbus-sdk
 tags`. It is the narrow waist both the CLI and the VS Code extension depend on.
 This lands independently of the program, ahead of it.
 
+**Rulesets become code, not clicks.** Fixing `nimbus-client` by hand fixes one
+repo once; the org has already demonstrated that UI-configured settings drift
+(the 2026-06-23 org settings audit left UI-only items pending, and
+`nimbus-client`'s missing rulesets *are* that drift). So P1 checks the desired
+ruleset shape into the `.github` repo as a declarative file applied by a `gh api`
+script, plus a scheduled job that diffs live configuration against it and fails
+on divergence. That converts "add rulesets to `nimbus-client`" from a one-time
+task into a gated property, which is what the operating principle demands.
+Terraform is rejected as disproportionate for nine repos with no existing
+state-backend, and it would violate the Actions-only infra tier.
+
 ### P2 — Release Train
 
 Three parts:
@@ -277,6 +298,18 @@ Three parts:
    is the Stage-1 dance — eight waves, `0.7.0` → `0.11.0`, each hand-driven —
    automated.
 
+   **Creation must be idempotent.** If a consumption PR for version `X` is
+   already open, update its branch or do nothing — never open a second. Without
+   this, a re-run, a retried publish, or two dispatches racing produces duplicate
+   PRs and duplicate CI spend.
+
+   **The topology is a DAG and must stay one.** `sdk → client → {Nimbus,
+   vscode}`; nothing downstream publishes anything upstream consumes, so a
+   propagation cycle is not reachable by construction. This is a property to
+   preserve deliberately, not a risk to add cycle-detection for: if a future
+   package ever introduces a back-edge, the dispatch train needs a hop limit
+   before that package ships, not after.
+
 ### P3 — Review Layer
 
 Step 1: give `Nimbus` a `.coderabbit.yaml` whose `path_instructions` encode
@@ -285,6 +318,18 @@ Correction 1). Step 2: rationalize the three installed bots — SonarCloud is
 required and blocking (keep as-is), CodeRabbit becomes tuned, `google-labs-jules`
 is assessed. Step 3: decide on a Claude-based review action *after* measuring
 what the tuned config still misses.
+
+**There is a fourth reviewer already designed, and it is a Nimbus product.**
+[`2026-06-20-github-app-design.md`](./2026-06-20-github-app-design.md) specifies
+a first-party PR-check Action under `packages/github-actions/pr-check/` that
+posts a preflight verdict (active P1 incidents, failing CI on the target ref,
+merge conflicts) plus DORA posture as an `ok | warn | block` comment, consuming
+only the already-shipped read-only HTTP API. It is a Phase 12 commercial-anchor
+deliverable, so P3 does not own its schedule — but P3 is the natural place to
+**dogfood** it, and an org that ships a PR-check product while not running it on
+its own PRs is making an argument against itself. Flagged as an open decision
+rather than folded in, because pulling a Phase 12 product deliverable forward is
+a roadmap call, not an infrastructure one.
 
 ### P4a — Main-CI concurrency fix
 
@@ -305,6 +350,21 @@ are stale against it, secret-expiry countdown (`VSCE_PAT` 2026-12-01,
 writes markdown to the `.github` repo profile or a pinned issue — zero hosting.
 **Tier B** (a hosted receiver for a live view) is the only candidate in the whole
 program for a real webhook service, and is deferrable indefinitely.
+
+**Public-surface constraint.** The `.github` repo is **public**, so Tier A must
+not aggregate private-repo metadata (names, versions, activity) onto it — six
+private scaffolds plus `nimbus-statuspage`, `nimbus-raycast`,
+`nimbus-mcp-servers`, `nimbus-connector-registry`, `nimbus-recipes` and
+`create-nimbus-connector` would otherwise become publicly enumerable with commit
+cadence attached. Tier A therefore covers the nine public repos on a public
+surface, or all repos on a private one — not a mix.
+
+Secret **names** are explicitly *not* in scope for this constraint: they are
+already public by design in [`ci-secrets.md`](../../ci-secrets.md), which is the
+canonical inventory and lives in a public repo. Publishing an expiry countdown
+for a name an attacker can already read costs nothing and is the entire point of
+the surface. Likewise CI pass-rates and job durations are already public for
+public repos through the Actions UI.
 
 P5 precedes P4b because it supplies the measurements P4b must be justified
 against.
@@ -338,9 +398,27 @@ against.
   exactly this — it never reached Codecov, and was ultimately retired rather than
   rotated. Every workflow P1 promotes must have its secret path verified as
   *observed working*, not assumed.
+- **Never `secrets: inherit`; map secrets explicitly.** The org uses `inherit`
+  nowhere today, and P1 must not introduce it. Two reasons, and the second is the
+  load-bearing one: blanket inheritance widens what a called workflow can reach,
+  *and* it hides the failure mode above — an explicitly mapped secret that is
+  missing fails loudly at the call site, whereas an inherited one that never
+  arrives fails silently, which is precisely how `CODECOV_TOKEN` went unnoticed.
+- **Do not extend `pull_request_target`.** `labeler.yml` and `pr-title-lint.yml`
+  use it, which runs with base-repo secret access against PR-authored content.
+  That is pre-existing and out of scope to fix here, but no workflow P1 promotes
+  to org scope may be reachable from `pull_request_target` *and* require
+  release-tier secrets. Release-tier secrets stay behind the `release`
+  environment, as `ci-secrets.md` already establishes.
 - **Branch-only workflow changes need live proof.** A bare `workflow_dispatch`
   runs `main`'s version of the workflow and fakes a pass. Push the branch first,
   then `gh workflow run --ref <branch>`.
+- **Cross-repo reusable workflows have a harder dev loop than same-repo ones.**
+  A caller references `nimbus-agent/.github/.github/workflows/<file>.yml@<ref>`,
+  so testing an unmerged change means temporarily pointing the caller at
+  `@<dev-branch>`, proving it green, then flipping back to `@main` before merge.
+  The flip-back is the step that gets forgotten and pins production CI to a
+  branch — P1 adds a check that no caller references a non-`main` ref.
 - **A conflicting PR runs no `pull_request` workflows at all**, which presents as
   a green PR with suspiciously few checks. Check `mergeStateStatus` before
   trusting `gh pr checks` on anything in this program.
@@ -364,6 +442,18 @@ against.
   P2 and P5 link to it.
 - **No human-reviewer workflow** — `CODEOWNERS` routing, review SLAs and
   round-robin assignment are out of scope; there are no human reviewers.
+- **No security invariant applies to this program.** Worth stating, because a
+  review of this spec invoked I2, I13, I27 and I29 against it and none of them
+  reach. I1–I30 are runtime properties of the **gateway on a user's machine**:
+  I2 is the `HITL_REQUIRED_BACKING` consent gate in `engine/executor.ts`, I13 the
+  HTTP write allowlist, I27 the outbound share chokepoint, I29 the egress-ledger
+  append before `connectors.dispatch`. None governs GitHub Actions, org secrets,
+  or PR merges. In particular, **"human-in-the-loop for an agent's tool call" and
+  "human review before a PR merges" are different things that share a word** —
+  auto-merging a dependency bump does not weaken I2, and reasoning as if it did
+  is exactly the invariant drift the triple rule exists to prevent. Changes here
+  must still respect the invariants in any gateway code they touch; the program
+  itself introduces no wiring site, so it adds no invariant and retires none.
 
 ---
 
@@ -382,6 +472,16 @@ against.
    `nimbus-web-clipper`?** They are both extensions but target different hosts
    (VS Code vs MV3 browsers). If the shared surface turns out to be thin, two
    thin workflows beat one over-parameterized one.
+4. **Do downstream consumption PRs auto-merge on green, or wait for a human?**
+   P2 opens them automatically; whether they *land* automatically is a separate
+   call. Auto-merge maximizes the toil win and risks a bad version propagating
+   unattended; manual merge keeps a checkpoint on a repo with no other human
+   reviewer. A defensible middle is auto-merge for patch bumps only.
+   **This is a GitHub merge-policy question, not an I2 question** — see the note
+   under [Explicit non-goals](#explicit-non-goals).
+5. **Should P3 dogfood the first-party PR-check Action?** Pulling a Phase 12
+   product deliverable forward is a roadmap decision;
+   [`roadmap.md`](../../roadmap.md) wins on sequencing it.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -662,7 +662,11 @@ tiny and each is currently costing something:
 5. **Should P3 dogfood the first-party PR-check Action?** Pulling a Phase 12
    product deliverable forward is a roadmap decision;
    [`roadmap.md`](../../roadmap.md) wins on sequencing it.
-6. **DCO or CLA?** DCO is a `Signed-off-by` line plus a bot — near-zero friction,
+6. **DCO or CLA? — RESOLVED 2026-07-24: CLA.** Chosen to preserve relicensing
+   optionality for a possible future commercial dual-licensing of the AGPL-3.0
+   core. Implementation is a separate sub-effort under P6; the P1 plan's Task 7
+   (DCO) is superseded. Original framing retained below.
+   DCO is a `Signed-off-by` line plus a bot — near-zero friction,
    and sufficient to establish that a contributor had the right to submit. A CLA
    additionally preserves relicensing optionality, which matters only if
    commercial dual-licensing is ever on the table. DCO is the recommendation

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -69,7 +69,7 @@ The other eight repos have a hand-copied `ci.yml`.
 | `step-security/harden-runner` | `v2.20.0` | `v2.19.4` |
 | `actions/checkout` | `v7.0.1` | `v7.0.0` |
 
-And the sharpest evidence of the pattern: **Nimbus's own preflight runs
+And the sharpest evidence: **Nimbus's own preflight runs
 `audit:action-sha-pins`** — a gate built precisely to catch stale action pins —
 scoped to one repo, while the drift it exists to catch happens one repo over,
 unwatched. `audit:consumed-by` has the same shape and the same blind spot.
@@ -77,6 +77,43 @@ unwatched. `audit:consumed-by` has the same shape and the same blind spot.
 The org `.github` repo already hosts cross-repo composite actions
 (`verify-npm-provenance`, `probe-publish-token`), so the promotion path exists
 and was simply never extended to workflows.
+
+### The named pattern: controls stop where they were written
+
+The statement above is the symptom. Investigating three unrelated areas of this
+program turned up the same failure three times, and naming it changes what the
+sub-programs are for.
+
+| Control | Written in | Covers | Where the risk actually is | Propagation |
+| --- | --- | --- | --- | --- |
+| `audit:action-sha-pins`, `audit:consumed-by` | `Nimbus` | `Nimbus` | The satellites — pins already drifted | monorepo → satellites, never made |
+| `.coderabbit.yaml` (tuned, with `path_instructions`) | the 4 satellites | those 4 | `Nimbus` — 30 invariants, reviewed stock | satellites → monorepo, never made |
+| `ci-secrets.md` "canonical inventory of **every** secret" | when authored | the secrets known then | `secret-health.yml`'s own App credentials, absent from it | forward in time, never made |
+
+**Two of the three point in opposite directions.** That is the load-bearing
+detail. If every gap ran monorepo → satellites, the story would be "the monorepo
+is ahead and the satellites need to catch up," and the fix would be a
+propagation *direction*. It does not: the best-tuned review configuration in the
+org lives in the four smallest repos and never reached the largest. The third
+instance does not travel through space at all — it is a completeness claim that
+was true when written and was never re-checked.
+
+So the root cause is not that one repo is ahead. It is that **a control here is
+scoped to whatever context its author happened to be in, and nothing carries it
+further** — not to another repo, not to a later day. Each of the three was
+correct at the moment it was written and silently stopped being sufficient.
+
+This is the failure mode the
+[operating principle](#operating-principle) already targets, which is why it is
+borrowed rather than invented: a control that has stopped covering the risk looks
+exactly like a control that is passing. Only a gate that would go *red* can tell
+the difference.
+
+**Consequence for every sub-program below.** The question a sub-program must
+answer is not "does this control exist?" but **"what makes this control
+propagate?"** That is why each gate in the table below is org-wide or scheduled
+rather than repo-local, and it is the reason P1 is sequenced first — it is
+specifically the propagation mechanism, not merely a tidier `ci.yml`.
 
 **A second structural fact shapes P3.** There are no human reviewers. Of the last
 80 merged PRs org-wide: 61 by `asafgolombek`, 18 by `nimbus-release-bot[bot]`,
@@ -120,6 +157,12 @@ Nimbus-aware review is likely reachable by writing the monorepo a
 the PAL import ban. Days, not weeks. Whether a Claude-based review action is
 *still* needed afterwards becomes a genuine open decision, answered by evidence
 rather than pre-committed.
+
+This is instance 2 of
+[the named pattern](#the-named-pattern-controls-stop-where-they-were-written),
+and the one that runs satellites → monorepo. It is the reason that section can
+claim the org has no propagation mechanism in *either* direction rather than
+merely a lagging periphery.
 
 ---
 
@@ -250,6 +293,10 @@ registration and treats it as part of the deliverable.
 | **P5** | Org Legibility | S | Actions-only | Dashboard regenerates on schedule; stale downstream and expiring secrets surface before they bite; `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
 
 ### P1 — Org CI Foundation
+
+**P1 is the propagation mechanism.** Everything else in the program is a control;
+this is the thing that carries controls past the repo they were written in. That
+is why it is first, and why "a tidier `ci.yml`" undersells it.
 
 Promote the reusable-workflow pattern from repo scope to org scope. The org
 `.github` repo gains `_ci-npm-package.yml` (consumed by `nimbus-sdk`,
@@ -402,10 +449,15 @@ Actions secret the workflows consume. Three are missing:
 
 **The two missing App credentials belong to `secret-health.yml` — the workflow
 whose job is monitoring secret health.** The monitor is invisible to the
-inventory it exists to serve, which is the same shape as `audit:action-sha-pins`
-auditing every repo except the drift next door. `nimbus-secret-auditor` is
-installed org-wide with `all` repository selection, so this is an App credential
-sitting outside the rotation inventory.
+inventory it exists to serve. `nimbus-secret-auditor` is installed org-wide with
+`all` repository selection, so this is an App credential sitting outside the
+rotation inventory.
+
+This is instance 3 of
+[the named pattern](#the-named-pattern-controls-stop-where-they-were-written) —
+the one that fails forward in time rather than across repos. The inventory was
+complete when written; `secret-health.yml` and `_perf.yml` added credentials
+afterwards and nothing carried the claim forward.
 
 A doc claiming completeness while incomplete is worse than one that is public,
 because the incompleteness is what people act on. **P5's gate therefore includes

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -1,0 +1,395 @@
+# Org delivery infrastructure — program design
+
+> **Status:** design drafted 2026-07-23, pending approval. Scope is the
+> `nimbus-agent` org's **delivery machinery** — CI, release automation, PR review,
+> and cross-repo coordination — across all nine active repos.
+>
+> Roadmap: [`docs/roadmap.md`](../../roadmap.md) is authoritative for gateway
+> capability. Ecosystem: [`docs/ecosystem-roadmap.md`](../../ecosystem-roadmap.md)
+> is authoritative for when capability becomes reachable. **This program owns
+> neither** — it creates a third sibling document,
+> `docs/infrastructure-roadmap.md`, and P1 delivers it.
+
+---
+
+## Contents
+
+- [Goal](#goal)
+- [The diagnosis](#the-diagnosis)
+- [Correction 1 — CodeRabbit is not noisy, it is blind](#correction-1--coderabbit-is-not-noisy-it-is-blind)
+- [Correction 2 — the merge queue is unjustified; main CI is the real defect](#correction-2--the-merge-queue-is-unjustified-main-ci-is-the-real-defect)
+- [Correction 3 — App-as-credential already exists](#correction-3--app-as-credential-already-exists)
+- [Operating principle](#operating-principle)
+- [Document placement and precedence](#document-placement-and-precedence)
+- [The sub-programs](#the-sub-programs)
+- [Sequence](#sequence)
+- [Design constraints](#design-constraints)
+- [Explicit non-goals](#explicit-non-goals)
+- [Open decisions](#open-decisions)
+- [How to update this document](#how-to-update-this-document)
+
+---
+
+## Goal
+
+Make the org's delivery machinery match the quality of the code it ships, and
+make each improvement hold through a gate a machine can check.
+
+Four outcomes, all in scope, none traded against the others:
+
+1. **Cut manual toil** — the per-release manual tag push, the hand-opened
+   downstream consumption PRs, the five hand-synced `ci.yml` files.
+2. **Catch problems earlier** — invariants enforced in CI rather than only in
+   local `preflight`.
+3. **Reduce latency** — but only against measurement, never against a hunch.
+4. **Make the org legible** — one place showing release state, downstream
+   staleness, and secret expiry.
+
+---
+
+## The diagnosis
+
+One fact explains all five sub-programs.
+
+> **The org has good delivery engineering. It exists in exactly one repo.**
+
+`Nimbus` has path-filtered change detection (the `filter` job), two local
+reusable workflows (`_test-suite.yml`, `_structure.yml`), two composite actions
+(`setup-nimbus-ci`, `setup-rust-tauri`), Actions caching, an 18-gate preflight
+manifest in `scripts/lib/preflight-gates.ts` with a drift test that fails when a
+CI gate goes missing, and a GitHub App (`nimbus-release-bot`) minting 1-hour
+installation tokens across five workflows.
+
+The other eight repos have a hand-copied `ci.yml`.
+
+**The drift is already measurable, not hypothetical:**
+
+| Action | `nimbus-client` / `nimbus-sdk` | `nimbus-web-clipper` |
+| --- | --- | --- |
+| `step-security/harden-runner` | `v2.20.0` | `v2.19.4` |
+| `actions/checkout` | `v7.0.1` | `v7.0.0` |
+
+And the sharpest evidence of the pattern: **Nimbus's own preflight runs
+`audit:action-sha-pins`** — a gate built precisely to catch stale action pins —
+scoped to one repo, while the drift it exists to catch happens one repo over,
+unwatched. `audit:consumed-by` has the same shape and the same blind spot.
+
+The org `.github` repo already hosts cross-repo composite actions
+(`verify-npm-provenance`, `probe-publish-token`), so the promotion path exists
+and was simply never extended to workflows.
+
+**A second structural fact shapes P3.** There are no human reviewers. Of the last
+80 merged PRs org-wide: 61 by `asafgolombek`, 18 by `nimbus-release-bot[bot]`,
+1 by `dependabot[bot]`. "Improve PR review" therefore means improving *automated*
+review of AI-assisted PRs — not routing work to teammates. `CODEOWNERS` routing,
+review SLAs and reviewer round-robin are all out of scope by construction.
+
+---
+
+## Correction 1 — CodeRabbit is not noisy, it is blind
+
+The initial framing was "CodeRabbit is non-required and noisy; demote or tune."
+That was wrong, and the evidence points the other way.
+
+**All four satellite repos carry a tuned `.coderabbit.yaml`. The `Nimbus`
+monorepo does not.** The satellite configs are good — `nimbus-client`'s sets
+`profile: chill`, disables `request_changes_workflow`, and carries real
+`path_instructions` telling the bot to flag any `any`, any `console.*` in
+published src, any new runtime dependency beyond `@nimbus-dev/sdk`, and any
+exported-type change without a semver-relevant Conventional Commit.
+
+So the bot is tuned in the four small repos and runs stock in the one with 30
+security invariants, a triple rule, the D10–D22 static checks, and a "no `any`"
+non-negotiable.
+
+Its actual output on Nimbus [#813](https://github.com/nimbus-agent/Nimbus/pull/813),
+untuned, included:
+
+> `graph-populator-clear.test.ts:73-90` — **Exercise replacement, not just
+> idempotency.** Both syncs target the same repo, so this passes even if stale
+> `targets` edges are never cleared.
+
+That is a real defect: a test that passes whether or not the code works. It also
+flagged `findCommitEntityIds` performing an unindexable scan per SHA. This is a
+competent reviewer operating without context, not a noise generator.
+
+**Consequence.** "Tune or remove" is not an open decision — it is a task, and it
+is P3's first step. It also materially cheapens P3: a large share of
+Nimbus-aware review is likely reachable by writing the monorepo a
+`.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and
+the PAL import ban. Days, not weeks. Whether a Claude-based review action is
+*still* needed afterwards becomes a genuine open decision, answered by evidence
+rather than pre-committed.
+
+---
+
+## Correction 2 — the merge queue is unjustified; main CI is the real defect
+
+The initial framing proposed a merge queue. Challenged for evidence, it does not
+survive — but chasing it surfaced a worse problem.
+
+**Last 40 `ci.yml` runs on `main`: 16 success, 1 failure, 22 cancelled.**
+
+`ci.yml` sets `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with
+`cancel-in-progress: true`. That is correct for PR branches and harmful on
+`main`, where every push shares one group: merging a PR starts a validation run,
+and the next merge kills it.
+
+On 2026-07-21, three PRs merged at 18:33:21, 18:33:33 and 18:33:46 — twelve
+seconds apart. Two of those three runs were cancelled by the next merge. **The
+single main-branch CI failure across all 40 runs is timestamped 18:33 on
+2026-07-21**, on that same batch.
+
+Treat the failure correlation as suggestive, not conclusive (n=1). The
+cancellation rate needs no inference: **56% of main-branch CI runs never
+complete.** The commit that actually ships frequently has no finished validation
+behind it, so "main is green" is more often "main was never asked."
+
+**Consequences.**
+
+- **No repo needs a merge queue.** `Nimbus` is the only repo with the volume to
+  theoretically want one, and its problem is a concurrency misconfiguration, not
+  a merge race. The satellites merge a handful of PRs each; a queue there is
+  ceremony. Dropped from the program.
+- **The fix is two lines** — keep `cancel-in-progress: true` for `pull_request`,
+  set it `false` for pushes to `main`. This becomes **P4a** and moves early.
+- A merge queue may be revisited only if semantic conflicts appear *after* main
+  is genuinely validated, at which point there will be evidence.
+
+---
+
+## Correction 3 — App-as-credential already exists
+
+The initial framing proposed replacing PAT sprawl with
+`actions/create-github-app-token` as new work. Per
+[`docs/ci-secrets.md`](../../ci-secrets.md), the **`nimbus-release-bot` GitHub
+App is already live**, minting 1-hour installation tokens from
+`RELEASE_BOT_CLIENT_ID` + `RELEASE_BOT_PRIVATE_KEY` across `release.yml`,
+`release-please.yml`, `publish-package-managers.yml`, `publish-linux-repo.yml`
+and `secret-health.yml`.
+
+P2(b) is therefore **propagation to the satellites**, not invention — a smaller
+job, and the same structural pattern as the CI diagnosis.
+
+Two refinements this forces:
+
+- **`VSCE_PAT` cannot be replaced by a GitHub App.** It is an Azure DevOps token
+  authenticating to the VS Code Marketplace, not to GitHub. It needs
+  rotation-with-a-reminder (it expires **2026-12-01**), and it belongs in P5's
+  expiry surface, not P2's migration.
+- `WINGET_PAT` is documented as the one remaining human-owned classic PAT in
+  `Nimbus` — it must fork an external repo the App cannot reach. It stays a PAT
+  by necessity; P5 watches its expiry.
+
+---
+
+## Operating principle
+
+**Every sub-program ends in a gate a machine can check.**
+
+Borrowed verbatim from
+[`ecosystem-roadmap.md`](../../ecosystem-roadmap.md#thesis-and-operating-principle),
+where it was adopted because agent-driven delivery writes confident code against
+wrong contracts. It applies at least as strongly to infrastructure work, where
+the failure mode is silent: a workflow that stopped running looks exactly like a
+workflow that passes.
+
+A sub-program is **done when its gate is green in CI and would go red if the
+property regressed** — not when its code merges. Concretely: P1 is not done when
+the reusable workflow lands, it is done when an org-wide SHA-drift sweep goes red
+if a stale action is pinned in *any* repo.
+
+---
+
+## Document placement and precedence
+
+P1 creates **`docs/infrastructure-roadmap.md`** as a sibling to the two existing
+roadmaps. Rejected alternatives: folding this into `ecosystem-roadmap.md` (whose
+scope is *how capability reaches a human*, and which polices that scope with an
+explicit non-goals section — only P2 of five sub-programs touches its subject);
+and growing `docs/ci-secrets.md` (a 466-line reference inventory, not a roadmap).
+
+The three-way precedence rule, stated in the same form the existing pair use:
+
+| Document | Authoritative for |
+| --- | --- |
+| [`roadmap.md`](../../roadmap.md) | What the gateway **does** — phases, acceptance criteria |
+| [`ecosystem-roadmap.md`](../../ecosystem-roadmap.md) | **When** capability becomes reachable — client surface width |
+| `infrastructure-roadmap.md` | **How** it gets built, reviewed and shipped |
+
+On disagreement about gateway capability, `roadmap.md` wins. On disagreement
+about client reachability, `ecosystem-roadmap.md` wins. The new file yields to
+both and owns only the machinery.
+
+**Registration is not free.** `audit:doc-refs` scans a fixed doc set and
+`audit:status-drift` watches status lines; a new tracked document must be
+registered in both or it either rots silently or fails the gate. P1 includes that
+registration and treats it as part of the deliverable.
+
+---
+
+## The sub-programs
+
+| | Sub-program | Size | Infra tier | Gate |
+| --- | --- | --- | --- | --- |
+| **P1** | Org CI Foundation | S–M | Actions-only | Org-wide SHA-pin + workflow-drift sweep goes red on any repo |
+| **P2** | Release Train | S–M | Actions + existing release-bot App | A publish that fails to open its downstream PR fails a scheduled staleness check |
+| **P3** | Review Layer | S–M | Actions-only | An invariant violation is caught in CI, not only in local `preflight` |
+| **P4a** | Main-CI concurrency fix | XS | Actions-only | Every commit on `main` has a completed CI run |
+| **P4b** | Latency | S–M | Actions-only | Per-job wall-clock tracked; regressions visible |
+| **P5** | Org Legibility | S | Actions-only | Dashboard regenerates on schedule; stale downstream and expiring secrets surface before they bite |
+
+### P1 — Org CI Foundation
+
+Promote the reusable-workflow pattern from repo scope to org scope. The org
+`.github` repo gains `_ci-npm-package.yml` (consumed by `nimbus-sdk`,
+`nimbus-client`) and `_ci-extension.yml` (consumed by `nimbus-vscode`,
+`nimbus-web-clipper`), plus shared composites; each satellite `ci.yml` shrinks to
+a short caller. One place to bump a SHA.
+
+Extend `audit:action-sha-pins` from a Nimbus-local preflight gate into a
+scheduled org-wide sweep — this is the gate, and it is what makes the drift in
+the diagnosis table structurally impossible to reintroduce.
+
+Also delivers `docs/infrastructure-roadmap.md` and its gate registration.
+
+**Carved out as an immediate standalone fix:** `nimbus-client` has **zero
+rulesets** — no branch protection and no required checks — while `nimbus-sdk`,
+`nimbus-vscode` and `nimbus-web-clipper` each have `General` + `Protected release
+tags`. It is the narrow waist both the CLI and the VS Code extension depend on.
+This lands independently of the program, ahead of it.
+
+### P2 — Release Train
+
+Three parts:
+
+1. **Root-cause the chronic manual tag push.** Every release parks at
+   `autorelease: pending` and requires `git tag vX.Y.Z <merge-commit>` by hand,
+   blocking the next run. This is chronic, not a regression. Diagnose against a
+   working-versus-broken run diff before naming a cause — a previous
+   investigation misattributed it to the GitHub App.
+2. **Propagate App-as-credential to the satellites** (see Correction 3),
+   retiring the undeleted release PATs and resolving the `RELEASE_PLEASE_PAT`
+   visibility drift.
+3. **Downstream auto-consumption.** An upstream publish fires
+   `repository_dispatch` downstream: `sdk@x` opens the consumption PR in
+   `nimbus-client`; `client@y` opens them in `Nimbus` and `nimbus-vscode`. This
+   is the Stage-1 dance — eight waves, `0.7.0` → `0.11.0`, each hand-driven —
+   automated.
+
+### P3 — Review Layer
+
+Step 1: give `Nimbus` a `.coderabbit.yaml` whose `path_instructions` encode
+I1–I30, the triple rule, the PAL import ban and the "no `any`" rule (see
+Correction 1). Step 2: rationalize the three installed bots — SonarCloud is
+required and blocking (keep as-is), CodeRabbit becomes tuned, `google-labs-jules`
+is assessed. Step 3: decide on a Claude-based review action *after* measuring
+what the tuned config still misses.
+
+### P4a — Main-CI concurrency fix
+
+Two lines (see Correction 2). Early, because it is the difference between a
+validated `main` and an unvalidated one.
+
+### P4b — Latency
+
+PR CI ~12–13 min; main pushes 18–31 min. Options: cache tuning, matrix sharding,
+finer path filters. Deliberately last, and only against P5's measurements. Merge
+queue explicitly dropped.
+
+### P5 — Org Legibility
+
+A scheduled workflow writing a dashboard: version per repo and which downstreams
+are stale against it, secret-expiry countdown (`VSCE_PAT` 2026-12-01,
+`WINGET_PAT`), open PRs by repo, CI pass-rate and per-job durations. **Tier A**
+writes markdown to the `.github` repo profile or a pinned issue — zero hosting.
+**Tier B** (a hosted receiver for a live view) is the only candidate in the whole
+program for a real webhook service, and is deferrable indefinitely.
+
+P5 precedes P4b because it supplies the measurements P4b must be justified
+against.
+
+---
+
+## Sequence
+
+**P1 → P4a → P2 → P5 → P3 → P4b**
+
+- **P1 first** — it creates the shared home everything else installs into, and it
+  is the cheapest.
+- **P4a second** — two lines, and until it lands, no other CI improvement can be
+  trusted to have been validated on `main`.
+- **P2 third** — highest toil payoff, and smaller than first estimated
+  (Correction 3).
+- **P5 fourth** — small, and it instruments P4b.
+- **P3 fifth** — its first step is cheap; its second step needs evidence P3's
+  first step generates.
+- **P4b last** — measured, never guessed.
+
+`nimbus-client` rulesets land ahead of all of it, independently.
+
+---
+
+## Design constraints
+
+- **The reusable-workflow secrets contract is a landmine, and P1 is entirely
+  inside its blast radius.** Secrets do not cross into reusable workflows without
+  `secrets: inherit` or explicit passing. `CODECOV_TOKEN` was silently broken by
+  exactly this — it never reached Codecov, and was ultimately retired rather than
+  rotated. Every workflow P1 promotes must have its secret path verified as
+  *observed working*, not assumed.
+- **Branch-only workflow changes need live proof.** A bare `workflow_dispatch`
+  runs `main`'s version of the workflow and fakes a pass. Push the branch first,
+  then `gh workflow run --ref <branch>`.
+- **A conflicting PR runs no `pull_request` workflows at all**, which presents as
+  a green PR with suspiciously few checks. Check `mergeStateStatus` before
+  trusting `gh pr checks` on anything in this program.
+- **Docs-only PRs were historically blocked** by a skipped job never expanding
+  `${{ }}` in its `name:`, so a required context was never created. Fixed by
+  `pr-quality-required` (#788), but the end-to-end case has not yet been observed
+  green. P1 adds tracked docs and will exercise it.
+
+---
+
+## Explicit non-goals
+
+- **No hosted webhook receiver.** Nothing in P1–P5 requires one. P5 Tier B is the
+  sole candidate and is deferrable indefinitely.
+- **No self-hosted runners.**
+- **No merge queue** (Correction 2).
+- **Not a second security document.**
+  [`SECURITY-INVARIANTS.md`](../../SECURITY-INVARIANTS.md) owns I1–I30; P3 links
+  to it and never restates it.
+- **Not a secrets inventory.** [`ci-secrets.md`](../../ci-secrets.md) owns that;
+  P2 and P5 link to it.
+- **No human-reviewer workflow** — `CODEOWNERS` routing, review SLAs and
+  round-robin assignment are out of scope; there are no human reviewers.
+
+---
+
+## Open decisions
+
+1. **Is a Claude-based review action still needed once `Nimbus` has a tuned
+   `.coderabbit.yaml`?** Deliberately unanswered. Tune first, measure what it
+   still misses on the invariants, then decide whether a second reviewer buys
+   something real. (Correction 1 removed the two decisions that used to sit here
+   alongside this one.)
+2. **What is `google-labs-jules`' role?** Installed org-wide with no visible
+   output on recent PRs. Either it has a job in P3 or it should be uninstalled;
+   an idle app with org-wide access is a standing permission grant with no
+   return.
+3. **Does `_ci-extension.yml` genuinely fit both `nimbus-vscode` and
+   `nimbus-web-clipper`?** They are both extensions but target different hosts
+   (VS Code vs MV3 browsers). If the shared surface turns out to be thin, two
+   thin workflows beat one over-parameterized one.
+
+---
+
+## How to update this document
+
+- This spec is superseded by `docs/infrastructure-roadmap.md` once P1 delivers
+  it. Until then, this is authoritative for the program.
+- A sub-program is **done** when its gate is green in CI, not when its code
+  merges.
+- Corrections stay as written. They record why the program is shaped this way,
+  and rewriting them after the fact erases the evidence.

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -70,9 +70,12 @@ The other eight repos have a hand-copied `ci.yml`.
 | `actions/checkout` | `v7.0.1` | `v7.0.0` |
 
 And the sharpest evidence: **Nimbus's own preflight runs
-`audit:action-sha-pins`** — a gate built precisely to catch stale action pins —
-scoped to one repo, while the drift it exists to catch happens one repo over,
-unwatched. `audit:consumed-by` has the same shape and the same blind spot.
+`audit:action-sha-pins`** — a gate built to reject *unpinned* action refs (tags
+or branches instead of a full 40-char commit SHA) — scoped to one repo, while the
+same unpinning risk sits one repo over, unwatched. `audit:consumed-by` has the
+same shape and the same blind spot. (Note the gate checks *that* a ref is
+SHA-pinned, not that the SHA is *current*; detecting stale-but-pinned refs is a
+separate freshness follow-up — see `docs/infrastructure-roadmap.md`.)
 
 The org `.github` repo already hosts cross-repo composite actions
 (`verify-npm-provenance`, `probe-publish-token`), so the promotion path exists
@@ -171,7 +174,7 @@ merely a lagging periphery.
 The initial framing proposed a merge queue. Challenged for evidence, it does not
 survive — but chasing it surfaced a worse problem.
 
-**Last 40 `ci.yml` runs on `main`: 16 success, 1 failure, 22 cancelled.**
+**Last 39 `ci.yml` runs on `main`: 16 success, 1 failure, 22 cancelled.**
 
 `ci.yml` sets `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with
 `cancel-in-progress: true`. That is correct for PR branches and harmful on
@@ -180,7 +183,7 @@ and the next merge kills it.
 
 On 2026-07-21, three PRs merged at 18:33:21, 18:33:33 and 18:33:46 — twelve
 seconds apart. Two of those three runs were cancelled by the next merge. **The
-single main-branch CI failure across all 40 runs is timestamped 18:33 on
+single main-branch CI failure across all 39 runs is timestamped 18:33 on
 2026-07-21**, on that same batch.
 
 Treat the failure correlation as suggestive, not conclusive (n=1). The
@@ -285,7 +288,7 @@ registration and treats it as part of the deliverable.
 
 | | Sub-program | Size | Infra tier | Gate |
 | --- | --- | --- | --- | --- |
-| **P1** | Org CI Foundation | S–M | Actions-only | Org-wide SHA-pin + workflow-drift sweep goes red on any repo |
+| **P1** | Org CI Foundation | S–M | Actions-only | Scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos |
 | **P2** | Release Train | S–M | Actions + existing release-bot App | A publish that fails to open its downstream PR fails a scheduled staleness check |
 | **P3** | Review Layer | S–M | Actions-only | An invariant violation is caught in CI, not only in local `preflight` |
 | **P4a** | Main-CI concurrency fix | XS | Actions-only | Every commit on `main` has a completed CI run |
@@ -515,17 +518,18 @@ into the checked-in ruleset config P1 creates, commented as the
 contributor-two switch set, so the transition is one reviewed diff rather than
 four remembered UI clicks. **That is P6's gate.**
 
-**3. Inbound contribution licensing is undecided — and this one is urgent.**
-`CONTRIBUTING.md` contains no DCO, sign-off or CLA terms. The repo is public
-*now*, so the first outside PR can arrive any day, and retroactive sign-off
-collection is far worse than prospective. The dual license sharpens it: a
-contributor patching the MIT `nimbus-sdk` with work derived from reading the
-AGPL gateway creates exactly the infection the ecosystem roadmap's one-way rule
-("MIT into AGPL is fine; the reverse would infect") exists to prevent — today
-enforced by architecture, but by nothing a contributor agrees to. DCO is the
-lightweight standard; a CLA is heavier and is what would preserve relicensing
-optionality for any future commercial dual-licensing. **Decide before the first
-outside PR, not after.**
+**3. Inbound contribution licensing — RESOLVED 2026-07-24: a CLA (see open
+decision 6). Implementation moves to P6.** `CONTRIBUTING.md` contains no DCO,
+sign-off or CLA terms. The repo is public *now*, so the first outside PR can
+arrive any day, and retroactive sign-off collection is far worse than
+prospective. The dual license sharpens it: a contributor patching the MIT
+`nimbus-sdk` with work derived from reading the AGPL gateway creates exactly the
+infection the ecosystem roadmap's one-way rule ("MIT into AGPL is fine; the
+reverse would infect") exists to prevent — today enforced by architecture, but
+by nothing a contributor agrees to. A **CLA** was chosen over a DCO because it
+additionally preserves relicensing optionality for any future commercial
+dual-licensing; it is a P6 sub-effort (ICLA/CCLA text + a signature bot), not a
+P1 blocker.
 
 **4. Two org settings and a plan ceiling.** `members_can_create_repositories` is
 `true` (should be `false`); `default_repository_permission` is `read`, which
@@ -558,9 +562,10 @@ tiny and each is currently costing something:
    improvement can be trusted to have been validated on `main` at all.
 2. **`nimbus-client` rulesets** — the only active repo with zero branch
    protection, and the narrow waist two consumers depend on.
-3. **The DCO/CLA decision** (P6 item 3) — the repo is public, so the first
-   outside PR can arrive before the program reaches P6, and prospective sign-off
-   is far cheaper than retroactive.
+3. **The contribution-licensing decision** (P6 item 3) — **resolved 2026-07-24 to
+   a CLA** (open decision 6). The *decision* landed immediately, as intended; the
+   CLA *implementation* (ICLA/CCLA text + a signature bot) moves to P6 and is not
+   a P1 blocker.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
+++ b/docs/superpowers/specs/2026-07-23-org-infrastructure-program-design.md
@@ -247,7 +247,7 @@ registration and treats it as part of the deliverable.
 | **P3** | Review Layer | S–M | Actions-only | An invariant violation is caught in CI, not only in local `preflight` |
 | **P4a** | Main-CI concurrency fix | XS | Actions-only | Every commit on `main` has a completed CI run |
 | **P4b** | Latency | S–M | Actions-only | Per-job wall-clock tracked; regressions visible |
-| **P5** | Org Legibility | S | Actions-only | Dashboard regenerates on schedule; stale downstream and expiring secrets surface before they bite |
+| **P5** | Org Legibility | S | Actions-only | Dashboard regenerates on schedule; stale downstream and expiring secrets surface before they bite; `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md` |
 
 ### P1 — Org CI Foundation
 
@@ -351,20 +351,71 @@ writes markdown to the `.github` repo profile or a pinned issue — zero hosting
 **Tier B** (a hosted receiver for a live view) is the only candidate in the whole
 program for a real webhook service, and is deferrable indefinitely.
 
-**Public-surface constraint.** The `.github` repo is **public**, so Tier A must
-not aggregate private-repo metadata (names, versions, activity) onto it — six
-private scaffolds plus `nimbus-statuspage`, `nimbus-raycast`,
-`nimbus-mcp-servers`, `nimbus-connector-registry`, `nimbus-recipes` and
-`create-nimbus-connector` would otherwise become publicly enumerable with commit
-cadence attached. Tier A therefore covers the nine public repos on a public
-surface, or all repos on a private one — not a mix.
+**Public-surface constraint.** The org is 12 public repos and 6 private
+(`nimbus-statuspage`, `nimbus-raycast`, `nimbus-mcp-servers`,
+`nimbus-connector-registry`, `create-nimbus-connector`, `nimbus-recipes`). The
+`.github` repo is **public**, so Tier A must not aggregate private-repo metadata
+onto it — those six would otherwise become publicly enumerable with commit
+cadence attached. Tier A covers the public repos on a public surface, or all
+repos on a private one; never a mix.
 
-Secret **names** are explicitly *not* in scope for this constraint: they are
-already public by design in [`ci-secrets.md`](../../ci-secrets.md), which is the
-canonical inventory and lives in a public repo. Publishing an expiry countdown
-for a name an attacker can already read costs nothing and is the entire point of
-the surface. Likewise CI pass-rates and job durations are already public for
-public repos through the Actions UI.
+Secret **names** are *not* in scope for that constraint, but the reasoning needs
+stating precisely rather than waved through. `grep -rhoE "secrets\.[A-Z_]+"
+.github/workflows/` yields 22 names, and the workflow files are public — so every
+name and its consuming workflow is already derivable without
+[`ci-secrets.md`](../../ci-secrets.md). Publishing an expiry countdown against a
+name an attacker can already read costs nothing, and is the point of the surface.
+CI pass-rates and job durations are likewise already public through the Actions
+UI for public repos.
+
+Three details in `ci-secrets.md` *do* exceed what `grep` yields, and two are
+worth trimming — not because names are secret, but because these change an
+attacker's plan rather than merely restating it:
+
+- **Which secrets are plain repo secrets versus `release`-environment-scoped.**
+  This is a map of which high-value credentials are reachable without the
+  environment's protection rules. Keep the operational fact, move the mapping
+  off the public page.
+- **A precise expiry date** (`VSCE_PAT`, 2026-09-20). Coarsen to a quarter on the
+  public page; the exact date belongs to the countdown surface and the
+  `secret-health.yml` job.
+- **Token type and scope** (e.g. `WINGET_PAT` is a classic PAT with
+  `public_repo`). **Keep as-is** — it serves auditors and Scorecard more than it
+  serves an attacker, and the scope is minimal by design.
+
+The document itself is not the problem and must not be deleted or privatized:
+it is why `secret-health.yml` exists, and the silently-expired-PAT root cause was
+findable only because the surface had been enumerated. Obscurity is the weakest
+control available here; the real ones (encryption at rest, environment scoping,
+1-hour App tokens, least privilege) are unaffected by what the doc says.
+
+### The inventory is incomplete, and that is the real defect
+
+`ci-secrets.md` opens by calling itself the canonical inventory of **every**
+Actions secret the workflows consume. Three are missing:
+
+| Secret | Consumed by |
+| --- | --- |
+| `SECRET_AUDITOR_CLIENT_ID` | `secret-health.yml` |
+| `SECRET_AUDITOR_PRIVATE_KEY` | `secret-health.yml` |
+| `BENCHER_API_KEY` | `_perf.yml`, `_perf-reference.yml` |
+
+**The two missing App credentials belong to `secret-health.yml` — the workflow
+whose job is monitoring secret health.** The monitor is invisible to the
+inventory it exists to serve, which is the same shape as `audit:action-sha-pins`
+auditing every repo except the drift next door. `nimbus-secret-auditor` is
+installed org-wide with `all` repository selection, so this is an App credential
+sitting outside the rotation inventory.
+
+A doc claiming completeness while incomplete is worse than one that is public,
+because the incompleteness is what people act on. **P5's gate therefore includes
+an `audit:secret-inventory` check** — the `grep secrets\.` set across all
+workflows must equal the `ci-secrets.md` table, and any divergence fails. Same
+idiom as `audit:action-sha-pins` and `audit:doc-refs`, and it makes this
+particular drift structurally unrepeatable.
+
+P5's first concrete tasks are therefore: add the three missing rows, apply the
+two trims above, then land the gate that keeps both true.
 
 P5 precedes P4b because it supplies the measurements P4b must be justified
 against.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "audit:status-drift": "bun scripts/structure-audit/check-status-drift.ts",
     "audit:action-sha-pins": "bun scripts/structure-audit/check-action-sha-pins.ts",
     "audit:consumed-by": "bun scripts/structure-audit/check-consumed-by.ts",
+    "audit:ruleset-drift": "bun scripts/structure-audit/check-ruleset-drift.ts",
     "audit:secrets": "gitleaks detect --source . --no-banner --redact --exit-code 1",
     "audit:links": "lychee --no-progress --config lychee.toml \"docs/**/*.md\" \"*.md\"",
     "lint": "biome check --error-on-warnings .",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -25,7 +25,6 @@ const FAST: readonly Gate[] = [
   { name: "audit:status-drift", cmd: ["bun", "run", "audit:status-drift"], tier: "fast" },
   { name: "audit:action-sha-pins", cmd: ["bun", "run", "audit:action-sha-pins"], tier: "fast" },
   { name: "audit:consumed-by", cmd: ["bun", "run", "audit:consumed-by"], tier: "fast" },
-  { name: "audit:ruleset-drift", cmd: ["bun", "run", "audit:ruleset-drift"], tier: "fast" },
   { name: "audit:exclusion-parity", cmd: ["bun", "run", "audit:exclusion-parity"], tier: "fast" },
   {
     // Reads .jscpd.json (min-lines 5 / min-tokens 50 / threshold ratchet / shared
@@ -64,6 +63,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "regen-slo:check", // SLO doc regeneration check — doc-gen check run separately, not a code gate
   "build:sandbox-helper", // make native C helper — platform-specific (Linux) native build, not a portable gate
   "vitest", // bunx vitest — UI component tests (packages/ui), run via the separate Vitest runner
+  "audit:ruleset-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml (ruleset-drift job), never the local FAST tier
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -25,6 +25,7 @@ const FAST: readonly Gate[] = [
   { name: "audit:status-drift", cmd: ["bun", "run", "audit:status-drift"], tier: "fast" },
   { name: "audit:action-sha-pins", cmd: ["bun", "run", "audit:action-sha-pins"], tier: "fast" },
   { name: "audit:consumed-by", cmd: ["bun", "run", "audit:consumed-by"], tier: "fast" },
+  { name: "audit:ruleset-drift", cmd: ["bun", "run", "audit:ruleset-drift"], tier: "fast" },
   { name: "audit:exclusion-parity", cmd: ["bun", "run", "audit:exclusion-parity"], tier: "fast" },
   {
     // Reads .jscpd.json (min-lines 5 / min-tokens 50 / threshold ratchet / shared

--- a/scripts/structure-audit/check-action-sha-pins.test.ts
+++ b/scripts/structure-audit/check-action-sha-pins.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { auditActionShaPins } from "./check-action-sha-pins.ts";
+import { auditActionShaPins, parseRootArg } from "./check-action-sha-pins.ts";
 
 function makeRepo(layout: Record<string, string>): string {
   const root = mkdtempSync(join(tmpdir(), "sha-pin-audit-"));
@@ -66,5 +66,19 @@ describe("auditActionShaPins", () => {
   test("returns ok on a repo with no workflow dirs", () => {
     const result = auditActionShaPins(makeRepo({ "README.md": "# x" }));
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("parseRootArg", () => {
+  test("defaults to cwd when --root is absent", () => {
+    expect(parseRootArg([])).toBe(process.cwd());
+  });
+
+  test("returns the path following --root", () => {
+    expect(parseRootArg(["--root", "/tmp/other-repo"])).toBe("/tmp/other-repo");
+  });
+
+  test("throws when --root is passed with no value", () => {
+    expect(() => parseRootArg(["--root"])).toThrow("--root requires a path");
   });
 });

--- a/scripts/structure-audit/check-action-sha-pins.ts
+++ b/scripts/structure-audit/check-action-sha-pins.ts
@@ -72,8 +72,24 @@ export function auditActionShaPins(repoRoot: string): AuditResult {
   return { ok: errors.length === 0, errors };
 }
 
+/**
+ * Resolves the repository root to audit. Defaults to the process cwd so the
+ * local preflight gate is unchanged; `--root <path>` lets the org-wide sweep
+ * aim the same audited logic at a checkout of another repository.
+ */
+export function parseRootArg(argv: string[]): string {
+  const ix = argv.indexOf("--root");
+  if (ix === -1) return process.cwd();
+  const value = argv[ix + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error("--root requires a path");
+  }
+  return value;
+}
+
 if (import.meta.main) {
-  const result = auditActionShaPins(process.cwd());
+  const root = parseRootArg(process.argv.slice(2));
+  const result = auditActionShaPins(root);
   if (!result.ok) {
     for (const err of result.errors) console.error(`audit:action-sha-pins: ${err}`);
     process.exit(1);

--- a/scripts/structure-audit/check-doc-references.ts
+++ b/scripts/structure-audit/check-doc-references.ts
@@ -79,6 +79,7 @@ const DOCS_FILES = [
   "CLAUDE.md",
   "GEMINI.md",
   "docs/architecture.md",
+  "docs/infrastructure-roadmap.md",
   "docs/SECURITY.md",
   "docs/SECURITY-INVARIANTS.md",
   "docs/security-hardening.md",

--- a/scripts/structure-audit/check-ruleset-drift.test.ts
+++ b/scripts/structure-audit/check-ruleset-drift.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { type DesiredRuleset, diffRuleset } from "./check-ruleset-drift.ts";
+
+const DESIRED: DesiredRuleset = {
+  repos: ["nimbus-client"],
+  name: "General",
+  target: "branch",
+  enforcement: "active",
+  pull_request: {
+    allowed_merge_methods: ["squash"],
+    dismiss_stale_reviews_on_push: true,
+    required_review_thread_resolution: true,
+    require_code_owner_review: false,
+    require_last_push_approval: false,
+    required_approving_review_count: 0,
+  },
+};
+
+function liveRuleset(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "General",
+    target: "branch",
+    enforcement: "active",
+    rules: [
+      {
+        type: "pull_request",
+        parameters: {
+          allowed_merge_methods: ["squash"],
+          dismiss_stale_reviews_on_push: true,
+          required_review_thread_resolution: true,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_approving_review_count: 0,
+          ...overrides,
+        },
+      },
+    ],
+  };
+}
+
+describe("diffRuleset", () => {
+  test("passes when live matches desired", () => {
+    const result = diffRuleset(DESIRED, liveRuleset());
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("flags a drifted pull_request parameter", () => {
+    const result = diffRuleset(DESIRED, liveRuleset({ required_approving_review_count: 1 }));
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("required_approving_review_count");
+    expect(result.errors[0]).toContain("expected 0");
+    expect(result.errors[0]).toContain("got 1");
+  });
+
+  test("flags disabled enforcement", () => {
+    const live = { ...liveRuleset(), enforcement: "disabled" };
+    const result = diffRuleset(DESIRED, live);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("enforcement");
+  });
+
+  test("flags a missing ruleset entirely", () => {
+    const result = diffRuleset(DESIRED, null);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("no 'General' ruleset");
+  });
+
+  test("flags a missing pull_request rule", () => {
+    const result = diffRuleset(DESIRED, {
+      name: "General",
+      target: "branch",
+      enforcement: "active",
+      rules: [],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("pull_request");
+  });
+});

--- a/scripts/structure-audit/check-ruleset-drift.test.ts
+++ b/scripts/structure-audit/check-ruleset-drift.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { type DesiredRuleset, diffRuleset } from "./check-ruleset-drift.ts";
+import {
+  type DesiredRuleset,
+  diffRuleset,
+  mergeDesired,
+  type SharedRuleset,
+} from "./check-ruleset-drift.ts";
 
-const DESIRED: DesiredRuleset = {
-  repos: ["nimbus-client"],
+const SHARED: SharedRuleset = {
   name: "General",
   target: "branch",
   enforcement: "active",
+  conditions_ref_include: ["refs/heads/main"],
+  required_rule_types: ["deletion", "non_fast_forward", "pull_request"],
   pull_request: {
     allowed_merge_methods: ["squash"],
     dismiss_stale_reviews_on_push: true,
@@ -17,12 +23,22 @@ const DESIRED: DesiredRuleset = {
   },
 };
 
+const DESIRED: DesiredRuleset = mergeDesired(SHARED, { bypass_actor_types: [] });
+
 function liveRuleset(overrides: Record<string, unknown> = {}) {
   return {
     name: "General",
     target: "branch",
     enforcement: "active",
+    conditions: {
+      ref_name: {
+        include: ["refs/heads/main"],
+        exclude: [],
+      },
+    },
     rules: [
+      { type: "deletion" },
+      { type: "non_fast_forward" },
       {
         type: "pull_request",
         parameters: {
@@ -36,6 +52,7 @@ function liveRuleset(overrides: Record<string, unknown> = {}) {
         },
       },
     ],
+    bypass_actors: [] as Array<{ actor_type: string }>,
   };
 }
 
@@ -75,6 +92,64 @@ describe("diffRuleset", () => {
       rules: [],
     });
     expect(result.ok).toBe(false);
-    expect(result.errors[0]).toContain("pull_request");
+    expect(result.errors.join("\n")).toContain("no pull_request rule present");
+  });
+
+  test("passes when conditions + bypass + protection rules all match", () => {
+    const desired = mergeDesired(SHARED, { bypass_actor_types: ["OrganizationAdmin"] });
+    const live = {
+      ...liveRuleset(),
+      bypass_actors: [{ actor_type: "OrganizationAdmin" }],
+    };
+    const result = diffRuleset(desired, live);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("flags a wrong conditions.ref_name.include", () => {
+    const live = {
+      ...liveRuleset(),
+      conditions: { ref_name: { include: ["refs/heads/develop"], exclude: [] } },
+    };
+    const result = diffRuleset(DESIRED, live);
+    expect(result.ok).toBe(false);
+    const msg = result.errors.join("\n");
+    expect(msg).toContain("conditions.ref_name.include");
+    expect(msg).toContain("refs/heads/main");
+    expect(msg).toContain("refs/heads/develop");
+  });
+
+  test("flags a missing deletion rule", () => {
+    const live = liveRuleset();
+    live.rules = live.rules.filter((r) => r.type !== "deletion");
+    const result = diffRuleset(DESIRED, live);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("missing required rule: deletion");
+  });
+
+  test("flags a bypass_actor_types mismatch", () => {
+    const desired = mergeDesired(SHARED, { bypass_actor_types: [] });
+    const live = {
+      ...liveRuleset(),
+      bypass_actors: [{ actor_type: "OrganizationAdmin" }],
+    };
+    const result = diffRuleset(desired, live);
+    expect(result.ok).toBe(false);
+    const msg = result.errors.join("\n");
+    expect(msg).toContain("bypass_actor_types");
+    expect(msg).toContain("OrganizationAdmin");
+  });
+
+  test("flags bypass mismatch regardless of order (set comparison)", () => {
+    const desired = mergeDesired(SHARED, {
+      bypass_actor_types: ["OrganizationAdmin", "RepositoryAdmin"],
+    });
+    const live = {
+      ...liveRuleset(),
+      bypass_actors: [{ actor_type: "RepositoryAdmin" }, { actor_type: "OrganizationAdmin" }],
+    };
+    const result = diffRuleset(desired, live);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 });

--- a/scripts/structure-audit/check-ruleset-drift.test.ts
+++ b/scripts/structure-audit/check-ruleset-drift.test.ts
@@ -13,6 +13,7 @@ const SHARED: SharedRuleset = {
   target: "branch",
   enforcement: "active",
   conditions_ref_include: ["refs/heads/main"],
+  conditions_ref_exclude: [],
   required_rule_types: ["deletion", "non_fast_forward", "pull_request"],
   pull_request: {
     allowed_merge_methods: ["squash"],
@@ -105,6 +106,18 @@ describe("diffRuleset", () => {
     const result = diffRuleset(desired, live);
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  test("flags a live exclude that exempts the default branch", () => {
+    const live = {
+      ...liveRuleset(),
+      conditions: { ref_name: { include: ["refs/heads/main"], exclude: ["refs/heads/main"] } },
+    };
+    const result = diffRuleset(DESIRED, live);
+    expect(result.ok).toBe(false);
+    const msg = result.errors.join("\n");
+    expect(msg).toContain("conditions.ref_name.exclude");
+    expect(msg).toContain("refs/heads/main");
   });
 
   test("flags a wrong conditions.ref_name.include", () => {

--- a/scripts/structure-audit/check-ruleset-drift.test.ts
+++ b/scripts/structure-audit/check-ruleset-drift.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   type DesiredRuleset,
+  decideExit,
   diffRuleset,
   mergeDesired,
   type SharedRuleset,
@@ -140,7 +141,7 @@ describe("diffRuleset", () => {
     expect(msg).toContain("OrganizationAdmin");
   });
 
-  test("flags bypass mismatch regardless of order (set comparison)", () => {
+  test("treats a reordered bypass set as a match (order-independent)", () => {
     const desired = mergeDesired(SHARED, {
       bypass_actor_types: ["OrganizationAdmin", "RepositoryAdmin"],
     });
@@ -151,5 +152,52 @@ describe("diffRuleset", () => {
     const result = diffRuleset(desired, live);
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+});
+
+describe("decideExit", () => {
+  test("all repos unreachable → skip green", () => {
+    const result = decideExit({
+      queried: 0,
+      errors: [],
+      unreachable: [
+        "nimbus-client",
+        "nimbus-sdk",
+        "nimbus-vscode",
+        "nimbus-web-clipper",
+        "linux-repo",
+      ],
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("skipped");
+  });
+
+  test("real drift on a queried repo is never masked by a different repo's gh failure (regression)", () => {
+    const result = decideExit({
+      queried: 4,
+      errors: ["nimbus-sdk: enforcement: expected active, got disabled"],
+      unreachable: ["nimbus-vscode"],
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("nimbus-sdk: enforcement: expected active, got disabled");
+    expect(result.message).toContain("could not query");
+    expect(result.message).toContain("nimbus-vscode");
+  });
+
+  test("all repos queried, no drift → OK", () => {
+    const result = decideExit({ queried: 5, errors: [], unreachable: [] });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("OK (5 repos)");
+  });
+
+  test("some repos unreachable but no drift on the queried ones → OK with a warning", () => {
+    const result = decideExit({
+      queried: 3,
+      errors: [],
+      unreachable: ["nimbus-vscode", "nimbus-web-clipper"],
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("OK (3 repos)");
+    expect(result.message).toContain("could not query");
   });
 });

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:ruleset-drift — asserts each active org repo's live `General` branch
+ * ruleset matches the declarative shape in `.github/rulesets/general-branch.json`.
+ *
+ * Manual UI configuration drifts: `nimbus-client` had zero rulesets while its
+ * three sibling repos each had two. Checking the desired shape into the repo and
+ * diffing it turns uniform protection from a one-time task into a gated property.
+ *
+ * The diff is pure and unit-tested; the CLI wrapper fetches live config via `gh`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export interface DesiredRuleset {
+  repos: string[];
+  name: string;
+  target: string;
+  enforcement: string;
+  pull_request: Record<string, unknown>;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Structural equality for the JSON-shaped values a ruleset parameter can hold. */
+function sameValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult {
+  const errors: string[] = [];
+
+  if (!isRecord(live)) {
+    return { ok: false, errors: [`no '${desired.name}' ruleset found (or it is not an object)`] };
+  }
+
+  for (const field of ["name", "target", "enforcement"] as const) {
+    if (live[field] !== desired[field]) {
+      errors.push(`${field}: expected ${String(desired[field])}, got ${String(live[field])}`);
+    }
+  }
+
+  const rules = Array.isArray(live["rules"]) ? live["rules"] : [];
+  const prRule = rules.find((r) => isRecord(r) && r["type"] === "pull_request");
+  if (!isRecord(prRule)) {
+    return { ok: false, errors: [...errors, "no pull_request rule present"] };
+  }
+
+  const params = isRecord(prRule["parameters"]) ? prRule["parameters"] : {};
+  for (const [key, want] of Object.entries(desired.pull_request)) {
+    const got = params[key];
+    if (!sameValue(got, want)) {
+      errors.push(
+        `pull_request.${key}: expected ${JSON.stringify(want)}, got ${JSON.stringify(got)}`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+export function loadDesired(repoRoot: string): DesiredRuleset {
+  const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
+  return JSON.parse(raw) as DesiredRuleset;
+}
+
+if (import.meta.main) {
+  const desired = loadDesired(process.cwd());
+  const allErrors: string[] = [];
+
+  for (const repo of desired.repos) {
+    const proc = Bun.spawnSync([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/rulesets`,
+      "--jq",
+      `.[] | select(.name=="${desired.name}") | .id`,
+    ]);
+    const id = new TextDecoder().decode(proc.stdout).trim();
+    if (id === "") {
+      allErrors.push(`${repo}: no '${desired.name}' ruleset found`);
+      continue;
+    }
+    const detail = Bun.spawnSync(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    const live: unknown = JSON.parse(new TextDecoder().decode(detail.stdout));
+    const result = diffRuleset(desired, live);
+    for (const err of result.errors) allErrors.push(`${repo}: ${err}`);
+  }
+
+  if (allErrors.length > 0) {
+    for (const err of allErrors) console.error(`audit:ruleset-drift: ${err}`);
+    process.exit(1);
+  }
+  console.log(`audit:ruleset-drift: OK (${desired.repos.length} repos)`);
+}

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -29,6 +29,7 @@ export interface SharedRuleset {
   target: string;
   enforcement: string;
   conditions_ref_include: string[];
+  conditions_ref_exclude: string[];
   required_rule_types: string[];
   pull_request: Record<string, unknown>;
 }
@@ -99,6 +100,16 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
     );
   }
 
+  // A live `exclude` that names the default branch exempts it from the whole
+  // ruleset — a total bypass that leaves `include` intact, so it must be diffed
+  // too or the gate stays green while protection is silently gone.
+  const liveExclude = stringArray(refName["exclude"]);
+  if (!sameSet(liveExclude, desired.conditions_ref_exclude)) {
+    errors.push(
+      `conditions.ref_name.exclude: expected ${JSON.stringify(desired.conditions_ref_exclude)}, got ${JSON.stringify(liveExclude)}`,
+    );
+  }
+
   const rules = Array.isArray(live["rules"]) ? live["rules"] : [];
   const liveRuleTypes = new Set(
     rules
@@ -112,6 +123,11 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
     }
   }
 
+  // We pin the *set of bypass actor types* — adding or removing any bypass actor
+  // is caught. We do NOT yet pin each actor's `bypass_mode` (`always` vs
+  // `pull_request`): tightening/loosening the mode of an already-permitted actor
+  // type is a narrower vector, and pinning it needs a richer per-actor declared
+  // shape. Tracked as a follow-up in docs/infrastructure-roadmap.md.
   const bypassActors = Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
   const liveBypassTypes = bypassActors
     .filter(isRecord)

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -146,52 +146,100 @@ export function loadDesiredFile(repoRoot: string): DesiredRulesetFile {
   return JSON.parse(raw) as DesiredRulesetFile;
 }
 
+/** A `gh` invocation's outcome — never throws; a missing binary/non-zero exit is `ok: false`. */
+interface GhResult {
+  ok: boolean;
+  stdout: string;
+}
+
+/** Wraps `Bun.spawnSync` so a missing `gh` binary or non-zero exit both surface as `ok: false`. */
+function runGh(args: string[]): GhResult {
+  try {
+    const proc = Bun.spawnSync(args);
+    if (!proc.success) return { ok: false, stdout: "" };
+    return { ok: true, stdout: new TextDecoder().decode(proc.stdout) };
+  } catch {
+    return { ok: false, stdout: "" };
+  }
+}
+
+/**
+ * Decides the CLI's exit code + message from what the per-repo loop observed.
+ *
+ * INVARIANT: real drift found on any successfully-queried repo is never
+ * discarded because a different repo's `gh` call failed. `queried === 0`
+ * (every repo unreachable) is the ONLY case that skips green — any drift
+ * recorded on a repo that WAS reachable always wins over partial coverage.
+ */
+export function decideExit(input: { queried: number; errors: string[]; unreachable: string[] }): {
+  code: 0 | 1;
+  message: string;
+} {
+  const { queried, errors, unreachable } = input;
+
+  if (queried === 0) {
+    return {
+      code: 0,
+      message:
+        "audit:ruleset-drift: skipped — gh unavailable or unauthenticated (needs org-read on nimbus-agent)",
+    };
+  }
+
+  if (errors.length > 0) {
+    const lines = errors.map((err) => `audit:ruleset-drift: ${err}`);
+    if (unreachable.length > 0) {
+      lines.push(`audit:ruleset-drift: WARNING — could not query: ${unreachable.join(", ")}`);
+    }
+    return { code: 1, message: lines.join("\n") };
+  }
+
+  if (unreachable.length > 0) {
+    return {
+      code: 0,
+      message: `audit:ruleset-drift: OK (${queried} repos) — WARNING: could not query ${unreachable.join(", ")}`,
+    };
+  }
+
+  return { code: 0, message: `audit:ruleset-drift: OK (${queried} repos)` };
+}
+
 if (import.meta.main) {
   const file = loadDesiredFile(process.cwd());
   const repoNames = Object.keys(file.repos);
   const allErrors: string[] = [];
-  let ghUnavailable = false;
+  const unreachable: string[] = [];
+  let queried = 0;
 
   for (const repo of repoNames) {
-    let listProc: ReturnType<typeof Bun.spawnSync>;
-    try {
-      listProc = Bun.spawnSync([
-        "gh",
-        "api",
-        `repos/nimbus-agent/${repo}/rulesets`,
-        "--jq",
-        `.[] | select(.name=="${file.shared.name}") | .id`,
-      ]);
-    } catch {
-      ghUnavailable = true;
-      break;
-    }
-    if (!listProc.success) {
-      ghUnavailable = true;
-      break;
+    const listResult = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/rulesets`,
+      "--jq",
+      `.[] | select(.name=="${file.shared.name}") | .id`,
+    ]);
+    if (!listResult.ok) {
+      unreachable.push(repo);
+      continue;
     }
 
-    const id = new TextDecoder().decode(listProc.stdout).trim();
+    const id = listResult.stdout.trim();
     if (id === "") {
       // gh succeeded (authenticated, reachable) and simply found no matching
       // ruleset on this repo — that is real drift, not a fail-soft skip.
+      queried += 1;
       allErrors.push(`${repo}: no '${file.shared.name}' ruleset found`);
       continue;
     }
 
-    let detailProc: ReturnType<typeof Bun.spawnSync>;
-    try {
-      detailProc = Bun.spawnSync(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
-    } catch {
-      ghUnavailable = true;
-      break;
-    }
-    if (!detailProc.success) {
-      ghUnavailable = true;
-      break;
+    const detailResult = runGh(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    if (!detailResult.ok) {
+      unreachable.push(repo);
+      continue;
     }
 
-    const live: unknown = JSON.parse(new TextDecoder().decode(detailProc.stdout));
+    queried += 1;
+    const live: unknown = JSON.parse(detailResult.stdout);
     const overrides = file.repos[repo];
     if (overrides === undefined) continue;
     const desired = mergeDesired(file.shared, overrides);
@@ -199,16 +247,13 @@ if (import.meta.main) {
     for (const err of result.errors) allErrors.push(`${repo}: ${err}`);
   }
 
-  if (ghUnavailable) {
-    console.warn(
-      "audit:ruleset-drift: skipped — gh unavailable or unauthenticated (needs org-read on nimbus-agent)",
-    );
-    process.exit(0);
+  const outcome = decideExit({ queried, errors: allErrors, unreachable });
+  if (outcome.code === 1) {
+    console.error(outcome.message);
+  } else if (outcome.message.includes("skipped")) {
+    console.warn(outcome.message);
+  } else {
+    console.log(outcome.message);
   }
-
-  if (allErrors.length > 0) {
-    for (const err of allErrors) console.error(`audit:ruleset-drift: ${err}`);
-    process.exit(1);
-  }
-  console.log(`audit:ruleset-drift: OK (${repoNames.length} repos)`);
+  process.exit(outcome.code);
 }

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -9,6 +9,10 @@
  * diffing it turns uniform protection from a one-time task into a gated property.
  *
  * The diff is pure and unit-tested; the CLI wrapper fetches live config via `gh`.
+ * The CLI is fail-soft: it needs network + `gh` auth + org-read, which offline
+ * maintainers and external contributors on this public repo lack, so it runs only
+ * in the scheduled org-drift-sweep workflow (never the FAST preflight tier) and
+ * skips green — rather than failing — when `gh` is unavailable/unauthenticated.
  */
 
 import { readFileSync } from "node:fs";
@@ -19,12 +23,30 @@ export interface AuditResult {
   errors: string[];
 }
 
-export interface DesiredRuleset {
-  repos: string[];
+/** The shape shared by every active org repo's declared ruleset. */
+export interface SharedRuleset {
   name: string;
   target: string;
   enforcement: string;
+  conditions_ref_include: string[];
+  required_rule_types: string[];
   pull_request: Record<string, unknown>;
+}
+
+/** The per-repo overrides layered on top of `SharedRuleset`. */
+export interface RepoRulesetOverrides {
+  bypass_actor_types: string[];
+}
+
+/** The on-disk shape of `.github/rulesets/general-branch.json`. */
+export interface DesiredRulesetFile {
+  shared: SharedRuleset;
+  repos: Record<string, RepoRulesetOverrides>;
+}
+
+/** `SharedRuleset` merged with one repo's overrides — what `diffRuleset` compares against live config. */
+export interface DesiredRuleset extends SharedRuleset {
+  bypass_actor_types: string[];
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -34,6 +56,25 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 /** Structural equality for the JSON-shaped values a ruleset parameter can hold. */
 function sameValue(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Order-independent set equality for string arrays (e.g. bypass actor types, ref conditions). */
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((v, i) => v === sortedB[i]);
+}
+
+function stringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+export function mergeDesired(
+  shared: SharedRuleset,
+  overrides: RepoRulesetOverrides,
+): DesiredRuleset {
+  return { ...shared, bypass_actor_types: overrides.bypass_actor_types };
 }
 
 export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult {
@@ -49,7 +90,39 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
     }
   }
 
+  const conditions = isRecord(live["conditions"]) ? live["conditions"] : {};
+  const refName = isRecord(conditions["ref_name"]) ? conditions["ref_name"] : {};
+  const liveInclude = stringArray(refName["include"]);
+  if (!sameSet(liveInclude, desired.conditions_ref_include)) {
+    errors.push(
+      `conditions.ref_name.include: expected ${JSON.stringify(desired.conditions_ref_include)}, got ${JSON.stringify(liveInclude)}`,
+    );
+  }
+
   const rules = Array.isArray(live["rules"]) ? live["rules"] : [];
+  const liveRuleTypes = new Set(
+    rules
+      .filter(isRecord)
+      .map((r) => r["type"])
+      .filter((t): t is string => typeof t === "string"),
+  );
+  for (const type of desired.required_rule_types) {
+    if (!liveRuleTypes.has(type)) {
+      errors.push(`missing required rule: ${type}`);
+    }
+  }
+
+  const bypassActors = Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
+  const liveBypassTypes = bypassActors
+    .filter(isRecord)
+    .map((a) => a["actor_type"])
+    .filter((t): t is string => typeof t === "string");
+  if (!sameSet(liveBypassTypes, desired.bypass_actor_types)) {
+    errors.push(
+      `bypass_actor_types: expected ${JSON.stringify(desired.bypass_actor_types)}, got ${JSON.stringify(liveBypassTypes)}`,
+    );
+  }
+
   const prRule = rules.find((r) => isRecord(r) && r["type"] === "pull_request");
   if (!isRecord(prRule)) {
     return { ok: false, errors: [...errors, "no pull_request rule present"] };
@@ -68,37 +141,74 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
   return { ok: errors.length === 0, errors };
 }
 
-export function loadDesired(repoRoot: string): DesiredRuleset {
+export function loadDesiredFile(repoRoot: string): DesiredRulesetFile {
   const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
-  return JSON.parse(raw) as DesiredRuleset;
+  return JSON.parse(raw) as DesiredRulesetFile;
 }
 
 if (import.meta.main) {
-  const desired = loadDesired(process.cwd());
+  const file = loadDesiredFile(process.cwd());
+  const repoNames = Object.keys(file.repos);
   const allErrors: string[] = [];
+  let ghUnavailable = false;
 
-  for (const repo of desired.repos) {
-    const proc = Bun.spawnSync([
-      "gh",
-      "api",
-      `repos/nimbus-agent/${repo}/rulesets`,
-      "--jq",
-      `.[] | select(.name=="${desired.name}") | .id`,
-    ]);
-    const id = new TextDecoder().decode(proc.stdout).trim();
+  for (const repo of repoNames) {
+    let listProc: ReturnType<typeof Bun.spawnSync>;
+    try {
+      listProc = Bun.spawnSync([
+        "gh",
+        "api",
+        `repos/nimbus-agent/${repo}/rulesets`,
+        "--jq",
+        `.[] | select(.name=="${file.shared.name}") | .id`,
+      ]);
+    } catch {
+      ghUnavailable = true;
+      break;
+    }
+    if (!listProc.success) {
+      ghUnavailable = true;
+      break;
+    }
+
+    const id = new TextDecoder().decode(listProc.stdout).trim();
     if (id === "") {
-      allErrors.push(`${repo}: no '${desired.name}' ruleset found`);
+      // gh succeeded (authenticated, reachable) and simply found no matching
+      // ruleset on this repo — that is real drift, not a fail-soft skip.
+      allErrors.push(`${repo}: no '${file.shared.name}' ruleset found`);
       continue;
     }
-    const detail = Bun.spawnSync(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
-    const live: unknown = JSON.parse(new TextDecoder().decode(detail.stdout));
+
+    let detailProc: ReturnType<typeof Bun.spawnSync>;
+    try {
+      detailProc = Bun.spawnSync(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    } catch {
+      ghUnavailable = true;
+      break;
+    }
+    if (!detailProc.success) {
+      ghUnavailable = true;
+      break;
+    }
+
+    const live: unknown = JSON.parse(new TextDecoder().decode(detailProc.stdout));
+    const overrides = file.repos[repo];
+    if (overrides === undefined) continue;
+    const desired = mergeDesired(file.shared, overrides);
     const result = diffRuleset(desired, live);
     for (const err of result.errors) allErrors.push(`${repo}: ${err}`);
+  }
+
+  if (ghUnavailable) {
+    console.warn(
+      "audit:ruleset-drift: skipped — gh unavailable or unauthenticated (needs org-read on nimbus-agent)",
+    );
+    process.exit(0);
   }
 
   if (allErrors.length > 0) {
     for (const err of allErrors) console.error(`audit:ruleset-drift: ${err}`);
     process.exit(1);
   }
-  console.log(`audit:ruleset-drift: OK (${desired.repos.length} repos)`);
+  console.log(`audit:ruleset-drift: OK (${repoNames.length} repos)`);
 }


### PR DESCRIPTION
## P1 — Org CI Foundation

First sub-program of the [infrastructure roadmap](../blob/dev/asafgolombek/org-infrastructure-program/docs/infrastructure-roadmap.md): build the mechanism that carries a control **past the repo it was written in**, and land the immediate carve-outs. Design of record and plan live in `docs/superpowers/`.

Operating principle: *a sub-program is done when its gate is green in CI and would go red if the property regressed — not when its code merges.*

### What's in this PR (P1 Tasks 1–6)

| Task | Change | Gate |
| --- | --- | --- |
| 1 (P4a) | `ci.yml` concurrency: `cancel-in-progress` only on `pull_request`, so consecutive `main` merges no longer cancel each other's validation | Every `main` commit gets a completed run |
| 3 | New `docs/infrastructure-roadmap.md` — the third roadmap (how it gets built/reviewed/shipped), registered in `check-doc-references.ts` (15 → 16 docs) | `audit:doc-refs` |
| 4 | `check-action-sha-pins.ts` gains `--root <path>` so the tested audit can be aimed at a checkout of any repo | unit-tested |
| 5 | `.github/workflows/org-drift-sweep.yml` — scheduled matrix checks out every org repo and runs the same `--root` audit against it | `Org drift sweep / sha-pins (<repo>)` |
| 6 | Rulesets checked into `.github/rulesets/general-branch.json`; new `audit:ruleset-drift` diffs declared vs live for the 5 active code repos (pure diff, unit-tested; fail-soft when unauthenticated) | `Org drift sweep / ruleset-drift` |

Plus Task 2 (already applied, remote): `nimbus-client` got the `General` branch ruleset it was missing.

**Task 7 (DCO) is SUPERSEDED** — the contribution-licensing decision resolved to a **CLA** (preserves relicensing optionality for the AGPL-3.0 core). The CLA is its own sub-effort under P6; it is not in this PR. See the roadmap's P1 progress log.

### Making the ruleset-drift gate real (org config)

The `ruleset-drift` job mints a token from the **`nimbus-release-bot`** App with `permission-administration: read` (needed by `GET /repos/{owner}/{repo}/rulesets`).

- ✅ **Done (2026-07-24):** the App was granted repository `Administration: read` — verified `"administration":"read"` on the org installation.
- ⏳ **Confirm before the first post-merge run:** the App is `selected`-scoped and the token requests all 5 repos, so it must be *installed on* all of them — `Nimbus`, `nimbus-client`, `nimbus-sdk`, `nimbus-vscode`, `nimbus-web-clipper`. web-clipper is the one to check (the `RELEASE_BOT_PRIVATE_KEY` secret is shared with only the other four). If it isn't in the App's Repository access, the token-mint fails red on that repo.

The `sha-pins` matrix half needs no token (public repos clone anonymously) and runs on the first post-merge schedule.

### Verification (local, worktree)

- `typecheck` 0 errors · `biome check scripts` clean · `lint:markdown` 0 errors
- `audit:doc-refs` — 610 refs across **16 docs**, all resolve
- `lychee` (CI scope `docs/**/*.md *.md`) — **0 errors**
- `audit:action-sha-pins: OK` · `audit:ruleset-drift: OK (5 repos)` (run with an admin token)
- structure-audit + preflight-manifest tests — 27 pass
- No `packages/` source touched → `coverage-floor` N/A

The `Org drift sweep` itself is dispatch/schedule-only and net-new, so it cannot fire from this feature branch — its first real run is post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
