### PR TITLE
ci(release): auto-recover phantom releases (create missing tag + relabel)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,9 +35,57 @@ jobs:
           repositories: Nimbus
           permission-contents: write
           permission-pull-requests: write
+          # `issues: write` is required to flip the `autorelease:` labels on the
+          # release PR (labels are an issues-API concept for GitHub Apps) — both
+          # for release-please's own pending→tagged flip and the reconcile step below.
+          permission-issues: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release-please
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
+
+      # Phantom-release guard. release-please in this repo intermittently merges the
+      # "chore: release main" PR (bumping the manifest) but never creates the tag/GitHub
+      # Release — an internal parse error breaks its release-creation phase, after which it
+      # aborts every run with "untagged, merged release PRs outstanding". The symptom is a
+      # merged release PR left labelled `autorelease: pending` with no matching tag. This
+      # step automates the standing manual recovery (create the tag + relabel), so releases
+      # ship hands-free regardless of why the native step misfired. It is idempotent: on a
+      # healthy run (nothing pending) it no-ops. The tag is created with the App token, which
+      # — unlike GITHUB_TOKEN — DOES trigger the tag-driven release.yml build.
+      - name: Reconcile phantom release (create missing tag + relabel)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pending=$(gh pr list --repo "$REPO" --state merged --label "autorelease: pending" \
+                      --json number,mergeCommit --jq '.[] | [.number, .mergeCommit.oid] | @tsv')
+          if [ -z "$pending" ]; then
+            echo "No untagged, merged release PRs — nothing to reconcile."
+            exit 0
+          fi
+          while IFS=$'\t' read -r num sha; do
+            [ -n "${num:-}" ] || continue
+            ver=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${sha}" \
+                    --jq '.content' | tr -d '\n' | base64 -d | jq -r '."."')
+            if [ -z "$ver" ] || [ "$ver" = "null" ]; then
+              echo "::warning::could not read manifest version for PR #${num} at ${sha}; skipping"
+              continue
+            fi
+            tag="v${ver}"
+            if gh api "repos/${REPO}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+              echo "${tag} already exists — relabelling PR #${num} only."
+            else
+              echo "Phantom detected: PR #${num} merged as ${ver} but ${tag} is missing. Creating it."
+              gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}"
+              echo "Created ${tag} at ${sha} (App token → triggers release.yml)."
+            fi
+            gh pr edit "$num" --repo "$REPO" \
+              --add-label "autorelease: tagged" --remove-label "autorelease: pending"
+            echo "Relabelled PR #${num}: autorelease: pending → tagged."
+          done <<< "$pending"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,10 @@ jobs:
       # healthy run (nothing pending) it no-ops. The tag is created with the App token, which
       # — unlike GITHUB_TOKEN — DOES trigger the tag-driven release.yml build.
       - name: Reconcile phantom release (create missing tag + relabel)
+        # `always()`: this is the recovery path — it must run even when the
+        # release-please step above errored (the very failure it recovers from),
+        # not just on success. Skipped only if the job is cancelled outright.
+        if: ${{ always() }}
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -78,12 +82,20 @@ jobs:
               continue
             fi
             tag="v${ver}"
-            if gh api "repos/${REPO}/git/ref/tags/${tag}" >/dev/null 2>&1; then
-              echo "${tag} already exists — relabelling PR #${num} only."
-            else
+            # Resolve the tag to its COMMIT (the commits endpoint dereferences both
+            # lightweight and annotated tags); empty => the tag does not exist.
+            existing=$(gh api "repos/${REPO}/commits/${tag}" --jq '.sha' 2>/dev/null || true)
+            if [ -z "$existing" ]; then
               echo "Phantom detected: PR #${num} merged as ${ver} but ${tag} is missing. Creating it."
               gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}"
               echo "Created ${tag} at ${sha} (App token → triggers release.yml)."
+            elif [ "$existing" != "$sha" ]; then
+              # Tag name exists but points elsewhere — do NOT relabel, or we would mark the
+              # PR released against the wrong tree. Surface it for a human instead.
+              echo "::warning::${tag} exists but points at ${existing}, not PR #${num}'s merge commit ${sha}; not relabelling — needs manual review."
+              continue
+            else
+              echo "${tag} already points at ${sha} — relabelling PR #${num} only."
             fi
             gh pr edit "$num" --repo "$REPO" \
               --add-label "autorelease: tagged" --remove-label "autorelease: pending"


### PR DESCRIPTION
## Problem — the chronic phantom release

release-please intermittently **merges the `chore: release main` PR** (bumping `.release-please-manifest.json` + CHANGELOG) **but never creates the `vX.Y.Z` tag / GitHub Release**. Root cause, from the run logs: an internal parse error during the run —

```
❯ error message: Error: unexpected token ' ' at 1:7, valid tokens [(, !, :]
```

— breaks its release-creation phase. After that, every subsequent run aborts with:

```
⚠ There are untagged, merged release PRs outstanding - aborting
```

so nothing new can release either. The tell-tale state is a **merged release PR still labelled `autorelease: pending` with no matching tag**. This has forced a manual recovery on ~5 consecutive releases (v0.23.1, v0.23.2, v0.24.0, v0.25.0, v0.26.0): `git tag vX.Y.Z <release-commit> && git push` + relabel the PR `pending → tagged`.

Confirmed this session that the tag alone does **not** clear it — release-please keys the "outstanding" check off the **label**, so the relabel is mandatory.

## Fix — automate the recovery

After the release-please step, a **reconcile step** runs the standing manual playbook automatically:

1. Find any merged release PR still labelled `autorelease: pending` (the phantom signature). If none → no-op.
2. Read the version from `.release-please-manifest.json` at that PR's merge commit.
3. If `vX.Y.Z` doesn't exist, create it **via the App token** — which, unlike `GITHUB_TOKEN`, **does trigger** the tag-driven `release.yml` build.
4. Flip the label `autorelease: pending → tagged` so release-please stops aborting on the next run.

Idempotent — on a healthy run (nothing pending) it exits immediately. Robust to *whatever* breaks release-please's native step, rather than chasing the internal parser bug (which has recurred across releases with different commit content → config/label-shaped, not content-shaped).

Also adds `permission-issues: write` to the minted App token: PR label edits are an issues-API scope for GitHub Apps (this also answers a long-standing open question — the label-flip needs `issues: write`).

## Notes / validation
- Workflow-only change; takes effect once on `main` and is **fully exercised on the next release**. YAML validated; `audit:action-sha-pins` green; no new `uses:` actions.
- **Dependency:** the `nimbus-release-bot` App must have **Issues: write** granted at install for the relabel (and `permission-issues: write` mint) to work. If it lacks it, the tag still gets created (release ships); only the auto-relabel would 403 — grant Issues:write to make it fully hands-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release handling by automatically reconciling merged releases missing their expected version tags.
  * Updated release status labels after successful tag creation, reducing stale pending release entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->