### PR TITLE
feat: nimbus index add + filesystem.ensureRoot — register blame roots (Stage 2a PR C)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-24 — `nimbus index add <path>` registers a blame root.** New local-only
+  `filesystem.ensureRoot` IPC method + `nimbus index add` CLI register a git repo as a
+  blame/index root (persisted to `registered-roots.json`, merged with `[[filesystem.roots]]` on
+  next start, TOML wins) — no hand-editing `nimbus.toml`. LAN-forbidden (I5); rejects any path
+  that is not an existing `.git` directory.
+
 - **2026-07-24 — Whole-file blame indexer.** A new `blame` syncable populates `git_blame_line`
   whole-file (one row per line, all languages) across git-tracked files changed in the last 90
   days, per configured `[[filesystem.roots]]` git repo. Incremental via a per-repo last-blamed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1186,6 +1186,8 @@ const streamReq: JSONRPCRequest = {
 //   emits security.scanProgress / security.scanDone / security.scanError; CLI-only, FORBIDDEN_OVER_LAN (ipc/security-rpc.ts)
 // index.reembed / index.reembedCancel — long-running re-embed job; CLI-only (I5/I7);
 //   emits index.reembedProgress / index.reembedDone / index.reembedError (ipc/index-reembed-rpc.ts)
+// filesystem.ensureRoot — register a local git repo as a blame/index root; CLI-only,
+//   FORBIDDEN_OVER_LAN (I5); persists to registered-roots.json, effective next start (ipc/filesystem-rpc.ts)
 //
 // Phase 6 surfaces (Team; full signatures in the nimbus-ipc skill registry):
 // federation.* — consent-scoped peer federation; LAN admits read-only answers (query / expertise / policy /

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1771,6 +1771,19 @@ nimbus db prune --yes
 
 ## Index Maintenance
 
+### `nimbus index add <path>`
+
+Register a local git repository as a blame/index root without hand-editing `nimbus.toml`. The path is resolved to an absolute path and sent to the Gateway, which canonicalizes it, verifies it is an existing directory containing a `.git` entry, and persists it to `registered-roots.json`. The registered root is merged with the `[[filesystem.roots]]` TOML set on the next Gateway start (TOML wins on collision), at which point the git-commit, blame, and other filesystem syncables begin indexing it.
+
+```bash
+nimbus index add .
+nimbus index add /path/to/repo
+```
+
+Output is `Registered blame root: <path>` for a new root, or `Already registered: <path>` if it was already present (idempotent).
+
+**Security:** `filesystem.ensureRoot` is CLI-only — the `filesystem` namespace is in `FORBIDDEN_OVER_LAN` (invariant I5), so a remote peer can never register an indexing root on your machine. A path that is not an existing directory, or lacks a `.git` entry, is rejected (this structurally rejects roots like `C:\` or `/`).
+
 ### `nimbus index reembed`
 
 Selectively re-embed indexed items to a target embedding model. Useful when switching between local MiniLM (384-dim, `vec_items_384`) and OpenAI `text-embedding-3-small` (1536-dim, `vec_items_1536`) — both tables can coexist; this command backfills missing chunks for a chosen model.

--- a/packages/cli/src/commands/index-cmd.test.ts
+++ b/packages/cli/src/commands/index-cmd.test.ts
@@ -40,6 +40,11 @@ describe("nimbus index — top-level dispatcher", () => {
     await expect(runIndexCmd(["bogus"])).rejects.toThrow(/Unknown index subcommand/);
   });
 
+  it("help mentions index add", async () => {
+    await runIndexCmd(["help"]);
+    expect(out.stdout).toContain("nimbus index add");
+  });
+
   it("reembed without --model throws usage error", async () => {
     await expect(runIndexCmd(["reembed"])).rejects.toThrow(/--model/);
   });
@@ -74,6 +79,66 @@ describe("nimbus index — top-level dispatcher", () => {
     expect(out.stdout).toContain("slack");
     expect(out.stdout).toContain("100");
     expect(out.stdout).toContain("16");
+  });
+});
+
+describe("nimbus index add — IPC flow", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  it("throws usage error when no path is given", async () => {
+    await expect(runIndexCmd(["add"])).rejects.toThrow(/Usage: nimbus index add/);
+  });
+
+  it("throws usage error when the arg looks like a flag", async () => {
+    await expect(runIndexCmd(["add", "--bogus"])).rejects.toThrow(/Usage: nimbus index add/);
+  });
+
+  it("throws when gateway is not running", async () => {
+    setFixture({});
+    await expect(runIndexCmd(["add", "."])).rejects.toThrow(/Gateway is not running/);
+  });
+
+  it("calls filesystem.ensureRoot with the resolved path and reports registration", async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: async (method: string, params: unknown) => {
+          calls.push({ method, params });
+          return { path: "/abs/repo", added: true };
+        },
+        connect: async () => {},
+        disconnect: async () => {},
+        onNotification: () => {},
+      },
+    });
+    await runIndexCmd(["add", "some/repo"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("filesystem.ensureRoot");
+    const params = calls[0]?.params as { path: string };
+    expect(typeof params.path).toBe("string");
+    // resolved to an absolute path before the call
+    expect(params.path).not.toBe("some/repo");
+    expect(out.stdout).toMatch(/Registered blame root: \/abs\/repo/);
+  });
+
+  it("reports 'Already registered' when added is false", async () => {
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: async () => ({ path: "/abs/repo", added: false }),
+        connect: async () => {},
+        disconnect: async () => {},
+        onNotification: () => {},
+      },
+    });
+    await runIndexCmd(["add", "some/repo"]);
+    expect(out.stdout).toMatch(/Already registered: \/abs\/repo/);
   });
 });
 

--- a/packages/cli/src/commands/index-cmd.ts
+++ b/packages/cli/src/commands/index-cmd.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { IPCClient } from "../ipc-client/index.ts";
 import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 
@@ -157,10 +158,26 @@ async function runRegraph(args: string[]): Promise<void> {
   }
 }
 
+async function runIndexAdd(args: string[]): Promise<void> {
+  const raw = args[0];
+  if (raw === undefined || raw === "" || raw.startsWith("-")) {
+    throw new Error("Usage: nimbus index add <path>");
+  }
+  const path = resolve(raw);
+  const result = await withGatewayIpc((c) =>
+    c.call<{ path: string; added: boolean }>("filesystem.ensureRoot", { path }),
+  );
+  console.log(
+    result.added ? `Registered blame root: ${result.path}` : `Already registered: ${result.path}`,
+  );
+}
+
 function printIndexHelp(): void {
   console.log(`nimbus index — local index maintenance (Gateway IPC)
 
 Usage:
+  nimbus index add <path>            register a local git repo as a blame/index root
+
   nimbus index reembed --model <id>
                        [--item-type <key>]   ("service:type" exact, or "type" alone)
                        [--service <name>]
@@ -188,6 +205,10 @@ export async function runIndexCmd(args: string[]): Promise<void> {
   const tail = args.slice(1);
   if (sub === undefined || sub === "help" || sub === "--help" || sub === "-h") {
     printIndexHelp();
+    return;
+  }
+  if (sub === "add") {
+    await runIndexAdd(tail);
     return;
   }
   if (sub === "reembed") {

--- a/packages/gateway/src/index/registered-roots-store.test.ts
+++ b/packages/gateway/src/index/registered-roots-store.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { NimbusFilesystemRootToml } from "../config/filesystem-toml.ts";
+import {
+  addRegisteredRoot,
+  canonicalizeRootPath,
+  loadRegisteredRoots,
+  mergeRoots,
+} from "./registered-roots-store.ts";
+
+function fsRoot(
+  path: string,
+  extra: Partial<NimbusFilesystemRootToml> = {},
+): NimbusFilesystemRootToml {
+  return { path, gitAware: true, codeIndex: false, dependencyGraph: false, exclude: [], ...extra };
+}
+
+describe("addRegisteredRoot + loadRegisteredRoots", () => {
+  test("add is idempotent and load round-trips a blame-oriented root", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    expect(addRegisteredRoot(cfg, cfg)).toBe(true);
+    expect(addRegisteredRoot(cfg, cfg)).toBe(false); // already present
+
+    const roots = loadRegisteredRoots(cfg);
+    expect(roots.map((r) => r.path)).toEqual([cfg]);
+    expect(roots[0]?.gitAware).toBe(true);
+    expect(roots[0]?.codeIndex).toBe(false);
+    expect(roots[0]?.dependencyGraph).toBe(false);
+  });
+
+  test("load returns [] when no registered-roots file exists", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    expect(loadRegisteredRoots(cfg)).toEqual([]);
+  });
+
+  test("two distinct paths both round-trip", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    const a = mkdtempSync(join(tmpdir(), "rra-"));
+    const b = mkdtempSync(join(tmpdir(), "rrb-"));
+    expect(addRegisteredRoot(cfg, a)).toBe(true);
+    expect(addRegisteredRoot(cfg, b)).toBe(true);
+    expect(new Set(loadRegisteredRoots(cfg).map((r) => r.path))).toEqual(new Set([a, b]));
+  });
+});
+
+describe("mergeRoots", () => {
+  test("TOML wins on collision, missing folders skipped", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-")); // exists
+    const gone = join(tmpdir(), "definitely-not-here-xyz-987654");
+    const merged = mergeRoots(
+      [fsRoot(cfg, { codeIndex: true })], // TOML: codeIndex true
+      [fsRoot(cfg), fsRoot(gone)], // registered: dup + missing
+    );
+    expect(merged).toHaveLength(1); // dup collapsed, missing skipped
+    expect(merged[0]?.codeIndex).toBe(true); // TOML won
+  });
+
+  test("keeps distinct existing roots from both sources", () => {
+    const t = mkdtempSync(join(tmpdir(), "rr-toml-"));
+    const r = mkdtempSync(join(tmpdir(), "rr-reg-"));
+    const merged = mergeRoots([fsRoot(t)], [fsRoot(r)]);
+    expect(new Set(merged.map((m) => m.path))).toEqual(new Set([t, r]));
+  });
+});
+
+describe("canonicalizeRootPath", () => {
+  test("a real directory round-trips without a Windows long-path prefix", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rr-canon-"));
+    const canon = canonicalizeRootPath(dir);
+    expect(canon).not.toBeNull();
+    expect(canon?.startsWith("\\\\?\\")).toBe(false);
+  });
+
+  test("a non-existent path returns null", () => {
+    expect(canonicalizeRootPath(join(tmpdir(), "nope-does-not-resolve-123456"))).toBeNull();
+  });
+});

