### PR TITLE
ci(infra): fix ruleset-drift bypass-actor false-positive; P1 gate green

### DIFF
--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs this against live config. P6 flips the contributor-two switches in `shared.pull_request`. `required_status_checks` and `code_quality` rules are per-repo CI shape and intentionally NOT diffed here.",
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs `shared` against each repo in `repos`. P6 flips the contributor-two switches in `shared.pull_request`. NOT diffed: `required_status_checks`/`code_quality` (per-repo CI shape) and `bypass_actors` (the CI App token cannot read org-level bypass actors — see the P1 progress log). Intended bypass, for the future higher-privilege check: OrganizationAdmin on Nimbus/nimbus-vscode/nimbus-web-clipper; none on nimbus-client/nimbus-sdk.",
   "shared": {
     "name": "General",
     "target": "branch",
@@ -16,11 +16,5 @@
       "required_approving_review_count": 0
     }
   },
-  "repos": {
-    "Nimbus": { "bypass_actor_types": ["OrganizationAdmin"] },
-    "nimbus-client": { "bypass_actor_types": [] },
-    "nimbus-sdk": { "bypass_actor_types": [] },
-    "nimbus-vscode": { "bypass_actor_types": ["OrganizationAdmin"] },
-    "nimbus-web-clipper": { "bypass_actor_types": ["OrganizationAdmin"] }
-  }
+  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"]
 }

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -67,7 +67,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
-      - name: Mint App token (Administration:Read on the active repos)
+      - name: Mint App token (Administration + Org-administration read on the active repos)
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -75,7 +75,14 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: Nimbus,nimbus-client,nimbus-sdk,nimbus-vscode,nimbus-web-clipper
+          # Administration:read is what `GET /repos/{o}/{r}/rulesets` needs. But a
+          # repo-scoped token with only that permission returns an EMPTY
+          # `bypass_actors` for org-level actors (e.g. OrganizationAdmin), which
+          # made the bypass_actor_types diff false-fail on the repos that carry
+          # that bypass. Org-administration:read (the App already holds it) gives
+          # the token the org context to resolve those actors.
           permission-administration: read
+          permission-organization-administration: read
       - name: Audit ruleset drift across active repos
         env:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -67,7 +67,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
-      - name: Mint App token (Administration + Org-administration read on the active repos)
+      - name: Mint App token (Administration:Read on the active repos)
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -75,14 +75,13 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: Nimbus,nimbus-client,nimbus-sdk,nimbus-vscode,nimbus-web-clipper
-          # Administration:read is what `GET /repos/{o}/{r}/rulesets` needs. But a
-          # repo-scoped token with only that permission returns an EMPTY
-          # `bypass_actors` for org-level actors (e.g. OrganizationAdmin), which
-          # made the bypass_actor_types diff false-fail on the repos that carry
-          # that bypass. Org-administration:read (the App already holds it) gives
-          # the token the org context to resolve those actors.
+          # Administration:read is what `GET /repos/{o}/{r}/rulesets` needs. Note it
+          # is NOT sufficient to read `bypass_actors` for org-level actors
+          # (OrganizationAdmin comes back empty) — proven live that even adding
+          # organization-administration:read does not restore it — so the drift
+          # audit deliberately does not diff bypass actors. See the P1 progress
+          # log in docs/infrastructure-roadmap.md.
           permission-administration: read
-          permission-organization-administration: read
       - name: Audit ruleset drift across active repos
         env:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -45,7 +45,7 @@ Design of record:
 
 | | Sub-program | Status | Gate |
 | --- | --- | --- | --- |
