### PR TITLE
docs(cla): CLA program Phase 1 — ICLA/CCLA drafts + cla-coverage drift gate

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -140,3 +140,31 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: bun scripts/structure-audit/check-team-reachability.ts --strict
+
+  cla-coverage:
+    name: cla-coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Mint App token
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus,nimbus-recipes
+          # cla-coverage reads .github/workflows/cla.yml from each gated repo — contents:read.
+          permission-contents: read
+      - name: Audit CLA coverage
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
+        run: bun scripts/structure-audit/check-cla-coverage.ts --strict

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -161,7 +161,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
-          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus,nimbus-recipes
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus
           # cla-coverage reads .github/workflows/cla.yml from each gated repo — contents:read.
           permission-contents: read
       - name: Audit CLA coverage

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -226,6 +226,31 @@ For security vulnerabilities, **do not open a public issue** — see [`SECURITY.
 
 ---
 
+## Contributor License Agreement (CLA)
+
+Before your first pull request to a Nimbus public repo can merge, you must sign
+the CLA — a one-time, sign-by-comment step enforced by a required `CLA Assistant`
+check. The bot will prompt you; reply with exactly:
+
+```text
+I have read the CLA Document and I hereby sign the CLA
+```
+
+One signature covers all Nimbus public repos. See the
+[Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md);
+contributing for an employer uses the
+[Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).
+
+**Why a CLA.** It grants a broad, relicensable license so the AGPL-3.0 core can
+be offered under more than one license in future — something a DCO cannot do.
+
+**MIT → AGPL is one-way.** The gateway/CLI/connectors are AGPL-3.0; `@nimbus-dev/sdk`
+and `@nimbus-dev/client` are MIT. Code may flow **MIT → AGPL** but never the
+reverse: a patch to the MIT packages must not be derived from AGPL-licensed parts
+of this repository. If unsure which side your change sits on, ask in the PR.
+
+---
+
 ## Questions
 
 Open a [GitHub Discussion](https://github.com/nimbus-agent/Nimbus/discussions) rather than an issue. Issues are for confirmed bugs and accepted feature requests.

--- a/docs/cla/CCLA.md
+++ b/docs/cla/CCLA.md
@@ -1,0 +1,53 @@
+# Nimbus Corporate Contributor License Agreement ("Agreement")
+
+Thank you for your interest in software projects stewarded by **nimbus-agent**
+("We" or "Us"). This Agreement documents the rights granted by contributing
+Corporations to Us. By signing this Agreement, the Corporation accepts and agrees
+to the following terms for its present and future Contributions Submitted to Us.
+
+## 1. Definitions
+
+"Corporation" (or "You") means the legal entity Submitting Contributions and all
+other entities that control, are controlled by, or are under common control with
+that entity. "Contribution", "Submit", and other capitalized terms carry the same
+meaning as in the Nimbus Individual CLA.
+
+## 2. Grant of Copyright License
+
+The Corporation grants to Us and to recipients of software distributed by Us the
+same perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license — including the sublicense and **relicensing** right stated in
+Section 2 of the Nimbus Individual CLA (the right to license Contributions under
+any terms, including proprietary or commercial terms, to preserve dual
+licensing) — for Contributions Submitted by the Corporation's Designated
+Employees.
+
+## 3. Grant of Patent License
+
+The Corporation grants the patent license stated in Section 3 of the Nimbus
+Individual CLA for Contributions Submitted by its Designated Employees.
+
+## 4. Designated Employees
+
+The Corporation's Contributions are made by the employees listed in **Schedule A**.
+The Corporation may update Schedule A by Submitting a revised list. The Corporation
+represents that it is legally entitled to grant the above licenses and that each
+Designated Employee is authorized to Submit Contributions on its behalf.
+
+## 5. Disclaimer
+
+Contributions are provided "AS IS", WITHOUT WARRANTY OF ANY KIND, as stated in
+Section 5 of the Nimbus Individual CLA.
+
+## 6. Point of Contact
+
+The Corporation designates a point of contact for CLA administration:
+`__________________________`.
+
+---
+
+## Schedule A — Designated Employees
+
+| GitHub username | Full name |
+| --- | --- |
+| | |

--- a/docs/cla/CCLA.md
+++ b/docs/cla/CCLA.md
@@ -60,11 +60,11 @@ The Corporation designates a point of contact for CLA administration:
 
 ## 7. Governing Law and Jurisdiction
 
-This Agreement is governed by, and construed in accordance with, the laws of
-`[GOVERNING JURISDICTION — owner to choose, e.g. the State of Delaware, USA]`,
-without regard to its conflict-of-laws principles, and any action arising under it
-shall be brought exclusively in the courts located in `[FORUM — city/county and
-state/country]` (the same governing law and forum as the Nimbus Individual CLA).
+This Agreement is governed by, and construed in accordance with, the laws of the
+State of Israel, without regard to its conflict-of-laws principles, and any action
+arising under it shall be brought exclusively in the competent courts of Tel
+Aviv-Jaffa, Israel (the same governing law and forum as the Nimbus Individual
+CLA).
 
 ---
 

--- a/docs/cla/CCLA.md
+++ b/docs/cla/CCLA.md
@@ -2,25 +2,35 @@
 
 Thank you for your interest in software projects stewarded by **nimbus-agent**
 ("We" or "Us"). This Agreement documents the rights granted by contributing
-Corporations to Us. By signing this Agreement, the Corporation accepts and agrees
-to the following terms for its present and future Contributions Submitted to Us.
+Corporations to Us. By submitting the electronic confirmation designated in our
+contribution guidelines, or by Submitting a Contribution through a Designated
+Employee, the Corporation accepts and agrees to be bound by the following terms
+for its present and future Contributions Submitted to Us. The Corporation agrees
+that such electronic assent constitutes a legally binding electronic signature
+under the Electronic Signatures in Global and National Commerce Act (ESIGN) and
+the Uniform Electronic Transactions Act (UETA).
 
 ## 1. Definitions
 
 "Corporation" (or "You") means the legal entity Submitting Contributions and all
 other entities that control, are controlled by, or are under common control with
 that entity. "Contribution", "Submit", and other capitalized terms carry the same
-meaning as in the Nimbus Individual CLA.
+meaning as in the Nimbus Individual CLA. The terms incorporated by reference from
+the Nimbus Individual Contributor License Agreement are those of the version in
+effect on the date the Corporation accepts this Agreement; in any such incorporated
+term, references to "You" or "Your" are read to mean the "Corporation" or "its
+Designated Employees" as the context requires.
 
 ## 2. Grant of Copyright License
 
-The Corporation grants to Us and to recipients of software distributed by Us the
-same perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license — including the sublicense and **relicensing** right stated in
-Section 2 of the Nimbus Individual CLA (the right to license Contributions under
+The Corporation grants to Us the same perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license — including the sublicense
+and **relicensing** right (and the waiver of termination and moral rights) stated
+in Section 2 of the Nimbus Individual CLA (the right to license Contributions under
 any terms, including proprietary or commercial terms, to preserve dual
 licensing) — for Contributions Submitted by the Corporation's Designated
-Employees.
+Employees. Downstream recipients receive their rights through the license We grant
+when We distribute the software, not directly under this Agreement.
 
 ## 3. Grant of Patent License
 
@@ -29,10 +39,14 @@ Individual CLA for Contributions Submitted by its Designated Employees.
 
 ## 4. Designated Employees
 
-The Corporation's Contributions are made by the employees listed in **Schedule A**.
-The Corporation may update Schedule A by Submitting a revised list. The Corporation
-represents that it is legally entitled to grant the above licenses and that each
-Designated Employee is authorized to Submit Contributions on its behalf.
+The Corporation's Contributions are made by the employees listed in **Schedule A**,
+or by individuals contributing from an authorized corporate email domain, or by
+members of a designated GitHub organization or team that the Corporation
+identifies. The Corporation may update Schedule A or its list of authorized domains
+and organizations by Submitting a revised list, and is responsible for keeping them
+accurate. The Corporation represents that it is legally entitled to grant the above
+licenses and that each Designated Employee is authorized to Submit Contributions on
+its behalf.
 
 ## 5. Disclaimer
 
@@ -43,6 +57,14 @@ Section 5 of the Nimbus Individual CLA.
 
 The Corporation designates a point of contact for CLA administration:
 `__________________________`.
+
+## 7. Governing Law and Jurisdiction
+
+This Agreement is governed by, and construed in accordance with, the laws of
+`[GOVERNING JURISDICTION — owner to choose, e.g. the State of Delaware, USA]`,
+without regard to its conflict-of-laws principles, and any action arising under it
+shall be brought exclusively in the courts located in `[FORUM — city/county and
+state/country]` (the same governing law and forum as the Nimbus Individual CLA).
 
 ---
 

--- a/docs/cla/ICLA.md
+++ b/docs/cla/ICLA.md
@@ -100,9 +100,8 @@ that would make these representations inaccurate in any respect.
 
 ## 7. Governing Law and Jurisdiction
 
-This Agreement is governed by, and construed in accordance with, the laws of
-`[GOVERNING JURISDICTION — owner to choose, e.g. the State of Delaware, USA]`,
-without regard to its conflict-of-laws principles. Any legal action or proceeding
-arising under or in connection with this Agreement shall be brought exclusively in
-the courts located in `[FORUM — city/county and state/country]`, and You consent
-to the personal jurisdiction and venue of those courts.
+This Agreement is governed by, and construed in accordance with, the laws of the
+State of Israel, without regard to its conflict-of-laws principles. Any legal
+action or proceeding arising under or in connection with this Agreement shall be
+brought exclusively in the competent courts of Tel Aviv-Jaffa, Israel, and You
+consent to the personal jurisdiction and venue of those courts.

--- a/docs/cla/ICLA.md
+++ b/docs/cla/ICLA.md
@@ -2,10 +2,14 @@
 
 Thank you for your interest in software projects stewarded by **nimbus-agent**
 ("We" or "Us"). This Agreement documents the rights granted by contributors to
-Us. By signing this Agreement (see CONTRIBUTING.md), You accept and agree to the
-following terms for Your present and future Contributions submitted to Us. Except
-for the license granted herein to Us, You reserve all right, title, and interest
-in and to Your Contributions.
+Us. By submitting the electronic confirmation designated in our contribution
+guidelines (commenting on a pull request as specified in CONTRIBUTING.md) or by
+Submitting a Contribution, You accept and agree to be bound by the following
+terms for Your present and future Contributions submitted to Us. You agree that
+this electronic assent constitutes a legally binding electronic signature under
+the Electronic Signatures in Global and National Commerce Act (ESIGN) and the
+Uniform Electronic Transactions Act (UETA). Except for the license granted herein
+to Us, You reserve all right, title, and interest in and to Your Contributions.
 
 ## 1. Definitions
 
@@ -19,33 +23,52 @@ electronic mailing lists, source code control systems, and pull requests.
 
 ## 2. Grant of Copyright License
 
-Subject to the terms and conditions of this Agreement, You hereby grant to Us and
-to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
-derivative works of, publicly display, publicly perform, sublicense, and
-distribute Your Contributions and such derivative works.
+Subject to the terms and conditions of this Agreement, You hereby grant to Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works. Downstream recipients receive their rights through the license
+We grant when We distribute the software, not directly under this Agreement.
 
 **Relicensing.** You expressly agree that We may license Your Contributions —
 including the right to grant sublicenses through multiple tiers — under **any
 license terms of Our choosing, including terms that differ from the then-current
-license of the project and including proprietary or commercial terms.** This
-right is granted to preserve Our ability to offer the software under more than one
-license (dual licensing). This paragraph does not obligate Us to relicense.
+license of the project and including proprietary or commercial terms.** You agree
+that such licenses or sublicenses may be granted without any obligation to
+distribute source code, display Your copyright attributions to end users, or apply
+copyleft or reciprocity terms to modifications. This right is granted to preserve
+Our ability to offer the software under more than one license (dual licensing).
+This paragraph does not obligate Us to relicense.
+
+**Waiver of termination rights.** To the maximum extent permitted by applicable
+law, You waive and agree not to assert any statutory or other right to terminate,
+rescind, or revoke the licenses granted herein. If under applicable law such
+license grants may not be made perpetual or irrevocable, You agree to grant Us
+successive, royalty-free, automatic renewals of such licenses on the same terms
+until the copyright term expires.
+
+**Moral rights.** To the extent permitted by applicable law, You hereby waive and
+agree not to assert any moral rights (including rights of attribution and
+integrity) that You may have in Your Contributions against Us, Our sublicensees,
+or Our successors. To the extent such rights cannot be waived, You agree not to
+assert them in a manner that interferes with the exercise of the licenses granted
+herein.
 
 ## 3. Grant of Patent License
 
-Subject to the terms and conditions of this Agreement, You hereby grant to Us and
-to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section) patent
-license to make, have made, use, offer to sell, sell, import, and otherwise
-transfer the Contribution, where such license applies only to those patent claims
-licensable by You that are necessarily infringed by Your Contribution alone or by
-combination of Your Contribution with the project to which it was Submitted. If
-any entity institutes patent litigation against You or any other entity alleging
-that Your Contribution, or the project it was Submitted to, constitutes direct or
-contributory patent infringement, then any patent licenses granted to that entity
-under this Agreement for that Contribution or project shall terminate as of the
-date such litigation is filed.
+Subject to the terms and conditions of this Agreement, You hereby grant to Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except
+as stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Contribution, where such license applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contribution alone or by combination of Your Contribution with the project to
+which it was Submitted. If any entity institutes patent litigation against You or
+any other entity alleging that Your Contribution, or the project it was Submitted
+to, constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this Agreement for that Contribution or
+project shall terminate as of the date such litigation is filed. Any commercial or
+proprietary sublicenses We grant under Section 2 inherit this patent license,
+subject to the same defensive-termination provision.
 
 ## 4. Representations
 
@@ -59,7 +82,10 @@ Corporate CLA with Us.
 You represent that each of Your Contributions is Your original creation. You
 represent that Your Contribution submissions include complete details of any
 third-party license or other restriction of which You are personally aware and
-which are associated with any part of Your Contributions.
+which are associated with any part of Your Contributions. You agree to clearly
+mark any third-party code or assets included in Your Contribution with their
+original licensing terms and copyright notices, in accordance with the project's
+formatting guidelines.
 
 ## 5. Disclaimer
 
@@ -71,3 +97,12 @@ for a particular purpose, or non-infringement.
 
 You agree to notify Us of any facts or circumstances of which You become aware
 that would make these representations inaccurate in any respect.
+
+## 7. Governing Law and Jurisdiction
+
+This Agreement is governed by, and construed in accordance with, the laws of
+`[GOVERNING JURISDICTION — owner to choose, e.g. the State of Delaware, USA]`,
+without regard to its conflict-of-laws principles. Any legal action or proceeding
+arising under or in connection with this Agreement shall be brought exclusively in
+the courts located in `[FORUM — city/county and state/country]`, and You consent
+to the personal jurisdiction and venue of those courts.

--- a/docs/cla/ICLA.md
+++ b/docs/cla/ICLA.md
@@ -1,0 +1,73 @@
+# Nimbus Individual Contributor License Agreement ("Agreement")
+
+Thank you for your interest in software projects stewarded by **nimbus-agent**
+("We" or "Us"). This Agreement documents the rights granted by contributors to
+Us. By signing this Agreement (see CONTRIBUTING.md), You accept and agree to the
+following terms for Your present and future Contributions submitted to Us. Except
+for the license granted herein to Us, You reserve all right, title, and interest
+in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") means the individual who Submits a Contribution to Us.
+"Contribution" means any original work of authorship, including any modifications
+or additions to an existing work, that is intentionally Submitted by You to Us for
+inclusion in, or documentation of, any of the projects owned or managed by Us.
+"Submit" means any form of electronic, verbal, or written communication sent to
+Us or our representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and pull requests.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and
+to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+**Relicensing.** You expressly agree that We may license Your Contributions —
+including the right to grant sublicenses through multiple tiers — under **any
+license terms of Our choosing, including terms that differ from the then-current
+license of the project and including proprietary or commercial terms.** This
+right is granted to preserve Our ability to offer the software under more than one
+license (dual licensing). This paragraph does not obligate Us to relicense.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and
+to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Contribution, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution alone or by
+combination of Your Contribution with the project to which it was Submitted. If
+any entity institutes patent litigation against You or any other entity alleging
+that Your Contribution, or the project it was Submitted to, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution or project shall terminate as of the
+date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above licenses. If Your
+employer(s) has rights to intellectual property that You create that includes Your
+Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to Us, or that Your employer has executed a separate
+Corporate CLA with Us.
+
+You represent that each of Your Contributions is Your original creation. You
+represent that Your Contribution submissions include complete details of any
+third-party license or other restriction of which You are personally aware and
+which are associated with any part of Your Contributions.
+
+## 5. Disclaimer
+
+Your Contributions are provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+implied, including, without limitation, any warranties of merchantability, fitness
+for a particular purpose, or non-infringement.
+
+## 6. Notice
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.

--- a/docs/cla/README.md
+++ b/docs/cla/README.md
@@ -31,8 +31,8 @@ To bump it (materially changed text → re-require signatures):
    Nimbus repo under `docs/cla/`; `.github/CLA/` is the *deployed* copy — edit
    `docs/cla/` and redeploy, don't diverge them.
 2. In **one** coordinated change, bump `version1` → `version2` in the `cla.yml`
-   of **all 7** gated repos.
-3. `audit:cla-coverage` asserts the version matches across all 7 — a partial bump
+   of **all 6** gated repos.
+3. `audit:cla-coverage` asserts the version matches across all 6 — a partial bump
    goes red.
 
 Never bump one repo at a time: a contributor would be blocked on a bumped repo

--- a/docs/cla/README.md
+++ b/docs/cla/README.md
@@ -27,7 +27,9 @@ MIT → AGPL one-way rule.
 The CLA text version lives in `path-to-signatures` (`signatures/version1/...`).
 To bump it (materially changed text → re-require signatures):
 
-1. Update the CLA doc(s) in `.github/CLA/`.
+1. Update the CLA doc(s). **Source of truth:** the canonical drafts live in the
+   Nimbus repo under `docs/cla/`; `.github/CLA/` is the *deployed* copy — edit
+   `docs/cla/` and redeploy, don't diverge them.
 2. In **one** coordinated change, bump `version1` → `version2` in the `cla.yml`
    of **all 7** gated repos.
 3. `audit:cla-coverage` asserts the version matches across all 7 — a partial bump

--- a/docs/cla/README.md
+++ b/docs/cla/README.md
@@ -1,0 +1,37 @@
+# Nimbus CLA
+
+Contributions to Nimbus's public repos require a signed CLA — a one-time,
+sign-by-comment step enforced by a required status check.
+
+## Signing
+
+On your first pull request the CLA bot comments asking you to sign. Reply with
+exactly:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded once and covers **all** Nimbus public repos.
+Contributing on behalf of an employer? Your employer signs the
+[Corporate CLA](./CCLA.md) and lists you in its Schedule A.
+
+- [Individual CLA](./ICLA.md) · [Corporate CLA](./CCLA.md)
+
+## Why a CLA (not a DCO)
+
+The CLA grants a broad, relicensable license so the AGPL-3.0 core can be offered
+under more than one license in future. See `docs/CONTRIBUTING.md` for the
+MIT → AGPL one-way rule.
+
+## Version-bump SOP (maintainers)
+
+The CLA text version lives in `path-to-signatures` (`signatures/version1/...`).
+To bump it (materially changed text → re-require signatures):
+
+1. Update the CLA doc(s) in `.github/CLA/`.
+2. In **one** coordinated change, bump `version1` → `version2` in the `cla.yml`
+   of **all 7** gated repos.
+3. `audit:cla-coverage` asserts the version matches across all 7 — a partial bump
+   goes red.
+
+Never bump one repo at a time: a contributor would be blocked on a bumped repo
+while allowed on a not-yet-bumped one.

--- a/docs/cla/cla.yml
+++ b/docs/cla/cla.yml
@@ -29,7 +29,7 @@ jobs:
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CLA_BOT_APP_ID }}
+          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: ${{ github.event.repository.name }},.github
@@ -43,6 +43,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           remote-repository-name: '.github'
           branch: 'cla-signatures'
-          allowlist: 'bot*,AsafGolombek'
+          allowlist: 'bot*,asafgolombek,claude'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-notsigned-prcomment: 'Thanks for your PR. Before it can be merged, please sign the [Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md) by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**. Contributing on behalf of an employer? See the [Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).'

--- a/docs/cla/cla.yml
+++ b/docs/cla/cla.yml
@@ -1,0 +1,48 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Only run on the sign/recheck comment or on a PR event — never on other comments.
+    if: >-
+      (github.event.issue.pull_request && contains(fromJSON('["I have read the CLA Document and I hereby sign the CLA","recheck"]'), github.event.comment.body))
+      || github.event_name == 'pull_request_target'
+    steps:
+      - name: Mint CLA App token
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: ${{ github.event.repository.name }},.github
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.apptoken.outputs.token }}
+        with:
+          path-to-document: 'https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md'
+          path-to-signatures: 'signatures/version1/cla.json'
+          remote-repository-name: '.github'
+          branch: 'cla-signatures'
+          allowlist: 'bot*,AsafGolombek'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: 'Thanks for your PR. Before it can be merged, please sign the [Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md) by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**. Contributing on behalf of an employer? See the [Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).'

--- a/docs/cla/cla.yml
+++ b/docs/cla/cla.yml
@@ -29,7 +29,7 @@ jobs:
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
+          app-id: ${{ secrets.CLA_BOT_APP_ID }}
           private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: ${{ github.event.repository.name }},.github

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -142,7 +142,11 @@ moves to P6).
   make the `CLA Assistant` check required in each ruleset; **red-prove** with a
   test PR; confirm `cla-coverage` green.
 - **Deferred:** CCLA employee-roster automation; private repos; retroactive
-  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`.
+  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`. Robustness
+  follow-up: `check-cla-coverage` treats any per-repo `gh` failure as "cla.yml
+  absent" (a public-repo 404 is genuine, but a transient 5xx/rate-limit would
+  false-red until the next run) — surface the `gh` exit code in `_gh-audit.ts`
+  and treat a non-404 failure as indeterminate, like `team-reachability`.
 
 ---
 

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -130,6 +130,20 @@ moves to P6).
   (the CI App token cannot read `bypass_actors`; a future owner-`gh`-run check,
   no PAT). Private-repo ruleset protection stays **blocked-on-Team** (Free plan).
 
+### CLA progress log
+
+- **Delivered (config + gate):** broad-relicensable ICLA + CCLA drafted
+  (`docs/cla/`, pending ratification), the reusable `cla.yml` template, the
+  `cla-coverage` drift gate (all 7 public repos have `cla.yml` at one version),
+  and `CONTRIBUTING.md` terms.
+- **Pending apply (org-owner):** ratify the CLA wording; create the dedicated CLA
+  App + `SELECTED` private-key secret; create the `.github` `cla-signatures`
+  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 7 repos;
+  make the `CLA Assistant` check required in each ruleset; **red-prove** with a
+  test PR; confirm `cla-coverage` green.
+- **Deferred:** CCLA employee-roster automation; private repos; retroactive
+  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`.
+
 ---
 
 ## How to update this document

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -134,11 +134,11 @@ moves to P6).
 
 - **Delivered (config + gate):** broad-relicensable ICLA + CCLA drafted
   (`docs/cla/`, pending ratification), the reusable `cla.yml` template, the
