### PR TITLE
docs: ecosystem Stage 3 — distribution (launch messaging + roadmap status)

### DIFF
--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -366,14 +366,22 @@ the spike feeds [Open decision 3](#open-decisions) rather than closing it.
 
 Capability without discovery is what the 3-install number measures.
 
-- **Marketplace re-cut**: description, keywords and categories in the ICP's
-  vocabulary — incident response, on-call, SRE, platform engineering,
-  observability, deploy. Today those words appear nowhere.
-- **One demo GIF per headline claim.** The `why` lens is a single hover.
-- **Cross-link the clients.** Each client repo's `ROADMAP.md` is reduced to a
-  pointer to this file plus its own local slice.
-- **Launch on the trust story where it is honest** — scoped to
-  `authorized-actions`, never overclaimed as raw-syscall capture.
+> **Status 2026-07-24 — three of four done; the GIF deferred.** The copy/metadata
+> work landed as PRs; nothing was published or posted.
+
+- **Marketplace re-cut** ✅ — the `nimbus-vscode` listing (displayName /
+  description / categories / keywords + README lead) re-cut for the on-call /
+  incident ICP, leading with the ops slash-commands + the egress ledger, `why`
+  lens teased as upcoming. Was: those words appeared nowhere.
+- **One demo GIF per headline claim** ⏳ **deferred** — the `why` lens is a single
+  hover, but the hover UI is unbuilt (Stage 4). Gated on that slice; no GIF yet.
+- **Cross-link the clients** ✅ — a `ROADMAP.md` pointing to this file + a local
+  slice now lives in `nimbus-{vscode,client,sdk,web-clipper}`.
+- **Launch on the trust story where it is honest** ✅ — a "Why Nimbus" section in
+  the `nimbus-vscode` README + a reusable `docs/launch-messaging.md`, scoped to
+  the agent's *authorized/dispatched actions* (the egress ledger records what the
+  agent did off-device, not raw network traffic), never overclaimed as
+  raw-syscall / whole-machine capture.
 
 ---
 

--- a/docs/launch-messaging.md
+++ b/docs/launch-messaging.md
@@ -1,0 +1,28 @@
+# Nimbus — Launch messaging (reusable copy)
+
+> Positioning copy for the marketplace, READMEs, and any future launch channel.
+> This is a reference sheet, **not** a launch action. The honesty guardrails below
+> are load-bearing.
+
+## One-liner
+
+Private, local-first agent for on-call & platform engineers — grounded in your
+own index, with a verifiable record of what it did off your machine.
+
+## The three pillars
+
+- **Banner — the `why` lens** (*habit*): hover any line for who/PR/ticket/incident/blast-radius. Built on the gateway and reachable through the client; the in-editor hover is next (**not yet shipped — never advertise it as present**).
+- **Moat — egress receipts** (*defensibility*): a signed, hash-chained record of every action the agent dispatches off-device. No cloud assistant can offer it.
+- **Multiplier — LM tools** (*value per install*): `nimbus_search` / `nimbus_ask` registered as VS Code language-model tools.
+
+## ICP vs generic (say the first, not the others)
+
+- ✅ *"Hover any line: who wrote it, what ticket, what incident, and what breaks if you change it."*
+- ✅ *"Verifiable proof of what your agent did off your machine."*
+- ⚠️ *"Give Copilot your private context"* — positions Nimbus as an accessory; avoid.
+
+## Honesty guardrails (do NOT claim)
+
+- The egress ledger records the agent's **dispatched actions** (the `I29` executor chokepoint) — **not** raw network traffic. Never say *"everything that left your machine"* or *"every byte."* It is not a firewall / host DLP and does not see the OS, other local processes, or an unsandboxed third-party MCP server.
+- Never describe the `why` hover UI, or any unbuilt surface, as shipped.
+- Egress = "authorized actions the agent took," never "raw-syscall / whole-machine capture."

--- a/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution-review.md
+++ b/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution-review.md
@@ -1,0 +1,43 @@
+# Plan Review: Ecosystem Stage 3 — Distribution — Implementation Plan
+
+This document reviews [2026-07-24-ecosystem-stage3-distribution.md](./2026-07-24-ecosystem-stage3-distribution.md) and notes questions, suggestions, and improvements for the execution phase.
+
+---
+
+## 1. Multi-Repository Workspace Permissions
+
+### Filesystem Access Scope
+
+- **Observation:** The plan directs the agent to modify files in multiple adjacent directories (`C:/gitrep/nimbus-vscode`, `C:/gitrep/nimbus-client`, etc.) outside the primary `C:/gitrep/Nimbus` repository.
+- **Suggestion:** Depending on the execution environment's sandboxing, the agent may not have automatic read/write permissions for sibling directories. The plan should include a reminder to check or request directory permissions (e.g., using `ask_permission` or verifying write access) before attempting any file writes in those repos.
+
+---
+
+## 2. Shell Compatibility for Verification Steps
+
+### Windows-Friendly Auditing
+
+- **Observation:** The final verification steps suggest running `grep` to audit egress wording (e.g., *"grep the vscode README..."*).
+- **Correction:** Since the environment runs PowerShell on Windows, standard `grep` is typically not available unless WSL or Git Bash is explicitly used.
+- **Improvement:** Update the verification commands to use standard PowerShell cmdlets (like `Select-String`) to avoid command failures.
+  - *PowerShell alternative:* `Select-String -Path "README.md" -Pattern "everything that left", "every byte", "firewall"`
+
+---
+
+## 3. GitHub CLI (`gh`) and Credentials Check
+
+### CLI Authentication Failures
+
+- **Observation:** The plan issues automated `git push` and `gh pr create` commands.
+- **Question:** If the developer's machine does not have `gh` installed, or if the current terminal session lacks pushing rights (due to expired tokens or credentials), these steps will fail.
+- **Suggestion:** Add a pre-check step to run `gh auth status` and verify git remote connectivity before initiating the commit/PR sequence. Document a fallback instructions/URL for manual PR creation if the automated `gh` commands fail.
+
+---
+
+## 4. Packaging and `vsce` Dependencies
+
+### Package Command Prerequisites
+
+- **Observation:** Step 2 of Task 1 suggests running `bun run package` or `bunx vsce package --no-dependencies`.
+- **Question:** Are the required packages (`vsce`) already globally available or defined in the repo's devDependencies?
+- **Suggestion:** Add a quick check to see if `vsce` is installed (`vsce --version` or check `package.json` for `@vscode/vsce`), and note that a local `bun install` might be required beforehand if packaging fails due to missing modules.

--- a/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
+++ b/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
@@ -16,6 +16,7 @@
 - **No pinned versions in `ROADMAP.md`.** Describe the role + link the Releases page; a hardcoded `0.x.y` drifts on the next publish.
 - **`description` ≤ ~200 chars** (marketplace cards truncate ~150–200).
 - **Branch hygiene:** each repo gets its own `dev/asafgolombek/stage3-*` branch; never commit on `main`. The Nimbus worktree branch already exists.