-| P1 | Org CI Foundation | 🔨 in progress | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos |
+| P1 | Org CI Foundation | ✅ done | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos — proven green end-to-end (run 30060920603) |
 | P2 | Release Train | ⬜ not started | A publish that fails to open its downstream PR fails a staleness check |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -77,10 +77,26 @@ moves to P6).
   (Access & Contribution Model)**; it is *not* a blocker for the P1 PR.
 - **Ruleset-drift coverage** — the diff pins name/target/enforcement,
   `ref_name.include` **and `ref_name.exclude`** (an `exclude` naming the default
-  branch is a silent total-bypass), the required rule types, the bypass **actor
-  type set**, and the pull-request parameters. **Follow-up:** it does not yet pin
-  each bypass actor's `bypass_mode` (`always` vs `pull_request`) — a narrower
-  loosen-in-place vector that needs a richer per-actor declared shape.
+  branch is a silent total-bypass), the required rule types, and the pull-request
+  parameters. **Bypass actors are deliberately NOT diffed** (finding from the
+  first live run, below): the CI credential is a repo-scoped App installation
+  token with `Administration: read`, and GitHub returns an **empty
+  `bypass_actors`** to it for org-level actors (`OrganizationAdmin`). Proven live
+  that adding `organization-administration: read` does **not** restore it, and
+  reading the field otherwise needs `Administration: write` — which a read-only
+  audit gate must not hold. Diffing it therefore false-failed on every repo that
+  carries an org-level bypass. **Follow-up:** audit bypass actors from a
+  higher-privilege context (a scheduled org-owner credential, not the sweep's App
+  token). The intended shape is recorded in `.github/rulesets/general-branch.json`:
+  `OrganizationAdmin` on Nimbus/nimbus-vscode/nimbus-web-clipper, none on
+  nimbus-client/nimbus-sdk.
+- **First post-merge sweep run (2026-07-24)** — P1 merged (#818), so the
+  net-new `workflow_dispatch` could finally fire. **`sha-pins`: green across all 8
+  repos** — the propagation mechanism works end-to-end. **`ruleset-drift`:** the
+  App-token path works (token mint succeeds once `nimbus-release-bot` has
+  `Administration: read` and is installed on all 5 repos), and the audit then
+  surfaced the `bypass_actors` token-visibility limitation above — closed by
+  dropping that one field from the diff. Every other check reads reliably.
 - **First org drift sweep (2026-07-23)** — all 8 repos pass `audit:action-sha-pins`
   (run locally as `bun scripts/structure-audit/check-action-sha-pins.ts --root
   <checkout>` against fresh clones, pending the workflow's first post-merge run —

--- a/scripts/structure-audit/check-ruleset-drift.test.ts
+++ b/scripts/structure-audit/check-ruleset-drift.test.ts
@@ -4,7 +4,6 @@ import {
   type DesiredRuleset,
   decideExit,
   diffRuleset,
-  mergeDesired,
   type SharedRuleset,
 } from "./check-ruleset-drift.ts";
 
@@ -25,7 +24,7 @@ const SHARED: SharedRuleset = {
   },
 };
 
-const DESIRED: DesiredRuleset = mergeDesired(SHARED, { bypass_actor_types: [] });
+const DESIRED: DesiredRuleset = SHARED;
 
 function liveRuleset(overrides: Record<string, unknown> = {}) {
   return {
@@ -97,13 +96,15 @@ describe("diffRuleset", () => {
     expect(result.errors.join("\n")).toContain("no pull_request rule present");
   });
 
-  test("passes when conditions + bypass + protection rules all match", () => {
-    const desired = mergeDesired(SHARED, { bypass_actor_types: ["OrganizationAdmin"] });
+  test("ignores bypass_actors — the CI token cannot read org-level actors", () => {
+    // A live ruleset carrying an OrganizationAdmin bypass must NOT be flagged:
+    // the repo-scoped App token returns an empty `bypass_actors` regardless, so
+    // diffing it would false-fail. See the note in diffRuleset.
     const live = {
       ...liveRuleset(),
       bypass_actors: [{ actor_type: "OrganizationAdmin" }],
     };
-    const result = diffRuleset(desired, live);
+    const result = diffRuleset(DESIRED, live);
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
   });
@@ -139,32 +140,6 @@ describe("diffRuleset", () => {
     const result = diffRuleset(DESIRED, live);
     expect(result.ok).toBe(false);
     expect(result.errors.join("\n")).toContain("missing required rule: deletion");
-  });
-
-  test("flags a bypass_actor_types mismatch", () => {
-    const desired = mergeDesired(SHARED, { bypass_actor_types: [] });
-    const live = {
-      ...liveRuleset(),
-      bypass_actors: [{ actor_type: "OrganizationAdmin" }],
-    };
-    const result = diffRuleset(desired, live);
-    expect(result.ok).toBe(false);
-    const msg = result.errors.join("\n");
-    expect(msg).toContain("bypass_actor_types");
-    expect(msg).toContain("OrganizationAdmin");
-  });
-
-  test("treats a reordered bypass set as a match (order-independent)", () => {
-    const desired = mergeDesired(SHARED, {
-      bypass_actor_types: ["OrganizationAdmin", "RepositoryAdmin"],
-    });
-    const live = {
-      ...liveRuleset(),
-      bypass_actors: [{ actor_type: "RepositoryAdmin" }, { actor_type: "OrganizationAdmin" }],
-    };
-    const result = diffRuleset(desired, live);
-    expect(result.ok).toBe(true);
-    expect(result.errors).toEqual([]);
   });
 });
 

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -34,21 +34,19 @@ export interface SharedRuleset {
   pull_request: Record<string, unknown>;
 }
 
-/** The per-repo overrides layered on top of `SharedRuleset`. */
-export interface RepoRulesetOverrides {
-  bypass_actor_types: string[];
-}
-
-/** The on-disk shape of `.github/rulesets/general-branch.json`. */
+/**
+ * The on-disk shape of `.github/rulesets/general-branch.json`: one shared
+ * declared ruleset plus the flat list of repos it is asserted against. There are
+ * no per-repo overrides — bypass actors are intentionally not diffed (see
+ * `diffRuleset` / the P1 progress log), and everything else is uniform.
+ */
 export interface DesiredRulesetFile {
   shared: SharedRuleset;
-  repos: Record<string, RepoRulesetOverrides>;
+  repos: string[];
 }
 
-/** `SharedRuleset` merged with one repo's overrides — what `diffRuleset` compares against live config. */
-export interface DesiredRuleset extends SharedRuleset {
-  bypass_actor_types: string[];
-}
+/** What `diffRuleset` compares against live config — currently identical to the shared shape. */
+export type DesiredRuleset = SharedRuleset;
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -69,13 +67,6 @@ function sameSet(a: readonly string[], b: readonly string[]): boolean {
 
 function stringArray(v: unknown): string[] {
   return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
-}
-
-export function mergeDesired(
-  shared: SharedRuleset,
-  overrides: RepoRulesetOverrides,
-): DesiredRuleset {
-  return { ...shared, bypass_actor_types: overrides.bypass_actor_types };
 }
 
 export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult {
@@ -123,21 +114,15 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
     }
   }
 
-  // We pin the *set of bypass actor types* — adding or removing any bypass actor
-  // is caught. We do NOT yet pin each actor's `bypass_mode` (`always` vs
-  // `pull_request`): tightening/loosening the mode of an already-permitted actor
-  // type is a narrower vector, and pinning it needs a richer per-actor declared
-  // shape. Tracked as a follow-up in docs/infrastructure-roadmap.md.
-  const bypassActors = Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
-  const liveBypassTypes = bypassActors
-    .filter(isRecord)
-    .map((a) => a["actor_type"])
-    .filter((t): t is string => typeof t === "string");
-  if (!sameSet(liveBypassTypes, desired.bypass_actor_types)) {
-    errors.push(
-      `bypass_actor_types: expected ${JSON.stringify(desired.bypass_actor_types)}, got ${JSON.stringify(liveBypassTypes)}`,
-    );
-  }
+  // Bypass actors are intentionally NOT diffed. The CI credential is a repo-
+  // scoped App installation token with `Administration: read`, which returns an
+  // EMPTY `bypass_actors` for org-level actors (OrganizationAdmin) — proven live
+  // that even adding `organization-administration: read` does not restore it, and
+  // reading them would need `Administration: write`, which an audit gate must not
+  // hold. Diffing the field against a declared value therefore false-fails on
+  // every repo that carries an org-level bypass. Auditing bypass actors is a
+  // follow-up requiring a higher-privilege context (see the P1 progress log in
+  // docs/infrastructure-roadmap.md).
 
   const prRule = rules.find((r) => isRecord(r) && r["type"] === "pull_request");
   if (!isRecord(prRule)) {
@@ -221,7 +206,7 @@ export function decideExit(input: { queried: number; errors: string[]; unreachab
 
 if (import.meta.main) {
   const file = loadDesiredFile(process.cwd());
-  const repoNames = Object.keys(file.repos);
+  const repoNames = file.repos;
   const allErrors: string[] = [];
   const unreachable: string[] = [];
   let queried = 0;
@@ -256,10 +241,7 @@ if (import.meta.main) {
 
     queried += 1;
     const live: unknown = JSON.parse(detailResult.stdout);
-    const overrides = file.repos[repo];
-    if (overrides === undefined) continue;
-    const desired = mergeDesired(file.shared, overrides);
-    const result = diffRuleset(desired, live);
+    const result = diffRuleset(file.shared, live);
     for (const err of result.errors) allErrors.push(`${repo}: ${err}`);
   }
 


### PR DESCRIPTION
## What & why

Follow-up to #818 (P1 — Org CI Foundation). P1's `org-drift-sweep` had its **first live post-merge run**, which surfaced one issue in the `ruleset-drift` job.

**Finding:** the job's credential is a repo-scoped `nimbus-release-bot` App installation token with `Administration: read`. GitHub returns an **empty `bypass_actors`** to that token for org-level actors (`OrganizationAdmin`), so the `bypass_actor_types` diff false-failed on `Nimbus` / `nimbus-vscode` / `nimbus-web-clipper` — the repos that carry that bypass — even though an org-owner token sees the actor exactly as declared.

I tried the coverage-preserving path first (per plan): adding `organization-administration: read` to the token. **Proven live on this branch that it does NOT restore visibility.** Reading the field otherwise requires `Administration: write`, which a read-only audit gate must not hold.

## Changes

- **Workflow:** revert the token step to `Administration: read` only (least privilege), with a comment recording the limitation.
- **Script:** drop `bypass_actors` from `diffRuleset` (with rationale), and simplify the desired-file schema to a flat `repos` list (no per-repo overrides). Every other check — enforcement, `ref_name.include`/`exclude`, required rule types, PR params — reads reliably under the App token.
- **JSON/roadmap:** record the intended bypass shape + the deferral (audit bypass actors from a higher-privilege context later) so the check isn't silently lost.
- **Roadmap:** mark **P1 done** — the gate is proven green end-to-end.

## Live proof

`org-drift-sweep` dispatched on this branch (run `30060920603`) is **fully green**: all 8 `sha-pins` jobs + `ruleset-drift` (`audit:ruleset-drift: OK (5 repos)`). The gate now goes red only on real drift.

## Local verification

`13 tests pass` · live gate `OK (5 repos)` · biome/scripts-tsc clean · `audit:action-sha-pins: OK` · markdown `0 errors` · doc-refs resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ruleset drift coverage, limitations, and planned handling of bypass actors.
  * Updated infrastructure roadmap status and rollout details.

* **Chores**
  * Simplified shared ruleset configuration across repositories.
  * Improved drift auditing to focus on supported ruleset settings and conditions.

* **Tests**
  * Updated validation to reflect the revised ruleset configuration and bypass-actor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->