-  `cla-coverage` drift gate (all 7 public repos have `cla.yml` at one version),
+  `cla-coverage` drift gate (all 6 public repos have `cla.yml` at one version),
   and `CONTRIBUTING.md` terms.
 - **Pending apply (org-owner):** ratify the CLA wording; create the dedicated CLA
   App + `SELECTED` private-key secret; create the `.github` `cla-signatures`
-  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 7 repos;
+  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 6 repos;
   make the `CLA Assistant` check required in each ruleset; **red-prove** with a
   test PR; confirm `cla-coverage` green.
 - **Deferred:** CCLA employee-roster automation; private repos; retroactive

--- a/docs/superpowers/plans/2026-07-24-cla-review.md
+++ b/docs/superpowers/plans/2026-07-24-cla-review.md
@@ -1,0 +1,46 @@
+# Plan Review: CLA Implementation Plan
+
+This document reviews [2026-07-24-cla.md](./2026-07-24-cla.md) and notes questions, suggestions, and improvements for the implementation steps.
+
+---
+
+## 1. Base64 Whitespace Cleaning vs. Decoded YAML Integrity
+
+### Clarification on Base64 Sanitization
+
+- **Observation:** In the `check-cla-coverage.ts` script, the base64 string is cleaned of whitespace *before* decoding:
+
+  ```typescript
+  const yaml = Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8");
+  ```
+
+- **Analysis:** This is correct and safe, as it strips newlines and spacing from the base64 envelope (which GitHub's API includes in its JSON response) without affecting the internal formatting of the decoded YAML string.
+- **Recommendation:** Keep this syntax as is, but add a brief code comment explaining that the replacement targets the base64 format itself, not the decoded YAML document, to prevent future developers from mistakenly refactoring it.
+
+---
+
+## 2. GitHub CLI `gh` and Git Credentials in Phase 2
+
+### Dependency on Github CLI (`gh`)
+
+- **Observation:** Tasks 6, 8, and 9 rely on the `gh` command (e.g., `gh api`, `gh pr create`) for creating rulesets and deploying files.
+- **Suggestion:** Add a check in Phase 2's starting steps to ensure the operator's local `gh` is authenticated (`gh auth status`) and that they have administrative/write permission for the `nimbus-agent` organization. Include instructions for a manual workaround (using the GitHub web UI) if `gh` CLI execution fails or is missing.
+
+---
+
+## 3. Scope of `.github` in `cla-coverage` Job
+
+### Gated Repositories list
+
+- **Observation:** The `.github` repository is installed with the CLA App (Task 6) and holds the signature store branch, but it is not listed in `GATED_REPOS` in the `check-cla-coverage.ts` script.
+- **Analysis:** This is correct, as `.github` contains organization-wide community health files and documentation rather than active project code contributions, meaning it does not need a PR gate workflow.
+- **Recommendation:** No change required.
+
+---
+
+## 4. Status Check Context Name Verification
+
+### Status Check Context Configuration
+
+- **Observation:** The plan mentions adding the `CLA Assistant` check to the ruleset after first observing the context published by the action.
+- **Suggestion:** To make this process deterministic and avoid trial-and-error, verify if the `contributor-assistant/github-action` allows specifying a custom status check context name via inputs (e.g., `context-name`), or explicitly document the default context name in the plan.

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -762,6 +762,17 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 
 ### Task 9: Required checks + red-prove + live-prove
 
+> **Recon (2026-07-24), grounding the ruleset step.** All 6 repos are on `main`.
+> Five have a `General` ruleset to attach the check to — `Nimbus` `14784377`,
+> `nimbus-sdk` `19006372`, `nimbus-client` `19635616`, `nimbus-vscode` `17993993`,
+> `nimbus-web-clipper` `18029432`. **`awesome-nimbus` has NO ruleset** — create a
+> minimal `General` ruleset there first (the P1 pattern used for `nimbus-client`),
+> then add the CLA check. Re-read the live ids at apply time in case they drifted.
+
+- [ ] **`awesome-nimbus`:** create a `General` branch ruleset (squash-only,
+  thread-resolution, 0 approvals — the org-standard shape from
+  `.github/rulesets/general-branch.json`) so there is a ruleset to attach the CLA
+  required check to. The other 5 already have one.
 - [ ] Determine the exact status-check **context** deterministically. The action
   exposes **no** `context-name` input; it emits a commit status named after its
   step (`CLA Assistant`). Confirm the literal string from the red-prove PR's head

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -1,0 +1,791 @@
+# CLA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up an org-wide Contributor License Agreement — a broad
+relicensable ICLA + CCLA, a self-hosted `contributor-assistant` gate on all 7
+public contribution repos, a shared signature store, and a `cla-coverage` drift
+gate — so no outside contribution merges without a signed, relicensing-capable
+grant.
+
+**Architecture:** The only Nimbus-repo *software* is the `cla-coverage` drift
+gate (same `scripts/structure-audit/` shape as P6a). Everything else is
+**authored artifacts** (ICLA/CCLA text, the `cla.yml` template, CONTRIBUTING
+text — drafted in `docs/cla/` for review, then deployed) and **org-owner
+apply-time config** (the `.github` repo, 6 satellite repos, a dedicated CLA App,
+7 rulesets). Design of record:
+[`docs/superpowers/specs/2026-07-24-cla-design.md`](../specs/2026-07-24-cla-design.md).
+
+**Tech Stack:** Markdown/legal text, GitHub Actions, `contributor-assistant/github-action`, Bun v1.2+ / TypeScript (the coverage gate), `gh` CLI.
+
+## Global Constraints
+
+- **Legal text is draft-for-ratification** — Tasks 1 authors from standard
+  templates; it must not be deployed (Phase 2) until the owner/counsel approves
+  the wording, especially the relicensing clause.
+- **No `any`; TypeScript strict + `noPropertyAccessFromIndexSignature`** — for the
+  coverage gate (external data `unknown`, bracket access for index signatures).
+- **Never commit on `main`** — work on `dev/asafgolombek/cla` in the worktree at
+  `.claude/worktrees/org-infra-program`. Read/Edit via the **worktree absolute
+  path**; a main-repo path silently edits main.
+- **SHA-pinned actions** — every `uses:` needs a full 40-hex SHA;
+  `audit:action-sha-pins` enforces it.
+- **No stored PAT** — the store-write token is a minted App installation token;
+  the App private-key org secret is `SELECTED`-scoped to the 7 gated repos.
+- **`pull_request_target` never runs PR code** — the `cla.yml` never checks out
+  `head.sha`/`.ref` and never runs `npm`/`bun`/`make`.
+- **CI-only gate** — `audit:cla-coverage` needs network + App auth → `CI_ONLY_GATES`, not the fast tier.
+- **Conventional Commits.** **Verify before claiming done** — run the command, read the output.
+
+## The 7 gated repos
+
+`Nimbus`, `nimbus-sdk`, `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`, `nimbus-recipes`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `docs/cla/ICLA.md` (create) | Individual CLA draft (broad relicensable grant) — reviewable source, deployed to `.github/CLA/` |
+| `docs/cla/CCLA.md` (create) | Corporate CLA draft + Schedule A |
+| `docs/cla/cla.yml` (create) | The reusable workflow template deployed verbatim to all 7 repos |
+| `docs/cla/README.md` (create) | Sign-flow, ICLA-vs-CCLA, version-bump SOP |
+| `docs/CONTRIBUTING.md` (modify) | CLA flow + MIT→AGPL one-way rule |
+| `scripts/structure-audit/check-cla-coverage.ts` (create) | Pure diff + CLI: all 7 repos have `cla.yml` + matching version |
+| `scripts/structure-audit/check-cla-coverage.test.ts` (create) | Unit tests |
+| `.github/workflows/org-drift-sweep.yml` (modify) | Add the `cla-coverage` job |
+| `package.json` (modify) | Register `audit:cla-coverage` |
+| `scripts/lib/preflight-gates.ts` (modify) | Add to `CI_ONLY_GATES` |
+| `docs/infrastructure-roadmap.md` (modify) | Record CLA delivered + deferrals |
+
+Phase 2 (org-owner apply) touches the `.github` repo, the 6 satellite repos, a dedicated CLA App, and 7 rulesets — no Nimbus files.
+
+---
+
+## Phase 1 — Author the artifacts (Nimbus repo, reviewable)
+
+### Task 1: Draft ICLA.md + CCLA.md
+
+**Files:** Create `docs/cla/ICLA.md`, `docs/cla/CCLA.md`
+
+**Interfaces:** Consumes nothing. Produces the two documents Phase 2 deploys to `.github/CLA/` and the `cla.yml` links to.
+
+> **BLOCKED ON RATIFICATION.** This task drafts from the Apache ICLA with a
+> relicensing modification. **Do not deploy until the owner/counsel approves the
+> wording.** The relicensing clause is the legally-sensitive part.
+
+- [ ] **Step 1: Write `docs/cla/ICLA.md`**
+
+Create `docs/cla/ICLA.md` with this draft (Apache ICLA v2 structure; the **License
+grant** paragraph is modified to add the relicensing right — marked):
+
+````markdown
+# Nimbus Individual Contributor License Agreement ("Agreement")
+
+Thank you for your interest in software projects stewarded by **nimbus-agent**
+("We" or "Us"). This Agreement documents the rights granted by contributors to
+Us. By signing this Agreement (see CONTRIBUTING.md), You accept and agree to the
+following terms for Your present and future Contributions submitted to Us. Except
+for the license granted herein to Us, You reserve all right, title, and interest
+in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") means the individual who Submits a Contribution to Us.
+"Contribution" means any original work of authorship, including any modifications
+or additions to an existing work, that is intentionally Submitted by You to Us for
+inclusion in, or documentation of, any of the projects owned or managed by Us.
+"Submit" means any form of electronic, verbal, or written communication sent to
+Us or our representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and pull requests.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and
+to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
+derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+**Relicensing.** You expressly agree that We may license Your Contributions —
+including the right to grant sublicenses through multiple tiers — under **any
+license terms of Our choosing, including terms that differ from the then-current
+license of the project and including proprietary or commercial terms.** This
+right is granted to preserve Our ability to offer the software under more than one
+license (dual licensing). This paragraph does not obligate Us to relicense.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and
+to recipients of software distributed by Us a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Contribution, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution alone or by
+combination of Your Contribution with the project to which it was Submitted. If
+any entity institutes patent litigation against You or any other entity alleging
+that Your Contribution, or the project it was Submitted to, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution or project shall terminate as of the
+date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above licenses. If Your
+employer(s) has rights to intellectual property that You create that includes Your
+Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to Us, or that Your employer has executed a separate
+Corporate CLA with Us.
+
+You represent that each of Your Contributions is Your original creation. You
+represent that Your Contribution submissions include complete details of any
+third-party license or other restriction of which You are personally aware and
+which are associated with any part of Your Contributions.
+
+## 5. Disclaimer
+
+Your Contributions are provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+implied, including, without limitation, any warranties of merchantability, fitness
+for a particular purpose, or non-infringement.
+
+## 6. Notice
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.
+````
+
+- [ ] **Step 2: Write `docs/cla/CCLA.md`**
+
+Create `docs/cla/CCLA.md` (same grant made by an entity + Schedule A):
+
+````markdown
+# Nimbus Corporate Contributor License Agreement ("Agreement")
+
+Thank you for your interest in software projects stewarded by **nimbus-agent**
+("We" or "Us"). This Agreement documents the rights granted by contributing
+Corporations to Us. By signing this Agreement, the Corporation accepts and agrees
+to the following terms for its present and future Contributions Submitted to Us.
+
+## 1. Definitions
+
+"Corporation" (or "You") means the legal entity Submitting Contributions and all
+other entities that control, are controlled by, or are under common control with
+that entity. "Contribution", "Submit", and other capitalized terms carry the same
+meaning as in the Nimbus Individual CLA.
+
+## 2. Grant of Copyright License
+
+The Corporation grants to Us and to recipients of software distributed by Us the
+same perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license — including the sublicense and **relicensing** right stated in
+Section 2 of the Nimbus Individual CLA (the right to license Contributions under
+any terms, including proprietary or commercial terms, to preserve dual
+licensing) — for Contributions Submitted by the Corporation's Designated
+Employees.
+
+## 3. Grant of Patent License
+
+The Corporation grants the patent license stated in Section 3 of the Nimbus
+Individual CLA for Contributions Submitted by its Designated Employees.
+
+## 4. Designated Employees
+
+The Corporation's Contributions are made by the employees listed in **Schedule A**.
+The Corporation may update Schedule A by Submitting a revised list. The Corporation
+represents that it is legally entitled to grant the above licenses and that each
+Designated Employee is authorized to Submit Contributions on its behalf.
+
+## 5. Disclaimer
+
+Contributions are provided "AS IS", WITHOUT WARRANTY OF ANY KIND, as stated in
+Section 5 of the Nimbus Individual CLA.
+
+## 6. Point of Contact
+
+The Corporation designates a point of contact for CLA administration:
+`__________________________`.
+
+---
+
+## Schedule A — Designated Employees
+
+| GitHub username | Full name |
+| --- | --- |
+| | |
+````
+
+- [ ] **Step 2b: Lint**
+
+Run: `bun run lint:markdown`
+Expected: `Summary: 0 error(s)` (run `bunx markdownlint-cli2 --fix docs/cla/ICLA.md docs/cla/CCLA.md` if it flags formatting, then re-check).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/cla/ICLA.md docs/cla/CCLA.md
+git commit -m "docs(cla): draft ICLA + CCLA (broad relicensable grant) — for ratification
+
+Apache-ICLA-derived, with the copyright-grant modified to add an explicit
+relicensing right (license under any terms, incl. proprietary) to preserve
+dual-licensing. DRAFT: not to be deployed until owner/counsel ratifies the
+wording, especially the relicensing clause."
+```
+
+---
+
+### Task 2: The `cla.yml` workflow template + `docs/cla/README.md`
+
+**Files:** Create `docs/cla/cla.yml`, `docs/cla/README.md`
+
+**Interfaces:** Consumes the ICLA/CCLA (Task 1) by URL. Produces the file deployed verbatim to all 7 repos and the version string the coverage gate (Task 4) reads.
+
+- [ ] **Step 1: Resolve the pinned action SHA**
+
+Run: `gh api repos/contributor-assistant/github-action/git/ref/tags/v1 --jq '.object.sha'`
+(If `v1` is a lightweight tag pointing straight at a commit, that SHA is the pin; if it is an annotated tag, run `gh api repos/contributor-assistant/github-action/git/tags/<sha> --jq '.object.sha'` to dereference. Record the resulting 40-hex commit SHA as `<CLA_ACTION_SHA>` and the matching `# vX.Y.Z` comment.)
+
+- [ ] **Step 2: Write `docs/cla/cla.yml`**
+
+Create `docs/cla/cla.yml` (deploy this verbatim to every repo; `<CLA_ACTION_SHA>` and the checkout/app-token SHAs are the org's existing pins):
+
+```yaml
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Only run on the sign/recheck comment or on a PR event — never on other comments.
+    if: >-
+      (github.event.issue.pull_request && contains(fromJSON('["I have read the CLA Document and I hereby sign the CLA","recheck"]'), github.event.comment.body))
+      || github.event_name == 'pull_request_target'
+    steps:
+      - name: Mint CLA App token
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: ${{ github.event.repository.name }},.github
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@<CLA_ACTION_SHA> # <CLA_ACTION_VERSION>
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.apptoken.outputs.token }}
+        with:
+          path-to-document: 'https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md'
+          path-to-signatures: 'signatures/version1/cla.json'
+          remote-repository-name: '.github'
+          branch: 'cla-signatures'
+          allowlist: 'bot*,AsafGolombek'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: 'Thanks for your PR. Before it can be merged, please sign the [Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md) by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**. Contributing on behalf of an employer? See the [Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).'
+```
+
+**Notes:** the workflow never checks out the PR head and runs no scripts (invariant). The token is minted per-run scoped to the PR repo + `.github`. `allowlist: bot*` covers every bot; `AsafGolombek` is the owner.
+
+- [ ] **Step 3: Write `docs/cla/README.md` (sign flow + SOP)**
+
+Create `docs/cla/README.md`:
+
+```markdown
+# Nimbus CLA
+
+Contributions to Nimbus's public repos require a signed CLA — a one-time,
+sign-by-comment step enforced by a required status check.
+
+## Signing
+
+On your first pull request the CLA bot comments asking you to sign. Reply with
+exactly:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded once and covers **all** Nimbus public repos.
+Contributing on behalf of an employer? Your employer signs the
+[Corporate CLA](./CCLA.md) and lists you in its Schedule A.
+
+- [Individual CLA](./ICLA.md) · [Corporate CLA](./CCLA.md)
+
+## Why a CLA (not a DCO)
+
+The CLA grants a broad, relicensable license so the AGPL-3.0 core can be offered
+under more than one license in future. See `docs/CONTRIBUTING.md` for the
+MIT → AGPL one-way rule.
+
+## Version-bump SOP (maintainers)
+
+The CLA text version lives in `path-to-signatures` (`signatures/version1/...`).
+To bump it (materially changed text → re-require signatures):
+
+1. Update the CLA doc(s) in `.github/CLA/`.
+2. In **one** coordinated change, bump `version1` → `version2` in the `cla.yml`
+   of **all 7** gated repos.
+3. `audit:cla-coverage` asserts the version matches across all 7 — a partial bump
+   goes red.
+
+Never bump one repo at a time: a contributor would be blocked on a bumped repo
+while allowed on a not-yet-bumped one.
+```
+
+- [ ] **Step 4: Verify pins + lint**
+
+Run: `bun run audit:action-sha-pins`
+Expected: `OK`. (The audit scans `.github/workflows/`; `docs/cla/cla.yml` is not under it yet, so also eyeball that every `uses:` in `docs/cla/cla.yml` has a 40-hex SHA + version comment.)
+
+Run: `bun run lint:markdown`
+Expected: `0 error(s)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/cla/cla.yml docs/cla/README.md
+git commit -m "docs(cla): reusable cla.yml workflow template + sign-flow/SOP readme
+
+contributor-assistant gated by the shared .github signature store; per-run
+minted App token (no PAT); pull_request_target never runs PR code; allowlist
+bot*+owner; version-bump SOP. Deployed verbatim to all 7 repos in Phase 2."
+```
+
+---
+
+### Task 3: Update `docs/CONTRIBUTING.md`
+
+**Files:** Modify `docs/CONTRIBUTING.md`
+
+**Interfaces:** Consumes nothing. Produces the contributor-facing CLA explanation.
+
+- [ ] **Step 1: Append the CLA section**
+
+Add to `docs/CONTRIBUTING.md` (before the `## Questions` section):
+
+````markdown
+## Contributor License Agreement (CLA)
+
+Before your first pull request to a Nimbus public repo can merge, you must sign
+the CLA — a one-time, sign-by-comment step enforced by a required `CLA Assistant`
+check. The bot will prompt you; reply with exactly:
+
+```text
+I have read the CLA Document and I hereby sign the CLA
+```
+
+One signature covers all Nimbus public repos. See the
+[Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md);
+contributing for an employer uses the
+[Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).
+
+**Why a CLA.** It grants a broad, relicensable license so the AGPL-3.0 core can
+be offered under more than one license in future — something a DCO cannot do.
+
+**MIT → AGPL is one-way.** The gateway/CLI/connectors are AGPL-3.0; `@nimbus-dev/sdk`
+and `@nimbus-dev/client` are MIT. Code may flow **MIT → AGPL** but never the
+reverse: a patch to the MIT packages must not be derived from AGPL-licensed parts
+of this repository. If unsure which side your change sits on, ask in the PR.
+````
+
+- [ ] **Step 2: Lint + link-check + commit**
+
+Run: `bun run lint:markdown` → `0 error(s)`.
+Run: `bun run audit:doc-refs` → resolves.
+
+```bash
+git add docs/CONTRIBUTING.md
+git commit -m "docs(cla): CONTRIBUTING — CLA sign flow + MIT->AGPL one-way rule"
+```
+
+---
+
+### Task 4: The `cla-coverage` drift gate (TDD)
+
+**Files:** Create `scripts/structure-audit/check-cla-coverage.ts`, `scripts/structure-audit/check-cla-coverage.test.ts`; modify `package.json`, `scripts/lib/preflight-gates.ts`, `.github/workflows/org-drift-sweep.yml`
+
+**Interfaces:**
+
+- Consumes `runGh`, `isStrict`, `strictSkip`, `isRecord` from `scripts/structure-audit/_gh-audit.ts` (from P6a).
+- Produces `diffClaCoverage(repos: string[], live: Record<string, string | null>): AuditResult` — pure: given the 7 repo names and each repo's observed `cla.yml` signature-version (or `null` if the workflow is absent), flags any repo missing the workflow and any repo whose version differs from the majority/first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/structure-audit/check-cla-coverage.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+
+import { diffClaCoverage } from "./check-cla-coverage.ts";
+
+const REPOS = ["Nimbus", "nimbus-sdk", "nimbus-client"];
+
+describe("diffClaCoverage", () => {
+  test("passes when all repos have cla.yml at the same version", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version1",
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("flags a repo missing cla.yml", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": null,
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("nimbus-sdk");
+    expect(r.errors.join("\n")).toContain("no cla.yml");
+  });
+
+  test("flags a version mismatch across repos", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version2",
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("version");
+    expect(r.errors.join("\n")).toContain("nimbus-sdk");
+  });
+
+  test("flags a repo whose cla.yml has no recognizable version", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version1",
+      "nimbus-client": "",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("nimbus-client");
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test scripts/structure-audit/check-cla-coverage.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the gate**
+
+Create `scripts/structure-audit/check-cla-coverage.ts`:
+
+```typescript
+#!/usr/bin/env bun
+
+/**
+ * audit:cla-coverage — asserts every gated public repo has `.github/workflows/cla.yml`
+ * AND that its CLA signature-version string is identical across all of them, so a
+ * missing workflow or a partial version bump goes red. Same fail-soft-local /
+ * strict-in-CI contract as the other org-drift-sweep gates.
+ */
+
+import { isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+const GATED_REPOS = [
+  "Nimbus",
+  "nimbus-sdk",
+  "nimbus-client",
+  "nimbus-vscode",
+  "nimbus-web-clipper",
+  "awesome-nimbus",
+  "nimbus-recipes",
+];
+
+/**
+ * Pure diff. `live[repo]` is the repo's observed CLA signature-version
+ * (e.g. "version1"), "" if a cla.yml exists but no version could be parsed, or
+ * `null` if cla.yml is absent. Flags absent workflows, unparseable versions, and
+ * any version differing from the first repo's.
+ */
+export function diffClaCoverage(
+  repos: string[],
+  live: Record<string, string | null>,
+): AuditResult {
+  const errors: string[] = [];
+  let expected: string | undefined;
+  for (const repo of repos) {
+    const v = live[repo];
+    if (v === null || v === undefined) {
+      errors.push(`${repo}: no cla.yml workflow`);
+      continue;
+    }
+    if (v === "") {
+      errors.push(`${repo}: cla.yml has no parseable signature version`);
+      continue;
+    }
+    if (expected === undefined) expected = v;
+    else if (v !== expected) {
+      errors.push(`${repo}: cla version ${v} != ${expected} (partial bump?)`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/** Extract the `version<N>` segment from a `path-to-signatures` line in cla.yml. */
+function parseVersion(yaml: string): string {
+  const m = yaml.match(/path-to-signatures:\s*['"]?signatures\/(version\d+)\//);
+  return m?.[1] ?? "";
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:cla-coverage";
+  const live: Record<string, string | null> = {};
+  let anyRead = false;
+
+  for (const repo of GATED_REPOS) {
+    const res = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/contents/.github/workflows/cla.yml`,
+      "--jq",
+      ".content",
+    ]);
+    if (!res.ok) {
+      // gh failed. A genuinely-absent file returns a non-zero gh (404) — but so
+      // does an auth failure, so we cannot tell them apart here. Treat the whole
+      // run as unauthenticated unless at least one repo read succeeds.
+      live[repo] = null;
+      continue;
+    }
+    anyRead = true;
+    const yaml = Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8");
+    live[repo] = parseVersion(yaml);
+  }
+
+  if (!anyRead) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const result = diffClaCoverage(GATED_REPOS, live);
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+  console.log(`${label}: OK (${GATED_REPOS.length} repos)`);
+}
+```
+
+**Note on the 404-vs-auth ambiguity:** a `gh` 404 (file absent) and an auth
+failure both surface as `!res.ok`. We only `strictSkip` when **no** repo read
+succeeded (`anyRead === false`); if at least one repo's `cla.yml` read OK, a
+`!res.ok` on another repo is treated as genuinely-missing (a real finding). This
+mirrors ruleset-drift's `queried === 0` distinction.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test scripts/structure-audit/check-cla-coverage.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Register the gate**
+
+In `package.json`, after `audit:team-reachability`, add:
+
+```json
+    "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
+```
+
+In `scripts/lib/preflight-gates.ts`, add to `CI_ONLY_GATES`:
+
+```typescript
+  "audit:cla-coverage", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+```
+
+- [ ] **Step 6: Add the sweep job**
+
+In `.github/workflows/org-drift-sweep.yml`, add after `team-reachability` (App token needs only `contents: read` to read the workflow files; mint minimal):
+
+```yaml
+  cla-coverage:
+    name: cla-coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Mint App token
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus,nimbus-recipes
+          # cla-coverage reads .github/workflows/cla.yml from each gated repo — contents:read.
+          permission-contents: read
+      - name: Audit CLA coverage
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
+        run: bun scripts/structure-audit/check-cla-coverage.ts --strict
+```
+
+- [ ] **Step 7: Verify + commit**
+
+Run: `bun test scripts/structure-audit/check-cla-coverage.test.ts scripts/lib/preflight-gates.test.ts`
+Expected: PASS.
+
+Run: `bunx tsc --noEmit -p scripts/tsconfig.json` → clean.
+Run: `bunx biome check scripts/structure-audit` → clean.
+Run: `bun run audit:action-sha-pins` → OK.
+Run: `bun run audit:cla-coverage`
+Expected: **red** listing all 7 repos as `no cla.yml workflow` (they aren't deployed yet — the expected pre-rollout state, proving the gate detects absence). After Phase 2 deploys `cla.yml`, this flips green.
+
+```bash
+git add scripts/structure-audit/check-cla-coverage.ts scripts/structure-audit/check-cla-coverage.test.ts package.json scripts/lib/preflight-gates.ts .github/workflows/org-drift-sweep.yml
+git commit -m "feat(audit): cla-coverage drift gate — every gated repo has cla.yml at one version"
+```
+
+---
+
+### Task 5: Roadmap update
+
+**Files:** Modify `docs/infrastructure-roadmap.md`
+
+- [ ] **Step 1: Add a CLA progress-log entry**
+
+Under the P6a log (or a new `### CLA progress log`), add:
+
+```markdown
+### CLA progress log
+
+- **Delivered (config + gate):** broad-relicensable ICLA + CCLA drafted
+  (`docs/cla/`, pending ratification), the reusable `cla.yml` template, the
+  `cla-coverage` drift gate (all 7 public repos have `cla.yml` at one version),
+  and `CONTRIBUTING.md` terms.
+- **Pending apply (org-owner):** ratify the CLA wording; create the dedicated CLA
+  App + `SELECTED` private-key secret; create the `.github` `cla-signatures`
+  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 7 repos;
+  make the `CLA Assistant` check required in each ruleset; **red-prove** with a
+  test PR; confirm `cla-coverage` green.
+- **Deferred:** CCLA employee-roster automation; private repos; retroactive
+  signatures. See `docs/superpowers/specs/2026-07-24-cla-design.md`.
+```
+
+- [ ] **Step 2: Lint + doc-refs + commit**
+
+Run: `bun run lint:markdown` → 0; `bun run audit:doc-refs` → resolves.
+
+```bash
+git add docs/infrastructure-roadmap.md
+git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
+```
+
+---
+
+## Phase 2 — Apply / rollout (org-owner; cross-repo; coordinate with the owner)
+
+> These are org-config + cross-repo actions, not Nimbus code. Several `gh api`
+> mutations are blocked by the auto-mode classifier and must be run by the owner
+> (via `!`) or explicitly authorized. **Do not start until the CLA text is
+> ratified (Task 1).**
+
+### Task 6: Dedicated CLA App + secrets
+
+- [ ] Create a dedicated **`nimbus-cla-bot`** GitHub App (org-owned) — cleaner than
+  reusing the release bot (which should not comment on every PR). Repository
+  permissions: **Contents: Read & write** (for the signature store), **Pull
+  requests: Read & write**, **Commit statuses: Read & write**. Install on the 7
+  gated repos **+ `.github`**.
+- [ ] Store `CLA_BOT_CLIENT_ID` + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
+  visibility **`SELECTED`** to exactly the 7 gated repos.
+- [ ] Verify: `gh api orgs/nimbus-agent/installations --jq '.installations[]|select(.app_slug=="nimbus-cla-bot")|.permissions'` shows `contents:write, pull_requests:write, statuses:write`.
+
+### Task 7: `.github` repo — text + signature store
+
+- [ ] Open a PR to `nimbus-agent/.github` adding `CLA/ICLA.md` + `CLA/CCLA.md`
+  (the **ratified** text from Task 1) and an org-default `CONTRIBUTING.md` (Task 3
+  content) for the satellites. Merge.
+- [ ] Create the empty **`cla-signatures`** branch in `.github`
+  (`git switch --orphan cla-signatures` → empty commit → push). Do **not** add
+  branch protection to it.
+
+### Task 8: Deploy `cla.yml` to all 7 repos
+
+- [ ] For each of the 7 repos, open a PR adding `.github/workflows/cla.yml` = the
+  Task 2 template verbatim (Nimbus's copy goes on this branch; the 6 satellites
+  each get their own PR). Confirm each repo's `audit:action-sha-pins` (or manual
+  SHA check) is clean.
+
+### Task 9: Required checks + red-prove + live-prove
+
+- [ ] In each of the 7 repos' `General` ruleset, add `CLA Assistant` to
+  `required_status_checks` (via `gh api .../rulesets/<id>`), pinning the exact
+  context the action publishes (confirm the context name from the first run).
+- [ ] **Red-prove:** from a **second, non-allowlisted** GitHub account, open a
+  trivial PR to `Nimbus`; confirm the `CLA Assistant` check is **red** and the bot
+  comments; sign via the comment; confirm it flips **green** and the signature
+  lands in `.github@cla-signatures`. (If no second account is available, this is
+  the one step that needs the owner to arrange a test contributor.)
+- [ ] **Verify all-authors:** in the same test PR, add a commit with a different
+  `Co-authored-by:`; confirm the gate still requires that author (or record that
+  the action only checks the sender → open a follow-up mitigation).
+- [ ] **Live-prove `cla-coverage`:** `gh workflow run org-drift-sweep.yml --ref main`
+  (post-merge) and confirm the `cla-coverage` job is **green** (all 7 have
+  `cla.yml` at `version1`).
+- [ ] Update `docs/infrastructure-roadmap.md`: CLA proven green (run id), required
+  checks live. Commit.
+
+---
+
+## Verification (Phase 1, before the PR)
+
+- [ ] `bun test scripts/structure-audit/` — incl. `check-cla-coverage.test.ts`
+- [ ] `bun test scripts/lib/preflight-gates.test.ts` — manifest satisfied
+- [ ] `bunx tsc --noEmit -p scripts/tsconfig.json` — clean
+- [ ] `bun run lint:markdown` — 0 errors (incl. `docs/cla/*.md`)
+- [ ] `bun run audit:doc-refs` — resolves
+- [ ] `bun run audit:action-sha-pins` — OK
+- [ ] `bun run audit:cla-coverage` — **red, all 7 "no cla.yml"** (expected pre-rollout — the gate detecting absence)
+- [ ] `~/.cargo/bin/lychee --config lychee.toml 'docs/**/*.md' '*.md'` — whole-branch link total
+
+**Known worktree caveats:** full `preflight` unusable in a worktree; `bun run lint` may report 0 files — use `bunx biome check scripts`. No `packages/` source touched → `coverage-floor` N/A.
+
+---
+
+## Self-review coverage map
+
+| Spec deliverable | Task |
+| --- | --- |
+| ICLA + CCLA (broad relicensable grant) | 1 |
+| `cla.yml` template (pull_request_target-safe, minted token, allowlist) | 2 |
+| CONTRIBUTING + one-way rule | 3 |
+| `cla-coverage` drift gate (presence + version consistency) | 4 |
+| Roadmap record | 5 |
+| CLA App + `SELECTED` secret | 6 |
+| Shared signature store on non-default branch | 7 |
+| Deploy to 7 repos | 8 |
+| Required `CLA Assistant` check + red-prove + all-authors verify + live-prove | 9 |

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -282,7 +282,7 @@ jobs:
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
+          app-id: ${{ secrets.CLA_BOT_APP_ID }}
           private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: ${{ github.event.repository.name }},.github