--- a/packages/gateway/src/index/registered-roots-store.test.ts
+++ b/packages/gateway/src/index/registered-roots-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -43,6 +43,26 @@ describe("addRegisteredRoot + loadRegisteredRoots", () => {
     expect(addRegisteredRoot(cfg, a)).toBe(true);
     expect(addRegisteredRoot(cfg, b)).toBe(true);
     expect(new Set(loadRegisteredRoots(cfg).map((r) => r.path))).toEqual(new Set([a, b]));
+  });
+});
+
+describe("loadRegisteredRoots — malformed file handling", () => {
+  test("a non-array JSON payload yields no roots", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    writeFileSync(join(cfg, "registered-roots.json"), JSON.stringify({ not: "an array" }), "utf8");
+    expect(loadRegisteredRoots(cfg)).toEqual([]);
+  });
+
+  test("malformed JSON yields no roots (no throw)", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    writeFileSync(join(cfg, "registered-roots.json"), "not json at all", "utf8");
+    expect(loadRegisteredRoots(cfg)).toEqual([]);
+  });
+
+  test("non-string array entries are filtered out", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "rr-"));
+    writeFileSync(join(cfg, "registered-roots.json"), JSON.stringify([1, "/ok", null]), "utf8");
+    expect(loadRegisteredRoots(cfg).map((r) => r.path)).toEqual(["/ok"]);
   });
 });
 

