### PR TITLE
refactor(gateway): clear 10 SonarCloud smells in why/blame/assemble

### DIFF
--- a/packages/gateway/src/agents/_lib/render.ts
+++ b/packages/gateway/src/agents/_lib/render.ts
@@ -237,13 +237,17 @@ const WHY_LANE_HEADINGS: Readonly<Record<WhyLane, string>> = Object.freeze({
   downstream: "Downstream",
 });
 
+function renderWhySubjectLine(brief: WhyBrief): string {
+  if (brief.subject === null) {
+    return `_Could not resolve \`${brief.query.ref}\` to an indexed location._`;
+  }
+  const lineSuffix = brief.subject.lineNo === null ? "" : `:${String(brief.subject.lineNo)}`;
+  return `\`${brief.subject.filePath}${lineSuffix}\` in \`${brief.subject.repoRoot}\``;
+}
+
 export function renderWhy(brief: WhyBrief): string {
   const lines: string[] = ["# Why"];
-  lines.push(
-    brief.subject === null
-      ? `_Could not resolve \`${brief.query.ref}\` to an indexed location._`
-      : `\`${brief.subject.filePath}${brief.subject.lineNo === null ? "" : `:${String(brief.subject.lineNo)}`}\` in \`${brief.subject.repoRoot}\``,
-  );
+  lines.push(renderWhySubjectLine(brief));
   for (const lane of WHY_LANE_ORDER) {
     const rows = brief.findings.filter((f) => f.lane === lane);
     if (rows.length === 0) continue;

--- a/packages/gateway/src/agents/why-peek.test.ts
+++ b/packages/gateway/src/agents/why-peek.test.ts
@@ -137,6 +137,60 @@ test("a symbol ref resolving to an out-of-roots repoRoot → null subject and ZE
   expect(spawns).toBe(0);
 });
 
+test("a resolvable file ref WITHOUT a line number → null peek (blame needs a line to anchor)", async () => {
+  const db = seededDb();
+  // Absolute path inside a configured root but with no `:line` suffix →
+  // resolveWhySubject returns a subject whose lineNo is null. runWhyPeek cannot
+  // anchor blame without a line, so it degrades to an all-null peek. This
+  // exercises the `whySubject?.lineNo == null` guard's subject-present branch.
+  let spawns = 0;
+  const spy = ((..._a: unknown[]) => {
+    spawns += 1;
+    throw new Error("must not spawn");
+  }) as typeof Bun.spawn;
+  const peek = await runWhyPeek(
+    { ref: path.join(ROOT, "src", "retry.ts") },
+    { db, roots, spawn: spy },
+  );
+  expect(peek.subject).toBeNull();
+  expect(peek.author).toBeNull();
+  expect(peek.hasMore).toBe(false);
+  expect(spawns).toBe(0);
+});
+
+test("blame present but the commit is unlinked (no commit entity / PR / ticket) → author only", async () => {
+  const db = seededDb();
+  // A blame row whose sha exists in NO graph_entity/PR/ticket — exercises the
+  // negative branches of the blame → commit → PR → ticket walk (commitEntity
+  // null, prForSha null, so pr/ticket stay null) while still returning the
+  // author from the seeded blame row.
+  const ORPHAN_SHA = "f".repeat(40);
+  upsertBlameLines(db, ROOT, "src/orphan.ts", [
+    {
+      lineNo: 5,
+      commitSha: ORPHAN_SHA,
+      authorName: "bob",
+      authorEmail: "bob@example.com",
+      authorTimeMs: 1_700_000_000_000,
+    },
+  ]);
+  let spawns = 0;
+  const spy = ((..._a: unknown[]) => {
+    spawns += 1;
+    throw new Error("must not spawn");
+  }) as typeof Bun.spawn;
+  const peek = await runWhyPeek(
+    { ref: `${path.join(ROOT, "src", "orphan.ts")}:5` },
+    { db, roots, spawn: spy },
+  );
+  expect(peek.author).toBe("bob");
+  expect(peek.commitSha).toBe(ORPHAN_SHA);
+  expect(peek.commitSubject).toBeNull();
+  expect(peek.pr).toBeNull();
+  expect(peek.ticket).toBeNull();
+  expect(spawns).toBe(0);
+});
+
 test("no blame row and no git dir → nulls, not an error", async () => {
   const db = seededDb();
   const peek = await runWhyPeek({ ref: `${path.join(ROOT, "src", "other.ts")}:9` }, { db, roots });

--- a/packages/gateway/src/agents/why-peek.ts
+++ b/packages/gateway/src/agents/why-peek.ts
@@ -118,7 +118,7 @@ export async function runWhyPeek(input: WhyInput, deps: WhyPeekDeps): Promise<Wh
   const { db, roots, spawn, exists } = deps;
   const whySubject = resolveWhySubject(db, roots, input, exists);
 
-  if (whySubject === null || whySubject.lineNo === null) {
+  if (whySubject?.lineNo == null) {
     return {
       subject: null,
       author: null,

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -119,6 +119,17 @@ function seedWhyFixture(db: Database, parts: FixtureParts): void {
 }
 
 describe("runWhy", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const d = tempDirs.pop();
+      if (d !== undefined) {
+        await fs.rm(d, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("authorship lane: blame row → author + commit subject finding", async () => {
     const db = freshDb();
     seedWhyFixture(db, { commit: true, blame: { lineNo: 42 } });
@@ -384,17 +395,6 @@ describe("runWhy", () => {
     expect(brief.subject).toBeNull();
     expect(brief.findings).toEqual([]);
     expect(brief.gaps.length).toBeGreaterThan(0);
-  });
-
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    while (tempDirs.length > 0) {
-      const d = tempDirs.pop();
-      if (d !== undefined) {
-        await fs.rm(d, { recursive: true, force: true });
-      }
-    }
   });
 
   async function makeTempGitDir(): Promise<string> {

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -244,7 +244,7 @@ function ticketRowsForPr(db: Database, prEntityId: string): TicketRow[] {
 // ---------------------------------------------------------------------------
 
 async function subAuthorship(db: Database, lane: LaneInput): Promise<SubAgentResult> {
-  if (lane.subject === null || lane.subject.lineNo === null) {
+  if (lane.subject?.lineNo == null) {
     return {
       gap: {
         category: "missing_relation_emit",

--- a/packages/gateway/src/connectors/blame-index-sync.test.ts
+++ b/packages/gateway/src/connectors/blame-index-sync.test.ts
@@ -79,12 +79,18 @@ describe("gitChangedSince", () => {
     const changes = await gitChangedSince(
       "/r",
       SHA_F,
-      fakeSpawn("M\0a.ts\0D\0b.ts\0R100\0old.ts\0new.ts\0", 0),
+      fakeSpawn("M\0a.ts\0D\0b.ts\0A\0c.ts\0R100\0old.ts\0new.ts\0", 0),
     );
     expect(changes).toContainEqual({ status: "M", path: "a.ts" });
     expect(changes).toContainEqual({ status: "D", path: "b.ts" });
+    expect(changes).toContainEqual({ status: "A", path: "c.ts" });
     expect(changes).toContainEqual({ status: "D", path: "old.ts" });
     expect(changes).toContainEqual({ status: "A", path: "new.ts", oldPath: "old.ts" });
+  });
+
+  test("maps an unknown status code (e.g. copy/type-change) to a modification", async () => {
+    const changes = await gitChangedSince("/r", SHA_F, fakeSpawn("T\0typed.ts\0", 0));
+    expect(changes).toEqual([{ status: "M", path: "typed.ts" }]);
   });
 
   test("returns [] on a non-zero exit", async () => {

--- a/packages/gateway/src/connectors/blame-index-sync.ts
+++ b/packages/gateway/src/connectors/blame-index-sync.ts
@@ -86,6 +86,14 @@ export async function gitBlameWindowFiles(
   return [...seen];
 }
 
+/** Maps a `git diff --name-status` status code to a `BlameChange` status: `A`/`D`
+ * pass through; everything else (`M`, `C`, `T`, …) is treated as a modification. */
+function statusFromCode(code: string): BlameChange["status"] {
+  if (code === "A") return "A";
+  if (code === "D") return "D";
+  return "M";
+}
+
 /** Parsed `git diff --name-status -M <sinceSha> HEAD`. Renames (`R###`) expand
  * to a `D` of the old path plus an `A` of the new path (carrying `oldPath`). */
 export async function gitChangedSince(
@@ -105,13 +113,13 @@ export async function gitChangedSince(
     const st = toks[i] ?? "";
     if (st.startsWith("R")) {
       // rename: <status>\0<oldPath>\0<newPath>
-      changes.push({ status: "D", path: toks[i + 1] ?? "" });
-      changes.push({ status: "A", path: toks[i + 2] ?? "", oldPath: toks[i + 1] ?? "" });
+      changes.push(
+        { status: "D", path: toks[i + 1] ?? "" },
+        { status: "A", path: toks[i + 2] ?? "", oldPath: toks[i + 1] ?? "" },
+      );
       i += 3;
     } else {
-      const s = st.charAt(0);
-      const status = s === "A" ? "A" : s === "D" ? "D" : "M";
-      changes.push({ status, path: toks[i + 1] ?? "" });
+      changes.push({ status: statusFromCode(st.charAt(0)), path: toks[i + 1] ?? "" });
       i += 2;
     }
   }
@@ -176,6 +184,57 @@ async function blameOneFile(ctx: SyncContext, root: string, relFile: string): Pr
   return rows.length;
 }
 
+/** Full path (first run or rewritten history): blame every windowed file up to
+ * the per-tick cap. Returns the number of files that yielded blame rows. */
+async function blameRootFull(ctx: SyncContext, root: string, windowDays: number): Promise<number> {
+  const files = await gitBlameWindowFiles(root, windowDays);
+  if (files.length > MAX_BLAME_FILES) {
+    ctx.logger.info(
+      { service: SERVICE_ID, root, total: files.length, cap: MAX_BLAME_FILES },
+      "blame window exceeds per-tick cap; remainder picked up on later ticks",
+    );
+  }
+  let filesBlamed = 0;
+  for (const f of files.slice(0, MAX_BLAME_FILES)) {
+    if ((await blameOneFile(ctx, root, f)) > 0) filesBlamed += 1;
+  }
+  return filesBlamed;
+}
+
+/** Incremental path: re-blame each file changed since `last` (pruning deletions).
+ * Returns the number of files that yielded blame rows. */
+async function blameRootIncremental(ctx: SyncContext, root: string, last: string): Promise<number> {
+  let filesBlamed = 0;
+  for (const ch of await gitChangedSince(root, last)) {
+    if (ch.status === "D") {
+      pruneBlameForFile(ctx.db, root, ch.path);
+    } else if ((await blameOneFile(ctx, root, ch.path)) > 0) {
+      filesBlamed += 1;
+    }
+  }
+  return filesBlamed;
+}
+
+/** Blames one configured root for this tick, choosing the full or incremental path
+ * from the recorded cursor head. Returns the new head to record plus the count of
+ * files blamed, or `null` when the root is skippable (missing dir / not a git repo). */
+async function blameOneRoot(
+  ctx: SyncContext,
+  root: string,
+  last: string | undefined,
+  windowDays: number,
+): Promise<{ head: string; filesBlamed: number } | null> {
+  if (!existsSync(root) || !statSync(root).isDirectory()) return null;
+  const head = await gitHeadSha(root);
+  if (head === null) return null; // not a git repo / empty repo
+
+  const filesBlamed =
+    last === undefined || !(await isAncestor(root, last))
+      ? await blameRootFull(ctx, root, windowDays)
+      : await blameRootIncremental(ctx, root, last);
+  return { head, filesBlamed };
+}
+
 /**
  * A whole-file, `windowDays`-bounded blame indexer. Per configured filesystem
  * root that is a git repo, it blames every git-tracked file with a commit in the
@@ -203,34 +262,10 @@ export function createBlameIndexSyncable(options: BlameIndexSyncableOptions): Sy
 
       for (const rootCfg of options.roots) {
         const root = rootCfg.path;
-        if (!existsSync(root) || !statSync(root).isDirectory()) continue;
-        const head = await gitHeadSha(root);
-        if (head === null) continue; // not a git repo / empty repo
-
-        const last = heads[root];
-        if (last === undefined || !(await isAncestor(root, last))) {
-          // Full path (first run or rewritten history).
-          const files = await gitBlameWindowFiles(root, windowDays);
-          if (files.length > MAX_BLAME_FILES) {
-            ctx.logger.info(
-              { service: SERVICE_ID, root, total: files.length, cap: MAX_BLAME_FILES },
-              "blame window exceeds per-tick cap; remainder picked up on later ticks",
-            );
-          }
-          for (const f of files.slice(0, MAX_BLAME_FILES)) {
-            if ((await blameOneFile(ctx, root, f)) > 0) filesBlamed += 1;
-          }
-        } else {
-          // Incremental path.
-          for (const ch of await gitChangedSince(root, last)) {
-            if (ch.status === "D") {
-              pruneBlameForFile(ctx.db, root, ch.path);
-            } else if ((await blameOneFile(ctx, root, ch.path)) > 0) {
-              filesBlamed += 1;
-            }
-          }
-        }
-        nextHeads[root] = head;
+        const blamed = await blameOneRoot(ctx, root, heads[root], windowDays);
+        if (blamed === null) continue;
+        filesBlamed += blamed.filesBlamed;
+        nextHeads[root] = blamed.head;
       }
 
       return {

--- a/packages/gateway/src/ipc/agents-rpc.why.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.why.test.ts
@@ -173,7 +173,7 @@ describe("dispatchAgentsRpc — agents.whyPeek", () => {
     await dispatchAgentsRpc("agents.whyPeek", { ref: "src/a.ts:1" }, ctx);
     // Give any accidental async notify a chance to fire before asserting silence.
     await new Promise((r) => setTimeout(r, 200));
-    expect(ctx.notify.mock.calls.length).toBe(0);
+    expect(ctx.notify.mock.calls).toHaveLength(0);
   });
 
   test("agents.whyPeek trims a whitespace-padded ref and resolves like the trimmed value", async () => {

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -1559,6 +1559,29 @@ function bootChatopsIntoAssembly(deps: {
   return chatopsBoot;
 }
 
+/**
+ * M-1: `loadNimbusServiceConfigsFromConfigDir` throws on any malformed
+ * `[metrics.dora.*]`/`[ci.service.*]` block (missing `repos`, unknown key, bad
+ * URN/regex, out-of-range window, invalid env name). Degrade to no service-identity
+ * bindings (timeline correlation falls back to plain `metadata.service`, as before
+ * this feature existed) rather than aborting gateway startup over a config typo.
+ */
+function loadServiceConfigsOrDegrade(
+  configDir: string,
+  logger: Logger,
+): ReturnType<typeof loadNimbusServiceConfigsFromConfigDir> {
+  try {
+    return loadNimbusServiceConfigsFromConfigDir(configDir);
+  } catch (err) {
+    logger.warn(
+      { err },
+      "failed to load [metrics.dora.*]/[ci.service.*] service configs — timeline " +
+        "correlation will fall back to metadata.service only until this is fixed",
+    );
+    return new Map();
+  }
+}
+
 export async function assemblePlatformServices(paths: PlatformPaths): Promise<PlatformServices> {
   const assemblyStartedMs = performance.now();
   const sidecarStops: Array<() => void> = [];
@@ -1612,23 +1635,10 @@ export async function assemblePlatformServices(paths: PlatformPaths): Promise<Pl
   // [ci.service.<id>] config, so cross-provider service identifiers (PagerDuty's
   // "PSVC1" vs. a forge's "checkout-web") resolve to the same `ServiceConfig.serviceId`.
   //
-  // M-1: `loadNimbusServiceConfigsFromConfigDir` throws on any malformed
-  // `[metrics.dora.*]`/`[ci.service.*]` block (missing `repos`, unknown key, bad
-  // URN/regex, out-of-range window, invalid env name). This is the only call site
-  // reached unconditionally at boot — degrade to no service-identity bindings
-  // (timeline correlation falls back to plain `metadata.service`, as before this
-  // feature existed) rather than aborting gateway startup over a config typo.
-  let serviceConfigs: ReturnType<typeof loadNimbusServiceConfigsFromConfigDir>;
-  try {
-    serviceConfigs = loadNimbusServiceConfigsFromConfigDir(paths.configDir);
-  } catch (err) {
-    syncLogger.warn(
-      { err },
-      "failed to load [metrics.dora.*]/[ci.service.*] service configs — timeline " +
-        "correlation will fall back to metadata.service only until this is fixed",
-    );
-    serviceConfigs = new Map();
-  }
+  // M-1 (see `loadServiceConfigsOrDegrade`): a malformed `[metrics.dora.*]`/
+  // `[ci.service.*]` block degrades to no service-identity bindings rather than
+  // aborting boot. This is the only call site reached unconditionally at boot.
+  const serviceConfigs = loadServiceConfigsOrDegrade(paths.configDir, syncLogger);
   // M-2: two ServiceConfigs claiming the same pagerdutyServices entry or repo URN
   // (a monorepo) resolve deterministically but silently otherwise; surface it the
   // same way `loadNimbusServiceConfigsFromConfigDir` already warns on duplicate ids.


### PR DESCRIPTION
Fix-not-exclude cleanup of all open SonarCloud code smells on the `nimbus-agent_Nimbus` project (10, all CODE_SMELL — no bugs/vulns/hotspots).

## Fixes
- **why-peek.ts / why.ts** (S6582): collapse `x === null || x.y === null` guards to `x?.y == null` optional chains.
- **_lib/render.ts** (S3358, S4624): extract `renderWhySubjectLine`, removing a nested ternary and a nested template literal.
- **blame-index-sync.ts**: single multi-arg `changes.push()` for the rename D+A pair (S7778); extract `statusFromCode` (S3358); split the `sync` root loop into `blameOneRoot`/`blameRootFull`/`blameRootIncremental`, dropping cognitive complexity 27 → well under 15 (S3776).
- **assemble.ts** (S3776): extract `loadServiceConfigsOrDegrade`, dropping `assemblePlatformServices` cognitive complexity 16 → 15.
- **why.test.ts** (S8782): move the `afterEach` hook to the top of the `describe` scope.
- **agents-rpc.why.test.ts** (S5906): `toHaveLength(0)` over a generic `.length` assertion.

## Coverage
Added a git-status `A` (added-file) case plus an unknown-code (`T` → `M`) case to the `gitChangedSince` parse test, covering all three `statusFromCode` branches.

All changes behavior-preserving.

## Verification
- Gateway `tsc --noEmit` ✅
- `biome check --error-on-warnings packages scripts` (2953 files) ✅
- Invariants static audit (`check-nimbus-invariants.ts`) ✅
- Full gateway suite: 8814 pass (1 unrelated 5s-timeout flake in `connector-rpc-handlers/auth.test.ts`, passes isolated in 204ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blame index updates for added, deleted, renamed, and modified files.
  * Unknown file-change statuses are now handled consistently as modifications.
  * Invalid service configuration no longer prevents platform startup; affected service bindings are skipped with a warning.
  * Preserved clear handling for unresolved code subjects and missing line information.

* **Refactor**
  * Simplified internal processing of repository synchronization and subject rendering without changing expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->