@@ -740,7 +740,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
   permissions: **Contents: Read & write** (for the signature store), **Pull
   requests: Read & write**, **Commit statuses: Read & write**. Install on the 6
   gated repos **+ `.github`**.
-- [ ] Store `CLA_BOT_CLIENT_ID` + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
+- [ ] Store `CLA_BOT_APP_ID` (App id `4382579`) + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
   visibility **`SELECTED`** to exactly the 6 gated repos.
 - [ ] Verify: `gh api orgs/nimbus-agent/installations --jq '.installations[]|select(.app_slug=="nimbus-cla-bot")|.permissions'` shows `contents:write, pull_requests:write, statuses:write`.
 

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -574,6 +574,9 @@ if (import.meta.main) {
       continue;
     }
     anyRead = true;
+    // `.replace(/\s/g, "")` strips the newlines GitHub inserts into the base64
+    // *envelope* of the contents API response — NOT the decoded YAML. Do not
+    // "simplify" it away: without it, Buffer decoding of the wrapped base64 fails.
     const yaml = Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8");
     live[repo] = parseVersion(yaml);
   }
@@ -713,6 +716,18 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 > (via `!`) or explicitly authorized. **Do not start until the CLA text is
 > ratified (Task 1).**
 
+### Task 5b: Phase-2 preflight (operator environment)
+
+- [ ] Confirm `gh` is authenticated as an org admin:
+  `gh auth status` (logged in) and
+  `gh api orgs/nimbus-agent/memberships/$(gh api user --jq .login) --jq .role`
+  → `admin`. Without admin, the ruleset/App/secret steps below fail.
+- [ ] **UI fallback:** every Phase-2 `gh` action has a web-UI equivalent — App
+  creation + permissions at `github.com/organizations/nimbus-agent/settings/apps`,
+  secrets at `.../settings/secrets/actions`, rulesets per repo under
+  Settings → Rules. If a `gh` call fails or is blocked, do the step in the UI and
+  record it. (Creating the App and granting its permissions is UI-only regardless.)
+
 ### Task 6: Dedicated CLA App + secrets
 
 - [ ] Create a dedicated **`nimbus-cla-bot`** GitHub App (org-owned) — cleaner than