--- a/packages/gateway/src/index/registered-roots-store.ts
+++ b/packages/gateway/src/index/registered-roots-store.ts
@@ -1,0 +1,94 @@
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import type { NimbusFilesystemRootToml } from "../config/filesystem-toml.ts";
+
+const REGISTERED_ROOTS_FILE = "registered-roots.json";
+
+// Registered (editor/CLI-added) roots are blame-oriented: git-aware, but without
+// the code-symbol scan or the dependency graph. Excludes mirror the TOML default.
+const DEFAULT_EXCLUDE = ["node_modules", ".git", "dist", "target", "build", ".next"] as const;
+
+/**
+ * Resolve + real-path a candidate root, stripping the Windows `\\?\` long-path
+ * prefix so the result is byte-identical to the path git sees via `-C` (and thus
+ * matches the SQLite `git_blame_line.repo_root` key). Returns `null` if the path
+ * does not resolve.
+ */
+export function canonicalizeRootPath(p: string): string | null {
+  try {
+    let r = realpathSync(resolve(p));
+    if (r.startsWith("\\\\?\\")) r = r.slice(4);
+    return r;
+  } catch {
+    return null; // does not resolve
+  }
+}
+
+function rootsFilePath(configDir: string): string {
+  return join(configDir, REGISTERED_ROOTS_FILE);
+}
+
+function readRegisteredPaths(configDir: string): string[] {
+  const path = rootsFilePath(configDir);
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Append a canonical root to `registered-roots.json`. Returns `false` (a no-op)
+ * if the exact path is already present. The caller supplies an already
+ * `canonicalizeRootPath`-normalized path.
+ */
+export function addRegisteredRoot(configDir: string, canonicalPath: string): boolean {
+  const paths = readRegisteredPaths(configDir);
+  if (paths.includes(canonicalPath)) return false;
+  paths.push(canonicalPath);
+  writeFileSync(rootsFilePath(configDir), `${JSON.stringify(paths, null, 2)}\n`, "utf8");
+  return true;
+}
+
+/** Load registered roots as blame-oriented `NimbusFilesystemRootToml` entries. */
+export function loadRegisteredRoots(configDir: string): NimbusFilesystemRootToml[] {
+  return readRegisteredPaths(configDir).map((path) => ({
+    path,
+    gitAware: true,
+    codeIndex: false,
+    dependencyGraph: false,
+    exclude: [...DEFAULT_EXCLUDE],
+  }));
+}
+
+function dedupeKey(p: string): string {
+  return process.platform === "win32" ? p.toLowerCase() : p;
+}
+
+/**
+ * Merge TOML-configured roots with editor/CLI-registered roots. Dedupe by
+ * canonical path (case-folded on win32); **TOML wins** on collision. Any root
+ * whose folder no longer exists is skipped (with a stderr warning) so a stale
+ * registration never blocks startup.
+ */
+export function mergeRoots(
+  tomlRoots: readonly NimbusFilesystemRootToml[],
+  registered: readonly NimbusFilesystemRootToml[],
+): NimbusFilesystemRootToml[] {
+  const byKey = new Map<string, NimbusFilesystemRootToml>();
+  for (const r of registered) byKey.set(dedupeKey(r.path), r);
+  for (const r of tomlRoots) byKey.set(dedupeKey(r.path), r); // TOML overrides
+  const out: NimbusFilesystemRootToml[] = [];
+  for (const r of byKey.values()) {
+    if (!existsSync(r.path)) {
+      process.stderr.write(`nimbus: skipping root (folder missing): ${r.path}\n`);
+      continue;
+    }
+    out.push(r);
+  }
+  return out;
+}

--- a/packages/gateway/src/ipc/filesystem-rpc.test.ts
+++ b/packages/gateway/src/ipc/filesystem-rpc.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { dispatchFilesystemRpc, FilesystemRpcError } from "./filesystem-rpc.ts";
+
+type HitOf<V> = { kind: "hit"; value: V };
+
+describe("dispatchFilesystemRpc", () => {
+  test("miss for an unknown method", async () => {
+    const out = await dispatchFilesystemRpc("foo.bar", {}, { configDir: tmpdir() });
+    expect(out.kind).toBe("miss");
+  });
+
+  test("rejects a non-object params", async () => {
+    await expect(
+      dispatchFilesystemRpc("filesystem.ensureRoot", "nope", { configDir: tmpdir() }),
+    ).rejects.toBeInstanceOf(FilesystemRpcError);
+  });
+
+  test("rejects a missing path", async () => {
+    await expect(
+      dispatchFilesystemRpc("filesystem.ensureRoot", {}, { configDir: tmpdir() }),
+    ).rejects.toBeInstanceOf(FilesystemRpcError);
+  });
+
+  test("rejects a path that does not resolve", async () => {
+    const cfg = mkdtempSync(join(tmpdir(), "fsrpc-"));
+    await expect(
+      dispatchFilesystemRpc(
+        "filesystem.ensureRoot",
+        { path: join(tmpdir(), "definitely-missing-xyz-42") },
+        { configDir: cfg },
+      ),
+    ).rejects.toBeInstanceOf(FilesystemRpcError);
+  });
+
+  test("rejects a non-git directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "fsrpc-nogit-"));
+    await expect(
+      dispatchFilesystemRpc("filesystem.ensureRoot", { path: dir }, { configDir: dir }),
+    ).rejects.toBeInstanceOf(FilesystemRpcError);
+  });
+
+  test("rejects a path that is a file, not a directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "fsrpc-file-"));
+    const file = join(dir, "a.ts");
+    writeFileSync(file, "x\n");
+    await expect(
+      dispatchFilesystemRpc("filesystem.ensureRoot", { path: file }, { configDir: dir }),
+    ).rejects.toBeInstanceOf(FilesystemRpcError);
+  });
+
+  test("registers a git repo idempotently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "fsrpc-git-"));
+    mkdirSync(join(dir, ".git"));
+    const cfg = mkdtempSync(join(tmpdir(), "fsrpc-cfg-"));
+
+    const first = (await dispatchFilesystemRpc(
+      "filesystem.ensureRoot",
+      { path: dir },
+      { configDir: cfg },
+    )) as HitOf<{ path: string; added: boolean }>;
+    expect(first.kind).toBe("hit");
+    expect(first.value.added).toBe(true);
+
+    const second = (await dispatchFilesystemRpc(
+      "filesystem.ensureRoot",
+      { path: dir },
+      { configDir: cfg },
+    )) as HitOf<{ path: string; added: boolean }>;
+    expect(second.value.added).toBe(false);
+    expect(second.value.path).toBe(first.value.path);
+  });
+});

