### PR TITLE
refactor(agents): consume promoted why types from sdk 1.6.0 + roadmap (why-lens step 2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
       "dependencies": {
         "@mastra/core": "^1.43.0",
         "@mastra/mcp": "^1.10.0",
-        "@nimbus-dev/sdk": "^1.5.0",
+        "@nimbus-dev/sdk": "^1.6.0",
         "@noble/hashes": "^2.2.0",
         "@scure/bip39": "^2.2.0",
         "@xenova/transformers": "^2.17.0",
@@ -4153,6 +4153,8 @@
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", "", {}, "sha512-mCVlMLbYUowRLsw1dAcDp61AyoLSW6hrfbdrJim7ho3kg78rJlS0DYrKpqQxbng6E83NscJkUHlIFanxp0hp5g=="],
+
+    "@nimbus/gateway/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-dHPSNP7GuNgM6oo0el4oZhqx1Xbtbwi+2XSKLmBfUcBj4zDTIKyqX9JQpmmSU9eaQcZgQNC7u9o5CmQTa8g1qA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -306,7 +306,22 @@ Extension version is the release that carries the item.
 | 2b | `/incident` → `agents.catchup`, `/deploys` → `metrics.dora`, `/owns` → `agents.expert`, `/blast` → `agents.impact` — structured brief calls, not prompt rewrites, degrading honestly (empty briefs surface the gateway's own gap notes). The Copilot three live on as quick-ask presets; infra-file presets for `*.tf` / k8s-helm YAML / `Dockerfile` / workflow YAML | `0.8.0` | [#49](https://github.com/nimbus-agent/nimbus-vscode/pull/49) |
 | 2c | Per-answer egress delta footer (zero renders as *"nothing left this machine"*); Prove-Window as a self-contained HTML proof artifact (embedded byte-equivalent JSON; the CLI is the verifier); opt-in signed `Nimbus-Egress-Proof` commit trailer; ⛔ proof-of-denial rows in the Egress view | `0.9.0` | [#50](https://github.com/nimbus-agent/nimbus-vscode/pull/50) |
 
-### 2a — the `why` lens: spiked, not built
+### 2a — the `why` lens: spiked, then built (2026-07-24)
+
+> **Update, 2026-07-24 — the lens is built and now reachable through the client.**
+> The prerequisites the spike named have landed: PR-title enrichment
+> ([#817](https://github.com/nimbus-agent/Nimbus/pull/817)) and the on-demand
+> blame indexer ([#819](https://github.com/nimbus-agent/Nimbus/pull/819)) are
+> merged, with root registration in flight
+> ([#822](https://github.com/nimbus-agent/Nimbus/pull/822)). On that basis the
+> lens itself shipped on the gateway + CLI — the `why` agent, `whyPeek`, and
+> `nimbus why` ([#820](https://github.com/nimbus-agent/Nimbus/pull/820)) — and
+> **step 2** exposes it through the narrow waist: `agents.why` / `agents.whyPeek`
+> now flow through `@nimbus-dev/sdk` 1.6.0 → `@nimbus-dev/client` 0.12.0, so the
+> VS Code hover UI can consume it. What remains is the editor UI itself (a
+> `nimbus-vscode` slice) and the demo, not the capability. The correlation-quality
+> caveat still holds — it is a data-density question the roadmap tracks, not a
+> reason the lens is unreachable. The spike record below is kept as written.
 
 The hover lens (author, PR, ticket, thread, incident, dependents per line) was
 the stage's headline, but its quality is data-dependent, so a read-only spike
@@ -330,9 +345,13 @@ the spike feeds [Open decision 3](#open-decisions) rather than closing it.
 - **Cross-client:** `metrics.dora` and `deploy.preflight` in
   `nimbus-statuspage`; `agents.*` in `nimbus-raycast`. Neither repo was touched
   in the VS Code slice.
-- **Gateway-side follow-ups surfaced by the spike:** why `git_blame_line` never
-  populates on a machine with active repos, and id-only PR titles from the
-  GitHub connector.
+- **Gateway-side follow-ups surfaced by the spike:** ✅ addressed — id-only PR
+  titles are enriched ([#817](https://github.com/nimbus-agent/Nimbus/pull/817)),
+  the blame lane populates on demand ([#819](https://github.com/nimbus-agent/Nimbus/pull/819)),
+  and root registration lands the pipeline ([#822](https://github.com/nimbus-agent/Nimbus/pull/822)).
+- **`why` lens reachability:** ✅ done — the lens ships on gateway + CLI
+  ([#820](https://github.com/nimbus-agent/Nimbus/pull/820)) and is exposed through
+  `@nimbus-dev/client` 0.12.0 (step 2). Remaining: the `nimbus-vscode` hover UI.
 
 ---
 
@@ -371,6 +390,13 @@ lands — but organise the story around the lens.
 > fired. Stage 3's story therefore leads with what exists — receipts, LM
 > tools, and the ops vocabulary — with the lens as the roadmap tease, not the
 > claim.
+>
+> **Update 2026-07-24:** the banner now exists as a capability. The spike's
+> prerequisites landed (#817/#819/#822), the `why` lens shipped on gateway + CLI
+> (#820), and step 2 made it reachable through `@nimbus-dev/client` 0.12.0. The
+> "Buildable → After Stage 1" cell is now *built*; what's left for the banner is
+> the `nimbus-vscode` hover UI and one demo GIF (Stage 3), not the capability.
+> The data-density caveat stays a live quality question, not a reachability one.
 
 **Why the lens and not the moat.** Verifiable egress is the stronger asset: a
 survey of nine major competitors plus the AI-DLP category found **none** offering

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -308,18 +308,19 @@ Extension version is the release that carries the item.
 
 ### 2a — the `why` lens: spiked, then built (2026-07-24)
 
-> **Update, 2026-07-24 — the lens is built and now reachable through the client.**
+> **Update, 2026-07-24 — the lens is built; step 2 wires it to the client.**
 > The prerequisites the spike named have landed: PR-title enrichment
 > ([#817](https://github.com/nimbus-agent/Nimbus/pull/817)) and the on-demand
 > blame indexer ([#819](https://github.com/nimbus-agent/Nimbus/pull/819)) are
-> merged, with root registration in flight
+> merged, with root registration in review
 > ([#822](https://github.com/nimbus-agent/Nimbus/pull/822)). On that basis the
 > lens itself shipped on the gateway + CLI — the `why` agent, `whyPeek`, and
 > `nimbus why` ([#820](https://github.com/nimbus-agent/Nimbus/pull/820)) — and
-> **step 2** exposes it through the narrow waist: `agents.why` / `agents.whyPeek`
-> now flow through `@nimbus-dev/sdk` 1.6.0 → `@nimbus-dev/client` 0.12.0, so the
-> VS Code hover UI can consume it. What remains is the editor UI itself (a
-> `nimbus-vscode` slice) and the demo, not the capability. The correlation-quality
+> **step 2** routes it through the narrow waist: `agents.why` / `agents.whyPeek`
+> flow through `@nimbus-dev/sdk` 1.6.0 (published) → `@nimbus-dev/client` 0.12.0
+> (in review), after which the VS Code hover UI can consume it. What remains is
+> the editor UI itself (a `nimbus-vscode` slice) and the demo, not the
+> capability. The correlation-quality
 > caveat still holds — it is a data-density question the roadmap tracks, not a
 > reason the lens is unreachable. The spike record below is kept as written.
 
@@ -345,13 +346,15 @@ the spike feeds [Open decision 3](#open-decisions) rather than closing it.
 - **Cross-client:** `metrics.dora` and `deploy.preflight` in
   `nimbus-statuspage`; `agents.*` in `nimbus-raycast`. Neither repo was touched
   in the VS Code slice.
-- **Gateway-side follow-ups surfaced by the spike:** ✅ addressed — id-only PR
-  titles are enriched ([#817](https://github.com/nimbus-agent/Nimbus/pull/817)),
-  the blame lane populates on demand ([#819](https://github.com/nimbus-agent/Nimbus/pull/819)),
-  and root registration lands the pipeline ([#822](https://github.com/nimbus-agent/Nimbus/pull/822)).
-- **`why` lens reachability:** ✅ done — the lens ships on gateway + CLI
-  ([#820](https://github.com/nimbus-agent/Nimbus/pull/820)) and is exposed through
-  `@nimbus-dev/client` 0.12.0 (step 2). Remaining: the `nimbus-vscode` hover UI.
+- **Gateway-side follow-ups surfaced by the spike:** id-only PR titles are
+  enriched ([#817](https://github.com/nimbus-agent/Nimbus/pull/817), merged) and
+  the blame lane populates on demand ([#819](https://github.com/nimbus-agent/Nimbus/pull/819),
+  merged); root registration is in review ([#822](https://github.com/nimbus-agent/Nimbus/pull/822)).
+- **`why` lens reachability:** the lens ships on gateway + CLI
+  ([#820](https://github.com/nimbus-agent/Nimbus/pull/820), merged); step 2
+  promotes its types to `@nimbus-dev/sdk` 1.6.0 (published) and exposes it
+  through `@nimbus-dev/client` 0.12.0 (in review). Remaining after that: the
+  `nimbus-vscode` hover UI.
 
 ---
 
@@ -392,8 +395,9 @@ lands — but organise the story around the lens.
 > claim.
 >
 > **Update 2026-07-24:** the banner now exists as a capability. The spike's
-> prerequisites landed (#817/#819/#822), the `why` lens shipped on gateway + CLI
-> (#820), and step 2 made it reachable through `@nimbus-dev/client` 0.12.0. The
+> prerequisites landed (#817/#819 merged, #822 in review), the `why` lens shipped
+> on gateway + CLI (#820), and step 2 routes it through the waist —
+> `@nimbus-dev/sdk` 1.6.0 (published) → `@nimbus-dev/client` 0.12.0 (in review). The
 > "Buildable → After Stage 1" cell is now *built*; what's left for the banner is
 > the `nimbus-vscode` hover UI and one demo GIF (Stage 3), not the capability.
 > The data-density caveat stays a live quality question, not a reachability one.

--- a/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop-review.md
+++ b/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop-review.md
@@ -1,0 +1,31 @@
+# Design Review: Why-lens step 2 — SDK → client hop — Implementation Plan
+
+This document reviews [2026-07-24-why-lens-step2-client-hop.md](file:///C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md) and identifies open questions, potential improvements, and suggestions.
+
+---
+
+## 1. Sync vs Async Methods Consistency
+
+### `agentsWhy` vs `agentsWhyPeek` Implementation
+
+- **Observation:** `agentsWhy` uses `runAgent("why", p, o)` to initiate the agent, which handles background execution, `sessionId`, and waits for the brief. `agentsWhyPeek` directly uses `this.ipc.call("agents.whyPeek", ...)` synchronously.
+- **Suggestion:** Verify if the timeout setting handles synchronous methods properly. If `agentsWhyPeek` takes longer (e.g. executing git blame across large files or commits), should it support an optional `timeoutMs` parameter as well? Adding `o?: { timeoutMs?: number }` to `agentsWhyPeek` signature would ensure API parity with the async one and protect client invocations from hanging.
+
+---
+
+## 2. Test Execution Details
+
+### CLI Workspace Verification
+
+- **Observation:** The plan targets three different directories: `C:/gitrep/nimbus-sdk`, `C:/gitrep/nimbus-client`, and `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2`.
+- **Suggestion:** Make sure the tasks explicitly remind the agent or human runner to run `bun install` or similar lockfile updates on the *gateway* side after changing the workspace references, especially since the monorepo structure might hoard node_modules.
+- **Bi-directional compilation check:** In Task 8, suggest checking `bun test` inside the gateway before removing `why-types.ts` types to confirm a baseline green, then verifying that the build and type checking remain green after the re-export swap.
+
+---
+
+## 3. Tauri Allowed Methods Audit
+
+### `ALLOWED_METHODS` Check
+
+- **Observation:** Although VS Code is the primary consumer for Step 2a, we should verify if `agents.why` and `agents.whyPeek` need to be exposed via Tauri to support future Tauri-based UI renders.
+- **Suggestion:** Add a step in Phase 3 to verify or add these methods to `ALLOWED_METHODS` in `ui/src-tauri/src/gateway_bridge.rs` (Invariant I7). This guarantees that both CLI, extension, and Tauri can access the lens.

--- a/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop-review.md
+++ b/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop-review.md
@@ -1,6 +1,6 @@
 # Design Review: Why-lens step 2 — SDK → client hop — Implementation Plan
 
-This document reviews [2026-07-24-why-lens-step2-client-hop.md](file:///C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md) and identifies open questions, potential improvements, and suggestions.
+This document reviews [2026-07-24-why-lens-step2-client-hop.md](./2026-07-24-why-lens-step2-client-hop.md) and identifies open questions, potential improvements, and suggestions.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
+++ b/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
@@ -440,6 +440,17 @@ Add to the `NimbusClient` class after `agentsPreflight`:
   }
 ```
 
+**No `timeoutMs` on `agentsWhyPeek` (deliberate).** Unlike `agentsWhy`, whose
+`timeoutMs` guards the *notification wait* for `why.briefReady` (which may never
+arrive), `agentsWhyPeek` is a plain request/response — `ipc.call` already
+applies the transport's **30 s default per-request timeout** (`ipc-transport.ts`,
+verified), so it cannot hang, and the gateway bounds its single `git blame`
+spawn at **20 s** (`BLAME_TIMEOUT_MS` + `AbortSignal.timeout`, verified). No
+synchronous client method (`searchRanked`, `metricsDora`, `queryItems`, `egress*`,
+…) takes a per-call `timeoutMs`; adding one only to `whyPeek` would break that
+convention, not improve parity. If a per-call override is ever wanted it belongs
+at the transport layer for all methods, not a `whyPeek` special case.
+
 - [ ] **Step 5: Run to verify PASS (after Task 6's mock lands the fixtures)** — the two validator tests pass now: `bun test src/agents-why.test.ts -t validateWhyPeek`. The `agentsWhy`/`agentsWhyPeek` mock tests pass once Task 6 implements the mock. Do Task 6 next, then run the full file.
 
 - [ ] **Step 6: Commit**
@@ -519,6 +530,8 @@ Expected: `0.12.0`.
 
 Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2` (branch `dev/asafgolombek/why-lens-step2-client-hop`). Confirm: `cd C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2 && git rev-parse --abbrev-ref HEAD`.
 
+**No Tauri change needed (verified).** `agents.why` and `agents.whyPeek` are already in the Tauri `ALLOWED_METHODS` allowlist (`packages/ui/src-tauri/src/gateway_bridge.rs`, added by #820, invariant I7) — the desktop UI can already reach them. Step 2 only changes where the *types* live and adds *client* methods; it introduces no new IPC method, so there is nothing to add to the allowlist and no `security-invariants.test.ts` count to bump.
+
 ### Task 8: Consume sdk 1.6.0 + re-export
 
 **Files:**
@@ -526,7 +539,17 @@ Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2
 - Modify: `packages/gateway/src/agents/_lib/findings.ts`
 - Modify: `packages/gateway/src/agents/_lib/why-types.ts`
 
-- [ ] **Step 1: Bump + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `packages/gateway/package.json`; from the repo root `bun install`. Expected: resolves 1.6.0.
+- [ ] **Step 0: Establish the baseline green (before any change).** Confirm the why suites pass on the unchanged worktree so a post-swap failure is unambiguously yours:
+```bash
+cd C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2
+bun install   # this worktree is git-ignored and may have NO node_modules of its own;
+              # install so it does not silently resolve against the PARENT repo's
+              # node_modules (a known worktree trap). Re-run if a later step 404s a dep.
+bun test packages/gateway/src/agents/ packages/gateway/src/ipc/agents-rpc.why.test.ts
+```
+Expected: PASS. Record the pass count — Step 4 must match it.
+
+- [ ] **Step 1: Bump + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `packages/gateway/package.json`; from the **worktree root** (`C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2`, not the main checkout) run `bun install`. Expected: resolves 1.6.0. If it does not, Phase 1 is not actually published on npm — stop and fix that gate first.
 
 - [ ] **Step 2: Add the why re-exports to `findings.ts`** — add `WhyBrief`, `WhyFinding`, `WhyLane`, `WhySubject`, `WhyPeek` to the `export type { … } from "@nimbus-dev/sdk"` block, and `isWhyBrief` to the `export { … } from "@nimbus-dev/sdk"` guards block.
 
@@ -553,7 +576,7 @@ bunx tsc --noEmit -p packages/gateway/tsconfig.json
 bun test packages/gateway/src/agents/ packages/gateway/src/ipc/agents-rpc.why.test.ts packages/gateway/test/e2e/scenarios/why.e2e.test.ts
 bun run audit:structure
 ```
-Expected: PASS, zero edits to any why test file. (tsc is the load-bearing check: if the SDK shapes drifted from `why.ts`/`why-peek.ts`'s producers, it fails here. `audit:structure` confirms no import cycle from the re-export.)
+Expected: PASS with the **same pass count as Step 0's baseline** and zero edits to any why test file. (tsc is the load-bearing check: if the SDK shapes drifted from `why.ts`/`why-peek.ts`'s producers, it fails here. `audit:structure` confirms no import cycle from the re-export.)
 
 - [ ] **Step 5: Commit**
 ```bash

--- a/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
+++ b/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
@@ -1,0 +1,598 @@
+# Why-lens step 2 — SDK → client hop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the `why` lens (`agents.why` async brief + `agents.whyPeek` synchronous peek) through `@nimbus-dev/client`, with the Why types promoted to `@nimbus-dev/sdk` as the single source of truth, and publish both packages so the VS Code extension can consume them.
+
+**Architecture:** Three repos, released in dependency order. `@nimbus-dev/sdk` 1.6.0 promotes the Why types + the 9th-agent machinery (this is the source-of-truth move). `@nimbus-dev/client` 0.12.0 depends on sdk `^1.6.0` and adds `agentsWhy` (reusing the existing `runAgent` brief-streaming machinery) + `agentsWhyPeek` (a new synchronous request/response). The gateway (Nimbus) then bumps to sdk `^1.6.0`, re-exports the promoted types from `findings.ts`, and deletes its local definitions — a pure type-move, no behavior change.
+
+**Tech Stack:** TypeScript 6.x strict, Bun, Biome. Three git repos: `C:/gitrep/nimbus-sdk`, `C:/gitrep/nimbus-client`, and the gateway worktree `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2` (branch `dev/asafgolombek/why-lens-step2-client-hop`, already created).
+
+## Global Constraints
+
+- **No `any`** — `unknown` for external data; TS strict is non-negotiable (all three repos).
+- **Copy the gateway's exact shapes.** The promoted SDK types must be byte-identical to the gateway's current `packages/gateway/src/agents/_lib/why-types.ts` definitions (today's source of truth), or the gateway re-export won't typecheck.
+- **Release order is publish-then-verify-then-proceed:** SDK 1.6.0 published + `npm view @nimbus-dev/sdk@1.6.0` live → client 0.12.0 published + `npm view @nimbus-dev/client@0.12.0` live → gateway PR. A dependent repo built against an unpublished version fails `bun install`.
+- **release-please may not auto-cut the tag** (known repo trap). Treat "PR merged" as *not released*; verify the npm version explicitly. If the tag did not cut, push it manually (`git tag vX.Y.Z <merge-commit> && git push origin vX.Y.Z`).
+- **Params stay client-local.** `WhyInput`/`WhyParams` are NOT promoted (all 8 existing agents define params client-side; only result types live in the SDK).
+- **Branch hygiene:** never commit on `main`; each repo gets its own `dev/asafgolombek/why-lens-step2-*` branch. The gateway worktree branch already exists.
+- Every code step below shows the exact code. Match the surrounding file's import style (`.js` specifiers in sdk/client, `.ts` in gateway).
+
+---
+
+## File structure
+
+**SDK (`C:/gitrep/nimbus-sdk`):**
+- Modify `src/agents/agent-names.ts` — add `"why"` to `AGENT_NAMES` + `AGENT_KIND`.
+- Modify `src/agents/brief-types.ts` — add `WhyLane`, `WhyFinding`, `WhySubject`.
+- Modify `src/agents/brief-composites.ts` — add `WhyBrief` (+ `AgentBrief` union + `BriefFor` map) and standalone `WhyPeek`.
+- Modify `src/agents/brief-guards.ts` — add `isWhyBrief` + `BRIEF_GUARDS.why`.
+- Modify `src/index.ts` — export the new symbols.
+- Modify `src/agents/agent-names.test.ts`, `src/agents/brief-guards.test.ts` — extend the exhaustive fixtures.
+- Modify `package.json` — version → 1.6.0 (or let release-please do it).
+
+**Client (`C:/gitrep/nimbus-client`):**
+- Modify `package.json` — `@nimbus-dev/sdk` → `^1.6.0`.
+- Modify `src/agents.ts` — add `WhyParams` + `AgentParamsFor.why`.
+- Modify `src/nimbus-client.ts` — `NimbusClientLike` gains `agentsWhy`/`agentsWhyPeek`; the class implements both; imports.
+- Modify `src/validate.ts` — add `validateWhyPeek`.
+- Modify `src/mock-client.ts` — `agentBriefs.why` + `whyPeek` fixtures + the two methods.
+- Modify `src/index.ts` — re-export `WhyParams`/`WhyBrief`/`WhyPeek`.
+- Add tests: `src/agents-why.test.ts` (or extend an existing client test file).
+
+**Gateway (worktree `why-lens-step2`):**
+- Modify `packages/gateway/package.json` — `@nimbus-dev/sdk` → `^1.6.0`.
+- Modify `packages/gateway/src/agents/_lib/findings.ts` — re-export the 5 types + `isWhyBrief`.
+- Modify `packages/gateway/src/agents/_lib/why-types.ts` — delete local defs, re-export from `./findings.ts`; keep `WhyInput`.
+- Modify `docs/ecosystem-roadmap.md` — record the lens is now client-reachable.
+
+---
+
+## PHASE 1 — `@nimbus-dev/sdk` 1.6.0
+
+Work in `C:/gitrep/nimbus-sdk`. First: `cd C:/gitrep/nimbus-sdk && git switch -c dev/asafgolombek/why-lens-sdk-types && git rev-parse --abbrev-ref HEAD` (confirm the branch).
+
+### Task 1: Promote the Why types
+
+**Files:**
+- Modify: `src/agents/brief-types.ts` (append leaf types)
+- Modify: `src/agents/brief-composites.ts` (add `WhyBrief`, union, `BriefFor`, `WhyPeek`)
+- Modify: `src/agents/agent-names.ts` (register the 9th agent)
+
+**Interfaces produced (later tasks + the client rely on these exact names):**
+```ts
+export type WhyLane = "authorship" | "pull_request" | "ticket" | "discussion" | "driver" | "downstream";
+export type WhyFinding = { lane: WhyLane; title: string; detail: string; url: string | null; occurredAt: number | null; entityId: string | null };
+export type WhySubject = { repoRoot: string; filePath: string; lineNo: number | null; symbol: string | null };
+export type WhyBrief = AgentBriefBase & { kind: "why"; query: { ref: string; line: number | null }; subject: WhySubject | null; findings: WhyFinding[] };
+export type WhyPeek = { subject: { repoRoot: string; filePath: string; lineNo: number } | null; author: string | null; authorEmail: string | null; commitSha: string | null; committedAt: number | null; commitSubject: string | null; pr: { number: number | null; title: string; url: string | null } | null; ticket: { key: string; title: string; url: string | null } | null; hasMore: boolean };
+```
+
+- [ ] **Step 1: Add leaf types to `src/agents/brief-types.ts`** (append at end of file):
+
+```ts
+export type WhyLane =
+  | "authorship"
+  | "pull_request"
+  | "ticket"
+  | "discussion"
+  | "driver"
+  | "downstream";
+
+export type WhyFinding = {
+  lane: WhyLane;
+  title: string;
+  detail: string;
+  url: string | null;
+  occurredAt: number | null;
+  entityId: string | null;
+};
+
+export type WhySubject = {
+  repoRoot: string;
+  filePath: string;
+  lineNo: number | null;
+  symbol: string | null;
+};
+```
+
+- [ ] **Step 2: Register the 9th agent in `src/agents/agent-names.ts`** — add `"why"` to the `AGENT_NAMES` array (after `"preflight"`), and `why: "why"` to `AGENT_KIND`. Update the leading comment from "eight" to "nine":
+
+```ts
+export const AGENT_NAMES = [
+  "expert",
+  "impact",
+  "catchup",
+  "ghost",
+  "conflicts",
+  "huddle",
+  "janitor",
+  "preflight",
+  "why",
+] as const;
+```
+```ts
+export const AGENT_KIND = {
+  expert: "expert",
+  impact: "impact",
+  catchup: "catchup",
+  ghost: "ghost",
+  conflicts: "conflict",
+  huddle: "huddle",
+  janitor: "janitor",
+  preflight: "preflight",
+  why: "why",
+} as const satisfies Record<AgentName, string>;
+```
+
+- [ ] **Step 3: Add `WhyFinding`/`WhySubject` to the `brief-types.js` import in `src/agents/brief-composites.ts`**, then add `WhyBrief` (before the `AgentBrief` union), add it to the union, add `why: WhyBrief` to the `BriefFor` map, and add standalone `WhyPeek`:
+
+Import block — add the two leaf names:
+```ts
+import type {
+  AgentBriefBase,
+  CatchupSection,
+  ConflictType,
+  ExpertFinding,
+  ImpactFinding,
+  JanitorPeerTouch,
+  PreflightDownstream,
+  WhyFinding,
+  WhySubject,
+} from "./brief-types.js";
+```
+Add `WhyBrief` immediately after `PreflightBrief`:
+```ts
+export type WhyBrief = AgentBriefBase & {
+  kind: "why";
+  query: { ref: string; line: number | null };
+  subject: WhySubject | null;
+  findings: WhyFinding[];
+};
+```
+Add to the `AgentBrief` union (append `| WhyBrief`) and to `BriefFor` (add `why: WhyBrief;`). Then add the standalone `WhyPeek` (NOT in the union — it is a synchronous peek result, not a brief):
+```ts
+/**
+ * `agents.whyPeek` result — a synchronous one-line answer, NOT a brief.
+ * Deliberately not part of `AgentBrief`: it carries no `AgentBriefBase` fields
+ * and no gap notes.
+ */
+export type WhyPeek = {
+  subject: { repoRoot: string; filePath: string; lineNo: number } | null;
+  author: string | null;
+  authorEmail: string | null;
+  commitSha: string | null;
+  committedAt: number | null;
+  commitSubject: string | null;
+  pr: { number: number | null; title: string; url: string | null } | null;
+  ticket: { key: string; title: string; url: string | null } | null;
+  hasMore: boolean;
+};
+```
+
+- [ ] **Step 4: Typecheck** — `cd C:/gitrep/nimbus-sdk && bunx tsc --noEmit`. Expected: PASS. (If `BriefFor` or `AGENT_KIND` is missing the `why` key, tsc reports it here — the mapped/`satisfies Record<AgentName>` types are exhaustive.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/agents/brief-types.ts src/agents/brief-composites.ts src/agents/agent-names.ts
+git commit -m "feat(agents): promote the why types + register the 9th agent"
+```
+
+### Task 2: `isWhyBrief` guard + exhaustive test fixtures
+
+**Files:**
+- Modify: `src/agents/brief-guards.ts`
+- Modify: `src/agents/brief-guards.test.ts`, `src/agents/agent-names.test.ts`
+
+**Interfaces produced:** `export const isWhyBrief: (x: unknown) => x is WhyBrief` and `BRIEF_GUARDS.why`.
+
+- [ ] **Step 1: Update `agent-names.test.ts`** — the "all eight agents are listed" test now expects nine. Rename it and append `"why"`:
+```ts
+  test("all nine agents are listed", () => {
+    expect([...AGENT_NAMES]).toEqual([
+      "expert",
+      "impact",
+      "catchup",
+      "ghost",
+      "conflicts",
+      "huddle",
+      "janitor",
+      "preflight",
+      "why",
+    ]);
+  });
+```
+
+- [ ] **Step 2: Add the `why` fixture to `brief-guards.test.ts`** — the `FIXTURES` map is `{ [A in AgentName]: … }` (exhaustive), so tsc requires a `why` entry. Add after `preflight`:
+```ts
+  why: {
+    brief: {
+      ...base,
+      kind: "why",
+      query: { ref: "src/a.ts", line: null },
+      subject: null,
+      findings: [],
+    },
+    distinguishing: ["findings"],
+  },
+```
+
+- [ ] **Step 3: Run the tests to verify they now FAIL** — `cd C:/gitrep/nimbus-sdk && bun test src/agents/`. Expected: FAIL — `BRIEF_GUARDS.why` does not exist yet (the loop over `AGENT_NAMES` dereferences `BRIEF_GUARDS["why"]`), and `isWhyBrief` is unresolved.
+
+- [ ] **Step 4: Implement `isWhyBrief` in `src/agents/brief-guards.ts`** — add `WhyBrief` to the `brief-composites.js` type import, add the guard after `isPreflightBrief`, and add `why: isWhyBrief` to `BRIEF_GUARDS`:
+```ts
+export const isWhyBrief = createBriefGuard<WhyBrief>(
+  "why",
+  (b) => Array.isArray(b["findings"]),
+  STRICT,
+);
+```
+```ts
+export const BRIEF_GUARDS: { [A in AgentName]: (x: unknown) => boolean } = {
+  expert: isExpertBrief,
+  impact: isImpactBrief,
+  catchup: isCatchupBrief,
+  ghost: isGhostBrief,
+  conflicts: isConflictBrief,
+  huddle: isHuddleBrief,
+  janitor: isJanitorBrief,
+  preflight: isPreflightBrief,
+  why: isWhyBrief,
+};
+```
+
+- [ ] **Step 5: Run tests to verify PASS** — `bun test src/agents/ && bunx tsc --noEmit`. Expected: PASS. The exhaustive loop now proves `isWhyBrief` accepts only the why fixture and rejects the other eight (kind mismatch), and rejects a why brief with `findings` deleted.
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/agents/brief-guards.ts src/agents/brief-guards.test.ts src/agents/agent-names.test.ts
+git commit -m "feat(agents): isWhyBrief guard + exhaustive why fixtures"
+```
+
+### Task 3: Export + release SDK 1.6.0
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `package.json` (version) — or defer to release-please
+
+- [ ] **Step 1: Export the new symbols from `src/index.ts`** — add the types to the `@nimbus-dev/sdk`-facing export block (find the block that exports `ExpertBrief`, `AgentBrief`, etc. from `./agents/brief-composites.js` and the leaf types from `./agents/brief-types.js`) and export `isWhyBrief` alongside the other `is*Brief` guards. Add: `WhyLane`, `WhyFinding`, `WhySubject`, `WhyBrief`, `WhyPeek` (types) and `isWhyBrief` (value).
+
+- [ ] **Step 2: Build + full test** — `cd C:/gitrep/nimbus-sdk && bun run build && bun test && bunx tsc --noEmit`. Expected: PASS + a `dist/` with the new exports. Confirm the public surface: `node -e "const s=require('./dist/index.js'); console.log(typeof s.isWhyBrief)"` → `function`.
+
+- [ ] **Step 3: Commit + open PR**
+```bash
+git add src/index.ts
+git commit -m "feat: export why types + isWhyBrief (sdk 1.6.0)"
+git push -u origin dev/asafgolombek/why-lens-sdk-types
+gh pr create --base main --title "feat: promote the why types to the SDK (1.6.0)" --body "Adds the ninth agent (why): WhyBrief into the AgentBrief union + BriefFor + AGENT_NAMES/AGENT_KIND/BRIEF_GUARDS, isWhyBrief guard, and the standalone WhyPeek. Consumed by the gateway re-export and @nimbus-dev/client 0.12.0 (why-lens step 2)."
+```
+
+- [ ] **Step 4: Merge + RELEASE + VERIFY.** After CI green + merge, ensure release-please cut `@nimbus-dev/sdk@1.6.0`. If the release PR did not cut the tag, push it manually against the merge commit. **Gate:** do not start Phase 2 until this prints a version:
+```bash
+npm view @nimbus-dev/sdk@1.6.0 version
+```
+Expected: `1.6.0`.
+
+---
+
+## PHASE 2 — `@nimbus-dev/client` 0.12.0
+
+Work in `C:/gitrep/nimbus-client`. First: `cd C:/gitrep/nimbus-client && git switch -c dev/asafgolombek/why-lens-client-methods && git rev-parse --abbrev-ref HEAD`.
+
+### Task 4: Bump SDK + add `WhyParams`
+
+**Files:**
+- Modify: `package.json` (`@nimbus-dev/sdk` → `^1.6.0`)
+- Modify: `src/agents.ts`
+
+**Interfaces produced:** `export type WhyParams = { ref: string; line?: number }` and `AgentParamsFor.why`.
+
+- [ ] **Step 1: Bump the dep + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `package.json`, then `cd C:/gitrep/nimbus-client && bun install`. Expected: resolves 1.6.0 (published in Phase 1). If it fails, Phase 1 is not actually published — stop and fix that first.
+
+- [ ] **Step 2: Add `WhyParams` + the params-map entry to `src/agents.ts`** — after `PreflightParams`:
+```ts
+export type WhyParams = { ref: string; line?: number };
+```
+and add `why: WhyParams;` to the `AgentParamsFor` map object.
+
+- [ ] **Step 3: Typecheck** — `bunx tsc --noEmit`. Expected: FAIL, because `NimbusClientLike`/`MockClient` do not yet implement the `why` members that `AgentName` now admits (this surfaces the surface-parity obligation). This failure is expected and resolved in Tasks 5–6. (If you prefer a clean gate here, proceed to Task 5 before re-running tsc.)
+
+- [ ] **Step 4: Commit**
+```bash
+git add package.json src/agents.ts bun.lock
+git commit -m "feat(agents): WhyParams + sdk ^1.6.0"
+```
+
+### Task 5: `agentsWhy` (async brief) + `agentsWhyPeek` (synchronous)
+
+**Files:**
+- Modify: `src/nimbus-client.ts` (imports, `NimbusClientLike`, class methods)
+- Modify: `src/validate.ts` (`validateWhyPeek`)
+
+**Interfaces produced:**
+```ts
+agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>;
+agentsWhyPeek(p: WhyParams): Promise<WhyPeek>;
+export function validateWhyPeek(method: string, v: unknown): WhyPeek;
+```
+
+- [ ] **Step 1: Write the failing test** — `src/agents-why.test.ts`:
+```ts
+import { expect, test } from "bun:test";
+import { MockClient } from "./mock-client.js";
+import type { WhyBrief, WhyPeek } from "@nimbus-dev/sdk";
+import { validateWhyPeek } from "./validate.js";
+
+const brief: WhyBrief = {
+  agentVersion: 1,
+  generatedAt: 1,
+  latencyMs: 1,
+  gaps: [],
+  kind: "why",
+  query: { ref: "src/a.ts", line: 42 },
+  subject: { repoRoot: "/r", filePath: "src/a.ts", lineNo: 42, symbol: null },
+  findings: [],
+};
+const peek: WhyPeek = {
+  subject: { repoRoot: "/r", filePath: "src/a.ts", lineNo: 42 },
+  author: "alice",
+  authorEmail: "alice@example.com",
+  commitSha: "abc",
+  committedAt: 1,
+  commitSubject: "fix",
+  pr: { number: 1, title: "PR", url: "u" },
+  ticket: { key: "NIM-1", title: "T", url: "u" },
+  hasMore: true,
+};
+
+test("agentsWhy resolves the mock why brief", async () => {
+  const c = new MockClient({ agentBriefs: { why: brief } });
+  expect(await c.agentsWhy({ ref: "src/a.ts", line: 42 })).toEqual(brief);
+});
+
+test("agentsWhyPeek resolves the mock peek", async () => {
+  const c = new MockClient({ whyPeek: peek });
+  expect(await c.agentsWhyPeek({ ref: "src/a.ts:42" })).toEqual(peek);
+});
+
+test("validateWhyPeek accepts a well-formed peek and is lenient about extras", () => {
+  expect(validateWhyPeek("agents.whyPeek", { ...peek, futureField: 1 })).toEqual(peek);
+});
+
+test("validateWhyPeek rejects a non-boolean hasMore", () => {
+  expect(() => validateWhyPeek("agents.whyPeek", { ...peek, hasMore: "yes" })).toThrow();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd C:/gitrep/nimbus-client && bun test src/agents-why.test.ts`. Expected: FAIL (`validateWhyPeek` undefined; `agentsWhy`/`agentsWhyPeek` missing; `whyPeek` fixture unknown).
+
+- [ ] **Step 3: Add `validateWhyPeek` to `src/validate.ts`** (uses the existing `record`/`nullableStr`/`nullableNum`/`nullableBool`/`bool`/`num`/`str` helpers; lenient about extra fields like every other validator):
+```ts
+export function validateWhyPeek(method: string, v: unknown): WhyPeek {
+  const o = record(method, v);
+  const subjRaw = o["subject"];
+  const subject =
+    subjRaw === null
+      ? null
+      : (() => {
+          const s = record(method, subjRaw);
+          return {
+            repoRoot: str(method, s, "repoRoot"),
+            filePath: str(method, s, "filePath"),
+            lineNo: num(method, s, "lineNo"),
+          };
+        })();
+  const prRaw = o["pr"];
+  const pr =
+    prRaw === null || prRaw === undefined
+      ? null
+      : (() => {
+          const p = record(method, prRaw);
+          return {
+            number: nullableNum(method, p, "number"),
+            title: str(method, p, "title"),
+            url: nullableStr(method, p, "url"),
+          };
+        })();
+  const tRaw = o["ticket"];
+  const ticket =
+    tRaw === null || tRaw === undefined
+      ? null
+      : (() => {
+          const t = record(method, tRaw);
+          return {
+            key: str(method, t, "key"),
+            title: str(method, t, "title"),
+            url: nullableStr(method, t, "url"),
+          };
+        })();
+  return {
+    subject,
+    author: nullableStr(method, o, "author"),
+    authorEmail: nullableStr(method, o, "authorEmail"),
+    commitSha: nullableStr(method, o, "commitSha"),
+    committedAt: nullableNum(method, o, "committedAt"),
+    commitSubject: nullableStr(method, o, "commitSubject"),
+    pr,
+    ticket,
+    hasMore: bool(method, o, "hasMore"),
+  };
+}
+```
+Add `import type { WhyPeek } from "@nimbus-dev/sdk";` to the top of `validate.ts`.
+
+- [ ] **Step 4: Wire the client methods in `src/nimbus-client.ts`** — add imports (`WhyParams` from `./agents.js`; `WhyBrief`, `WhyPeek` from `@nimbus-dev/sdk`; `validateWhyPeek` from `./validate.js`). Add to the `NimbusClientLike` interface after `agentsPreflight`:
+```ts
+  agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>;
+  agentsWhyPeek(p: WhyParams): Promise<WhyPeek>;
+```
+Add to the `NimbusClient` class after `agentsPreflight`:
+```ts
+  agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief> {
+    return this.runAgent("why", p, o);
+  }
+  async agentsWhyPeek(p: WhyParams): Promise<WhyPeek> {
+    const raw = await this.ipc.call("agents.whyPeek", {
+      ref: p.ref,
+      ...(p.line === undefined ? {} : { line: p.line }),
+    });
+    return validateWhyPeek("agents.whyPeek", raw);
+  }
+```
+
+- [ ] **Step 5: Run to verify PASS (after Task 6's mock lands the fixtures)** — the two validator tests pass now: `bun test src/agents-why.test.ts -t validateWhyPeek`. The `agentsWhy`/`agentsWhyPeek` mock tests pass once Task 6 implements the mock. Do Task 6 next, then run the full file.
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/nimbus-client.ts src/validate.ts src/agents-why.test.ts
+git commit -m "feat(agents): agentsWhy + agentsWhyPeek + validateWhyPeek"
+```
+
+### Task 6: Mock + full pass
+
+**Files:**
+- Modify: `src/mock-client.ts`
+
+- [ ] **Step 1: Add the fixtures + methods to `src/mock-client.ts`.** Add `why: WhyBrief;` to the `agentBriefs` partial, add `whyPeek?: WhyPeek;` to `MockClientFixtures`, import `WhyBrief`/`WhyPeek`/`WhyParams`, and implement both methods after `agentsPreflight`:
+```ts
+  async agentsWhy(_p: WhyParams): Promise<WhyBrief> {
+    return this.brief("why");
+  }
+  async agentsWhyPeek(_p: WhyParams): Promise<WhyPeek> {
+    if (this.fixtures.whyPeek === undefined) {
+      return Promise.reject(new Error("MockClient: no whyPeek fixture configured"));
+    }
+    return this.fixtures.whyPeek;
+  }
+```
+
+- [ ] **Step 2: Run the full file + typecheck** — `bun test src/agents-why.test.ts && bunx tsc --noEmit`. Expected: PASS. tsc passing proves `MockClient implements NimbusClientLike` is satisfied — the surface-parity guard (both methods present on the mock).
+
+- [ ] **Step 3: Enrich the human-facing mock fixture (high-fidelity, per the spec).** In whatever shared mock-fixtures the repo ships for consumers (grep for where `agentBriefs` example fixtures are constructed, e.g. a `examples/` or fixtures module; if none, add a `WHY_BRIEF_FIXTURE` export in `src/mock-client.ts`), provide a `WhyBrief` carrying one finding per lane and a fully-populated `WhyPeek`:
+```ts
+export const WHY_BRIEF_FIXTURE: WhyBrief = {
+  agentVersion: 1, generatedAt: 1, latencyMs: 5, gaps: [],
+  kind: "why",
+  query: { ref: "src/retry.ts", line: 42 },
+  subject: { repoRoot: "/repo", filePath: "src/retry.ts", lineNo: 42, symbol: "retryBackoff" },
+  findings: (["authorship","pull_request","ticket","discussion","driver","downstream"] as const).map(
+    (lane, i) => ({ lane, title: `${lane} finding`, detail: `${lane} detail`, url: `https://x/${lane}`, occurredAt: 1_700_000_000_000 + i, entityId: `e${i}` }),
+  ),
+};
+```
+(One rich fixture; null/empty variants stay the consumer's test to construct — YAGNI.)
+
+- [ ] **Step 4: Full client verify** — `bun test && bunx tsc --noEmit && bunx biome check src`. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/mock-client.ts
+git commit -m "feat(agents): mock why brief + whyPeek (high-fidelity fixture)"
+```
+
+### Task 7: Export + release client 0.12.0
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Re-export the public why types from `src/index.ts`** — add `WhyParams` to the block that exports `ExpertParams` etc. from `./agents.js`, and add `WhyBrief`/`WhyPeek`/`WhyLane`/`WhyFinding`/`WhySubject` to the block that re-exports agent brief types from `@nimbus-dev/sdk` (so `nimbus-vscode` can name them).
+
+- [ ] **Step 2: Full verify + build** — `cd C:/gitrep/nimbus-client && bun run build && bun test && bunx tsc --noEmit && bun run verify:sdk`. Expected: PASS (`verify:sdk` checks against the local SDK; it must be the 1.6.0 line).
+
+- [ ] **Step 3: Commit + PR**
+```bash
+git add src/index.ts
+git commit -m "feat: expose agents.why + agents.whyPeek (client 0.12.0, why-lens step 2)"
+git push -u origin dev/asafgolombek/why-lens-client-methods
+gh pr create --base main --title "feat: expose agents.why + agents.whyPeek (client 0.12.0)" --body "why-lens step 2. agentsWhy reuses runAgent (async brief); agentsWhyPeek is a new synchronous method. Depends on @nimbus-dev/sdk ^1.6.0. Mock + validateWhyPeek + high-fidelity fixture."
+```
+
+- [ ] **Step 4: Merge + RELEASE + VERIFY.** As Phase 1: confirm release-please cut `@nimbus-dev/client@0.12.0`, manual-tag if needed. **Gate:**
+```bash
+npm view @nimbus-dev/client@0.12.0 version
+```
+Expected: `0.12.0`.
+
+---
+
+## PHASE 3 — Gateway re-export + roadmap
+
+Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2` (branch `dev/asafgolombek/why-lens-step2-client-hop`). Confirm: `cd C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2 && git rev-parse --abbrev-ref HEAD`.
+
+### Task 8: Consume sdk 1.6.0 + re-export
+
+**Files:**
+- Modify: `packages/gateway/package.json` (`@nimbus-dev/sdk` → `^1.6.0`)
+- Modify: `packages/gateway/src/agents/_lib/findings.ts`
+- Modify: `packages/gateway/src/agents/_lib/why-types.ts`
+
+- [ ] **Step 1: Bump + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `packages/gateway/package.json`; from the repo root `bun install`. Expected: resolves 1.6.0.
+
+- [ ] **Step 2: Add the why re-exports to `findings.ts`** — add `WhyBrief`, `WhyFinding`, `WhyLane`, `WhySubject`, `WhyPeek` to the `export type { … } from "@nimbus-dev/sdk"` block, and `isWhyBrief` to the `export { … } from "@nimbus-dev/sdk"` guards block.
+
+- [ ] **Step 3: Rewrite `why-types.ts` to re-export** — delete the local `WhyLane`/`WhyFinding`/`WhySubject`/`WhyBrief`/`WhyPeek` definitions and the `AgentBriefBase` import; keep `WhyInput` (the local request-shape). Replace the header comment. New file:
+```ts
+/**
+ * Why-lens types.
+ *
+ * The result types now live in `@nimbus-dev/sdk` (promoted in step 2 / sdk
+ * 1.6.0) so the gateway, CLI and `@nimbus-dev/client` share one definition.
+ * Re-exported here via `findings.ts` (the gateway's SDK shim) so existing
+ * gateway imports keep working unchanged. `WhyInput` stays local: it is the
+ * request-params shape, not a shared result type (params are client-local for
+ * every agent).
+ */
+export type { WhyBrief, WhyFinding, WhyLane, WhyPeek, WhySubject } from "./findings.ts";
+
+export type WhyInput = { ref: string; line?: number };
+```
+
+- [ ] **Step 4: Verify no behavior change** — the why suites must be green unchanged, and tsc must prove the promoted shapes match the gateway's runtime producers:
+```bash
+bunx tsc --noEmit -p packages/gateway/tsconfig.json
+bun test packages/gateway/src/agents/ packages/gateway/src/ipc/agents-rpc.why.test.ts packages/gateway/test/e2e/scenarios/why.e2e.test.ts
+bun run audit:structure
+```
+Expected: PASS, zero edits to any why test file. (tsc is the load-bearing check: if the SDK shapes drifted from `why.ts`/`why-peek.ts`'s producers, it fails here. `audit:structure` confirms no import cycle from the re-export.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/gateway/package.json packages/gateway/src/agents/_lib/findings.ts packages/gateway/src/agents/_lib/why-types.ts bun.lock
+git commit -m "refactor(agents): consume the promoted why types from @nimbus-dev/sdk ^1.6.0"
+```
+
+### Task 9: Roadmap truth-pass + gateway PR
+
+**Files:**
+- Modify: `docs/ecosystem-roadmap.md`
+
+- [ ] **Step 1: Update `docs/ecosystem-roadmap.md`** — in Stage 2 / "2a — the `why` lens", record that the lens is now built (gateway+CLI in #820) and reachable through `@nimbus-dev/client` 0.12.0 (this PR's step-2 hop); retire the "spiked, not built / banner did not ship" framing for the *reachability* claim (keep the data-quality caveat, which #822 addresses). Add a line to the "Left open from Stage 2" list marking the client hop done. Keep edits factual and scoped.
+
+- [ ] **Step 2: Doc gates** — `bun run audit:doc-refs && bun run audit:readme-cli && bun run lint:markdown`. Expected: PASS (markdown gate lives outside preflight — run it explicitly; see the step-1b lesson).
+
+- [ ] **Step 3: Commit**
+```bash
+git add docs/ecosystem-roadmap.md
+git commit -m "docs(roadmap): why lens now reachable through @nimbus-dev/client (step 2)"
+```
+
+- [ ] **Step 4: Pre-flight + PR.** Run the ship-readiness gates (tsc, biome via `bunx biome check packages scripts`, `audit:structure`, the why suites, `lint:markdown`) — see the step-1b ship-readiness playbook — then push and open the gateway PR:
+```bash
+git push -u origin dev/asafgolombek/why-lens-step2-client-hop
+gh pr create --base main --title "refactor(agents): consume promoted why types from sdk 1.6.0 + roadmap (why-lens step 2)" --body "Gateway half of why-lens step 2: bumps @nimbus-dev/sdk to ^1.6.0, re-exports the promoted Why types from findings.ts, drops the local why-types definitions (keeps WhyInput). Pure type-move; all why suites green unchanged. Records the lens as client-reachable in the ecosystem roadmap. Follows @nimbus-dev/client 0.12.0."
+```
+
+---
+
+## Final verification (definition of done)
+
+- [ ] `npm view @nimbus-dev/sdk@1.6.0 version` → `1.6.0`; `npm view @nimbus-dev/client@0.12.0 version` → `0.12.0`.
+- [ ] `client.agentsWhy(...)` returns a `WhyBrief`; `client.agentsWhyPeek(...)` returns a `WhyPeek`, both typed from the SDK.
+- [ ] Gateway builds against sdk `^1.6.0`; `why-types.ts` re-exports; all why suites green.
+- [ ] `ecosystem-roadmap.md` Stage 2a records the lens as client-reachable.
+- [ ] All three PRs merged.
+
+## Self-review notes
+
+- **Spec coverage:** SDK promotion (Task 1–3), client `agentsWhy`/`agentsWhyPeek` + Mock + validator (Task 4–7), gateway re-export (Task 8), roadmap update (Task 9), release verification (Task 3/7 gates + Final verification) — all spec sections covered. The plan additionally captures SDK coupling the spec under-specified (`AGENT_NAMES`/`AGENT_KIND`/`BRIEF_GUARDS`/`BriefFor` + the two exhaustive SDK tests) — required because the client's `AgentName` is SDK-derived.
+- **Type consistency:** `WhyParams` (client), `WhyInput` (gateway), `WhyBrief`/`WhyPeek`/`WhyFinding`/`WhyLane`/`WhySubject` + `isWhyBrief` (SDK) used consistently across tasks; method names `agentsWhy`/`agentsWhyPeek` and `validateWhyPeek` match between the interface, class, mock, and tests.

--- a/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
+++ b/docs/superpowers/plans/2026-07-24-why-lens-step2-client-hop.md
@@ -23,6 +23,7 @@
 ## File structure
 
 **SDK (`C:/gitrep/nimbus-sdk`):**
+
 - Modify `src/agents/agent-names.ts` — add `"why"` to `AGENT_NAMES` + `AGENT_KIND`.
 - Modify `src/agents/brief-types.ts` — add `WhyLane`, `WhyFinding`, `WhySubject`.
 - Modify `src/agents/brief-composites.ts` — add `WhyBrief` (+ `AgentBrief` union + `BriefFor` map) and standalone `WhyPeek`.
@@ -32,6 +33,7 @@
 - Modify `package.json` — version → 1.6.0 (or let release-please do it).
 
 **Client (`C:/gitrep/nimbus-client`):**
+
 - Modify `package.json` — `@nimbus-dev/sdk` → `^1.6.0`.
 - Modify `src/agents.ts` — add `WhyParams` + `AgentParamsFor.why`.
 - Modify `src/nimbus-client.ts` — `NimbusClientLike` gains `agentsWhy`/`agentsWhyPeek`; the class implements both; imports.
@@ -41,6 +43,7 @@
 - Add tests: `src/agents-why.test.ts` (or extend an existing client test file).
 
 **Gateway (worktree `why-lens-step2`):**
+
 - Modify `packages/gateway/package.json` — `@nimbus-dev/sdk` → `^1.6.0`.
 - Modify `packages/gateway/src/agents/_lib/findings.ts` — re-export the 5 types + `isWhyBrief`.
 - Modify `packages/gateway/src/agents/_lib/why-types.ts` — delete local defs, re-export from `./findings.ts`; keep `WhyInput`.
@@ -55,11 +58,13 @@ Work in `C:/gitrep/nimbus-sdk`. First: `cd C:/gitrep/nimbus-sdk && git switch -c
 ### Task 1: Promote the Why types
 
 **Files:**
+
 - Modify: `src/agents/brief-types.ts` (append leaf types)
 - Modify: `src/agents/brief-composites.ts` (add `WhyBrief`, union, `BriefFor`, `WhyPeek`)
 - Modify: `src/agents/agent-names.ts` (register the 9th agent)
 
 **Interfaces produced (later tasks + the client rely on these exact names):**
+
 ```ts
 export type WhyLane = "authorship" | "pull_request" | "ticket" | "discussion" | "driver" | "downstream";
 export type WhyFinding = { lane: WhyLane; title: string; detail: string; url: string | null; occurredAt: number | null; entityId: string | null };
@@ -111,6 +116,7 @@ export const AGENT_NAMES = [
   "why",
 ] as const;
 ```
+
 ```ts
 export const AGENT_KIND = {
   expert: "expert",
@@ -128,6 +134,7 @@ export const AGENT_KIND = {
 - [ ] **Step 3: Add `WhyFinding`/`WhySubject` to the `brief-types.js` import in `src/agents/brief-composites.ts`**, then add `WhyBrief` (before the `AgentBrief` union), add it to the union, add `why: WhyBrief` to the `BriefFor` map, and add standalone `WhyPeek`:
 
 Import block — add the two leaf names:
+
 ```ts
 import type {
   AgentBriefBase,
@@ -141,7 +148,9 @@ import type {
   WhySubject,
 } from "./brief-types.js";
 ```
+
 Add `WhyBrief` immediately after `PreflightBrief`:
+
 ```ts
 export type WhyBrief = AgentBriefBase & {
   kind: "why";
@@ -150,7 +159,9 @@ export type WhyBrief = AgentBriefBase & {
   findings: WhyFinding[];
 };
 ```
+
 Add to the `AgentBrief` union (append `| WhyBrief`) and to `BriefFor` (add `why: WhyBrief;`). Then add the standalone `WhyPeek` (NOT in the union — it is a synchronous peek result, not a brief):
+
 ```ts
 /**
  * `agents.whyPeek` result — a synchronous one-line answer, NOT a brief.
@@ -173,6 +184,7 @@ export type WhyPeek = {
 - [ ] **Step 4: Typecheck** — `cd C:/gitrep/nimbus-sdk && bunx tsc --noEmit`. Expected: PASS. (If `BriefFor` or `AGENT_KIND` is missing the `why` key, tsc reports it here — the mapped/`satisfies Record<AgentName>` types are exhaustive.)
 
 - [ ] **Step 5: Commit**
+
 ```bash
 git add src/agents/brief-types.ts src/agents/brief-composites.ts src/agents/agent-names.ts
 git commit -m "feat(agents): promote the why types + register the 9th agent"
@@ -181,12 +193,14 @@ git commit -m "feat(agents): promote the why types + register the 9th agent"
 ### Task 2: `isWhyBrief` guard + exhaustive test fixtures
 
 **Files:**
+
 - Modify: `src/agents/brief-guards.ts`
 - Modify: `src/agents/brief-guards.test.ts`, `src/agents/agent-names.test.ts`
 
 **Interfaces produced:** `export const isWhyBrief: (x: unknown) => x is WhyBrief` and `BRIEF_GUARDS.why`.
 
 - [ ] **Step 1: Update `agent-names.test.ts`** — the "all eight agents are listed" test now expects nine. Rename it and append `"why"`:
+
 ```ts
   test("all nine agents are listed", () => {
     expect([...AGENT_NAMES]).toEqual([
@@ -204,6 +218,7 @@ git commit -m "feat(agents): promote the why types + register the 9th agent"
 ```
 
 - [ ] **Step 2: Add the `why` fixture to `brief-guards.test.ts`** — the `FIXTURES` map is `{ [A in AgentName]: … }` (exhaustive), so tsc requires a `why` entry. Add after `preflight`:
+
 ```ts
   why: {
     brief: {
@@ -220,6 +235,7 @@ git commit -m "feat(agents): promote the why types + register the 9th agent"
 - [ ] **Step 3: Run the tests to verify they now FAIL** — `cd C:/gitrep/nimbus-sdk && bun test src/agents/`. Expected: FAIL — `BRIEF_GUARDS.why` does not exist yet (the loop over `AGENT_NAMES` dereferences `BRIEF_GUARDS["why"]`), and `isWhyBrief` is unresolved.
 
 - [ ] **Step 4: Implement `isWhyBrief` in `src/agents/brief-guards.ts`** — add `WhyBrief` to the `brief-composites.js` type import, add the guard after `isPreflightBrief`, and add `why: isWhyBrief` to `BRIEF_GUARDS`:
+
 ```ts
 export const isWhyBrief = createBriefGuard<WhyBrief>(
   "why",
@@ -227,6 +243,7 @@ export const isWhyBrief = createBriefGuard<WhyBrief>(
   STRICT,
 );
 ```
+
 ```ts
 export const BRIEF_GUARDS: { [A in AgentName]: (x: unknown) => boolean } = {
   expert: isExpertBrief,
@@ -244,6 +261,7 @@ export const BRIEF_GUARDS: { [A in AgentName]: (x: unknown) => boolean } = {
 - [ ] **Step 5: Run tests to verify PASS** — `bun test src/agents/ && bunx tsc --noEmit`. Expected: PASS. The exhaustive loop now proves `isWhyBrief` accepts only the why fixture and rejects the other eight (kind mismatch), and rejects a why brief with `findings` deleted.
 
 - [ ] **Step 6: Commit**
+
 ```bash
 git add src/agents/brief-guards.ts src/agents/brief-guards.test.ts src/agents/agent-names.test.ts
 git commit -m "feat(agents): isWhyBrief guard + exhaustive why fixtures"
@@ -252,6 +270,7 @@ git commit -m "feat(agents): isWhyBrief guard + exhaustive why fixtures"
 ### Task 3: Export + release SDK 1.6.0
 
 **Files:**
+
 - Modify: `src/index.ts`
 - Modify: `package.json` (version) — or defer to release-please
 
@@ -260,6 +279,7 @@ git commit -m "feat(agents): isWhyBrief guard + exhaustive why fixtures"
 - [ ] **Step 2: Build + full test** — `cd C:/gitrep/nimbus-sdk && bun run build && bun test && bunx tsc --noEmit`. Expected: PASS + a `dist/` with the new exports. Confirm the public surface: `node -e "const s=require('./dist/index.js'); console.log(typeof s.isWhyBrief)"` → `function`.
 
 - [ ] **Step 3: Commit + open PR**
+
 ```bash
 git add src/index.ts
 git commit -m "feat: export why types + isWhyBrief (sdk 1.6.0)"
@@ -268,9 +288,11 @@ gh pr create --base main --title "feat: promote the why types to the SDK (1.6.0)
 ```
 
 - [ ] **Step 4: Merge + RELEASE + VERIFY.** After CI green + merge, ensure release-please cut `@nimbus-dev/sdk@1.6.0`. If the release PR did not cut the tag, push it manually against the merge commit. **Gate:** do not start Phase 2 until this prints a version:
+
 ```bash
 npm view @nimbus-dev/sdk@1.6.0 version
 ```
+
 Expected: `1.6.0`.
 
 ---
@@ -282,6 +304,7 @@ Work in `C:/gitrep/nimbus-client`. First: `cd C:/gitrep/nimbus-client && git swi
 ### Task 4: Bump SDK + add `WhyParams`
 
 **Files:**
+
 - Modify: `package.json` (`@nimbus-dev/sdk` → `^1.6.0`)
 - Modify: `src/agents.ts`
 
@@ -290,14 +313,17 @@ Work in `C:/gitrep/nimbus-client`. First: `cd C:/gitrep/nimbus-client && git swi
 - [ ] **Step 1: Bump the dep + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `package.json`, then `cd C:/gitrep/nimbus-client && bun install`. Expected: resolves 1.6.0 (published in Phase 1). If it fails, Phase 1 is not actually published — stop and fix that first.
 
 - [ ] **Step 2: Add `WhyParams` + the params-map entry to `src/agents.ts`** — after `PreflightParams`:
+
 ```ts
 export type WhyParams = { ref: string; line?: number };
 ```
+
 and add `why: WhyParams;` to the `AgentParamsFor` map object.
 
 - [ ] **Step 3: Typecheck** — `bunx tsc --noEmit`. Expected: FAIL, because `NimbusClientLike`/`MockClient` do not yet implement the `why` members that `AgentName` now admits (this surfaces the surface-parity obligation). This failure is expected and resolved in Tasks 5–6. (If you prefer a clean gate here, proceed to Task 5 before re-running tsc.)
 
 - [ ] **Step 4: Commit**
+
 ```bash
 git add package.json src/agents.ts bun.lock
 git commit -m "feat(agents): WhyParams + sdk ^1.6.0"
@@ -306,10 +332,12 @@ git commit -m "feat(agents): WhyParams + sdk ^1.6.0"
 ### Task 5: `agentsWhy` (async brief) + `agentsWhyPeek` (synchronous)
 
 **Files:**
+
 - Modify: `src/nimbus-client.ts` (imports, `NimbusClientLike`, class methods)
 - Modify: `src/validate.ts` (`validateWhyPeek`)
 
 **Interfaces produced:**
+
 ```ts
 agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>;
 agentsWhyPeek(p: WhyParams): Promise<WhyPeek>;
@@ -317,6 +345,7 @@ export function validateWhyPeek(method: string, v: unknown): WhyPeek;
 ```
 
 - [ ] **Step 1: Write the failing test** — `src/agents-why.test.ts`:
+
 ```ts
 import { expect, test } from "bun:test";
 import { MockClient } from "./mock-client.js";
@@ -367,6 +396,7 @@ test("validateWhyPeek rejects a non-boolean hasMore", () => {
 - [ ] **Step 2: Run to verify it fails** — `cd C:/gitrep/nimbus-client && bun test src/agents-why.test.ts`. Expected: FAIL (`validateWhyPeek` undefined; `agentsWhy`/`agentsWhyPeek` missing; `whyPeek` fixture unknown).
 
 - [ ] **Step 3: Add `validateWhyPeek` to `src/validate.ts`** (uses the existing `record`/`nullableStr`/`nullableNum`/`nullableBool`/`bool`/`num`/`str` helpers; lenient about extra fields like every other validator):
+
 ```ts
 export function validateWhyPeek(method: string, v: unknown): WhyPeek {
   const o = record(method, v);
@@ -419,14 +449,18 @@ export function validateWhyPeek(method: string, v: unknown): WhyPeek {
   };
 }
 ```
+
 Add `import type { WhyPeek } from "@nimbus-dev/sdk";` to the top of `validate.ts`.
 
 - [ ] **Step 4: Wire the client methods in `src/nimbus-client.ts`** — add imports (`WhyParams` from `./agents.js`; `WhyBrief`, `WhyPeek` from `@nimbus-dev/sdk`; `validateWhyPeek` from `./validate.js`). Add to the `NimbusClientLike` interface after `agentsPreflight`:
+
 ```ts
   agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>;
   agentsWhyPeek(p: WhyParams): Promise<WhyPeek>;
 ```
+
 Add to the `NimbusClient` class after `agentsPreflight`:
+
 ```ts
   agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief> {
     return this.runAgent("why", p, o);
@@ -454,6 +488,7 @@ at the transport layer for all methods, not a `whyPeek` special case.
 - [ ] **Step 5: Run to verify PASS (after Task 6's mock lands the fixtures)** — the two validator tests pass now: `bun test src/agents-why.test.ts -t validateWhyPeek`. The `agentsWhy`/`agentsWhyPeek` mock tests pass once Task 6 implements the mock. Do Task 6 next, then run the full file.
 
 - [ ] **Step 6: Commit**
+
 ```bash
 git add src/nimbus-client.ts src/validate.ts src/agents-why.test.ts
 git commit -m "feat(agents): agentsWhy + agentsWhyPeek + validateWhyPeek"
@@ -462,9 +497,11 @@ git commit -m "feat(agents): agentsWhy + agentsWhyPeek + validateWhyPeek"
 ### Task 6: Mock + full pass
 
 **Files:**
+
 - Modify: `src/mock-client.ts`
 
 - [ ] **Step 1: Add the fixtures + methods to `src/mock-client.ts`.** Add `why: WhyBrief;` to the `agentBriefs` partial, add `whyPeek?: WhyPeek;` to `MockClientFixtures`, import `WhyBrief`/`WhyPeek`/`WhyParams`, and implement both methods after `agentsPreflight`:
+
 ```ts
   async agentsWhy(_p: WhyParams): Promise<WhyBrief> {
     return this.brief("why");
@@ -480,6 +517,7 @@ git commit -m "feat(agents): agentsWhy + agentsWhyPeek + validateWhyPeek"
 - [ ] **Step 2: Run the full file + typecheck** — `bun test src/agents-why.test.ts && bunx tsc --noEmit`. Expected: PASS. tsc passing proves `MockClient implements NimbusClientLike` is satisfied — the surface-parity guard (both methods present on the mock).
 
 - [ ] **Step 3: Enrich the human-facing mock fixture (high-fidelity, per the spec).** In whatever shared mock-fixtures the repo ships for consumers (grep for where `agentBriefs` example fixtures are constructed, e.g. a `examples/` or fixtures module; if none, add a `WHY_BRIEF_FIXTURE` export in `src/mock-client.ts`), provide a `WhyBrief` carrying one finding per lane and a fully-populated `WhyPeek`:
+
 ```ts
 export const WHY_BRIEF_FIXTURE: WhyBrief = {
   agentVersion: 1, generatedAt: 1, latencyMs: 5, gaps: [],
@@ -491,11 +529,13 @@ export const WHY_BRIEF_FIXTURE: WhyBrief = {
   ),
 };
 ```
+
 (One rich fixture; null/empty variants stay the consumer's test to construct — YAGNI.)
 
 - [ ] **Step 4: Full client verify** — `bun test && bunx tsc --noEmit && bunx biome check src`. Expected: PASS.
 
 - [ ] **Step 5: Commit**
+
 ```bash
 git add src/mock-client.ts
 git commit -m "feat(agents): mock why brief + whyPeek (high-fidelity fixture)"
@@ -504,6 +544,7 @@ git commit -m "feat(agents): mock why brief + whyPeek (high-fidelity fixture)"
 ### Task 7: Export + release client 0.12.0
 
 **Files:**
+
 - Modify: `src/index.ts`
 
 - [ ] **Step 1: Re-export the public why types from `src/index.ts`** — add `WhyParams` to the block that exports `ExpertParams` etc. from `./agents.js`, and add `WhyBrief`/`WhyPeek`/`WhyLane`/`WhyFinding`/`WhySubject` to the block that re-exports agent brief types from `@nimbus-dev/sdk` (so `nimbus-vscode` can name them).
@@ -511,6 +552,7 @@ git commit -m "feat(agents): mock why brief + whyPeek (high-fidelity fixture)"
 - [ ] **Step 2: Full verify + build** — `cd C:/gitrep/nimbus-client && bun run build && bun test && bunx tsc --noEmit && bun run verify:sdk`. Expected: PASS (`verify:sdk` checks against the local SDK; it must be the 1.6.0 line).
 
 - [ ] **Step 3: Commit + PR**
+
 ```bash
 git add src/index.ts
 git commit -m "feat: expose agents.why + agents.whyPeek (client 0.12.0, why-lens step 2)"
@@ -519,9 +561,11 @@ gh pr create --base main --title "feat: expose agents.why + agents.whyPeek (clie
 ```
 
 - [ ] **Step 4: Merge + RELEASE + VERIFY.** As Phase 1: confirm release-please cut `@nimbus-dev/client@0.12.0`, manual-tag if needed. **Gate:**
+
 ```bash
 npm view @nimbus-dev/client@0.12.0 version
 ```
+
 Expected: `0.12.0`.
 
 ---
@@ -535,11 +579,13 @@ Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2
 ### Task 8: Consume sdk 1.6.0 + re-export
 
 **Files:**
+
 - Modify: `packages/gateway/package.json` (`@nimbus-dev/sdk` → `^1.6.0`)
 - Modify: `packages/gateway/src/agents/_lib/findings.ts`
 - Modify: `packages/gateway/src/agents/_lib/why-types.ts`
 
 - [ ] **Step 0: Establish the baseline green (before any change).** Confirm the why suites pass on the unchanged worktree so a post-swap failure is unambiguously yours:
+
 ```bash
 cd C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2
 bun install   # this worktree is git-ignored and may have NO node_modules of its own;
@@ -547,6 +593,7 @@ bun install   # this worktree is git-ignored and may have NO node_modules of its
               # node_modules (a known worktree trap). Re-run if a later step 404s a dep.
 bun test packages/gateway/src/agents/ packages/gateway/src/ipc/agents-rpc.why.test.ts
 ```
+
 Expected: PASS. Record the pass count — Step 4 must match it.
 
 - [ ] **Step 1: Bump + install** — set `"@nimbus-dev/sdk": "^1.6.0"` in `packages/gateway/package.json`; from the **worktree root** (`C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2`, not the main checkout) run `bun install`. Expected: resolves 1.6.0. If it does not, Phase 1 is not actually published on npm — stop and fix that gate first.
@@ -554,6 +601,7 @@ Expected: PASS. Record the pass count — Step 4 must match it.
 - [ ] **Step 2: Add the why re-exports to `findings.ts`** — add `WhyBrief`, `WhyFinding`, `WhyLane`, `WhySubject`, `WhyPeek` to the `export type { … } from "@nimbus-dev/sdk"` block, and `isWhyBrief` to the `export { … } from "@nimbus-dev/sdk"` guards block.
 
 - [ ] **Step 3: Rewrite `why-types.ts` to re-export** — delete the local `WhyLane`/`WhyFinding`/`WhySubject`/`WhyBrief`/`WhyPeek` definitions and the `AgentBriefBase` import; keep `WhyInput` (the local request-shape). Replace the header comment. New file:
+
 ```ts
 /**
  * Why-lens types.
@@ -571,14 +619,17 @@ export type WhyInput = { ref: string; line?: number };
 ```
 
 - [ ] **Step 4: Verify no behavior change** — the why suites must be green unchanged, and tsc must prove the promoted shapes match the gateway's runtime producers:
+
 ```bash
 bunx tsc --noEmit -p packages/gateway/tsconfig.json
 bun test packages/gateway/src/agents/ packages/gateway/src/ipc/agents-rpc.why.test.ts packages/gateway/test/e2e/scenarios/why.e2e.test.ts
 bun run audit:structure
 ```
+
 Expected: PASS with the **same pass count as Step 0's baseline** and zero edits to any why test file. (tsc is the load-bearing check: if the SDK shapes drifted from `why.ts`/`why-peek.ts`'s producers, it fails here. `audit:structure` confirms no import cycle from the re-export.)
 
 - [ ] **Step 5: Commit**
+
 ```bash
 git add packages/gateway/package.json packages/gateway/src/agents/_lib/findings.ts packages/gateway/src/agents/_lib/why-types.ts bun.lock
 git commit -m "refactor(agents): consume the promoted why types from @nimbus-dev/sdk ^1.6.0"
@@ -587,6 +638,7 @@ git commit -m "refactor(agents): consume the promoted why types from @nimbus-dev
 ### Task 9: Roadmap truth-pass + gateway PR
 
 **Files:**
+
 - Modify: `docs/ecosystem-roadmap.md`
 
 - [ ] **Step 1: Update `docs/ecosystem-roadmap.md`** — in Stage 2 / "2a — the `why` lens", record that the lens is now built (gateway+CLI in #820) and reachable through `@nimbus-dev/client` 0.12.0 (this PR's step-2 hop); retire the "spiked, not built / banner did not ship" framing for the *reachability* claim (keep the data-quality caveat, which #822 addresses). Add a line to the "Left open from Stage 2" list marking the client hop done. Keep edits factual and scoped.
@@ -594,12 +646,14 @@ git commit -m "refactor(agents): consume the promoted why types from @nimbus-dev
 - [ ] **Step 2: Doc gates** — `bun run audit:doc-refs && bun run audit:readme-cli && bun run lint:markdown`. Expected: PASS (markdown gate lives outside preflight — run it explicitly; see the step-1b lesson).
 
 - [ ] **Step 3: Commit**
+
 ```bash
 git add docs/ecosystem-roadmap.md
 git commit -m "docs(roadmap): why lens now reachable through @nimbus-dev/client (step 2)"
 ```
 
 - [ ] **Step 4: Pre-flight + PR.** Run the ship-readiness gates (tsc, biome via `bunx biome check packages scripts`, `audit:structure`, the why suites, `lint:markdown`) — see the step-1b ship-readiness playbook — then push and open the gateway PR:
+
 ```bash
 git push -u origin dev/asafgolombek/why-lens-step2-client-hop
 gh pr create --base main --title "refactor(agents): consume promoted why types from sdk 1.6.0 + roadmap (why-lens step 2)" --body "Gateway half of why-lens step 2: bumps @nimbus-dev/sdk to ^1.6.0, re-exports the promoted Why types from findings.ts, drops the local why-types definitions (keeps WhyInput). Pure type-move; all why suites green unchanged. Records the lens as client-reachable in the ecosystem roadmap. Follows @nimbus-dev/client 0.12.0."

--- a/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design-review.md
@@ -1,6 +1,6 @@
 # Design Review: Why-lens step 2 — client-hop
 
-This document reviews [2026-07-24-why-lens-step2-client-hop-design.md](file:///C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md) and notes questions, suggestions, and improvements.
+This document reviews [2026-07-24-why-lens-step2-client-hop-design.md](./2026-07-24-why-lens-step2-client-hop-design.md) and notes questions, suggestions, and improvements.
 
 ---
 
@@ -23,7 +23,7 @@ This document reviews [2026-07-24-why-lens-step2-client-hop-design.md](file:///C
 ### Tauri `ALLOWED_METHODS` Check (Invariant I7)
 
 - **Observation:** While the immediate target is the VS Code extension via the client, the desktop app (Tauri) might eventually want to display the hover lens.
-- **Question:** Do `agents.why` and `agents.whyPeek` need to be explicitly added to `ALLOWED_METHODS` in [gateway_bridge.rs](file:///C:/gitrep/Nimbus/packages/ui/src-tauri/src/gateway_bridge.rs)? Even if Tauri support is a future goal, checking if the current IPC setup guards these methods at the Tauri boundary is a good pre-flight step.
+- **Question:** Do `agents.why` and `agents.whyPeek` need to be explicitly added to `ALLOWED_METHODS` in [gateway_bridge.rs](../../../packages/ui/src-tauri/src/gateway_bridge.rs)? Even if Tauri support is a future goal, checking if the current IPC setup guards these methods at the Tauri boundary is a good pre-flight step.
 
 ### Circular Dependency Risk
 

--- a/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design-review.md
@@ -1,0 +1,45 @@
+# Design Review: Why-lens step 2 — client-hop
+
+This document reviews [2026-07-24-why-lens-step2-client-hop-design.md](file:///C:/gitrep/Nimbus/.claude/worktrees/why-lens-step2/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Type Unification & Drift Prevention
+
+### `WhyInput` vs `WhyParams`
+
+- **Observation:** The spec suggests keeping `WhyInput` local to the gateway/CLI while the client defines `WhyParams` independently, despite having the exact same structure: `{ ref: string; line?: number }`.
+- **Suggestion:** To maximize the "single source of truth" waist pattern, we should consider promoting `WhyParams` (or `WhyInput`) to `@nimbus-dev/sdk` alongside `WhyBrief` and `WhyPeek`. This eliminates type duplication and prevents future parameter drift if additional filtering/parameters are added to the lens.
+
+### Omitted `line` Parameter Mapping
+
+- **Observation:** In request params, `line` is optional (`line?: number`). In `WhyBrief`, the query records it as `line: number | null`.
+- **Question:** How does the gateway handle an omitted/undefined `line` internally? Does the RPC handler explicitly map `undefined` to `null` before compiling the `WhyBrief` response? We should ensure the validator and typescript definitions handle this boundary cleanly.
+
+---
+
+## 2. Security & Gateway Integration
+
+### Tauri `ALLOWED_METHODS` Check (Invariant I7)
+
+- **Observation:** While the immediate target is the VS Code extension via the client, the desktop app (Tauri) might eventually want to display the hover lens.
+- **Question:** Do `agents.why` and `agents.whyPeek` need to be explicitly added to `ALLOWED_METHODS` in [gateway_bridge.rs](file:///C:/gitrep/Nimbus/packages/ui/src-tauri/src/gateway_bridge.rs)? Even if Tauri support is a future goal, checking if the current IPC setup guards these methods at the Tauri boundary is a good pre-flight step.
+
+### Circular Dependency Risk
+
+- **Observation:** The gateway's `agents/_lib/why-types.ts` is planned to re-export the promoted types from `./findings.ts`.
+- **Suggestion:** Run `bun run audit` or check dependency flows to ensure that re-exporting through `findings.ts` does not introduce any circular imports within the gateway's `agents/_lib/` directory.
+
+---
+
+## 3. Mock & Validation Robustness
+
+### Fixture Completeness
+
+- **Observation:** The Mock client (`src/mock-client.ts`) needs to expose a deterministic mock `WhyBrief` and `WhyPeek`.
+- **Suggestion:** Ensure the mock fixtures populate realistic values for all lanes (`WhyLane`) and nullable fields (`subject`, `author`, `pr`, `ticket`) so that consumer UI testing gets high-fidelity mock representations.
+
+### Schema Validation
+
+- **Observation:** `validateWhyPeek` will shape-check `WhyPeek`.
+- **Question:** Should we ensure the validator accepts extra fields gracefully (e.g., ignoring extra fields instead of failing fast) to allow future gateway-side additions to `WhyPeek` without breaking older clients?

--- a/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md
+++ b/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md
@@ -1,0 +1,164 @@
+# Why-lens step 2 — expose `why` / `whyPeek` through the narrow waist
+
+> Design spec. Roadmap: [`docs/ecosystem-roadmap.md`](../../ecosystem-roadmap.md) § Stage 2 → 2a.
+> Predecessor: [`2026-07-23-nimbus-why-lens-design.md`](./2026-07-23-nimbus-why-lens-design.md)
+> (step 1a graph edges, step 1b the agent). This is **step 2**: the SDK → client hop.
+
+## Problem
+
+Step 1b (PR #820) shipped the `why` lens on two surfaces: the gateway
+(`agents.why` / `agents.whyPeek`) and the CLI (`nimbus why`). It is **not
+reachable through `@nimbus-dev/client`**, because the two methods landed after
+the client's last publish (0.11.0). Until the client exposes them, the VS Code
+extension — where the roadmap's Stage 2a hover lens and Stage 3 demo live —
+cannot consume the lens. The narrow-waist thesis of the whole ecosystem
+roadmap is that a built capability must be *reachable*; today `why` is built
+but stranded one hop short.
+
+The gateway's own `why-types.ts` header already designs the fix: the Why types
+"deliberately do NOT live in `@nimbus-dev/sdk` yet … promoting the ninth agent
+is the step-2 sdk → client hop. When that lands, these move to the SDK and
+`findings.ts` re-exports them like the other eight."
+
+## Goal
+
+Expose the `why` lens through the client with the same one-source-of-truth
+typing every other agent already has, and publish the releases so the VS Code
+extension can depend on them.
+
+Non-goal: the VS Code hover UI itself (a separate `nimbus-vscode` slice) and
+any change to the lens's behavior. This is a pure reachability + type-promotion
+hop — no new gateway logic.
+
+## Approach (chosen: A — full SDK promotion)
+
+Three repos, released in dependency order:
+
+1. **`@nimbus-dev/sdk` 1.5.2 → 1.6.0** — promote the Why types (single
+   definition shared by gateway, CLI, client).
+2. **`@nimbus-dev/client` 0.11.0 → 0.12.0** — depend on sdk `^1.6.0`; add
+   `agentsWhy` + `agentsWhyPeek` + Mock + validator + surface-parity coverage.
+3. **Gateway (Nimbus)** — depend on sdk `^1.6.0`; re-export the promoted types
+   from `agents/_lib/findings.ts`; delete the local definitions in
+   `agents/_lib/why-types.ts`.
+
+Rejected alternatives: **B (client-local types)** duplicates the type across
+the waist and re-creates the drift Stage 0 sealed — the gateway comment
+explicitly rejects it. **C (SDK + client, defer the gateway re-export)** leaves
+twin definitions in gateway and SDK; the gateway cleanup is cheap enough to do
+now and avoids a stranded follow-up.
+
+## Release order and verification
+
+Publish is dependency-gated:
+
+1. Merge + publish **SDK 1.6.0**; verify `npm view @nimbus-dev/sdk@1.6.0` is
+   live before touching the client.
+2. Merge + publish **client 0.12.0** (dep `^1.6.0`); verify
+   `npm view @nimbus-dev/client@0.12.0` is live.
+3. Merge the **gateway PR** (dep `^1.6.0` + re-export). The gateway only needs
+   1.6.0 to exist on npm; it does not need the client.
+
+Both SDK and client release via their own `release-please` pipelines. Per the
+repo's release history, a manual tag push is sometimes required for the tag to
+cut — treat "PR merged" as *not yet released* and verify the npm version
+explicitly (this spec's definition of done includes both packages resolvable on
+npm at the new versions).
+
+## Component design
+
+### SDK 1.6.0 — the promoted types
+
+Copied **verbatim** from the gateway's current `why-types.ts` (today's source
+of truth) so the shapes are byte-identical and the gateway re-export
+typechecks.
+
+- `src/agents/brief-types.ts` — add the leaf types: `WhyLane` (the 6-lane
+  union), `WhyFinding`, `WhySubject`.
+- `src/agents/brief-composites.ts` — add:
+  - `WhyBrief = AgentBriefBase & { kind: "why"; query: { ref: string; line: number | null }; subject: WhySubject | null; findings: WhyFinding[] }`, added **into the `AgentBrief` discriminated union**.
+  - `WhyPeek` as a **standalone** export (author/PR/ticket/hasMore synchronous
+    peek result). It is **not** a brief and is **not** in the `AgentBrief`
+    union — it carries no `AgentBriefBase` fields and no gap notes.
+- `src/agents/brief-guards.ts` — add `isWhyBrief` via the existing
+  `createBriefGuard<WhyBrief>("why")`. **No `isWhyPeek`** — `WhyPeek` is not a
+  union member, so a discriminated guard would be dead code (YAGNI).
+- `src/index.ts` — export `WhyLane`, `WhyFinding`, `WhySubject`, `WhyBrief`,
+  `WhyPeek`, `isWhyBrief`.
+
+`WhyInput` (`{ ref: string; line?: number }`) is a *request-params* type, not a
+result type; the client owns its own `WhyParams` (below), so `WhyInput` need
+not be promoted.
+
+### Gateway — consume + re-export
+
+- `package.json` — bump `@nimbus-dev/sdk` to `^1.6.0`.
+- `agents/_lib/findings.ts` — add `WhyBrief`, `WhyFinding`, `WhyLane`,
+  `WhySubject`, `WhyPeek` to the `export type { … } from "@nimbus-dev/sdk"`
+  block and `isWhyBrief` to the guard re-export block (mirrors the other 8).
+- `agents/_lib/why-types.ts` — delete the local type definitions; re-export the
+  five promoted types **from `./findings.ts`** (which is the gateway's SDK
+  re-export shim — `why-types.ts` already imports `AgentBriefBase` from it, so
+  the dependency direction is unchanged). Keep `WhyInput` defined locally (it
+  stays the gateway/CLI request-shape). Update the header comment (the "do NOT
+  live in the SDK yet" note is now obsolete).
+- No change to `why.ts` / `why-peek.ts` / `agents-rpc.ts` runtime — they import
+  the same names, now sourced from the SDK. `bunx tsc` is the proof the shapes
+  still line up.
+
+### Client 0.12.0 — the two methods
+
+- `package.json` — bump `@nimbus-dev/sdk` to `^1.6.0`.
+- `src/agents.ts` — add `"why"` to `AgentName`; add `why: WhyParams` to the
+  params map and `why: WhyBrief` to the brief map (so `AgentParamsFor<"why">`
+  and `BriefFor<"why">` resolve). `WhyParams = { ref: string; line?: number }`.
+- `src/nimbus-client.ts`:
+  - `agentsWhy(p: WhyParams, o?: { timeoutMs?: number }): Promise<WhyBrief>` →
+    `this.runAgent("why", p, o)` (unchanged machinery: calls `agents.why`,
+    validates the `sessionId`, awaits `why.briefReady`).
+  - `agentsWhyPeek(p: WhyParams): Promise<WhyPeek>` — a **new synchronous
+    method** mirroring `searchRanked`: `const raw = await this.ipc.call("agents.whyPeek", { ref, line }); return validateWhyPeek("agents.whyPeek", raw);`.
+- `src/validate.ts` — add `validateWhyPeek` (shape-check the `WhyPeek` fields:
+  nullable `subject`/`author`/`pr`/`ticket`, boolean `hasMore`), mirroring the
+  existing validators (e.g. `validateSessionRecall`).
+- `src/mock-client.ts` — add a `why: WhyBrief` entry to the mock brief map and
+  an `agentsWhyPeek` returning a deterministic `WhyPeek` fixture; the mock must
+  expose both new methods so the surface-parity guard stays balanced.
+- `src/index.ts` — re-export `WhyParams`/`WhyBrief`/`WhyPeek` types if the
+  client barrels its public types (follow the existing convention).
+
+## Testing
+
+- **SDK:** unit test for `isWhyBrief` (positive + negative), mirroring
+  `isExpertBrief`; the type additions are compile-checked by the existing build.
+- **Client:** a unit test per method against the Mock (`agentsWhy` resolves a
+  `WhyBrief`; `agentsWhyPeek` resolves a `WhyPeek`); the standing **surface-
+  parity guard** asserting the real client and the Mock expose the same method
+  set (now +2); `verify:sdk` against the locally-built SDK 1.6.0.
+- **Gateway:** the existing `why` / `why-peek` / `agents-rpc.why` suites must
+  stay **green unchanged** after the re-export swap (behavior is identical);
+  `bunx tsc -p packages/gateway/tsconfig.json` is the load-bearing check that
+  the promoted SDK shapes match the gateway's runtime producers.
+
+## Risks
+
+- **Shape drift between the gateway producers and the promoted SDK types** —
+  mitigated by copying the gateway's exact definitions and letting the gateway
+  `tsc` re-export fail loudly if they diverge.
+- **Release sequencing** — a dependent repo built against an unpublished
+  version fails `bun install`. Mitigated by the explicit
+  publish-then-verify-then-proceed order above.
+- **`release-please` not auto-cutting the tag** — a known repo trap; verified
+  by checking npm, not by trusting the merge.
+
+## Definition of done
+
+- `@nimbus-dev/sdk@1.6.0` and `@nimbus-dev/client@0.12.0` both resolvable on
+  npm.
+- `client.agentsWhy(...)` and `client.agentsWhyPeek(...)` callable and typed
+  against the SDK.
+- Gateway builds against sdk `^1.6.0` with `why-types.ts` re-exporting; all why
+  suites green.
+- `ecosystem-roadmap.md` Stage 2a updated to record the lens is now reachable
+  through the client (the "spiked, not built / banner didn't ship" framing
+  retired for the reachability claim).

--- a/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md
+++ b/docs/superpowers/specs/2026-07-24-why-lens-step2-client-hop-design.md
@@ -87,8 +87,14 @@ typechecks.
   `WhyPeek`, `isWhyBrief`.
 
 `WhyInput` (`{ ref: string; line?: number }`) is a *request-params* type, not a
-result type; the client owns its own `WhyParams` (below), so `WhyInput` need
-not be promoted.
+result type, and is deliberately **not** promoted. The established convention
+(verified) is that all eight existing agents define their params **client-local**
+in `src/agents.ts` (`ExpertParams`, `ImpactParams`, `CatchupParams`, …) while
+only the **result** types (briefs) live in the SDK. Promoting only `why`'s
+params would be asymmetric with every other agent — it would *introduce* an
+inconsistency, not prevent drift — and the params shape is trivial (`{ ref;
+line? }`) with no speculative future fields (YAGNI). So the client owns its own
+`WhyParams`, the gateway keeps `WhyInput` local, exactly as the other agents do.
 
 ### Gateway — consume + re-export
 
@@ -106,6 +112,24 @@ not be promoted.
   the same names, now sourced from the SDK. `bunx tsc` is the proof the shapes
   still line up.
 
+**No new circular import.** The dependency direction is unchanged: `why-types.ts`
+already imports `AgentBriefBase` *from* `findings.ts`, and `findings.ts` imports
+only *from* `@nimbus-dev/sdk` (never from `why-types.ts`). Adding why re-exports
+keeps the one-way arrow `why-types.ts → findings.ts → sdk`. The existing
+`audit:structure` dependency-cruiser gate (no-cycles) is the backstop and must
+stay green.
+
+**No Tauri change.** `agents.why` and `agents.whyPeek` are **already** in the
+Tauri `ALLOWED_METHODS` allowlist (`gateway_bridge.rs`, added by #820, invariant
+I7) — verified present. Step 2 exposes them through the client, not the renderer,
+so it touches nothing under `packages/ui`.
+
+**The `line` boundary is already handled gateway-side** (a step-1b concern, not
+step 2): `why.ts` compiles `query.line` as `input.line ?? parseRef(input.ref).line`,
+where `parseRef` yields `number | null` — so an omitted `line` resolves cleanly
+to the parsed suffix or `null`. The client relays the gateway's `WhyBrief`
+verbatim; no undefined→null mapping is needed client-side.
+
 ### Client 0.12.0 — the two methods
 
 - `package.json` — bump `@nimbus-dev/sdk` to `^1.6.0`.
@@ -120,10 +144,22 @@ not be promoted.
     method** mirroring `searchRanked`: `const raw = await this.ipc.call("agents.whyPeek", { ref, line }); return validateWhyPeek("agents.whyPeek", raw);`.
 - `src/validate.ts` — add `validateWhyPeek` (shape-check the `WhyPeek` fields:
   nullable `subject`/`author`/`pr`/`ticket`, boolean `hasMore`), mirroring the
-  existing validators (e.g. `validateSessionRecall`).
+  existing validators (e.g. `validateSessionRecall`). Like every existing guard
+  it is **lenient about extra fields** (verified: `validate.ts` header — "Guards
+  check the required shape and are lenient about extra") — it validates the
+  required shape and passes unknown fields through, so a future gateway-side
+  addition to `WhyPeek` does not break an older client.
 - `src/mock-client.ts` — add a `why: WhyBrief` entry to the mock brief map and
   an `agentsWhyPeek` returning a deterministic `WhyPeek` fixture; the mock must
-  expose both new methods so the surface-parity guard stays balanced.
+  expose both new methods so the surface-parity guard stays balanced. The
+  fixtures are **high-fidelity** so downstream consumers (the VS Code hover UI
+  in step 3) get a representative shape to render against: the `WhyBrief` mock
+  carries at least one finding for **each of the six `WhyLane` values**, and the
+  `WhyPeek` mock returns a fully-populated result (non-null `subject`, `author`,
+  `commitSha`, `pr`, `ticket`, `hasMore: true`). One rich fixture per method,
+  matching the single-fixture convention of the other agent mocks — null/empty
+  edge cases stay the consumer's own test to construct (YAGNI on variant
+  fixtures here).
 - `src/index.ts` — re-export `WhyParams`/`WhyBrief`/`WhyPeek` types if the
   client barrels its public types (follow the existing convention).
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@mastra/core": "^1.43.0",
     "@mastra/mcp": "^1.10.0",
-    "@nimbus-dev/sdk": "^1.5.0",
+    "@nimbus-dev/sdk": "^1.6.0",
     "@noble/hashes": "^2.2.0",
     "@scure/bip39": "^2.2.0",
     "@xenova/transformers": "^2.17.0",

--- a/packages/gateway/src/agents/_lib/findings.ts
+++ b/packages/gateway/src/agents/_lib/findings.ts
@@ -33,6 +33,11 @@ export type {
   JanitorPeerTouch,
   PreflightBrief,
   PreflightDownstream,
+  WhyBrief,
+  WhyFinding,
+  WhyLane,
+  WhyPeek,
+  WhySubject,
 } from "@nimbus-dev/sdk";
 
 export {
@@ -44,4 +49,5 @@ export {
   isImpactBrief,
   isJanitorBrief,
   isPreflightBrief,
+  isWhyBrief,
 } from "@nimbus-dev/sdk";

--- a/packages/gateway/src/agents/_lib/why-types.ts
+++ b/packages/gateway/src/agents/_lib/why-types.ts
@@ -1,54 +1,13 @@
 /**
- * Why-brief types, gateway-local.
+ * Why-lens types.
  *
- * These deliberately do NOT live in `@nimbus-dev/sdk` yet: the published SDK
- * is 1.5.x and promoting the ninth agent is the step-2 `sdk 1.6.0` →
- * `client 0.8.0` hop (see the why-lens design spec). When that lands, these
- * move to the SDK and `findings.ts` re-exports them like the other eight.
+ * The result types now live in `@nimbus-dev/sdk` (promoted in step 2 / sdk
+ * 1.6.0) so the gateway, CLI and `@nimbus-dev/client` share one definition.
+ * Re-exported here via `findings.ts` (the gateway's SDK shim) so existing
+ * gateway imports keep working unchanged. `WhyInput` stays local: it is the
+ * request-params shape, not a shared result type (params are client-local for
+ * every agent).
  */
-import type { AgentBriefBase } from "./findings.ts";
-
-export type WhyLane =
-  | "authorship"
-  | "pull_request"
-  | "ticket"
-  | "discussion"
-  | "driver"
-  | "downstream";
-
-export type WhyFinding = {
-  lane: WhyLane;
-  title: string;
-  detail: string;
-  url: string | null;
-  occurredAt: number | null;
-  entityId: string | null;
-};
-
-export type WhySubject = {
-  repoRoot: string;
-  filePath: string;
-  lineNo: number | null;
-  symbol: string | null;
-};
-
-export type WhyBrief = AgentBriefBase & {
-  kind: "why";
-  query: { ref: string; line: number | null };
-  subject: WhySubject | null;
-  findings: WhyFinding[];
-};
-
-export type WhyPeek = {
-  subject: { repoRoot: string; filePath: string; lineNo: number } | null;
-  author: string | null;
-  authorEmail: string | null;
-  commitSha: string | null;
-  committedAt: number | null;
-  commitSubject: string | null;
-  pr: { number: number | null; title: string; url: string | null } | null;
-  ticket: { key: string; title: string; url: string | null } | null;
-  hasMore: boolean;
-};
+export type { WhyBrief, WhyFinding, WhyLane, WhyPeek, WhySubject } from "./findings.ts";
 
 export type WhyInput = { ref: string; line?: number };

--- a/scripts/agent-brief-shape.snapshot.json
+++ b/scripts/agent-brief-shape.snapshot.json
@@ -113,5 +113,20 @@
     ".findings.query.namespace:string",
     ".findings.query.ref:string",
     ".sessionId:string"
+  ],
+  "why": [
+    ".brief:string",
+    ".findings.agentVersion:number",
+    ".findings.findings[]:empty",
+    ".findings.gaps[].category:string",
+    ".findings.gaps[].detail:string",
+    ".findings.gaps[].remediation:string",
+    ".findings.generatedAt:number",
+    ".findings.kind:string",
+    ".findings.latencyMs:number",
+    ".findings.query.line:number",
+    ".findings.query.ref:string",
+    ".findings.subject:null",
+    ".sessionId:string"
   ]
 }

--- a/scripts/gen-agent-brief-fixtures.ts
+++ b/scripts/gen-agent-brief-fixtures.ts
@@ -19,6 +19,7 @@ const PARAMS: Record<string, Record<string, unknown>> = {
   huddle: { sinceMs: 259_200_000 },
   janitor: { resourceRef: "repo:acme/payments#branch/wip" },
   preflight: { ref: "HEAD", namespace: "payments" },
+  why: { ref: "src/payments/charge.ts:42" },
 };
 
 /**


### PR DESCRIPTION
## Why-lens step 2 — gateway half

The `why` lens shipped on the gateway + CLI in #820; **step 2** promotes its types into `@nimbus-dev/sdk` (single source of truth) and exposes it through `@nimbus-dev/client`. This is the gateway slice of that hop.

### What this PR does
- **Consume the promoted types** — bumps `@nimbus-dev/sdk` to `^1.6.0` (published) and re-exports `WhyBrief` / `WhyFinding` / `WhyLane` / `WhySubject` / `WhyPeek` + `isWhyBrief` from `agents/_lib/findings.ts`. `agents/_lib/why-types.ts` drops its local duplicate definitions and re-exports the five from `findings.ts`, keeping only `WhyInput` (the client-local request shape). Pure type-move — no behavior change (`why.ts`/`why-peek.ts`/`agents-rpc.ts` untouched; `tsc` is the proof the shapes still line up).
- **9th agent in the fixture generator** — adds `why` to `scripts/gen-agent-brief-fixtures.ts` PARAMS and regenerates `agent-brief-shape.snapshot.json` (why-only addition), so the gateway-generated golden fixture that `@nimbus-dev/client`'s conformance gate consumes carries the `why` brief.
- **Roadmap truth-pass** — records the lens as built + client-reachable in `docs/ecosystem-roadmap.md`, retiring the stale "spiked, not built" framing for the reachability claim.
- Carries the step-2 design spec, implementation plan, and the design/plan review notes.

### Verification
- Baseline 228 gateway-agent tests → 228 after the swap (exact match); full why suite (agents + `agents-rpc.why` + `why.e2e`) **232 pass / 0 fail**.
- `tsc -p packages/gateway/tsconfig.json` clean; `audit:structure` dependency-cruiser OK (no import cycle from the re-export); `agent-brief-shape.test.ts` 10/10.
- biome clean; `lint:markdown` 0 errors; doc-refs + readme-cli green.

### Companion PRs (the rest of step 2)
- `@nimbus-dev/sdk` **1.6.0** — promoted types (merged + published).
- `@nimbus-dev/client` **0.12.0** — `agentsWhy` + `agentsWhyPeek` (nimbus-client#31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shipped client-accessible “why” lens support, including brief and peek views, routed through the gateway for the step 2 SDK→client path.
  * Extended the “why” result typing surface to align responses across gateway and supporting tooling.
  * Expanded “why” brief schema coverage and added new fixture parameters for better response coverage.
* **Documentation**
  * Updated the ecosystem roadmap with Stage 2a delivery status and clarified remaining banner/hover work.
  * Added/updated implementation plans and design reviews for the SDK→client integration and verification gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->