@@ -742,9 +757,15 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 
 ### Task 9: Required checks + red-prove + live-prove
 
-- [ ] In each of the 7 repos' `General` ruleset, add `CLA Assistant` to
-  `required_status_checks` (via `gh api .../rulesets/<id>`), pinning the exact
-  context the action publishes (confirm the context name from the first run).
+- [ ] Determine the exact status-check **context** deterministically. The action
+  exposes **no** `context-name` input; it emits a commit status named after its
+  step (`CLA Assistant`). Confirm the literal string from the red-prove PR's head
+  commit before pinning:
+  `gh api repos/nimbus-agent/Nimbus/commits/<head-sha>/status --jq '.statuses[].context'`
+  — expect `CLA Assistant`. Then add **that exact context** to each of the 7
+  repos' `General` ruleset `required_status_checks` (via `gh api .../rulesets/<id>`).
+  Do this **after** the red-prove below produces the first status, so the pinned
+  context is observed, not guessed.
 - [ ] **Red-prove:** from a **second, non-allowlisted** GitHub account, open a
   trivial PR to `Nimbus`; confirm the `CLA Assistant` check is **red** and the bot
   comments; sign via the comment; confirm it flips **green** and the signature
@@ -789,3 +810,16 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 | Shared signature store on non-default branch | 7 |
 | Deploy to 7 repos | 8 |
 | Required `CLA Assistant` check + red-prove + all-authors verify + live-prove | 9 |