+- **Preflight the tooling once** (all verified present in this environment): `gh auth status` must show logged-in before any `git push` / `gh pr create` — if `gh` is unavailable or the token expired, open each PR manually from the branch's compare URL (`https://github.com/nimbus-agent/<repo>/compare/main...<branch>`). The five client repos are sibling checkouts under `C:/gitrep/` (writable). Run `bun install` in a repo only if a fresh checkout lacks `node_modules`.
 
 ---
 
@@ -45,7 +46,7 @@ Work in `C:/gitrep/nimbus-vscode`. First: `cd C:/gitrep/nimbus-vscode && git swi
   - `categories` (lines 25–28): `["AI", "Other"]` → `["AI", "Chat"]`.
   - `keywords` (lines 29–36): keep `ai, agent, local-first, nimbus, privacy, mcp`; **add** `on-call, incident-response, sre, platform-engineering, observability, dora, deploy, egress, audit`.
 
-- [ ] **Step 2: Validate categories + package.** `cd C:/gitrep/nimbus-vscode && bun run package` (`bunx vsce package --no-dependencies`). Expected: PASS. **`vsce` fails on an unknown category** — if it rejects `"Chat"`, set `categories` to `["AI"]` and re-run (the ICP terms are in keywords regardless). Also confirm no "description too long" warning; trim if warned.
+- [ ] **Step 2: Validate categories + package.** `cd C:/gitrep/nimbus-vscode && bun run package` (`bunx vsce package --no-dependencies`; `@vscode/vsce` is a devDep — if this fails on missing modules, run `bun install` first). Expected: PASS. **`vsce` fails on an unknown category** — if it rejects `"Chat"`, set `categories` to `["AI"]` and re-run (the ICP terms are in keywords regardless). Also confirm no "description too long" warning; trim if warned.
 
 - [ ] **Step 3: Green check.** `bun run typecheck && bun run lint && bun run test`. Expected: PASS (metadata only, no code touched).
 
@@ -309,7 +310,7 @@ gh pr create --base main --title "docs: ecosystem Stage 3 — distribution (laun
 
 - [ ] `nimbus-vscode`: `bun run package` succeeds (categories valid, description not over-length); `typecheck`/`lint`/`test` green; README has no shipped-claim for the `why` lens (it's only under "On the roadmap").
 - [ ] Every `ROADMAP.md` deep link (`/blob/main/docs/ecosystem-roadmap.md`) resolves against the public repo; no pinned versions anywhere.
-- [ ] Egress wording audit: grep the vscode README + `launch-messaging.md` for "everything that left" / "every byte" / "firewall" — the honest scoping ("what the agent did off your machine", "dispatched actions") must be the only framing.
+- [ ] Egress wording audit — search the vscode README + `launch-messaging.md` for the forbidden framings `everything that left` / `every byte` / `firewall` (shell-agnostic: the **Grep tool** / ripgrep is always available; or `grep -rniE` in Bash; or `Select-String -Pattern` in PowerShell). The honest scoping ("what the agent did off your machine", "dispatched actions") must be the only framing.
 - [ ] Nimbus PR: `audit:doc-refs` + `lint:markdown` clean.
 - [ ] No `vsce publish`, no release, no posting anywhere.
 

--- a/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
+++ b/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
@@ -1,0 +1,320 @@
+# Ecosystem Stage 3 — Distribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the shipped capability discoverable and legible to the incident-response ICP — re-cut the VS Code marketplace listing, add pointer `ROADMAP.md` files to the client repos, and write an honestly-scoped trust story — as copy/metadata only, delivered as PRs (no publish, no posting).
+
+**Architecture:** Docs/metadata across five repos. One PR each: `nimbus-vscode` (A marketplace re-cut + C1 trust section + its `ROADMAP.md`), `nimbus-client` / `nimbus-sdk` / `nimbus-web-clipper` (each a `ROADMAP.md`), and `nimbus-agent/Nimbus` (C2 `docs/launch-messaging.md` + the ecosystem-roadmap Stage 3 update + this spec/plan). No code, no behavior change.
+
+**Tech Stack:** Markdown + a VS Code extension `package.json`. Repos: `C:/gitrep/nimbus-vscode`, `C:/gitrep/nimbus-client`, `C:/gitrep/nimbus-sdk`, `C:/gitrep/nimbus-web-clipper`, and the Nimbus worktree `C:/gitrep/Nimbus/.claude/worktrees/ecosystem-stage3` (branch `dev/asafgolombek/ecosystem-stage3-distribution`, already created).
+
+## Global Constraints
+
+- **Copy only — no publish, no posting.** No `vsce publish`, no marketplace release, no launch post. Deliver PRs.
+- **Honesty scope on egress (load-bearing).** The egress ledger records **every outbound action the agent dispatches** through its executor chokepoint (one hash-chained `egress_ledger` row before dispatch, invariant I29). It is **NOT** a network firewall/DLP and does **not** capture raw sockets/HTTP made outside the agent framework (OS, other local processes, a user-added unsandboxed MCP server). The honest phrasing is *"a signed, verifiable record of what the agent did off your machine"* — **never** *"everything that left your machine."* This wording is mandatory everywhere egress is mentioned (description, README, launch doc).
+- **No unbuilt feature described as shipped.** The `why` lens is teased **last, under an explicit not-yet-shipped heading**, never in the feature list.
+- **No pinned versions in `ROADMAP.md`.** Describe the role + link the Releases page; a hardcoded `0.x.y` drifts on the next publish.
+- **`description` ≤ ~200 chars** (marketplace cards truncate ~150–200).
+- **Branch hygiene:** each repo gets its own `dev/asafgolombek/stage3-*` branch; never commit on `main`. The Nimbus worktree branch already exists.
+
+---
+
+## File structure
+
+- `nimbus-vscode/package.json` — `displayName`, `description`, `categories`, `keywords` (A).
+- `nimbus-vscode/README.md` — lead rewrite (A) + "Why Nimbus" trust section (C1) + "On the roadmap" `why`-lens tease (B link).
+- `nimbus-vscode/ROADMAP.md` — new (B).
+- `nimbus-client/ROADMAP.md`, `nimbus-sdk/ROADMAP.md`, `nimbus-web-clipper/ROADMAP.md` — new (B).
+- `Nimbus/docs/launch-messaging.md` — new (C2).
+- `Nimbus/docs/ecosystem-roadmap.md` — Stage 3 status update.
+
+---
+
+## PR 1 — `nimbus-vscode` (A + C1 + B-vscode)
+
+Work in `C:/gitrep/nimbus-vscode`. First: `cd C:/gitrep/nimbus-vscode && git switch main && git pull --ff-only && git switch -c dev/asafgolombek/stage3-marketplace-recut && git rev-parse --abbrev-ref HEAD`.
+
+### Task 1: `package.json` marketplace re-cut
+
+**Files:** Modify `package.json` (lines ~3–4, ~25–35).
+
+- [ ] **Step 1: Edit the four fields.**
+  - `displayName` (line 3): `"Nimbus Agent"` → `"Nimbus — On-Call & Incident Agent"`
+  - `description` (line 4) → (≤200 chars, honesty-scoped):
+    `"Private, local-first agent for on-call & platform engineers — /incident, /deploys, /owns, /blast grounded in your own index, with a signed, verifiable record of every action it takes off-device."`
+  - `categories` (lines 25–28): `["AI", "Other"]` → `["AI", "Chat"]`.
+  - `keywords` (lines 29–36): keep `ai, agent, local-first, nimbus, privacy, mcp`; **add** `on-call, incident-response, sre, platform-engineering, observability, dora, deploy, egress, audit`.
+
+- [ ] **Step 2: Validate categories + package.** `cd C:/gitrep/nimbus-vscode && bun run package` (`bunx vsce package --no-dependencies`). Expected: PASS. **`vsce` fails on an unknown category** — if it rejects `"Chat"`, set `categories` to `["AI"]` and re-run (the ICP terms are in keywords regardless). Also confirm no "description too long" warning; trim if warned.
+
+- [ ] **Step 3: Green check.** `bun run typecheck && bun run lint && bun run test`. Expected: PASS (metadata only, no code touched).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add package.json
+git commit -m "feat(marketplace): re-cut listing for the on-call/incident ICP"
+```
+
+### Task 2: README lead rewrite + "Why Nimbus" trust section + roadmap tease
+
+**Files:** Modify `README.md`.
+
+**Interfaces produced:** the reordered README — differentiators first, general features below, trust section, roadmap tease last.
+
+- [ ] **Step 1: Rewrite the top of `README.md`.** Replace the current hero line (`# Nimbus for VS Code` + "Local-first AI agent for the editor…") with this structure, keeping all existing feature bullets but **moved below** the new lead:
+
+```markdown
+# Nimbus — On-Call & Incident Agent for VS Code
+
+A **private, local-first** agent for on-call and platform engineers. It answers
+from *your own* indexed context — incidents, deploys, ownership, code — and keeps
+a verifiable record of what it does off your machine. All running locally; your
+data never leaves the box except through actions you can see and prove.
+
+## Built for incident response & platform work
+
+Structured, grounded answers via the built-in Chat participant — not generic prompts:
+
+- **`/incident`** — what's going on right now: a catch-up brief across the services you own.
+- **`/deploys <service>`** — DORA metrics (deploy frequency, lead time, change-fail rate, MTTR).
+- **`/owns <file|service|topic>`** — who owns it, from your indexed history.
+- **`/blast <file|PR>`** — blast radius: what a change touches downstream.
+
+Each degrades honestly — an empty brief tells you *why* (missing connector, no data), never a confident guess.
+
+## A verifiable record of what the agent does off your machine
+
+Nimbus keeps a **signed, hash-chained egress ledger** of **every outbound action
+the agent dispatches** — one row, appended before the action leaves. Inspect it,
+verify the chain, and export a signed proof for any time window, all locally. A
+claim no cloud assistant can make, because completeness *for the agent's actions*
+can only be established at the point of departure, under your control.
+
+**Scope, stated plainly:** this records the agent's *dispatched actions*, not raw
+network traffic. It is not a firewall or host DLP and does not capture sockets or
+HTTP made outside the agent (the OS, other processes, or an unsandboxed
+third-party MCP server). It is a provable record of *what the agent did* — not a
+claim about every byte that left the machine.
+```
+
+- [ ] **Step 2: Keep the existing feature list**, reordered below the sections above, under a heading like `## Everything else it does` (Ask, Search, `@nimbus` chat participant with `/explain` `/fix` `/test` as a *secondary* "also works as a general assistant" note, Quick Ask, Find related, dev-workflow trio, sidebar, audit/egress ledgers, troubleshooter, walkthrough). Do not delete or alter their accuracy.
+
+- [ ] **Step 3: Add the roadmap tease LAST**, under an explicit not-yet-shipped heading:
+
+```markdown
+## On the roadmap (not yet shipped)
+
+- **The `why` lens** — hover any line to see who wrote it, the PR, the ticket, the
+  incident it responded to, and what breaks if you change it. Built on the gateway
+  and reachable through the client today ([`agents.why`/`agents.whyPeek`](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)); the in-editor hover is the next slice.
+
+See the [Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md) for the full plan.
+```
+
+- [ ] **Step 4: Verify links + render.** `bunx markdownlint-cli2 README.md` if the repo has it (else skip); if lychee is installed, `~/.cargo/bin/lychee --offline README.md`. Expected: clean. Eyeball that no shipped-feature description now overclaims and the `why` lens is only under "not yet shipped".
+
+- [ ] **Step 5: Commit.**
+```bash
+git add README.md
+git commit -m "docs(readme): lead with the ICP + ops commands + egress receipts; tease the why lens as upcoming"
+```
+
+### Task 3: `nimbus-vscode/ROADMAP.md`
+
+**Files:** Create `ROADMAP.md`.
+
+- [ ] **Step 1: Create `ROADMAP.md`:**
+```markdown
+# nimbus-vscode — Roadmap
+
+The Nimbus VS Code / Open VSX extension — the editor surface of the local-first
+Nimbus agent.
+
+The product roadmap lives in the gateway repo:
+**[Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)**
+— it owns the cross-surface plan (client surfaces / delivery).
+
+## This repo's slice
+
+- **Role:** the VS Code / Open VSX extension; consumes the published `@nimbus-dev/client`.
+- **Released:** on the VS Code Marketplace + Open VSX (`nimbus-agent.nimbus-vscode`); see [Releases](https://github.com/nimbus-agent/nimbus-vscode/releases) for the current version.
+- **Next here:** the `why`-lens hover UI (Stage 4) — the client methods already ship.
+```
+
+- [ ] **Step 2: Commit + open the PR.**
+```bash
+git add ROADMAP.md
+git commit -m "docs: add ROADMAP pointer to the ecosystem roadmap + local slice"
+git push -u origin dev/asafgolombek/stage3-marketplace-recut
+gh pr create --base main --title "Stage 3: marketplace re-cut + ROADMAP + why-lens tease" --body "Re-cuts the listing for the on-call/incident ICP (displayName/description/categories/keywords), leads the README with the ops slash-commands + the honestly-scoped egress ledger, teases the why lens as upcoming (not shipped), and adds a ROADMAP pointer. Copy/metadata only — no publish."
+```
+
+---
+
+## PR 2 — `nimbus-client/ROADMAP.md`
+
+Work in `C:/gitrep/nimbus-client`. `git switch main && git pull --ff-only && git switch -c dev/asafgolombek/stage3-roadmap`.
+
+### Task 4: `nimbus-client/ROADMAP.md`
+
+- [ ] **Step 1: Create `ROADMAP.md`:**
+```markdown
+# nimbus-client — Roadmap
+
+`@nimbus-dev/client` — the typed JSON-RPC IPC wrapper every Nimbus client
+consumes to talk to the local gateway.
+
+The product roadmap lives in the gateway repo:
+**[Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)**
+— it owns the cross-surface plan (client surfaces / delivery).
+
+## This repo's slice
+
+- **Role:** the single typed seam over the gateway's JSON-RPC surface; the `packages/cli` and the VS Code extension consume it.
+- **Released:** on npm as `@nimbus-dev/client`; see [Releases](https://github.com/nimbus-agent/nimbus-client/releases) for the current version.
+- **Next here:** track the gateway's method surface as new namespaces land.
+```
+
+- [ ] **Step 2: Commit + PR.**
+```bash
+git add ROADMAP.md
+git commit -m "docs: add ROADMAP pointer to the ecosystem roadmap + local slice"
+git push -u origin dev/asafgolombek/stage3-roadmap
+gh pr create --base main --title "docs: add ROADMAP (Stage 3 cross-link)" --body "Adds a ROADMAP.md pointing at the public Nimbus ecosystem roadmap plus this repo's local slice. No version pins (Stage 3)."
+```
+
+---
+
+## PR 3 — `nimbus-sdk/ROADMAP.md`
+
+Work in `C:/gitrep/nimbus-sdk`. `git switch main && git pull --ff-only && git switch -c dev/asafgolombek/stage3-roadmap`.
+
+### Task 5: `nimbus-sdk/ROADMAP.md`
+
+- [ ] **Step 1: Create `ROADMAP.md`:**
+```markdown
+# nimbus-sdk — Roadmap
+
+`@nimbus-dev/sdk` — the MIT extension-authoring contract: the shared item/brief
+types and guards that the gateway, CLI, and `@nimbus-dev/client` all speak.
+
+The product roadmap lives in the gateway repo:
+**[Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)**
+— it owns the cross-surface plan (client surfaces / delivery).
+
+## This repo's slice
+
+- **Role:** the one source of truth for the narrow-waist types (`NimbusItem`, the agent briefs + guards); first-party MCP connectors and clients consume it.
+- **Released:** on npm as `@nimbus-dev/sdk` (published dep-free); see [Releases](https://github.com/nimbus-agent/nimbus-sdk/releases) for the current version.
+- **Next here:** promote new shared types as agents/surfaces graduate to the waist.
+```
+
+- [ ] **Step 2: Commit + PR** (same shape as Task 4, `--title "docs: add ROADMAP (Stage 3 cross-link)"`).
+
+---
+
+## PR 4 — `nimbus-web-clipper/ROADMAP.md`
+
+Work in `C:/gitrep/nimbus-web-clipper`. `git switch main && git pull --ff-only && git switch -c dev/asafgolombek/stage3-roadmap`.
+
+### Task 6: `nimbus-web-clipper/ROADMAP.md`
+
+- [ ] **Step 1: Create `ROADMAP.md`:**
+```markdown
+# nimbus-web-clipper — Roadmap
+
+The Nimbus Web Clipper — a Chrome + Firefox MV3 extension that clips pages into
+your local Nimbus index.
+
+The product roadmap lives in the gateway repo:
+**[Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)**
+— it owns the cross-surface plan (client surfaces / delivery).
+
+## This repo's slice
+
+- **Role:** the browser capture surface; posts to the gateway's web-clip HTTP endpoint (`POST /v1/clips`) behind the owner-opened pairing window (invariant I30).
+- **Released:** as a Chrome/Firefox MV3 extension; see [Releases](https://github.com/nimbus-agent/nimbus-web-clipper/releases) for the current version.
+- **Next here:** tracked with the gateway's clip surface.
+```
+
+- [ ] **Step 2: Commit + PR** (same shape as Task 4).
+
+---
+
+## PR 5 — `nimbus-agent/Nimbus` (C2 + roadmap update)
+
+Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/ecosystem-stage3` (branch `dev/asafgolombek/ecosystem-stage3-distribution`). Confirm the branch first.
+
+### Task 7: `docs/launch-messaging.md`
+
+**Files:** Create `docs/launch-messaging.md`.
+
+- [ ] **Step 1: Create `docs/launch-messaging.md`** — a reusable messaging sheet (copy, not a launch):
+```markdown
+# Nimbus — Launch messaging (reusable copy)
+
+> Positioning copy for the marketplace, READMEs, and any future launch channel.
+> This is a reference sheet, **not** a launch action. Honesty guardrails below are
+> load-bearing.
+
+## One-liner
+
+Private, local-first agent for on-call & platform engineers — grounded in your
+own index, with a verifiable record of what it did off your machine.
+
+## The three pillars
+
+- **Banner — the `why` lens** (*habit*): hover any line for who/PR/ticket/incident/blast-radius. Built + reachable through the client; the in-editor hover is next (not yet shipped — never advertise it as present).
+- **Moat — egress receipts** (*defensibility*): a signed, hash-chained record of every action the agent dispatches off-device. No cloud assistant can offer it.
+- **Multiplier — LM tools** (*value per install*): `nimbus_search` / `nimbus_ask` registered as VS Code language-model tools.
+
+## ICP vs generic (say the first, not the others)
+
+- ✅ *"Hover any line: who wrote it, what ticket, what incident, and what breaks if you change it."*
+- ✅ *"Verifiable proof of what your agent did off your machine."*
+- ⚠️ *"Give Copilot your private context"* — positions Nimbus as an accessory; avoid.
+
+## Honesty guardrails (do NOT claim)
+
+- The egress ledger records the agent's **dispatched actions** (I29 executor chokepoint) — **not** raw network traffic. Never say *"everything that left your machine."* It is not a firewall/DLP and does not see the OS, other processes, or an unsandboxed third-party MCP server.
+- Never describe the `why` hover UI, or any unbuilt surface, as shipped.
+- Egress = "authorized actions," never "raw-syscall / whole-machine capture."
+```
+
+- [ ] **Step 2: Commit.**
+```bash
+git add docs/launch-messaging.md
+git commit -m "docs: launch-messaging sheet (three pillars + honesty guardrails)"
+```
+
+### Task 8: ecosystem-roadmap Stage 3 status update
+
+**Files:** Modify `docs/ecosystem-roadmap.md` (the Stage 3 section).
+
+- [ ] **Step 1: Update the Stage 3 section** to record A/B/C done and the demo GIF as the one deferred item. Add a dated status note under `## Stage 3 — Distribution` (keep the four original bullets; annotate each): marketplace re-cut ✅ (nimbus-vscode listing re-cut for the ICP), cross-link ✅ (`ROADMAP.md` in vscode/client/sdk/web-clipper), launch trust-story ✅ (`docs/launch-messaging.md` + the "Why Nimbus" README section), **demo GIF ⏳ deferred — gated on the `why`-lens hover UI (Stage 4)**. Keep edits factual and scoped; don't touch other stages.
+
+- [ ] **Step 2: Doc gates.** `bun run audit:doc-refs && bun run lint:markdown` (markdown gate is outside preflight — run it explicitly; the launch-messaging doc + roadmap edits must lint clean). If lychee is set up, run it over the changed docs and match CI's link total.
+
+- [ ] **Step 3: Commit + PR.**
+```bash
+git add docs/ecosystem-roadmap.md
+git commit -m "docs(roadmap): Stage 3 distribution done (marketplace/cross-links/launch copy); demo GIF deferred to Stage 4"
+git push -u origin dev/asafgolombek/ecosystem-stage3-distribution
+gh pr create --base main --title "docs: ecosystem Stage 3 — distribution (launch messaging + roadmap)" --body "Stage 3 copy that lives in this repo: docs/launch-messaging.md and the Stage 3 status update (marketplace re-cut + cross-link ROADMAPs + launch trust-story done; demo GIF deferred to the Stage 4 hover UI). Carries the Stage 3 spec + plan + review. Companion PRs: nimbus-vscode / -client / -sdk / -web-clipper."
+```
+
+---
+
+## Final verification (before pushing each PR)
+
+- [ ] `nimbus-vscode`: `bun run package` succeeds (categories valid, description not over-length); `typecheck`/`lint`/`test` green; README has no shipped-claim for the `why` lens (it's only under "On the roadmap").
+- [ ] Every `ROADMAP.md` deep link (`/blob/main/docs/ecosystem-roadmap.md`) resolves against the public repo; no pinned versions anywhere.
+- [ ] Egress wording audit: grep the vscode README + `launch-messaging.md` for "everything that left" / "every byte" / "firewall" — the honest scoping ("what the agent did off your machine", "dispatched actions") must be the only framing.
+- [ ] Nimbus PR: `audit:doc-refs` + `lint:markdown` clean.
+- [ ] No `vsce publish`, no release, no posting anywhere.
+
+## Self-review notes
+
+- **Spec coverage:** A (Task 1–2), B (Tasks 3–6), C1 (Task 2 README section), C2 (Task 7), roadmap update (Task 8), GIF deferral recorded (Task 8). All spec sections covered.
+- **Honesty scope** is repeated as a Global Constraint and enforced in the description (Task 1), the README trust section (Task 2), the launch sheet guardrails (Task 7), and the final grep audit.
+- **No version pins** in any `ROADMAP.md` (Tasks 3–6) per the review fix.

--- a/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
+++ b/docs/superpowers/plans/2026-07-24-ecosystem-stage3-distribution.md
@@ -51,6 +51,7 @@ Work in `C:/gitrep/nimbus-vscode`. First: `cd C:/gitrep/nimbus-vscode && git swi
 - [ ] **Step 3: Green check.** `bun run typecheck && bun run lint && bun run test`. Expected: PASS (metadata only, no code touched).
 
 - [ ] **Step 4: Commit.**
+
 ```bash
 git add package.json
 git commit -m "feat(marketplace): re-cut listing for the on-call/incident ICP"
@@ -115,6 +116,7 @@ See the [Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/m
 - [ ] **Step 4: Verify links + render.** `bunx markdownlint-cli2 README.md` if the repo has it (else skip); if lychee is installed, `~/.cargo/bin/lychee --offline README.md`. Expected: clean. Eyeball that no shipped-feature description now overclaims and the `why` lens is only under "not yet shipped".
 
 - [ ] **Step 5: Commit.**
+
 ```bash
 git add README.md
 git commit -m "docs(readme): lead with the ICP + ops commands + egress receipts; tease the why lens as upcoming"
@@ -125,6 +127,7 @@ git commit -m "docs(readme): lead with the ICP + ops commands + egress receipts;
 **Files:** Create `ROADMAP.md`.
 
 - [ ] **Step 1: Create `ROADMAP.md`:**
+
 ```markdown
 # nimbus-vscode — Roadmap
 
@@ -143,6 +146,7 @@ The product roadmap lives in the gateway repo:
 ```
 
 - [ ] **Step 2: Commit + open the PR.**
+
 ```bash
 git add ROADMAP.md
 git commit -m "docs: add ROADMAP pointer to the ecosystem roadmap + local slice"
@@ -159,6 +163,7 @@ Work in `C:/gitrep/nimbus-client`. `git switch main && git pull --ff-only && git
 ### Task 4: `nimbus-client/ROADMAP.md`
 
 - [ ] **Step 1: Create `ROADMAP.md`:**
+
 ```markdown
 # nimbus-client — Roadmap
 
@@ -177,6 +182,7 @@ The product roadmap lives in the gateway repo:
 ```
 
 - [ ] **Step 2: Commit + PR.**
+
 ```bash
 git add ROADMAP.md
 git commit -m "docs: add ROADMAP pointer to the ecosystem roadmap + local slice"
@@ -193,6 +199,7 @@ Work in `C:/gitrep/nimbus-sdk`. `git switch main && git pull --ff-only && git sw
 ### Task 5: `nimbus-sdk/ROADMAP.md`
 
 - [ ] **Step 1: Create `ROADMAP.md`:**
+
 ```markdown
 # nimbus-sdk — Roadmap
 
@@ -221,6 +228,7 @@ Work in `C:/gitrep/nimbus-web-clipper`. `git switch main && git pull --ff-only &
 ### Task 6: `nimbus-web-clipper/ROADMAP.md`
 
 - [ ] **Step 1: Create `ROADMAP.md`:**
+
 ```markdown
 # nimbus-web-clipper — Roadmap
 
@@ -251,6 +259,7 @@ Work in the existing worktree `C:/gitrep/Nimbus/.claude/worktrees/ecosystem-stag
 **Files:** Create `docs/launch-messaging.md`.
 
 - [ ] **Step 1: Create `docs/launch-messaging.md`** — a reusable messaging sheet (copy, not a launch):
+
 ```markdown
 # Nimbus — Launch messaging (reusable copy)
 
@@ -283,6 +292,7 @@ own index, with a verifiable record of what it did off your machine.
 ```
 
 - [ ] **Step 2: Commit.**
+
 ```bash
 git add docs/launch-messaging.md
 git commit -m "docs: launch-messaging sheet (three pillars + honesty guardrails)"
@@ -297,6 +307,7 @@ git commit -m "docs: launch-messaging sheet (three pillars + honesty guardrails)
 - [ ] **Step 2: Doc gates.** `bun run audit:doc-refs && bun run lint:markdown` (markdown gate is outside preflight — run it explicitly; the launch-messaging doc + roadmap edits must lint clean). If lychee is set up, run it over the changed docs and match CI's link total.
 
 - [ ] **Step 3: Commit + PR.**
+
 ```bash
 git add docs/ecosystem-roadmap.md
 git commit -m "docs(roadmap): Stage 3 distribution done (marketplace/cross-links/launch copy); demo GIF deferred to Stage 4"

--- a/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design-review.md
@@ -1,0 +1,58 @@
+# Design Review: Ecosystem Stage 3 — Distribution
+
+This document reviews [2026-07-24-ecosystem-stage3-distribution-design.md](./2026-07-24-ecosystem-stage3-distribution-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Marketplace Metadata & Character Limits
+
+### Truncation of Package Description
+
+- **Observation:** The proposed description for `package.json` is 231 characters. While the absolute maximum limit set by VS Code is 280 characters, search engines and the marketplace listing cards often truncate description fields at around 150–200 characters.
+- **Suggestion:** To prevent mid-sentence truncation in search result previews, we should consider a slightly more compact version.
+  - *Alternative (190 chars):* `"Private, local-first AI agent for on-call & platform engineers. Slash commands (/incident, /deploys, /owns, /blast) grounded in your local index with a signed, verifiable egress record."`
+
+### Category Validation
+
+- **Observation:** The categories list is updated to `["AI", "Chat"]`.
+- **Check:** Ensure both `"AI"` and `"Chat"` are fully recognized as valid categories by the marketplace packager (`vsce`) at release time, as `vsce` will fail packaging if an unrecognized category is declared.
+
+---
+
+## 2. Trust Story & Egress Receipt Framing (Honesty Scoping)
+
+### Egress Receipt Boundary
+
+- **Observation:** The trust story highlights Nimbus's ability to maintain a signed, verifiable record of everything sent off the machine.
+- **Suggestion:** To maintain strict honesty and prevent false security assumptions, the documentation must explicitly state the boundaries of the egress ledger:
+  - It records all *agent-dispatched actions and tool executions* (via the coordinator/executor).
+  - It is **not** a low-level network firewall and does not monitor raw TCP/IP sockets or direct HTTP calls made outside the agent framework (e.g., by third-party unsandboxed MCP servers or local system binaries).
+
+---
+
+## 3. Link Safety & Default Branches
+
+### URL Target Branch Resilience
+
+- **Observation:** The `ROADMAP.md` files point to `https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md`.
+- **Question:** Is `main` confirmed as the default branch for `nimbus-agent/Nimbus`? If the repository switches default branches or moves the file, these links will break.
+- **Suggestion:** If supported, use relative links for in-repo navigation, and verify that the target URL resolves dynamically or has a permanent redirect if the branch name shifts.
+
+---
+
+## 4. Maintenance of Client `ROADMAP.md` Files
+
+### Version Number Staleness
+
+- **Observation:** Section B templates a hardcoded version and status line (e.g., `@nimbus-dev/client 0.12.0`).
+- **Suggestion:** Hardcoding specific minor/patch versions in multiple repositories introduces a high likelihood of documentation drift as client libraries get updated.
+- **Alternative:** Keep the local slice description high-level and refer users to the releases page for active version numbers (e.g., *"Role: The typed IPC wrapper. Currently released on npm. Next here: The `why` hover UI (Stage 4)."*).
+
+---
+
+## 5. Legibility of the "why" Lens Teaser
+
+### Teaser Distinction
+
+- **Observation:** Teasing the upcoming `why` lens in the main README is a great way to show active development.
+- **Suggestion:** Ensure the "why lens" teaser is clearly separated under an "Upcoming Features" or "Roadmap" header so that users installing the current version do not mistake it for a shipped feature, which could lead to negative marketplace reviews.

--- a/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
+++ b/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
@@ -1,0 +1,122 @@
+# Ecosystem Stage 3 — Distribution
+
+> Design spec. Roadmap: [`docs/ecosystem-roadmap.md`](../../ecosystem-roadmap.md) § Stage 3.
+> Spans repos: `nimbus-vscode` (A, C), `nimbus-{vscode,client,sdk,web-clipper}` (B),
+> `nimbus-agent/Nimbus` (C's launch doc + this spec).
+
+## Problem
+
+Stages 0–2 built and re-cut the capability; the `why` lens is now reachable
+through `@nimbus-dev/client` 0.12.0 (step 2). But **capability without discovery
+is what the 3-install number measures** (roadmap § Stage 3). The VS Code listing
+— the one public discovery surface — is generically positioned: `displayName`
+"Nimbus Agent", `description` "Local-first AI agent for the editor", `categories`
+`[AI, Other]`, keywords `ai/agent/local-first/privacy/mcp`. **None of the ICP's
+words (on-call, incident response, SRE, platform engineering, observability,
+deploy) appear anywhere**, and the differentiators that actually shipped — the
+ops slash-commands (`/incident`, `/deploys`, `/owns`, `/blast`; Stage 2b) and
+egress receipts (the moat; Stage 2c) — are buried below generic "Ask/Search".
+The client repos have no `ROADMAP.md`, so a visitor can't see how the pieces fit.
+
+## Goal
+
+Make what's built **discoverable and legible** to the incident-response ICP,
+leading with what exists and is differentiated (ops commands + verifiable
+egress), with the `why` lens as a tease. Three deliverables (A/B/C below).
+
+**Non-goals:**
+- **The demo GIF** (roadmap Stage 3 bullet 2) is gated on the `nimbus-vscode`
+  hover UI, which is unbuilt (Stage 4). Deferred, not in this pass.
+- **No publishing or posting.** This writes copy and metadata; releasing the
+  extension and any launch posting stay the owner's actions.
+- No behavior/feature changes to any extension or package.
+
+## A — Marketplace re-cut (`nimbus-vscode`)
+
+Reposition the listing for the ICP; lead with the shipped differentiators. Blend
+of "reposition the name" + "lead with the moat".
+
+**`package.json` fields:**
+- `displayName`: `"Nimbus — On-Call & Incident Agent"` (was "Nimbus Agent").
+- `description`: `"Your private, local-first agent for on-call & platform engineers — /incident, /deploys, /owns, /blast grounded in your own index, with a signed, verifiable record of everything it sends off your machine that no cloud assistant can match."` (≤ the marketplace 200-ish char sweet spot; trim if the packager warns).
+- `categories`: `["AI", "Chat"]` (VS Code categories are a fixed enum — the ICP vocabulary can't live here; "Chat" is valid because the extension ships a chat participant; drop "Other").
+- `keywords`: keep `ai, agent, local-first, nimbus, privacy, mcp`; **add** `on-call, incident-response, sre, platform-engineering, observability, dora, deploy, egress, audit`.
+
+**`README.md` lead rewrite** (the marketplace listing body — the first screen is what converts): restructure the top so it opens with **who it's for + the differentiators**, not "generic AI agent":
+1. A one-line hero in the ICP's voice (mirror the new `description`).
+2. A short **"Built for incident response & platform work"** intro naming the ops slash-commands (`/incident` → catchup, `/deploys` → DORA, `/owns` → expert, `/blast` → impact) as the lead capability.
+3. **"A verifiable record of what left your machine"** — the egress receipts / audit ledger, framed as the moat (a claim no cloud assistant can make), scoped honestly (see C).
+4. A one-line **"`why` lens — coming"** tease (author/PR/ticket/incident per line), linking the ecosystem-roadmap.
+5. THEN the existing general features (Ask, Search, chat participant, dev-workflow trio, walkthrough) — kept, reordered below the differentiators, not deleted.
+
+Keep the exact feature descriptions accurate (no overclaiming an unbuilt feature as shipped). The Copilot-vocabulary trap (`/explain` `/fix` `/test`) stays as a secondary "also works like a general assistant" line, not the lead.
+
+## B — Cross-link the client ROADMAPs
+
+Create a short `ROADMAP.md` at the root of **four** repos: `nimbus-vscode`,
+`nimbus-client`, `nimbus-sdk`, `nimbus-web-clipper` (exclude `nimbus-trio` — a
+working copy of vscode, not a distinct surface). Each is a **pointer + local
+slice**, per the roadmap's own prescription. Template:
+
+```markdown
+# <repo> — Roadmap
+
+<repo> is <one line: its role in the Nimbus narrow waist>.
+
+The product roadmap lives in the gateway repo:
+**[Nimbus Ecosystem Roadmap](https://github.com/nimbus-agent/Nimbus/blob/main/docs/ecosystem-roadmap.md)**
+— it owns the cross-surface plan (client surfaces / delivery).
+
+## This repo's slice
+
+- **Role:** <e.g. the typed IPC wrapper every client consumes / the VS Code surface / …>
+- **Current:** <version + one line of status, e.g. `@nimbus-dev/client` 0.12.0 — 52 methods incl. `agents.why`/`whyPeek`>
+- **Next here:** <the repo-local next step, e.g. the `why` hover UI (Stage 4)>
+```
+
+`nimbus-agent/Nimbus` is public, so the deep link resolves for external
+visitors. Per-repo one-liners are filled from each repo's actual role/version at
+authoring time.
+
+## C — Launch trust-story copy
+
+Two artifacts, **copy only** (nothing posted):
+
+1. **A "Why Nimbus" section in the `nimbus-vscode` README** — the honest trust
+   story: Nimbus keeps a **verifiable, signed record of everything the agent
+   sent off your machine** (the egress ledger), a claim structurally impossible
+   for a cloud assistant (completeness of an egress record can only be
+   established at the point of departure, under the user's control). **Scoped
+   exactly:** it records the agent's *authorized actions* — never overclaimed as
+   raw-syscall / whole-machine capture. This is the differentiator that "sells to
+   the buyer and earns procurement's signature."
+2. **`docs/launch-messaging.md`** in the Nimbus repo — a reusable messaging
+   sheet: the one-liner, the three-pillar frame (banner = `why` lens; moat =
+   egress receipts; multiplier = LM tools), the ICP-vs-generic positioning
+   contrast (from the roadmap's "Put an SRE in front of a listing" section), and
+   the honesty guardrails (what NOT to claim). For reuse across marketplace,
+   README, and any future launch channel — not a launch action itself.
+
+## Testing / verification
+
+- **A:** `nimbus-vscode` still packages — `bunx vsce package` (or the repo's
+  package script) succeeds and warns of nothing new; `bun run` typecheck/lint/
+  test stay green (metadata + README only, no code touched). Marketplace
+  `description` within length; `categories` are valid enum values.
+- **B/C:** every new/changed doc passes the repos' link checks (lychee where
+  present); the ecosystem-roadmap deep link resolves (public repo). Markdown
+  lints clean where a gate exists.
+- Each repo's change is its own PR; nothing is published/released here.
+
+## Definition of done
+
+- `nimbus-vscode` listing (package.json + README lead) re-cut for the ICP,
+  leading with ops commands + egress receipts, `why` lens teased; extension
+  still packages, tests green.
+- `ROADMAP.md` present in vscode/client/sdk/web-clipper, each pointing to the
+  ecosystem-roadmap + its local slice.
+- "Why Nimbus" trust section in the vscode README + `docs/launch-messaging.md`
+  in the Nimbus repo, both honestly scoped to authorized-actions.
+- The ecosystem-roadmap Stage 3 section updated to record A/B/C done and the GIF
+  as the one deferred item (gated on the Stage 4 hover UI).
+- All changes as PRs; no marketplace publish, no posting.

--- a/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
+++ b/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
@@ -25,6 +25,7 @@ leading with what exists and is differentiated (ops commands + verifiable
 egress), with the `why` lens as a tease. Three deliverables (A/B/C below).
 
 **Non-goals:**
+
 - **The demo GIF** (roadmap Stage 3 bullet 2) is gated on the `nimbus-vscode`
   hover UI, which is unbuilt (Stage 4). Deferred, not in this pass.
 - **No publishing or posting.** This writes copy and metadata; releasing the
@@ -37,12 +38,14 @@ Reposition the listing for the ICP; lead with the shipped differentiators. Blend
 of "reposition the name" + "lead with the moat".
 
 **`package.json` fields:**
+
 - `displayName`: `"Nimbus — On-Call & Incident Agent"` (was "Nimbus Agent").
 - `description` (**≤200 chars** — marketplace search cards + listing previews truncate ~150–200 chars, so the full line must read whole before the cut; the earlier 231-char draft truncated mid-sentence): `"Private, local-first agent for on-call & platform engineers — /incident, /deploys, /owns, /blast grounded in your own index, with a signed, verifiable record of every action it takes off-device."` (~192 chars). Note "record of every **action it takes**" — not "everything that leaves your machine" — is the honesty-scoped wording (see C); do not widen it back to a network-level claim.
 - `categories`: `["AI", "Chat"]` — VS Code categories are a **fixed enum** and the ICP vocabulary can't live here; "Chat" is valid because the extension ships a chat participant. **`vsce`/packaging fails on an unrecognized category** — the plan MUST verify both against the current marketplace category list at authoring time; if "Chat" is not accepted, fall back to `["AI"]` (the ICP terms live in keywords regardless). Drop "Other".
 - `keywords`: keep `ai, agent, local-first, nimbus, privacy, mcp`; **add** `on-call, incident-response, sre, platform-engineering, observability, dora, deploy, egress, audit`.
 
 **`README.md` lead rewrite** (the marketplace listing body — the first screen is what converts): restructure the top so it opens with **who it's for + the differentiators**, not "generic AI agent":
+
 1. A one-line hero in the ICP's voice (mirror the new `description`).
 2. A short **"Built for incident response & platform work"** intro naming the ops slash-commands (`/incident` → catchup, `/deploys` → DORA, `/owns` → expert, `/blast` → impact) as the lead capability.
 3. **"A verifiable record of what left your machine"** — the egress receipts / audit ledger, framed as the moat (a claim no cloud assistant can make), scoped honestly (see C).

--- a/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
+++ b/docs/superpowers/specs/2026-07-24-ecosystem-stage3-distribution-design.md
@@ -38,18 +38,18 @@ of "reposition the name" + "lead with the moat".
 
 **`package.json` fields:**
 - `displayName`: `"Nimbus — On-Call & Incident Agent"` (was "Nimbus Agent").
-- `description`: `"Your private, local-first agent for on-call & platform engineers — /incident, /deploys, /owns, /blast grounded in your own index, with a signed, verifiable record of everything it sends off your machine that no cloud assistant can match."` (≤ the marketplace 200-ish char sweet spot; trim if the packager warns).
-- `categories`: `["AI", "Chat"]` (VS Code categories are a fixed enum — the ICP vocabulary can't live here; "Chat" is valid because the extension ships a chat participant; drop "Other").
+- `description` (**≤200 chars** — marketplace search cards + listing previews truncate ~150–200 chars, so the full line must read whole before the cut; the earlier 231-char draft truncated mid-sentence): `"Private, local-first agent for on-call & platform engineers — /incident, /deploys, /owns, /blast grounded in your own index, with a signed, verifiable record of every action it takes off-device."` (~192 chars). Note "record of every **action it takes**" — not "everything that leaves your machine" — is the honesty-scoped wording (see C); do not widen it back to a network-level claim.
+- `categories`: `["AI", "Chat"]` — VS Code categories are a **fixed enum** and the ICP vocabulary can't live here; "Chat" is valid because the extension ships a chat participant. **`vsce`/packaging fails on an unrecognized category** — the plan MUST verify both against the current marketplace category list at authoring time; if "Chat" is not accepted, fall back to `["AI"]` (the ICP terms live in keywords regardless). Drop "Other".
 - `keywords`: keep `ai, agent, local-first, nimbus, privacy, mcp`; **add** `on-call, incident-response, sre, platform-engineering, observability, dora, deploy, egress, audit`.
 
 **`README.md` lead rewrite** (the marketplace listing body — the first screen is what converts): restructure the top so it opens with **who it's for + the differentiators**, not "generic AI agent":
 1. A one-line hero in the ICP's voice (mirror the new `description`).
 2. A short **"Built for incident response & platform work"** intro naming the ops slash-commands (`/incident` → catchup, `/deploys` → DORA, `/owns` → expert, `/blast` → impact) as the lead capability.
 3. **"A verifiable record of what left your machine"** — the egress receipts / audit ledger, framed as the moat (a claim no cloud assistant can make), scoped honestly (see C).
-4. A one-line **"`why` lens — coming"** tease (author/PR/ticket/incident per line), linking the ecosystem-roadmap.
-5. THEN the existing general features (Ask, Search, chat participant, dev-workflow trio, walkthrough) — kept, reordered below the differentiators, not deleted.
+4. THEN the existing general features (Ask, Search, chat participant, dev-workflow trio, walkthrough) — kept, reordered below the differentiators, not deleted.
+5. The **`why` lens tease goes LAST, under an explicit `## On the roadmap` (or "Coming soon") heading** — clearly marked as **not yet shipped**, one line (author/PR/ticket/incident per line) linking the ecosystem-roadmap. It must NOT appear in the shipped-feature list: a user installing this version seeing "why lens" among the features and not finding it earns a 1-star "advertised a feature that isn't there" review.
 
-Keep the exact feature descriptions accurate (no overclaiming an unbuilt feature as shipped). The Copilot-vocabulary trap (`/explain` `/fix` `/test`) stays as a secondary "also works like a general assistant" line, not the lead.
+Keep every shipped-feature description accurate — **no unbuilt feature described as present**. The Copilot-vocabulary trap (`/explain` `/fix` `/test`) stays as a secondary "also works like a general assistant" line, not the lead.
 
 ## B — Cross-link the client ROADMAPs
 
@@ -70,26 +70,43 @@ The product roadmap lives in the gateway repo:
 ## This repo's slice
 
 - **Role:** <e.g. the typed IPC wrapper every client consumes / the VS Code surface / …>
-- **Current:** <version + one line of status, e.g. `@nimbus-dev/client` 0.12.0 — 52 methods incl. `agents.why`/`whyPeek`>
-- **Next here:** <the repo-local next step, e.g. the `why` hover UI (Stage 4)>
+- **Released:** <where, NO pinned version — e.g. "on npm (`@nimbus-dev/client`); see [Releases](../../releases) for the current version"> — a hardcoded `0.x.y` here drifts the moment the package publishes again; point at the releases page instead.
+- **Next here:** <the repo-local next step, e.g. "the `why` hover UI (Stage 4)">
 ```
 
-`nimbus-agent/Nimbus` is public, so the deep link resolves for external
-visitors. Per-repo one-liners are filled from each repo's actual role/version at
-authoring time.
+**No pinned versions in these files** (they update rarely; a hardcoded minor/patch
+goes stale immediately) — describe the role + link the releases page. The
+ecosystem-roadmap deep link uses `/blob/main/` deliberately: it must track the
+*living* roadmap, and `main` is the confirmed, stable default branch of the
+public `nimbus-agent/Nimbus` repo. A commit-SHA permalink would pin a stale
+snapshot; relative links are impossible across repos. If the default branch is
+ever renamed, GitHub auto-redirects `/blob/main/` and the links here are updated
+in the same change.
 
 ## C — Launch trust-story copy
 
 Two artifacts, **copy only** (nothing posted):
 
 1. **A "Why Nimbus" section in the `nimbus-vscode` README** — the honest trust
-   story: Nimbus keeps a **verifiable, signed record of everything the agent
-   sent off your machine** (the egress ledger), a claim structurally impossible
-   for a cloud assistant (completeness of an egress record can only be
-   established at the point of departure, under the user's control). **Scoped
-   exactly:** it records the agent's *authorized actions* — never overclaimed as
-   raw-syscall / whole-machine capture. This is the differentiator that "sells to
-   the buyer and earns procurement's signature."
+   story: Nimbus keeps a **verifiable, signed record of every outbound action the
+   agent takes** (the egress ledger), a claim structurally impossible for a cloud
+   assistant (completeness *for the agent's actions* can only be established at
+   the point of departure, under the user's control). **The boundary is stated
+   explicitly and must not be softened into a whole-machine claim:**
+   - **What it records:** every action the agent *dispatches* through its
+     executor chokepoint — one appended, hash-chained `egress_ledger` row per
+     gated action *before* it leaves (invariant I29). That is the exact, provable
+     scope.
+   - **What it is NOT:** a network firewall or host DLP. It does **not** monitor
+     raw TCP/UDP sockets or HTTP made *outside* the agent framework — e.g. by the
+     OS, other local processes, or a user-added **unsandboxed** MCP server. (Nimbus
+     first-party connectors run sandboxed (I15), but the ledger's claim is about
+     *the agent's dispatched actions*, not every byte on the wire.)
+
+   The honest one-liner is *"a signed, verifiable record of what the agent did
+   off your machine"* — never *"everything that left your machine."* This is the
+   differentiator that "sells to the buyer and earns procurement's signature,"
+   and it only holds if the scope is stated, not blurred.
 2. **`docs/launch-messaging.md`** in the Nimbus repo — a reusable messaging
    sheet: the one-liner, the three-pillar frame (banner = `why` lens; moat =
    egress receipts; multiplier = LM tools), the ICP-vs-generic positioning


### PR DESCRIPTION
Stage 3 (Distribution) copy that lives in this repo, plus the spec/plan/reviews.

- **`docs/launch-messaging.md`** — reusable messaging sheet (three pillars: banner=`why` lens, moat=egress receipts, multiplier=LM tools) with load-bearing **honesty guardrails** (the egress ledger records the agent's *dispatched actions* at the I29 chokepoint — never "everything that left your machine").
- **Stage 3 roadmap status** — marketplace re-cut ✅, cross-link ROADMAPs ✅, launch trust-story ✅; **demo GIF ⏳ deferred** (gated on the Stage 4 hover UI).

Copy/metadata only — nothing published or posted. **Companion PRs:** nimbus-vscode (marketplace re-cut) + nimbus-client/-sdk/-web-clipper (ROADMAP cross-links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)