--- a/packages/gateway/src/ipc/filesystem-rpc.ts
+++ b/packages/gateway/src/ipc/filesystem-rpc.ts
@@ -1,0 +1,62 @@
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { addRegisteredRoot, canonicalizeRootPath } from "../index/registered-roots-store.ts";
+import { dispatchByMethod, type RpcMissOrHit } from "./_lib/dispatch-by-method.ts";
+
+export class FilesystemRpcError extends Error {
+  readonly rpcCode: number;
+  constructor(rpcCode: number, message: string) {
+    super(message);
+    this.name = "FilesystemRpcError";
+    this.rpcCode = rpcCode;
+  }
+}
+
+export type FilesystemRpcContext = {
+  configDir: string;
+};
+
+interface EnsureRootResult {
+  readonly path: string;
+  readonly added: boolean;
+}
+
+/**
+ * Register a local git repository as a blame/index root. Local-only (LAN-forbidden,
+ * see FORBIDDEN_OVER_LAN). The caller supplies a path; the destination is the
+ * config-pinned `registered-roots.json`. Requires an existing directory with a
+ * `.git` entry — this structurally rejects `C:\` / `/`. The registered root takes
+ * effect on the next gateway start (assemble merges it into the syncable roots).
+ */
+function handleEnsureRoot(params: unknown, ctx: FilesystemRpcContext): EnsureRootResult {
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {
+    throw new FilesystemRpcError(-32602, "params must be an object");
+  }
+  const raw = (params as Record<string, unknown>)["path"];
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw new FilesystemRpcError(-32602, "params.path is required");
+  }
+  const canonical = canonicalizeRootPath(raw);
+  if (canonical === null) {
+    throw new FilesystemRpcError(-32602, "path does not resolve");
+  }
+  if (!statSync(canonical).isDirectory()) {
+    throw new FilesystemRpcError(-32602, "path is not a directory");
+  }
+  if (!existsSync(join(canonical, ".git"))) {
+    throw new FilesystemRpcError(-32602, "not a git repository");
+  }
+  const added = addRegisteredRoot(ctx.configDir, canonical);
+  return { path: canonical, added };
+}
+
+export async function dispatchFilesystemRpc(
+  method: string,
+  params: unknown,
+  ctx: FilesystemRpcContext,
+): Promise<RpcMissOrHit> {
+  return dispatchByMethod<FilesystemRpcContext>(method, params, ctx, {
+    "filesystem.ensureRoot": handleEnsureRoot,
+  });
+}