+
+---
+
+## Plan-review dispositions
+
+Responses to [the plan review](./2026-07-24-cla-review.md):
+
+| # | Point | Disposition |
+| --- | --- | --- |
+| 1 | Comment the base64 whitespace strip | **Fixed** — added a comment noting it strips the API base64 *envelope*, not the decoded YAML; "do not simplify" (Task 4). |
+| 2 | `gh` auth/permission preflight + UI fallback | **Fixed** — added Task 5b: `gh auth status` + org-admin check, and a per-action web-UI fallback (App/secrets/rulesets). |
+| 3 | `.github` absent from `GATED_REPOS` | **No change** — correct as-is: `.github` is community-health, no PR gate; it still gets the App + signature store (Tasks 6/7). |
+| 4 | Deterministic status-check context name | **Fixed** — noted the action has no `context-name` input; expected context is `CLA Assistant`, confirmed from the red-prove commit's `/status` before pinning it into the 7 rulesets (Task 9). |

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -282,7 +282,7 @@ jobs:
         id: apptoken
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CLA_BOT_APP_ID }}
+          client-id: ${{ secrets.CLA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
           repositories: ${{ github.event.repository.name }},.github
@@ -296,7 +296,7 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           remote-repository-name: '.github'
           branch: 'cla-signatures'
-          allowlist: 'bot*,AsafGolombek'
+          allowlist: 'bot*,asafgolombek,claude'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-notsigned-prcomment: 'Thanks for your PR. Before it can be merged, please sign the [Individual CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/ICLA.md) by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**. Contributing on behalf of an employer? See the [Corporate CLA](https://github.com/nimbus-agent/.github/blob/main/CLA/CCLA.md).'
 ```
@@ -740,7 +740,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
   permissions: **Contents: Read & write** (for the signature store), **Pull
   requests: Read & write**, **Commit statuses: Read & write**. Install on the 6
   gated repos **+ `.github`**.
-- [ ] Store `CLA_BOT_APP_ID` (App id `4382579`) + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
+- [ ] Store `CLA_BOT_CLIENT_ID` + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
   visibility **`SELECTED`** to exactly the 6 gated repos.
 - [ ] Verify: `gh api orgs/nimbus-agent/installations --jq '.installations[]|select(.app_slug=="nimbus-cla-bot")|.permissions'` shows `contents:write, pull_requests:write, statuses:write`.
 

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -555,9 +555,22 @@ function parseVersion(yaml: string): string {
 if (import.meta.main) {
   const strict = isStrict(process.argv.slice(2), process.env);
   const label = "audit:cla-coverage";
-  const live: Record<string, string | null> = {};
-  let anyRead = false;
 
+  // Reachability probe. The 7 gated repos are PUBLIC, so reading their contents
+  // needs no auth and a per-repo 404 unambiguously means "cla.yml absent" — a
+  // real finding, not an auth question. The only fail-soft case is `gh`/network
+  // being unavailable at all, which this one probe detects. (This is why we do
+  // NOT reuse ruleset-drift's queried===0 heuristic: there, a 404 could mean
+  // unauthorized; here it cannot.)
+  const probe = runGh(["gh", "api", "repos/nimbus-agent/Nimbus", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const live: Record<string, string | null> = {};
   for (const repo of GATED_REPOS) {
     const res = runGh([
       "gh",
@@ -566,26 +579,17 @@ if (import.meta.main) {
       "--jq",
       ".content",
     ]);
+    // Reachability already confirmed by the probe → a failure here is a genuine
+    // 404 (file absent), recorded as `null` and flagged by diffClaCoverage.
     if (!res.ok) {
-      // gh failed. A genuinely-absent file returns a non-zero gh (404) — but so
-      // does an auth failure, so we cannot tell them apart here. Treat the whole
-      // run as unauthenticated unless at least one repo read succeeds.
       live[repo] = null;
       continue;
     }
-    anyRead = true;
     // `.replace(/\s/g, "")` strips the newlines GitHub inserts into the base64
     // *envelope* of the contents API response — NOT the decoded YAML. Do not
     // "simplify" it away: without it, Buffer decoding of the wrapped base64 fails.
     const yaml = Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8");
     live[repo] = parseVersion(yaml);
-  }
-
-  if (!anyRead) {
-    const outcome = strictSkip(label, strict);
-    if (outcome.code === 1) console.error(outcome.message);
-    else console.warn(outcome.message);
-    process.exit(outcome.code);
   }
 
   const result = diffClaCoverage(GATED_REPOS, live);
@@ -597,11 +601,13 @@ if (import.meta.main) {
 }
 ```
 
-**Note on the 404-vs-auth ambiguity:** a `gh` 404 (file absent) and an auth
-failure both surface as `!res.ok`. We only `strictSkip` when **no** repo read
-succeeded (`anyRead === false`); if at least one repo's `cla.yml` read OK, a
-`!res.ok` on another repo is treated as genuinely-missing (a real finding). This
-mirrors ruleset-drift's `queried === 0` distinction.
+**Note — why a probe, not ruleset-drift's `queried===0` heuristic:** for the
+private/admin data ruleset-drift reads, a 404 could mean "unauthorized", so it
+must fail soft when nothing reads. Here the 7 repos are **public**, so a 404 on
+`cla.yml` unambiguously means the file is **absent** (a real finding). The single
+reachability probe (`repos/nimbus-agent/Nimbus`) separates the one true fail-soft
+case — `gh`/network unavailable — from genuine absence, so **all-7-missing
+(pre-rollout) correctly goes red**, not skipped.
 
 - [ ] **Step 4: Run the tests**
 

--- a/docs/superpowers/plans/2026-07-24-cla.md
+++ b/docs/superpowers/plans/2026-07-24-cla.md
@@ -3,7 +3,7 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Stand up an org-wide Contributor License Agreement — a broad
-relicensable ICLA + CCLA, a self-hosted `contributor-assistant` gate on all 7
+relicensable ICLA + CCLA, a self-hosted `contributor-assistant` gate on all 6
 public contribution repos, a shared signature store, and a `cla-coverage` drift
 gate — so no outside contribution merges without a signed, relicensing-capable
 grant.
@@ -13,7 +13,7 @@ gate (same `scripts/structure-audit/` shape as P6a). Everything else is
 **authored artifacts** (ICLA/CCLA text, the `cla.yml` template, CONTRIBUTING
 text — drafted in `docs/cla/` for review, then deployed) and **org-owner
 apply-time config** (the `.github` repo, 6 satellite repos, a dedicated CLA App,
-7 rulesets). Design of record:
+6 rulesets). Design of record:
 [`docs/superpowers/specs/2026-07-24-cla-design.md`](../specs/2026-07-24-cla-design.md).
 
 **Tech Stack:** Markdown/legal text, GitHub Actions, `contributor-assistant/github-action`, Bun v1.2+ / TypeScript (the coverage gate), `gh` CLI.
@@ -31,15 +31,15 @@ apply-time config** (the `.github` repo, 6 satellite repos, a dedicated CLA App,
 - **SHA-pinned actions** — every `uses:` needs a full 40-hex SHA;
   `audit:action-sha-pins` enforces it.
 - **No stored PAT** — the store-write token is a minted App installation token;
-  the App private-key org secret is `SELECTED`-scoped to the 7 gated repos.
+  the App private-key org secret is `SELECTED`-scoped to the 6 gated repos.
 - **`pull_request_target` never runs PR code** — the `cla.yml` never checks out
   `head.sha`/`.ref` and never runs `npm`/`bun`/`make`.
 - **CI-only gate** — `audit:cla-coverage` needs network + App auth → `CI_ONLY_GATES`, not the fast tier.
 - **Conventional Commits.** **Verify before claiming done** — run the command, read the output.
 
-## The 7 gated repos
+## The 6 gated repos
 
-`Nimbus`, `nimbus-sdk`, `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`, `nimbus-recipes`.
+`Nimbus`, `nimbus-sdk`, `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`.
 
 ---
 
@@ -49,17 +49,17 @@ apply-time config** (the `.github` repo, 6 satellite repos, a dedicated CLA App,
 | --- | --- |
 | `docs/cla/ICLA.md` (create) | Individual CLA draft (broad relicensable grant) — reviewable source, deployed to `.github/CLA/` |
 | `docs/cla/CCLA.md` (create) | Corporate CLA draft + Schedule A |
-| `docs/cla/cla.yml` (create) | The reusable workflow template deployed verbatim to all 7 repos |
+| `docs/cla/cla.yml` (create) | The reusable workflow template deployed verbatim to all 6 repos |
 | `docs/cla/README.md` (create) | Sign-flow, ICLA-vs-CCLA, version-bump SOP |
 | `docs/CONTRIBUTING.md` (modify) | CLA flow + MIT→AGPL one-way rule |
-| `scripts/structure-audit/check-cla-coverage.ts` (create) | Pure diff + CLI: all 7 repos have `cla.yml` + matching version |
+| `scripts/structure-audit/check-cla-coverage.ts` (create) | Pure diff + CLI: all 6 repos have `cla.yml` + matching version |
 | `scripts/structure-audit/check-cla-coverage.test.ts` (create) | Unit tests |
 | `.github/workflows/org-drift-sweep.yml` (modify) | Add the `cla-coverage` job |
 | `package.json` (modify) | Register `audit:cla-coverage` |
 | `scripts/lib/preflight-gates.ts` (modify) | Add to `CI_ONLY_GATES` |
 | `docs/infrastructure-roadmap.md` (modify) | Record CLA delivered + deferrals |
 
-Phase 2 (org-owner apply) touches the `.github` repo, the 6 satellite repos, a dedicated CLA App, and 7 rulesets — no Nimbus files.
+Phase 2 (org-owner apply) touches the `.github` repo, the 6 satellite repos, a dedicated CLA App, and 6 rulesets — no Nimbus files.
 
 ---
 
@@ -239,7 +239,7 @@ wording, especially the relicensing clause."
 
 **Files:** Create `docs/cla/cla.yml`, `docs/cla/README.md`
 
-**Interfaces:** Consumes the ICLA/CCLA (Task 1) by URL. Produces the file deployed verbatim to all 7 repos and the version string the coverage gate (Task 4) reads.
+**Interfaces:** Consumes the ICLA/CCLA (Task 1) by URL. Produces the file deployed verbatim to all 6 repos and the version string the coverage gate (Task 4) reads.
 
 - [ ] **Step 1: Resolve the pinned action SHA**
 
@@ -339,8 +339,8 @@ To bump it (materially changed text → re-require signatures):
 
 1. Update the CLA doc(s) in `.github/CLA/`.
 2. In **one** coordinated change, bump `version1` → `version2` in the `cla.yml`
-   of **all 7** gated repos.
-3. `audit:cla-coverage` asserts the version matches across all 7 — a partial bump
+   of **all 6** gated repos.
+3. `audit:cla-coverage` asserts the version matches across all 6 — a partial bump
    goes red.
 
 Never bump one repo at a time: a contributor would be blocked on a bumped repo
@@ -363,7 +363,7 @@ git commit -m "docs(cla): reusable cla.yml workflow template + sign-flow/SOP rea
 
 contributor-assistant gated by the shared .github signature store; per-run
 minted App token (no PAT); pull_request_target never runs PR code; allowlist
-bot*+owner; version-bump SOP. Deployed verbatim to all 7 repos in Phase 2."
+bot*+owner; version-bump SOP. Deployed verbatim to all 6 repos in Phase 2."
 ```
 
 ---
@@ -422,7 +422,7 @@ git commit -m "docs(cla): CONTRIBUTING — CLA sign flow + MIT->AGPL one-way rul
 **Interfaces:**
 
 - Consumes `runGh`, `isStrict`, `strictSkip`, `isRecord` from `scripts/structure-audit/_gh-audit.ts` (from P6a).
-- Produces `diffClaCoverage(repos: string[], live: Record<string, string | null>): AuditResult` — pure: given the 7 repo names and each repo's observed `cla.yml` signature-version (or `null` if the workflow is absent), flags any repo missing the workflow and any repo whose version differs from the majority/first.
+- Produces `diffClaCoverage(repos: string[], live: Record<string, string | null>): AuditResult` — pure: given the 6 repo names and each repo's observed `cla.yml` signature-version (or `null` if the workflow is absent), flags any repo missing the workflow and any repo whose version differs from the majority/first.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -513,7 +513,6 @@ const GATED_REPOS = [
   "nimbus-vscode",
   "nimbus-web-clipper",
   "awesome-nimbus",
-  "nimbus-recipes",
 ];
 
 /**
@@ -556,7 +555,7 @@ if (import.meta.main) {
   const strict = isStrict(process.argv.slice(2), process.env);
   const label = "audit:cla-coverage";
 
-  // Reachability probe. The 7 gated repos are PUBLIC, so reading their contents
+  // Reachability probe. The 6 gated repos are PUBLIC, so reading their contents
   // needs no auth and a per-repo 404 unambiguously means "cla.yml absent" — a
   // real finding, not an auth question. The only fail-soft case is `gh`/network
   // being unavailable at all, which this one probe detects. (This is why we do
@@ -603,10 +602,10 @@ if (import.meta.main) {
 
 **Note — why a probe, not ruleset-drift's `queried===0` heuristic:** for the
 private/admin data ruleset-drift reads, a 404 could mean "unauthorized", so it
-must fail soft when nothing reads. Here the 7 repos are **public**, so a 404 on
+must fail soft when nothing reads. Here the 6 repos are **public**, so a 404 on
 `cla.yml` unambiguously means the file is **absent** (a real finding). The single
 reachability probe (`repos/nimbus-agent/Nimbus`) separates the one true fail-soft
-case — `gh`/network unavailable — from genuine absence, so **all-7-missing
+case — `gh`/network unavailable — from genuine absence, so **all-6-missing
 (pre-rollout) correctly goes red**, not skipped.
 
 - [ ] **Step 4: Run the tests**
@@ -653,7 +652,7 @@ In `.github/workflows/org-drift-sweep.yml`, add after `team-reachability` (App t
           client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
-          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus,nimbus-recipes
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus
           # cla-coverage reads .github/workflows/cla.yml from each gated repo — contents:read.
           permission-contents: read
       - name: Audit CLA coverage
@@ -671,7 +670,7 @@ Run: `bunx tsc --noEmit -p scripts/tsconfig.json` → clean.
 Run: `bunx biome check scripts/structure-audit` → clean.
 Run: `bun run audit:action-sha-pins` → OK.
 Run: `bun run audit:cla-coverage`
-Expected: **red** listing all 7 repos as `no cla.yml workflow` (they aren't deployed yet — the expected pre-rollout state, proving the gate detects absence). After Phase 2 deploys `cla.yml`, this flips green.
+Expected: **red** listing all 6 repos as `no cla.yml workflow` (they aren't deployed yet — the expected pre-rollout state, proving the gate detects absence). After Phase 2 deploys `cla.yml`, this flips green.
 
 ```bash
 git add scripts/structure-audit/check-cla-coverage.ts scripts/structure-audit/check-cla-coverage.test.ts package.json scripts/lib/preflight-gates.ts .github/workflows/org-drift-sweep.yml
@@ -693,11 +692,11 @@ Under the P6a log (or a new `### CLA progress log`), add:
 
 - **Delivered (config + gate):** broad-relicensable ICLA + CCLA drafted
   (`docs/cla/`, pending ratification), the reusable `cla.yml` template, the
-  `cla-coverage` drift gate (all 7 public repos have `cla.yml` at one version),
+  `cla-coverage` drift gate (all 6 public repos have `cla.yml` at one version),
   and `CONTRIBUTING.md` terms.
 - **Pending apply (org-owner):** ratify the CLA wording; create the dedicated CLA
   App + `SELECTED` private-key secret; create the `.github` `cla-signatures`
-  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 7 repos;
+  branch + deploy `CLA/ICLA.md`/`CLA/CCLA.md`; deploy `cla.yml` to all 6 repos;
   make the `CLA Assistant` check required in each ruleset; **red-prove** with a
   test PR; confirm `cla-coverage` green.
 - **Deferred:** CCLA employee-roster automation; private repos; retroactive
@@ -739,10 +738,10 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 - [ ] Create a dedicated **`nimbus-cla-bot`** GitHub App (org-owned) — cleaner than
   reusing the release bot (which should not comment on every PR). Repository
   permissions: **Contents: Read & write** (for the signature store), **Pull
-  requests: Read & write**, **Commit statuses: Read & write**. Install on the 7
+  requests: Read & write**, **Commit statuses: Read & write**. Install on the 6
   gated repos **+ `.github`**.
 - [ ] Store `CLA_BOT_CLIENT_ID` + `CLA_BOT_PRIVATE_KEY` as **org** secrets,
-  visibility **`SELECTED`** to exactly the 7 gated repos.
+  visibility **`SELECTED`** to exactly the 6 gated repos.
 - [ ] Verify: `gh api orgs/nimbus-agent/installations --jq '.installations[]|select(.app_slug=="nimbus-cla-bot")|.permissions'` shows `contents:write, pull_requests:write, statuses:write`.
 
 ### Task 7: `.github` repo — text + signature store
@@ -754,9 +753,9 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
   (`git switch --orphan cla-signatures` → empty commit → push). Do **not** add
   branch protection to it.
 
-### Task 8: Deploy `cla.yml` to all 7 repos
+### Task 8: Deploy `cla.yml` to all 6 repos
 
-- [ ] For each of the 7 repos, open a PR adding `.github/workflows/cla.yml` = the
+- [ ] For each of the 6 repos, open a PR adding `.github/workflows/cla.yml` = the
   Task 2 template verbatim (Nimbus's copy goes on this branch; the 6 satellites
   each get their own PR). Confirm each repo's `audit:action-sha-pins` (or manual
   SHA check) is clean.
@@ -768,7 +767,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
   step (`CLA Assistant`). Confirm the literal string from the red-prove PR's head
   commit before pinning:
   `gh api repos/nimbus-agent/Nimbus/commits/<head-sha>/status --jq '.statuses[].context'`
-  — expect `CLA Assistant`. Then add **that exact context** to each of the 7
+  — expect `CLA Assistant`. Then add **that exact context** to each of the 6
   repos' `General` ruleset `required_status_checks` (via `gh api .../rulesets/<id>`).
   Do this **after** the red-prove below produces the first status, so the pinned
   context is observed, not guessed.
@@ -781,7 +780,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
   `Co-authored-by:`; confirm the gate still requires that author (or record that
   the action only checks the sender → open a follow-up mitigation).
 - [ ] **Live-prove `cla-coverage`:** `gh workflow run org-drift-sweep.yml --ref main`
-  (post-merge) and confirm the `cla-coverage` job is **green** (all 7 have
+  (post-merge) and confirm the `cla-coverage` job is **green** (all 6 have
   `cla.yml` at `version1`).
 - [ ] Update `docs/infrastructure-roadmap.md`: CLA proven green (run id), required
   checks live. Commit.
@@ -796,7 +795,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 - [ ] `bun run lint:markdown` — 0 errors (incl. `docs/cla/*.md`)
 - [ ] `bun run audit:doc-refs` — resolves
 - [ ] `bun run audit:action-sha-pins` — OK
-- [ ] `bun run audit:cla-coverage` — **red, all 7 "no cla.yml"** (expected pre-rollout — the gate detecting absence)
+- [ ] `bun run audit:cla-coverage` — **red, all 6 "no cla.yml"** (expected pre-rollout — the gate detecting absence)
 - [ ] `~/.cargo/bin/lychee --config lychee.toml 'docs/**/*.md' '*.md'` — whole-branch link total
 
 **Known worktree caveats:** full `preflight` unusable in a worktree; `bun run lint` may report 0 files — use `bunx biome check scripts`. No `packages/` source touched → `coverage-floor` N/A.
@@ -814,7 +813,7 @@ git commit -m "docs(infra): record CLA config + gate delivered; apply pending"
 | Roadmap record | 5 |
 | CLA App + `SELECTED` secret | 6 |
 | Shared signature store on non-default branch | 7 |
-| Deploy to 7 repos | 8 |
+| Deploy to 6 repos | 8 |
 | Required `CLA Assistant` check + red-prove + all-authors verify + live-prove | 9 |
 
 ---
@@ -828,4 +827,4 @@ Responses to [the plan review](./2026-07-24-cla-review.md):
 | 1 | Comment the base64 whitespace strip | **Fixed** — added a comment noting it strips the API base64 *envelope*, not the decoded YAML; "do not simplify" (Task 4). |
 | 2 | `gh` auth/permission preflight + UI fallback | **Fixed** — added Task 5b: `gh auth status` + org-admin check, and a per-action web-UI fallback (App/secrets/rulesets). |
 | 3 | `.github` absent from `GATED_REPOS` | **No change** — correct as-is: `.github` is community-health, no PR gate; it still gets the App + signature store (Tasks 6/7). |
-| 4 | Deterministic status-check context name | **Fixed** — noted the action has no `context-name` input; expected context is `CLA Assistant`, confirmed from the red-prove commit's `/status` before pinning it into the 7 rulesets (Task 9). |
+| 4 | Deterministic status-check context name | **Fixed** — noted the action has no `context-name` input; expected context is `CLA Assistant`, confirmed from the red-prove commit's `/status` before pinning it into the 6 rulesets (Task 9). |

--- a/docs/superpowers/specs/2026-07-24-cla-design-review.md
+++ b/docs/superpowers/specs/2026-07-24-cla-design-review.md
@@ -1,0 +1,63 @@
+# Design Review: CLA — Contributor License Agreement Design
+
+This document reviews [2026-07-24-cla-design.md](./2026-07-24-cla-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Concurrency & Race Conditions in Shared Store
+
+### Concurrency Conflicts on Push
+
+- **Observation:** With 7 active public repositories concurrently updating a single JSON file (`signatures/version1/cla.json` on the `cla-signatures` branch of `.github`), there is a risk of git push conflicts (e.g., `non-fast-forward` errors) if multiple contributors sign CLAs or comment at similar times across repos.
+- **Suggestion:** Verify how `contributor-assistant/github-action` handles concurrent push retries. We should configure the Action with retry parameters (e.g. `retries` or backoff) if supported, or document how conflicts are mitigated to prevent workflow run failures.
+
+### Branch Protection Rules
+
+- **Question:** How will branch protection rules be configured on the `.github` repository for the `cla-signatures` branch? Since the GitHub App needs to push directly to it, we must ensure it bypasses standard pull request requirements or approval checks without weakening the security of the `main` branch.
+
+---
+
+## 2. GitHub App Token Distribution & Secrets Scoping
+
+### Scoping of the App Token
+
+- **Observation:** The workflow runs in all 7 repos and needs a token to write to `.github`. The design proposes using a GitHub App token scoped to `contents: write` on the `.github` repo only.
+- **Question:** How is this App Private Key shared securely? Since organization secrets are available to workflows triggered by `pull_request_target` even from forks, we must confirm that the App Private Key secret is restricted to only execute within the specific workflows and cannot be exposed by custom pull request triggers.
+- **Suggestion:** Explicitly document the recommended configuration for the organization secret, ensuring it is restricted to the specific repositories requiring it.
+
+---
+
+## 3. Workflow Security & Execution Safeguards
+
+### `pull_request_target` Isolation
+
+- **Observation:** The use of `pull_request_target` executes in the context of the base branch but has write permissions and access to secrets.
+- **Important Rule:** Ensure that the `.github/workflows/cla.yml` configuration across all 7 repositories never checks out the PR head branch (`github.event.pull_request.head.sha`) or runs package scripts (such as `npm run` or `bun run`) which could allow malicious code to execute inside the privileged runner.
+
+---
+
+## 4. Multi-Contributor Commit Verification
+
+### Verification of All Commit Authors
+
+- **Observation:** Pull requests frequently contain commits from multiple different authors or contributors (e.g., co-authored-by commits or cherry-picked work).
+- **Question:** Does the `contributor-assistant/github-action` validate and require signatures for *all* unique commit authors and committers present in the PR history, or does it only validate the PR author/sender?
+- **Suggestion:** Configure the action to check all commit authors to prevent unsigned code from being merged under a signed PR author's name.
+
+---
+
+## 5. Drift Prevention & Allowlist Management
+
+### Centralized Allowlist
+
+- **Observation:** The allowlist of org members and bots (e.g., `dependabot[bot]`) is specified inside the `.github/workflows/cla.yml` files in all 7 repositories.
+- **Suggestion:** Rather than duplicating this allowlist in 7 distinct files, check if `contributor-assistant/github-action` supports pointing to a central config/allowlist file (e.g., inside `.github`) or dynamically querying organization membership via the GitHub API to prevent configuration drift.
+
+---
+
+## 6. Versioning & Re-signing Operations
+
+### Standard Operating Procedure (SOP) for Bumping versions
+
+- **Observation:** Bumping the CLA version (e.g., `version1` -> `version2`) requires re-signing by all contributors.
+- **Suggestion:** Include a brief guide or SOP in the spec on how to coordinate a version bump (e.g. updating the workflow files across all 7 repos concurrently to avoid state mismatches where a contributor is prompt-blocked on one repo but allowed on another).

--- a/docs/superpowers/specs/2026-07-24-cla-design.md
+++ b/docs/superpowers/specs/2026-07-24-cla-design.md
@@ -73,7 +73,23 @@ architecture enforces.
   per-repo).
 - Versioning: the store path carries a version (`version1`). Bumping the CLA text
   materially bumps the version, which re-requires signatures — a deliberate,
-  visible event, not silent.
+  visible event, not silent. **Version-bump SOP:** a bump must update the CLA doc
+  **and** the `path-to-signatures` version in **all 7** workflows in **one
+  coordinated PR** — otherwise a contributor is blocked on a not-yet-bumped repo
+  while allowed on a bumped one. The `cla-coverage` gate (§4) asserts the version
+  string is identical across the 7 repos, so a partial bump goes red.
+- **Concurrent writes:** the action writes `cla.json` via a conditional API write
+  to one shared file; the action documents **no** retry/back-off. Two *new*
+  contributors signing within the same few seconds across different repos could
+  collide (`non-fast-forward`), failing one run. This is **low-severity** —
+  signing is a once-per-contributor-ever event, so the window is tiny — and
+  self-recovering: the affected contributor re-comments `recheck` (or re-signs).
+  The plan verifies the action's actual conflict behavior; no cross-repo write
+  serialization is built (disproportionate for the volume).
+- **Branch protection:** signatures live on the **non-default** `cla-signatures`
+  branch, so `.github`'s `main`-targeted `General` ruleset does **not** gate it —
+  the App token writes with plain `contents: write`, bypassing nothing on `main`.
+  Do **not** add branch protection to `cla-signatures` (it would block the bot).
 
 ### 3. The enforcement Action (`.github/workflows/cla.yml`, per repo)
 
@@ -87,20 +103,35 @@ policy):
 - **Runs** `contributor-assistant/github-action@<SHA>` configured with: the
   shared store (`remote-repository-name: .github`, `branch: cla-signatures`,
   `path-to-signatures`), the ICLA URL (`path-to-document`), a custom PR comment
-  that also links the **CCLA** path for corporate contributors, and an
-  **allowlist** of org members + bots (`dependabot[bot]`, the release bot, the
-  owner) so their PRs auto-pass and never block on a signature.
-- **Security invariant (`pull_request_target`):** this trigger runs with the base
-  repo's secrets **even on fork PRs**, so the workflow **must never check out or
-  execute PR head code** — it reads only PR metadata and the comment body.
-  Minimal `permissions:` (`contents: read`, `pull-requests: write`,
-  `statuses: write`, `actions: write`) and pinned action SHAs. Writing to the
-  signature store uses a separate scoped token, below — never the fork's code.
-- **Token:** writing the signature file to the shared store needs
-  `contents: write` on the `.github` repo. Supplied as a **GitHub App token
-  scoped to `contents: write`** on that one repo (no PAT — consistent with the
-  retiring-PATs stance). This may require an App permission/install step, like
-  P6a's `members: read` grant.
+  that also links the **CCLA** path for corporate contributors, and a **minimal
+  `allowlist`** — the `bot*` wildcard (covers `dependabot[bot]`, the release bot,
+  every bot) plus the single org owner's username. Keeping it to a pattern + one
+  name minimizes the per-file duplication across the 7 (byte-identical) workflows;
+  dynamic org-membership querying is a follow-up, YAGNI for a one-member org.
+- **All commit authors must sign, not just the PR sender.** A PR can carry commits
+  by multiple authors (co-authored-by, cherry-picks). The gate must require a
+  signature from **every unique commit author/committer** in the PR — an unsigned
+  co-author must not merge under a signed sender. The plan **verifies** that
+  `contributor-assistant` enforces this (it is the expected behavior); if it only
+  checks the sender, the plan adds a mitigation (a supplementary all-authors check
+  or requiring external PRs be single-author). This is a correctness requirement,
+  not a nicety.
+- **Security invariant (`pull_request_target`):** this trigger runs the **base
+  repo's** trusted workflow with base secrets **even on fork PRs**, so the workflow
+  **must never** check out the PR head (`github.event.pull_request.head.sha`/`.ref`)
+  and **must never** run repo scripts (`npm`/`bun`/`make` etc.) — it reads only PR
+  metadata and the comment body. This is exactly what keeps a fork PR from
+  exfiltrating the store token. Minimal `permissions:` and SHA-pinned actions.
+- **Token (corrected):** the action's **required** `PERSONAL_ACCESS_TOKEN` input
+  is fed a **minted GitHub App installation token** (via `create-github-app-token`
+  at run time) — so no long-lived PAT is ever stored, consistent with the
+  retiring-PATs stance. With a **remote** store the token's scope spans **both**
+  the store repo (`contents: write` on `.github`) **and** the PR repo
+  (`pull-requests: write`, `statuses: write`, `contents: read`) to post the
+  comment + status. That means one App installed on `.github` + the 7 gated repos
+  with those permissions — broader than a single repo, and likely needing an App
+  permission/install step (as P6a's `members: read` did). The plan confirms an
+  App token is accepted in the `PERSONAL_ACCESS_TOKEN` slot before rollout.
 
 ### 4. The gate — two layers (per the program's "goes red on regression" rule)
 
@@ -111,11 +142,13 @@ policy):
    gate that has been observed red, not merely assumed.
 2. **Coverage drift gate:** a new **`cla-coverage`** job in the existing
    `org-drift-sweep` asserts that each of the 7 gated repos has
-   `.github/workflows/cla.yml` present. This makes "the CLA is wired in every
-   gated repo" a checked, goes-red-on-regression property — so it cannot silently
-   stop at one repo (the exact "controls stop where they were written" pattern
-   the program exists to break). It reuses the P1/P6a `_gh-audit.ts` fail-soft /
-   `--strict`-in-CI plumbing and the App token.
+   `.github/workflows/cla.yml` present **and that its `path-to-signatures`
+   version string matches across all 7** (so a partial version bump — §2 — goes
+   red). This makes "the CLA is wired, and identically, in every gated repo" a
+   checked, goes-red-on-regression property — so it cannot silently stop at one
+   repo or drift between them (the exact "controls stop where they were written"
+   pattern the program exists to break). It reuses the P1/P6a `_gh-audit.ts`
+   fail-soft / `--strict`-in-CI plumbing and the App token.
 
 ### 5. `CONTRIBUTING.md`
 
@@ -172,8 +205,11 @@ catches a repo whose workflow (and thus its check) is missing.
 
 - **`pull_request_target` never runs PR code** (§3) — the one real security edge
   here; stated as an invariant, minimal-permissions, SHA-pinned.
-- **No PAT** — the store-write token is a scoped GitHub App token
-  (`contents: write` on `.github` only).
+- **No stored PAT** — the `PERSONAL_ACCESS_TOKEN` input receives a **minted** App
+  installation token (§3), never a long-lived PAT. The App's **private-key org
+  secret** is stored **`SELECTED`-scoped** to only the 7 gated repos (not `ALL`),
+  and because `pull_request_target` runs the trusted base workflow (never fork
+  code), a fork PR cannot read or exfiltrate it.
 - **SHA-pinned actions** — `contributor-assistant/github-action` and any others
   are pinned to a full 40-hex SHA; `audit:action-sha-pins` enforces it.
 - **No signature data off-machine** — stored in-repo, in the org.
@@ -190,3 +226,20 @@ catches a repo whose workflow (and thus its check) is missing.
 4. The `cla-coverage` sweep gate is green and would go **red** if a repo's
    `cla.yml` regressed.
 5. The roadmap records the CLA delivered + the CCLA-automation deferral.
+
+---
+
+## Design-review dispositions
+
+Responses to [the review](./2026-07-24-cla-design-review.md); the action's
+behaviour was verified against its published README.
+
+| # | Point | Disposition |
+| --- | --- | --- |
+| 1a | Concurrent writes to the shared `cla.json` | **Fixed (documented).** Confirmed the action documents no retry. Low-severity (signing is once-ever per contributor); recovery = re-comment `recheck`; plan verifies actual behaviour; no cross-repo serialization built (§2). |
+| 1b | Branch protection on the signature branch | **Fixed (clarified).** Signatures live on the non-default `cla-signatures` branch, so `.github`'s `main` ruleset doesn't gate it; App writes with plain `contents: write`; do not protect that branch (§2). |
+| 2 | App-token distribution + secret scoping | **Fixed (corrected).** Token story rewritten: a minted App token is fed to the required `PERSONAL_ACCESS_TOKEN` input (no stored PAT); the private-key org secret is `SELECTED`-scoped to the 7 repos; `pull_request_target` running trusted base code is what prevents fork exfiltration (§3, Security). |
+| 3 | `pull_request_target` never runs PR code | **Fixed (strengthened).** Invariant now names the exact anti-patterns (never checkout `head.sha`/`.ref`, never run `npm`/`bun`/`make`) (§3). |
+| 4 | All commit authors must sign, not just the sender | **Fixed (requirement + plan-verify).** Added as a correctness requirement; the plan verifies `contributor-assistant` enforces it and adds a mitigation if not (§3). |
+| 5 | Allowlist duplicated across 7 files → drift | **Fixed + partial defer.** Confirmed `bot*` wildcard works → allowlist shrinks to `bot*` + one owner name; 7 workflows byte-identical from one template; `cla-coverage` asserts consistency. Dynamic org-membership querying deferred (YAGNI, 1-member org) (§3). |
+| 6 | Version-bump SOP | **Fixed.** Added a coordinated-bump SOP; `cla-coverage` asserts the version string matches across the 7 repos so a partial bump goes red (§2). |

--- a/docs/superpowers/specs/2026-07-24-cla-design.md
+++ b/docs/superpowers/specs/2026-07-24-cla-design.md
@@ -38,9 +38,8 @@ architecture enforces.
    *including the right to sublicense/relicense under any terms, including
    proprietary*. (Not copyright assignment.)
 3. **Documents:** both an **ICLA** (individual) and a **CCLA** (corporate), now.
-4. **Scope:** **all 7 public contribution repos** — `Nimbus`, `nimbus-sdk`,
-   `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`,
-   `nimbus-recipes`.
+4. **Scope:** **all 6 public contribution repos** — `Nimbus`, `nimbus-sdk`,
+   `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`.
 
 ---
 
@@ -68,16 +67,16 @@ architecture enforces.
 
 - Signatures are stored **once** — in a dedicated `cla-signatures` branch of the
   `.github` repo, at `signatures/version1/cla.json`, written by the Action.
-- All 7 repos' workflows point at this **same** store, so a contributor **signs
+- All 6 repos' workflows point at this **same** store, so a contributor **signs
   once and is covered across every gated repo** (the store is shared, not
   per-repo).
 - Versioning: the store path carries a version (`version1`). Bumping the CLA text
   materially bumps the version, which re-requires signatures — a deliberate,
   visible event, not silent. **Version-bump SOP:** a bump must update the CLA doc
-  **and** the `path-to-signatures` version in **all 7** workflows in **one
+  **and** the `path-to-signatures` version in **all 6** workflows in **one
   coordinated PR** — otherwise a contributor is blocked on a not-yet-bumped repo
   while allowed on a bumped one. The `cla-coverage` gate (§4) asserts the version
-  string is identical across the 7 repos, so a partial bump goes red.
+  string is identical across the 6 repos, so a partial bump goes red.
 - **Concurrent writes:** the action writes `cla.json` via a conditional API write
   to one shared file; the action documents **no** retry/back-off. Two *new*
   contributors signing within the same few seconds across different repos could
@@ -93,7 +92,7 @@ architecture enforces.
 
 ### 3. The enforcement Action (`.github/workflows/cla.yml`, per repo)
 
-Each of the 7 repos gets an identical workflow (SHA-pinned actions, per org
+Each of the 6 repos gets an identical workflow (SHA-pinned actions, per org
 policy):
 
 - **Triggers:** `issue_comment` (types: `created`) + `pull_request_target`
@@ -106,7 +105,7 @@ policy):
   that also links the **CCLA** path for corporate contributors, and a **minimal
   `allowlist`** — the `bot*` wildcard (covers `dependabot[bot]`, the release bot,
   every bot) plus the single org owner's username. Keeping it to a pattern + one
-  name minimizes the per-file duplication across the 7 (byte-identical) workflows;
+  name minimizes the per-file duplication across the 6 (byte-identical) workflows;
   dynamic org-membership querying is a follow-up, YAGNI for a one-member org.
 - **All commit authors must sign, not just the PR sender.** A PR can carry commits
   by multiple authors (co-authored-by, cherry-picks). The gate must require a
@@ -128,7 +127,7 @@ policy):
   retiring-PATs stance. With a **remote** store the token's scope spans **both**
   the store repo (`contents: write` on `.github`) **and** the PR repo
   (`pull-requests: write`, `statuses: write`, `contents: read`) to post the
-  comment + status. That means one App installed on `.github` + the 7 gated repos
+  comment + status. That means one App installed on `.github` + the 6 gated repos
   with those permissions — broader than a single repo, and likely needing an App
   permission/install step (as P6a's `members: read` did). The plan confirms an
   App token is accepted in the `PERSONAL_ACCESS_TOKEN` slot before rollout.
@@ -141,9 +140,9 @@ policy):
    check **red** until the account comments its signature, then **green** — a
    gate that has been observed red, not merely assumed.
 2. **Coverage drift gate:** a new **`cla-coverage`** job in the existing
-   `org-drift-sweep` asserts that each of the 7 gated repos has
+   `org-drift-sweep` asserts that each of the 6 gated repos has
    `.github/workflows/cla.yml` present **and that its `path-to-signatures`
-   version string matches across all 7** (so a partial version bump — §2 — goes
+   version string matches across all 6** (so a partial version bump — §2 — goes
    red). This makes "the CLA is wired, and identically, in every gated repo" a
    checked, goes-red-on-regression property — so it cannot silently stop at one
    repo or drift between them (the exact "controls stop where they were written"
@@ -207,7 +206,7 @@ catches a repo whose workflow (and thus its check) is missing.
   here; stated as an invariant, minimal-permissions, SHA-pinned.
 - **No stored PAT** — the `PERSONAL_ACCESS_TOKEN` input receives a **minted** App
   installation token (§3), never a long-lived PAT. The App's **private-key org
-  secret** is stored **`SELECTED`-scoped** to only the 7 gated repos (not `ALL`),
+  secret** is stored **`SELECTED`-scoped** to only the 6 gated repos (not `ALL`),
   and because `pull_request_target` runs the trusted base workflow (never fork
   code), a fork PR cannot read or exfiltrate it.
 - **SHA-pinned actions** — `contributor-assistant/github-action` and any others
@@ -221,7 +220,7 @@ catches a repo whose workflow (and thus its check) is missing.
 1. `ICLA.md` + `CCLA.md` (broad relicensable grant) are checked into `.github`;
    `CONTRIBUTING.md` explains the flow + the one-way rule.
 2. The shared signature store + the scoped App token exist; `cla.yml` is wired in
-   all 7 repos; the `CLA Assistant` check is **required** in each repo's ruleset.
+   all 6 repos; the `CLA Assistant` check is **required** in each repo's ruleset.
 3. The runtime gate is **red-proven** on a test PR (red unsigned → green signed).
 4. The `cla-coverage` sweep gate is green and would go **red** if a repo's
    `cla.yml` regressed.
@@ -238,8 +237,8 @@ behaviour was verified against its published README.
 | --- | --- | --- |
 | 1a | Concurrent writes to the shared `cla.json` | **Fixed (documented).** Confirmed the action documents no retry. Low-severity (signing is once-ever per contributor); recovery = re-comment `recheck`; plan verifies actual behaviour; no cross-repo serialization built (§2). |
 | 1b | Branch protection on the signature branch | **Fixed (clarified).** Signatures live on the non-default `cla-signatures` branch, so `.github`'s `main` ruleset doesn't gate it; App writes with plain `contents: write`; do not protect that branch (§2). |
-| 2 | App-token distribution + secret scoping | **Fixed (corrected).** Token story rewritten: a minted App token is fed to the required `PERSONAL_ACCESS_TOKEN` input (no stored PAT); the private-key org secret is `SELECTED`-scoped to the 7 repos; `pull_request_target` running trusted base code is what prevents fork exfiltration (§3, Security). |
+| 2 | App-token distribution + secret scoping | **Fixed (corrected).** Token story rewritten: a minted App token is fed to the required `PERSONAL_ACCESS_TOKEN` input (no stored PAT); the private-key org secret is `SELECTED`-scoped to the 6 repos; `pull_request_target` running trusted base code is what prevents fork exfiltration (§3, Security). |
 | 3 | `pull_request_target` never runs PR code | **Fixed (strengthened).** Invariant now names the exact anti-patterns (never checkout `head.sha`/`.ref`, never run `npm`/`bun`/`make`) (§3). |
 | 4 | All commit authors must sign, not just the sender | **Fixed (requirement + plan-verify).** Added as a correctness requirement; the plan verifies `contributor-assistant` enforces it and adds a mitigation if not (§3). |
-| 5 | Allowlist duplicated across 7 files → drift | **Fixed + partial defer.** Confirmed `bot*` wildcard works → allowlist shrinks to `bot*` + one owner name; 7 workflows byte-identical from one template; `cla-coverage` asserts consistency. Dynamic org-membership querying deferred (YAGNI, 1-member org) (§3). |
-| 6 | Version-bump SOP | **Fixed.** Added a coordinated-bump SOP; `cla-coverage` asserts the version string matches across the 7 repos so a partial bump goes red (§2). |
+| 5 | Allowlist duplicated across 6 files → drift | **Fixed + partial defer.** Confirmed `bot*` wildcard works → allowlist shrinks to `bot*` + one owner name; 6 workflows byte-identical from one template; `cla-coverage` asserts consistency. Dynamic org-membership querying deferred (YAGNI, 1-member org) (§3). |
+| 6 | Version-bump SOP | **Fixed.** Added a coordinated-bump SOP; `cla-coverage` asserts the version string matches across the 6 repos so a partial bump goes red (§2). |

--- a/docs/superpowers/specs/2026-07-24-cla-design.md
+++ b/docs/superpowers/specs/2026-07-24-cla-design.md
@@ -1,0 +1,192 @@
+# CLA — Contributor License Agreement Design
+
+A P6 sub-effort of the [infrastructure roadmap](../../infrastructure-roadmap.md).
+P6a made the org's *access* model a gated property; this makes inbound
+*contribution licensing* one too, before contributor two arrives.
+
+> **Legal caveat.** The CLA documents this spec defines are a binding legal
+> commitment by the project owner. This spec adapts widely-used, standard
+> templates and calls out the legally-sensitive clause explicitly, but the final
+> wording is the owner's (or counsel's) to ratify — it is **not** authoritative
+> legal advice.
+
+---
+
+## Why a CLA (and why now)
+
+The DCO-vs-CLA decision was **resolved to a CLA** (2026-07-24, org-program open
+decision 6) for one reason a DCO cannot provide: a CLA can grant the project the
+right to **relicense** contributions, preserving the option of future commercial
+dual-licensing of the AGPL-3.0 core. `CONTRIBUTING.md` currently carries **no**
+sign-off or CLA terms and the repos are **public**, so the first outside PR can
+arrive any day; prospective collection is far cheaper than retroactive.
+
+The dual license sharpens it: the gateway/CLI/connectors are **AGPL-3.0**, while
+`@nimbus-dev/sdk` and `@nimbus-dev/client` are **MIT**. Code may flow **MIT →
+AGPL** but never the reverse; a CLA (plus a restated one-way rule in
+`CONTRIBUTING.md`) makes that a thing contributors *agree to*, not just a thing
+architecture enforces.
+
+## Decisions taken (this brainstorm)
+
+1. **Mechanism:** the self-hosted **`contributor-assistant/github-action`** —
+   sign by PR comment, signatures stored **in-repo** (shared store), a required
+   status check. No external SaaS, no signature data off-machine, App-token auth
+   (no PAT).
+2. **Grant model:** a **broad license grant** — the contributor keeps copyright
+   but grants `nimbus-agent` a perpetual, irrevocable, worldwide license
+   *including the right to sublicense/relicense under any terms, including
+   proprietary*. (Not copyright assignment.)
+3. **Documents:** both an **ICLA** (individual) and a **CCLA** (corporate), now.
+4. **Scope:** **all 7 public contribution repos** — `Nimbus`, `nimbus-sdk`,
+   `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`, `awesome-nimbus`,
+   `nimbus-recipes`.
+
+---
+
+## Architecture
+
+### 1. The legal text (single source, org-wide)
+
+- **`ICLA.md`** — Individual CLA, based on the **Apache ICLA** structure
+  (copyright license, patent license, origin certification, "as-is"), with the
+  **license-grant clause modified** so the contributor grants `nimbus-agent` a
+  perpetual, irrevocable, worldwide, royalty-free license to reproduce, prepare
+  derivative works of, publicly display/perform, sublicense, and distribute the
+  contribution **and to license it under any terms, including terms that differ
+  from the repository's then-current license (e.g. a commercial/proprietary
+  license)**. This relicensing clause is the legally-sensitive part and the whole
+  reason a CLA was chosen over a DCO — it is flagged for owner/counsel review.
+- **`CCLA.md`** — Corporate CLA. The same grant made by a legal entity, with a
+  **Schedule A** of covered employees the signer maintains, and a designated
+  point of contact.
+- **Home:** both live **once** in the org **`.github`** repo under `CLA/`
+  (`CLA/ICLA.md`, `CLA/CCLA.md`) — GitHub's org community-health home. Every
+  gated repo's Action links to the same canonical URLs.
+
+### 2. The shared signature store (sign once, covered everywhere)
+
+- Signatures are stored **once** — in a dedicated `cla-signatures` branch of the
+  `.github` repo, at `signatures/version1/cla.json`, written by the Action.
+- All 7 repos' workflows point at this **same** store, so a contributor **signs
+  once and is covered across every gated repo** (the store is shared, not
+  per-repo).
+- Versioning: the store path carries a version (`version1`). Bumping the CLA text
+  materially bumps the version, which re-requires signatures — a deliberate,
+  visible event, not silent.
+
+### 3. The enforcement Action (`.github/workflows/cla.yml`, per repo)
+
+Each of the 7 repos gets an identical workflow (SHA-pinned actions, per org
+policy):
+
+- **Triggers:** `issue_comment` (types: `created`) + `pull_request_target`
+  (types: `opened`, `synchronize`, `reopened`). A contributor signs by commenting
+  a fixed phrase (e.g. *"I have read the CLA Document and I hereby sign the
+  CLA"*) on their PR.
+- **Runs** `contributor-assistant/github-action@<SHA>` configured with: the
+  shared store (`remote-repository-name: .github`, `branch: cla-signatures`,
+  `path-to-signatures`), the ICLA URL (`path-to-document`), a custom PR comment
+  that also links the **CCLA** path for corporate contributors, and an
+  **allowlist** of org members + bots (`dependabot[bot]`, the release bot, the
+  owner) so their PRs auto-pass and never block on a signature.
+- **Security invariant (`pull_request_target`):** this trigger runs with the base
+  repo's secrets **even on fork PRs**, so the workflow **must never check out or
+  execute PR head code** — it reads only PR metadata and the comment body.
+  Minimal `permissions:` (`contents: read`, `pull-requests: write`,
+  `statuses: write`, `actions: write`) and pinned action SHAs. Writing to the
+  signature store uses a separate scoped token, below — never the fork's code.
+- **Token:** writing the signature file to the shared store needs
+  `contents: write` on the `.github` repo. Supplied as a **GitHub App token
+  scoped to `contents: write`** on that one repo (no PAT — consistent with the
+  retiring-PATs stance). This may require an App permission/install step, like
+  P6a's `members: read` grant.
+
+### 4. The gate — two layers (per the program's "goes red on regression" rule)
+
+1. **Runtime gate (the sub-program's definition of done):** the `CLA Assistant`
+   status check is made a **required** check in each repo's ruleset. It is
+   **red-proven**: a test PR from a **non-allowlisted** account shows the CLA
+   check **red** until the account comments its signature, then **green** — a
+   gate that has been observed red, not merely assumed.
+2. **Coverage drift gate:** a new **`cla-coverage`** job in the existing
+   `org-drift-sweep` asserts that each of the 7 gated repos has
+   `.github/workflows/cla.yml` present. This makes "the CLA is wired in every
+   gated repo" a checked, goes-red-on-regression property — so it cannot silently
+   stop at one repo (the exact "controls stop where they were written" pattern
+   the program exists to break). It reuses the P1/P6a `_gh-audit.ts` fail-soft /
+   `--strict`-in-CI plumbing and the App token.
+
+### 5. `CONTRIBUTING.md`
+
+Updated (in `Nimbus`, and mirrored as the org default in `.github` for the
+satellites) to explain: the sign-by-PR-comment flow, **ICLA vs CCLA** (when a
+contributor needs the corporate one), and a restated **MIT → AGPL one-way rule**
+— a patch to the MIT packages must not be derived from AGPL-licensed parts of the
+repo. The broad-grant CLA supersedes a DCO sign-off, so the two are **not**
+stacked.
+
+---
+
+## The required-check context-name caveat
+
+The required-status-check **context name** is per-repo and is the most
+drift-prone part of a ruleset (P1's Task 2 deliberately omitted required checks
+for this reason). The `contributor-assistant` action publishes a fixed context
+(e.g. `CLA Assistant` / `license/cla`); the spec **pins the exact context name**
+and the ruleset requires it verbatim. The `cla-coverage` gate is the backstop: it
+catches a repo whose workflow (and thus its check) is missing.
+
+---
+
+## Rollout (phased; detailed in the plan)
+
+1. **Foundation + Nimbus, red-proven:** author `ICLA.md`/`CCLA.md` in `.github`;
+   create the `cla-signatures` store; mint the scoped App token; add `cla.yml`
+   to **`Nimbus`**; update `CONTRIBUTING.md`; make the CLA check required on
+   `Nimbus`; **red-prove** with a test PR.
+2. **Propagate:** add the identical `cla.yml` to the other 6 repos and make the
+   CLA check required in each repo's ruleset.
+3. **Coverage gate:** add the `cla-coverage` job to `org-drift-sweep`, registered
+   in `CI_ONLY_GATES`, and prove it green (and red on a missing wiring).
+
+---
+
+## Non-goals / explicitly deferred
+
+- **CCLA automation.** The action gates against the ICLA; the corporate flow
+  (employer signs, maintains Schedule A) is **document + manual review**, not an
+  automated per-employee check. Automating CCLA employee rosters is a follow-up.
+- **A bespoke CLA bot.** `contributor-assistant` is mature and self-hosted;
+  writing our own is out of scope (rejected in the brainstorm).
+- **cla-assistant.io SaaS** — rejected (external dependency + signatures
+  off-machine).
+- **Private repos** — not public, no external PRs; out of scope (revisit if one
+  opens to contribution).
+- **Retroactive signatures** — the store starts empty; there are no prior outside
+  contributors to backfill.
+
+---
+
+## Security & non-negotiables
+
+- **`pull_request_target` never runs PR code** (§3) — the one real security edge
+  here; stated as an invariant, minimal-permissions, SHA-pinned.
+- **No PAT** — the store-write token is a scoped GitHub App token
+  (`contents: write` on `.github` only).
+- **SHA-pinned actions** — `contributor-assistant/github-action` and any others
+  are pinned to a full 40-hex SHA; `audit:action-sha-pins` enforces it.
+- **No signature data off-machine** — stored in-repo, in the org.
+
+---
+
+## Definition of done
+
+1. `ICLA.md` + `CCLA.md` (broad relicensable grant) are checked into `.github`;
+   `CONTRIBUTING.md` explains the flow + the one-way rule.
+2. The shared signature store + the scoped App token exist; `cla.yml` is wired in
+   all 7 repos; the `CLA Assistant` check is **required** in each repo's ruleset.
+3. The runtime gate is **red-proven** on a test PR (red unsigned → green signed).
+4. The `cla-coverage` sweep gate is green and would go **red** if a repo's
+   `cla.yml` regressed.
+5. The roadmap records the CLA delivered + the CCLA-automation deferral.

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "audit:ruleset-drift": "bun scripts/structure-audit/check-ruleset-drift.ts",
     "audit:org-settings-drift": "bun scripts/structure-audit/check-org-settings-drift.ts",
     "audit:team-reachability": "bun scripts/structure-audit/check-team-reachability.ts",
+    "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
     "audit:secrets": "gitleaks detect --source . --no-banner --redact --exit-code 1",
     "audit:links": "lychee --no-progress --config lychee.toml \"docs/**/*.md\" \"*.md\"",
     "lint": "biome check --error-on-warnings .",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -66,6 +66,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:ruleset-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:org-settings-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:cla-coverage", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -66,7 +66,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:ruleset-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:org-settings-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
-  "audit:cla-coverage", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/structure-audit/check-cla-coverage.test.ts
+++ b/scripts/structure-audit/check-cla-coverage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { diffClaCoverage } from "./check-cla-coverage.ts";
+
+const REPOS = ["Nimbus", "nimbus-sdk", "nimbus-client"];
+
+describe("diffClaCoverage", () => {
+  test("passes when all repos have cla.yml at the same version", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version1",
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("flags a repo missing cla.yml", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": null,
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("nimbus-sdk");
+    expect(r.errors.join("\n")).toContain("no cla.yml");
+  });
+
+  test("flags a version mismatch across repos", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version2",
+      "nimbus-client": "version1",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("version");
+    expect(r.errors.join("\n")).toContain("nimbus-sdk");
+  });
+
+  test("flags a repo whose cla.yml has no recognizable version", () => {
+    const r = diffClaCoverage(REPOS, {
+      Nimbus: "version1",
+      "nimbus-sdk": "version1",
+      "nimbus-client": "",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toContain("nimbus-client");
+  });
+});

--- a/scripts/structure-audit/check-cla-coverage.ts
+++ b/scripts/structure-audit/check-cla-coverage.ts
@@ -21,7 +21,6 @@ const GATED_REPOS = [
   "nimbus-vscode",
   "nimbus-web-clipper",
   "awesome-nimbus",
-  "nimbus-recipes",
 ];
 
 /**

--- a/scripts/structure-audit/check-cla-coverage.ts
+++ b/scripts/structure-audit/check-cla-coverage.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:cla-coverage — asserts every gated public repo has `.github/workflows/cla.yml`
+ * AND that its CLA signature-version string is identical across all of them, so a
+ * missing workflow or a partial version bump goes red. Same fail-soft-local /
+ * strict-in-CI contract as the other org-drift-sweep gates.
+ */
+
+import { isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+const GATED_REPOS = [
+  "Nimbus",
+  "nimbus-sdk",
+  "nimbus-client",
+  "nimbus-vscode",
+  "nimbus-web-clipper",
+  "awesome-nimbus",
+  "nimbus-recipes",
+];
+
+/**
+ * Pure diff. `live[repo]` is the repo's observed CLA signature-version
+ * (e.g. "version1"), "" if a cla.yml exists but no version could be parsed, or
+ * `null` if cla.yml is absent. Flags absent workflows, unparseable versions, and
+ * any version differing from the first repo's.
+ */
+export function diffClaCoverage(repos: string[], live: Record<string, string | null>): AuditResult {
+  const errors: string[] = [];
+  let expected: string | undefined;
+  for (const repo of repos) {
+    const v = live[repo];
+    if (v === null || v === undefined) {
+      errors.push(`${repo}: no cla.yml workflow`);
+      continue;
+    }
+    if (v === "") {
+      errors.push(`${repo}: cla.yml has no parseable signature version`);
+      continue;
+    }
+    if (expected === undefined) expected = v;
+    else if (v !== expected) {
+      errors.push(`${repo}: cla version ${v} != ${expected} (partial bump?)`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/** Extract the `version<N>` segment from a `path-to-signatures` line in cla.yml. */
+function parseVersion(yaml: string): string {
+  const m = yaml.match(/path-to-signatures:\s*['"]?signatures\/(version\d+)\//);
+  return m?.[1] ?? "";
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:cla-coverage";
+
+  // Reachability probe. The 7 gated repos are PUBLIC, so reading their contents
+  // needs no auth and a per-repo 404 unambiguously means "cla.yml absent" — a
+  // real finding, not an auth question. The only fail-soft case is `gh`/network
+  // being unavailable at all, which this one probe detects. (This is why we do
+  // NOT reuse ruleset-drift's queried===0 heuristic: there, a 404 could mean
+  // unauthorized; here it cannot.)
+  const probe = runGh(["gh", "api", "repos/nimbus-agent/Nimbus", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const live: Record<string, string | null> = {};
+  for (const repo of GATED_REPOS) {
+    const res = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/contents/.github/workflows/cla.yml`,
+      "--jq",
+      ".content",
+    ]);
+    // Reachability already confirmed by the probe → a failure here is a genuine
+    // 404 (file absent), recorded as `null` and flagged by diffClaCoverage.
+    if (!res.ok) {
+      live[repo] = null;
+      continue;
+    }
+    // `.replace(/\s/g, "")` strips the newlines GitHub inserts into the base64
+    // *envelope* of the contents API response — NOT the decoded YAML. Do not
+    // "simplify" it away: without it, Buffer decoding of the wrapped base64 fails.
+    const yaml = Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8");
+    live[repo] = parseVersion(yaml);
+  }
+
+  const result = diffClaCoverage(GATED_REPOS, live);
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+  console.log(`${label}: OK (${GATED_REPOS.length} repos)`);
+}


### PR DESCRIPTION
## CLA Program — Phase 1 (docs + coverage gate)

Delivers the source-of-truth CLA artifacts and the org-wide drift gate. The live `.github/workflows/cla.yml` + CLA text on `nimbus-agent/.github` were already deployed to all 6 gated repos in Phase 2; this PR lands the in-repo templates, the design/plan/review docs, and the enforcement gate.

### What's in it
- **`docs/cla/ICLA.md` + `CCLA.md`** — Individual + Corporate CLA, broad relicensable grant (dual-license optionality for the AGPL-3.0 core). Gemini legal review applied (grant to Us only; §203 termination waiver; moral-rights waiver; ESIGN/UETA assent; CCLA cross-ref + version pin; Schedule A). Governing law: **State of Israel / Tel Aviv-Jaffa**.
- **`docs/cla/cla.yml`** — reusable workflow template (contributor-assistant@v2.6.1, App-token mint via `client-id`, allowlist `bot*,asafgolombek,claude`).
- **`docs/cla/README.md`** — sign-flow + version-bump SOP.
- **`docs/CONTRIBUTING.md`** — CLA section + MIT→AGPL one-way rule.
- **`scripts/structure-audit/check-cla-coverage.ts` (+ test)** — drift gate: every gated repo (6 public) must carry `cla.yml` at one pinned signature version; reachability-probe based (public repos → 404 = absent). Registered in `package.json` + `scripts/lib/preflight-gates.ts`.
- **`.github/workflows/org-drift-sweep.yml`** — `cla-coverage` job (RELEASE_BOT token, `--strict`).
- Design/plan/review docs under `docs/superpowers/`.

### Verification
- `check-cla-coverage` test: 4/4 ✅
- preflight-gates drift test: 5/5 ✅
- biome clean; gate typechecks clean
- `cla-coverage` sweep proven green against all 6 repos

Rebased onto current `main` (the two live-deploy CLA commits + #830/#831 ecosystem docs are already there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)