--- a/packages/gateway/src/ipc/lan-rpc.ts
+++ b/packages/gateway/src/ipc/lan-rpc.ts
@@ -12,6 +12,7 @@ const FORBIDDEN_OVER_LAN = new Set([
   "updater",
   "lan",
   "profile",
+  "filesystem", // Stage 2a — local-only blame-root registration, never over LAN (I5 defense-in-depth)
   "chatops", // Slice 5 — local/Tauri-read-only bot lifecycle; never answerable over the wire
   "tribal", // Slice 6c — local/Tauri-read-only knowledge extraction + owner-HITL capture; never over the wire
   // Slice 8 — share: create is the I27 owner-HITL outbound chokepoint; prune deletes local

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -772,6 +772,23 @@ describe("tryDispatchPhase4Rpc", () => {
       unknown
     >;
     expect(out["enabled"]).toBe(false);
+  });
+  test("filesystem.ensureRoot hit through chain (registers a git repo)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "disp-fs-"));
+    mkdirSync(join(dir, ".git"));
+    const cfg = mkdtempSync(join(tmpdir(), "disp-fs-cfg-"));
+    const { ctx } = makeCtx({ configDir: cfg });
+    const out = (await tryDispatchPhase4Rpc(ctx, "filesystem.ensureRoot", { path: dir }, "c1")) as {
+      path: string;
+      added: boolean;
+    };
+    expect(out.added).toBe(true);
+  });
+  test("filesystem.ensureRoot bubbles the configDir error via chain", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      tryDispatchPhase4Rpc(ctx, "filesystem.ensureRoot", { path: tmpdir() }, "c1"),
+    ).rejects.toThrow(/configDir is required/);
   });
   test("audit.verify falls through audit chain when not configured", async () => {
     const { ctx } = makeCtx();

--- a/packages/gateway/src/ipc/server/dispatchers.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.ts
@@ -26,6 +26,7 @@ import { DeploymentRpcError, dispatchDeploymentRpc } from "../deployment-rpc.ts"
 import { DiagnosticsRpcError, dispatchDiagnosticsRpc } from "../diagnostics-rpc.ts";
 import { dispatchEgressRpc, type EgressRpcCtx, EgressRpcError } from "../egress-rpc.ts";
 import { dispatchFederationRpc, FederationRpcError } from "../federation-rpc.ts";
+import { dispatchFilesystemRpc, FilesystemRpcError } from "../filesystem-rpc.ts";
 import { dispatchHitlRpc, HitlRpcError } from "../hitl-rpc.ts";
 import { dispatchIdentityRpc, type IdentityRpcContext, IdentityRpcError } from "../identity-rpc.ts";
 import { dispatchIndexReembedRpc, IndexReembedRpcError } from "../index-reembed-rpc.ts";
@@ -575,6 +576,29 @@ export async function tryDispatchIndexRegraphRpc(
   return phase4RpcSkipped;
 }
 
+export async function tryDispatchFilesystemRpc(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+): Promise<unknown> {
+  if (!method.startsWith("filesystem.")) return phase4RpcSkipped;
+  if (ctx.options.configDir === undefined) {
+    throw new RpcMethodError(-32603, "configDir is required for filesystem.* RPCs");
+  }
+  try {
+    const out = await dispatchFilesystemRpc(method, params, {
+      configDir: ctx.options.configDir,
+    });
+    if (out.kind === "hit") return out.value;
+  } catch (e) {
+    if (e instanceof FilesystemRpcError) {
+      throw new RpcMethodError(e.rpcCode, e.message);
+    }
+    throw e;
+  }
+  return phase4RpcSkipped;
+}
+
 export async function tryDispatchProfileRpc(
   ctx: ServerCtx,
   method: string,
@@ -992,6 +1016,8 @@ async function dispatchPhase4PlatformGroup(
   if (indexReembedOutcome !== phase4RpcSkipped) return indexReembedOutcome;
   const indexRegraphOutcome = await tryDispatchIndexRegraphRpc(ctx, method, params);
   if (indexRegraphOutcome !== phase4RpcSkipped) return indexRegraphOutcome;
+  const filesystemOutcome = await tryDispatchFilesystemRpc(ctx, method, params);
+  if (filesystemOutcome !== phase4RpcSkipped) return filesystemOutcome;
   const policyOutcome = await tryDispatchPolicyRpc(ctx, method, params);
   if (policyOutcome !== phase4RpcSkipped) return policyOutcome;
   const chatopsOutcome = await tryDispatchChatopsRpc(ctx, method, params);

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -344,24 +344,32 @@ function registerFilesystemRootSyncables(
   syncScheduler: SyncScheduler,
   localIndex: LocalIndex,
   configDir: string,
-  fsV2Roots: ReturnType<typeof loadNimbusFilesystemRootsFromConfigDir>,
+  tomlRoots: ReturnType<typeof loadNimbusFilesystemRootsFromConfigDir>,
+  registeredRoots: ReturnType<typeof loadNimbusFilesystemRootsFromConfigDir>,
 ): void {
-  if (fsV2Roots.length === 0) {
-    return;
+  // filesystem-v2 (git commits + optional symbols/deps per the root's own flags) and the blame
+  // indexer act on the full set — a CLI-registered blame root needs git_commit items so its blame
+  // SHAs resolve (the why-lens join). TOML wins on collision; a missing folder is dropped.
+  const allRoots = mergeRoots(tomlRoots, registeredRoots);
+  if (allRoots.length > 0) {
+    localIndex.ensureConnectorSchedulerRegistration("filesystem", 10 * 60 * 1000, Date.now());
+    syncScheduler.register(createFilesystemV2Syncable({ roots: allRoots }));
+    localIndex.ensureConnectorSchedulerRegistration("blame", 10 * 60 * 1000, Date.now());
+    syncScheduler.register(createBlameIndexSyncable({ roots: allRoots }));
   }
-  localIndex.ensureConnectorSchedulerRegistration("filesystem", 10 * 60 * 1000, Date.now());
-  syncScheduler.register(createFilesystemV2Syncable({ roots: fsV2Roots }));
-  localIndex.ensureConnectorSchedulerRegistration("openapi", 10 * 60 * 1000, Date.now());
-  syncScheduler.register(
-    createOpenapiIndexerSyncable({
-      roots: fsV2Roots,
-      config: loadOpenapiConfig(configDir),
-    }),
-  );
-  localIndex.ensureConnectorSchedulerRegistration("obsidian", 10 * 60 * 1000, Date.now());
-  syncScheduler.register(createObsidianSyncable({ roots: fsV2Roots }));
-  localIndex.ensureConnectorSchedulerRegistration("blame", 10 * 60 * 1000, Date.now());
-  syncScheduler.register(createBlameIndexSyncable({ roots: fsV2Roots }));
+  // OpenAPI spec indexing and Obsidian vault semantics are opt-in via [[filesystem.roots]] only:
+  // `nimbus index add <repo>` registers a blame/index root, NOT an API-spec source or a note vault.
+  if (tomlRoots.length > 0) {
+    localIndex.ensureConnectorSchedulerRegistration("openapi", 10 * 60 * 1000, Date.now());
+    syncScheduler.register(
+      createOpenapiIndexerSyncable({
+        roots: tomlRoots,
+        config: loadOpenapiConfig(configDir),
+      }),
+    );
+    localIndex.ensureConnectorSchedulerRegistration("obsidian", 10 * 60 * 1000, Date.now());
+    syncScheduler.register(createObsidianSyncable({ roots: tomlRoots }));
+  }
 }
 
 interface SchedulerWithMeshOpts {
@@ -412,17 +420,23 @@ async function createSchedulerWithMesh(
       evaluateWatchersAfterSync(db, serviceId, at, (t, b) => notifications.show(t, b), watcherOpts);
     },
   });
-  const fsV2Roots = mergeRoots(
-    loadNimbusFilesystemRootsFromConfigDir(paths.configDir),
-    loadRegisteredRoots(paths.configDir),
+  const tomlRoots = loadNimbusFilesystemRootsFromConfigDir(paths.configDir);
+  const registeredRoots = loadRegisteredRoots(paths.configDir);
+  registerFilesystemRootSyncables(
+    syncScheduler,
+    localIndex,
+    paths.configDir,
+    tomlRoots,
+    registeredRoots,
   );
-  registerFilesystemRootSyncables(syncScheduler, localIndex, paths.configDir, fsV2Roots);
   const connectorMesh = await createLazyConnectorMesh(paths, vault, {
     listUserMcpConnectors: () => listUserMcpConnectors(db),
     healthDb: db,
     auditDb: db,
     logger: syncLogger,
-    obsidianVaultPaths: fsV2Roots.map((r) => r.path),
+    // Obsidian vault semantics are opt-in via [[filesystem.roots]] only — CLI-registered blame
+    // roots must not be silently treated as note vaults.
+    obsidianVaultPaths: tomlRoots.map((r) => r.path),
     isConnectorAllowed,
   });
   const pagerdutyCfg = loadNimbusPagerdutyFromConfigDir(paths.configDir);

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -120,6 +120,7 @@ import {
   type SemanticSearchDeps,
 } from "../index/local-index.ts";
 import { readIndexedUserVersion } from "../index/migrations/runner.ts";
+import { loadRegisteredRoots, mergeRoots } from "../index/registered-roots-store.ts";
 import type { StatusReaders } from "../ipc/admin-status-rpc.ts";
 import { resumePendingRemovals } from "../ipc/connector-rpc-handlers/index.ts";
 import type { EgressRpcCtx } from "../ipc/egress-rpc.ts";
@@ -411,7 +412,10 @@ async function createSchedulerWithMesh(
       evaluateWatchersAfterSync(db, serviceId, at, (t, b) => notifications.show(t, b), watcherOpts);
     },
   });
-  const fsV2Roots = loadNimbusFilesystemRootsFromConfigDir(paths.configDir);
+  const fsV2Roots = mergeRoots(
+    loadNimbusFilesystemRootsFromConfigDir(paths.configDir),
+    loadRegisteredRoots(paths.configDir),
+  );
   registerFilesystemRootSyncables(syncScheduler, localIndex, paths.configDir, fsV2Roots);
   const connectorMesh = await createLazyConnectorMesh(paths, vault, {
     listUserMcpConnectors: () => listUserMcpConnectors(db),

--- a/packages/gateway/src/security-invariants.test.ts
+++ b/packages/gateway/src/security-invariants.test.ts
@@ -137,6 +137,16 @@ describe("I5 — LAN method allowlist is intrinsic to LanServer", () => {
     expect(() => checkLanMethodAllowed("share.verify", peer)).not.toThrow();
   });
 
+  test("FORBIDDEN_OVER_LAN blocks filesystem.ensureRoot (Stage 2a)", async () => {
+    const { checkLanMethodAllowed } = await import("./ipc/lan-rpc.ts");
+    const peer = { peerId: "peer:x", writeAllowed: true };
+    // Blame-root registration is a local-only owner action; a remote peer must never be able
+    // to add an indexing root on this machine.
+    expect(() => checkLanMethodAllowed("filesystem.ensureRoot", peer)).toThrow(
+      /ERR_METHOD_NOT_ALLOWED/,
+    );
+  });
+
   test("admits the team-vault wire methods but FORBIDS team-vault/HITL management over LAN (Slice 2)", async () => {
     const { checkLanMethodAllowed } = await import("./ipc/lan-rpc.ts");
     const peer = { peerId: "peer:x", writeAllowed: true };


### PR DESCRIPTION
## Stage 2a un-park — PR C of 3 (editor/CLI root registration)

**Problem.** The blame indexer (PR B, #819) and git-commit/symbol syncables only run on paths in `[[filesystem.roots]]`. On the live machine that array is empty, so nothing gets blamed — and the only way to add a root was to hand-edit `nimbus.toml`. This PR makes registering a repo a one-liner.

**What it adds.**
- **`nimbus index add <path>`** — resolves the path and calls the new `filesystem.ensureRoot` IPC method (generic `IPCClient.call`, no `@nimbus-dev/client` change). Reports `Registered blame root: <path>` or `Already registered: <path>`.
- **`filesystem.ensureRoot` IPC** — narrows `{ path }`, canonicalizes (real-path + strips the Windows `\?\` long-path prefix so `repo_root` matches `git -C`), requires an existing directory with a `.git` entry (structurally rejecting `C:\` / `/`), and persists to `registered-roots.json`. Fail-closed on missing `configDir`.
- **`registered-roots-store`** — persist/load + `mergeRoots(toml, registered)`: dedupe by canonical path (case-folded on win32), **TOML wins** on collision, skip any root whose folder is gone (stderr warning). Registered roots are blame-oriented (git-aware, no code-index, no dependency graph).
- **Assembly wiring** — the `fsV2Roots` load site now merges TOML + registered roots, so a registered repo feeds the existing filesystem/git-commit/blame syncables on the next Gateway start (TOML wins).

### Security
- `filesystem.*` added to `FORBIDDEN_OVER_LAN` (invariant I5) — a remote peer can never register an indexing root on your machine. Enforcement test added to `security-invariants.test.ts`; static invariant audit green.
- Not exposed to the Tauri renderer (CLI-only), consistent with `index.reembed`.

### Tests
- `registered-roots-store.test.ts` (10): idempotent add, round-trip, `mergeRoots` (TOML-wins / missing-skip), `canonicalizeRootPath`, malformed-JSON / non-array / non-string-element handling.
- `filesystem-rpc.test.ts` (7): miss, bad params, non-resolving path, non-git dir, file-not-dir, idempotent register.
- `dispatchers.test.ts`: `filesystem.ensureRoot` reached via the Phase-4 chain + the `configDir`-missing error bubbles.
- `index-cmd.test.ts` (+6): usage errors, gateway-down, resolved-path call, `Already registered`.

### Verification (local, pre-push, CI-Linux-authoritative floor)
- New files above floor: `registered-roots-store.ts` 100% line / 83.3% branch (remaining 2 branches are win32-only), `filesystem-rpc.ts` 100/100, `index-cmd.ts` 100 line / 94.1% branch.
- typecheck ✓ (gateway + cli), biome ✓ (2947 files), invariant audit ✓, `audit:readme-cli` ✓, `audit:doc-refs` ✓ (610 refs), lychee ✓.
- Rebased cleanly onto current `main` (resolved with #819 blame indexer + #820 why-lens/index-regraph — both `tryDispatchIndexRegraphRpc` and `tryDispatchFilesystemRpc`, and both `index add` / `index regraph` CLI subcommands, coexist).
- The only floor/test failures in the full local run are pre-existing environment cases in files this PR does not touch (updater factory detects a package-manager install on this dev box; OAuth-arm timeout) — green on CI Ubuntu.

Completes the Stage 2a un-park trio (A #817 titles, B #819 blame indexer, C root registration). Do not merge without the usual CI pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `nimbus index add <path>` to register an existing local Git repo as a blame/index root.
  - Registered roots persist to be applied on the next Gateway start, merging with `nimbus.toml` (with `nimbus.toml` taking precedence).
  - Command output is idempotent, indicating newly added vs already registered roots.
- **Bug Fixes**
  - Validates inputs, requires an existing directory containing `.git`, and blocks the action over LAN.
- **Documentation**
  - Updated CLI reference plus IPC/architecture notes and the changelog.
- **Tests**
  - Added end-to-end coverage for the command and IPC dispatch, plus registered-roots load/merge/canonicalization cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->