### PR TITLE
feat(audit): P5 gates — secret inventory + Actions allowlist

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -189,3 +189,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bun scripts/structure-audit/check-release-staleness.ts --strict
+
+  actions-allowlist:
+    name: actions-allowlist
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: `actions/permissions` and `actions/runs` on this repo are
+      # readable by the default github.token, which already carries actions:read.
+      - name: Audit the Actions allowlist + startup failures
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/structure-audit/check-actions-allowlist.ts --strict

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -194,6 +194,17 @@ jobs:
     name: actions-allowlist
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # `actions: read` covers the workflow + run lists, which is the half that
+    # matters most. The Actions ALLOWLIST endpoint additionally wants repo
+    # Administration, and the GITHUB_TOKEN permissions block has no
+    # `administration` scope at all — so that half may be unreadable here. The
+    # audit degrades to a warning in that case rather than failing, so the
+    # startup-failure detection still runs. To enable the allowlist half, mint
+    # the release-bot App token with `permission-administration: read` (see the
+    # ruleset-drift job above) and pass it as GH_TOKEN instead.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout Nimbus
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -46,6 +46,11 @@ a plain repository secret.
 | ~~`CODECOV_TOKEN`~~ | **Retired 2026-07-21** — uploads use OIDC | — | — |
 | `SCORECARD_TOKEN` | OSSF Scorecard (optional) | Fine-grained PAT — read-only | `scorecard.yml` |
 | `NIMBUS_CHECKS_TOKEN` | Cross-workflow check runs (optional) | Fine-grained PAT — Checks: RW | `ci.yml`, `_test-suite.yml` |
+| `SECRET_AUDITOR_CLIENT_ID` | Minting the read-only auditor App token | GitHub App client ID | `secret-health.yml` |
+| `SECRET_AUDITOR_PRIVATE_KEY` | Minting the read-only auditor App token | GitHub App private key (PEM) | `secret-health.yml` |
+| `CLA_BOT_CLIENT_ID` | Minting CLA Assistant App tokens | GitHub App client ID | `cla.yml` |
+| `CLA_BOT_PRIVATE_KEY` | Minting CLA Assistant App tokens | GitHub App private key (PEM) | `cla.yml` |
+| `BENCHER_API_KEY` | Benchmark upload (optional) | Bencher service token | `_perf.yml`, `_perf-reference.yml` |
 | `GITHUB_TOKEN` | — | **Automatic**, no action needed | all |
 
 `GITHUB_TOKEN` is injected by Actions automatically; it is never set by hand.

--- a/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
+++ b/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
@@ -205,6 +205,40 @@ failure does not red the sweep forever: the question is "can this start *now*",
 not "has it ever failed". Any workflow whose latest run is `startup_failure` is
 a hard finding.
 
+**Runs are fetched per workflow, not repo-wide** (review finding). The obvious
+`actions/runs?per_page=100` returns the newest runs across the WHOLE repo, so a
+quiet workflow falls off the page: measured here, 26 workflows but only 13
+represented in the newest 100 runs. The gate would have been blind to half of
+them — including `cla.yml`, which runs only on PRs, and the scheduled nightly
+jobs. Each active workflow's latest run is therefore fetched individually
+(`actions/workflows/{id}/runs?per_page=1`); disabled workflows are skipped,
+since one that cannot run has history rather than a live defect. A partial read
+reports unknown rather than a false all-clear — the workflow that failed to read
+might be the broken one.
+
+Fixing this immediately paid for itself: the per-workflow fetch found **"Lock
+Threads" failing at startup nightly since at least 2026-07-24**, because
+`dessant/lock-threads` is absent from `patterns_allowed`. That is a second live
+instance of the CLA failure mode, and the repo-wide window could not see it.
+It also corrects an assumption in this design: the five refs classified
+`unverifiable` were presumed permitted via `verified_allowed`, and at least one
+is not — which is precisely why the startup-failure half is the authoritative
+one.
+
+### The two halves are evaluated independently
+
+`actions/permissions` wants repo **Administration** on an App token, and the
+workflow `permissions:` block has **no `administration` scope at all**, so
+`github.token` may be unable to read it. Making that fatal would put the sweep
+permanently red for a reason nobody can fix from CI — the failure mode this
+design already rejected once for `verified_allowed`.
+
+So an unreadable allowlist degrades to a warning and the startup-failure half
+still runs on `actions: read` alone. Only when BOTH are unreadable is there
+nothing to say, which is the existing `strictSkip` path. The allowlist half can
+be enabled later by minting the release-bot App token with
+`permission-administration: read`, exactly as `ruleset-drift` already does.
+
 ### Verdicts
 
 `ok` / `not-permitted` (finding) / `unverifiable` (warn, never red) /

--- a/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
+++ b/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
@@ -46,21 +46,47 @@ recording; no code is owed.
 
 ## Effort 1 — `audit:secret-inventory`
 
-**Property:** every secret a workflow in this repo consumes is documented in
-`docs/ci-secrets.md`.
+**Property:** every secret a workflow in this repo consumes appears in **both**
+inventories — `scripts/release/credential-registry.ts` and `docs/ci-secrets.md`.
 
-**Why it matters here specifically.** Row 3 of the roadmap's opening table names
-`ci-secrets.md`'s completeness claim as a control that stopped where it was
-written — the doc did not cover `secret-health.yml`'s *own* credentials. That
-drift is still present today, along with four more:
+### There are two inventories, and only one of them had drifted
 
-| Undocumented secret | Introduced by |
-| --- | --- |
-| `SECRET_AUDITOR_CLIENT_ID` | the secret-health probe itself |
-| `SECRET_AUDITOR_PRIVATE_KEY` | the secret-health probe itself |
-| `CLA_BOT_CLIENT_ID` | the CLA program |
-| `CLA_BOT_PRIVATE_KEY` | the CLA program |
-| `BENCHER_API_KEY` | the benchmark workflow |
+The first draft of this design asserted that row 3 of the roadmap's opening
+table — `ci-secrets.md` not covering `secret-health.yml`'s *own* credentials —
+was still unfixed. **Reading the code disproved that**, and the correction is
+worth recording because it changes what the gate should check.
+
+There are two inventories with different jobs:
+
+- `scripts/release/credential-registry.ts` — the **authoritative**,
+  machine-checked manifest: state, owner, type, rotation policy, consuming
+  workflows. `credential-audit.ts` already gates *live org secret → registry*.
+  `ci-secrets.md` says so itself: "when they disagree, the manifest is right."
+- `docs/ci-secrets.md` — the narrative: what each credential is for and how to
+  mint it. The page consulted during an incident.
+
+All five secrets below are **already in the registry**. The drift is narrative
+only — they never reached the page that opens with "This page is the canonical
+inventory of every GitHub Actions secret the Nimbus workflows consume":
+
+| Missing from the prose doc | Introduced by | In the registry? |
+| --- | --- | --- |
+| `SECRET_AUDITOR_CLIENT_ID` | the secret-health probe itself | yes |
+| `SECRET_AUDITOR_PRIVATE_KEY` | the secret-health probe itself | yes |
+| `CLA_BOT_CLIENT_ID` | the CLA program | yes |
+| `CLA_BOT_PRIVATE_KEY` | the CLA program | yes |
+| `BENCHER_API_KEY` | the benchmark workflow | yes |
+
+So the gate asserts membership in **both**, and its finding says **which** is
+missing — because the two failures need different repairs. Absent from the doc
+is "add a row to a table". Absent from the registry is "this credential is
+unmanaged: no owner, no rotation policy, and `secret-health` is not watching
+it." Collapsing them into one message would let the serious case hide behind
+the cosmetic one.
+
+Neither existing check covers this axis: `credential-audit` compares *live org
+secrets* to the registry, so a secret referenced by a workflow but never
+provisioned — or provisioned and never documented — is nobody's finding today.
 
 ### Direction: one-way, deliberately
 
@@ -92,8 +118,10 @@ Pure function over already-read text, mirroring `check-release-staleness.ts`:
 - `documentedSecrets(doc: string): Set<string>` — every backtick-quoted
   `UPPER_SNAKE` token in `ci-secrets.md`. Deliberately loose: the doc's shape is
   prose plus a table, and a parser tied to the table would break the moment
-  someone documents a secret in a paragraph.
-- `evaluateInventory(used, documented, exclusions): Finding[]`.
+  someone documents a secret in a paragraph. A struck-through retired entry
+  still counts — that is a deliberate record, not an omission.
+- `evaluateInventory(used, documented, registered, exclusions): Finding[]`,
+  where each finding carries `missingFrom: "doc" | "registry" | "both"`.
 
 **This gate is local and runs on every PR**, unlike the sweep gates — it reads
 only checked-in files, needs no token, and is deterministic. It therefore joins
@@ -143,26 +171,52 @@ An action reference `owner/repo@ref` (or `owner/repo/path@ref`) is covered when:
 Local `./...` and Docker `docker://...` references are not subject to the
 allowlist and are ignored.
 
-**`verified_allowed` is the honest hard case.** Whether an action's creator is a
-verified GitHub partner is not derivable from the repo's own API response. When
-`verified_allowed` is true and a reference is not otherwise covered, the verdict
-is **`indeterminate`, never a finding** — the same fail-closed-toward-silence
-rule the rest of the program uses for anything unreadable. Reporting it as a
-violation would produce false reds on legitimately-permitted verified actions;
-reporting it as covered would reintroduce the blind spot. Saying "cannot tell"
-is the only honest option, and under `--strict` a run that could evaluate
-nothing is red anyway.
+Actions owned by the **same org as the consuming repo** are always permitted by
+GitHub regardless of the allowlist, so `nimbus-agent/.github/actions/*` is
+covered and counting it would be a false finding.
+
+**`verified_allowed` breaks the pattern approach, and running it proved so.**
+Whether an action's creator is a verified Marketplace partner is not derivable
+from any API. The live allowlist has `verified_allowed: true` and five refs
+(`dessant/lock-threads`, `oven-sh/setup-bun`, `googleapis/release-please-action`,
+`bencherdev/bencher`) that are covered *only* by it. The first implementation
+called that `indeterminate`, which under the program's own strict rule is red —
+making the gate **permanently red for a reason nobody can fix**. A gate that is
+always red is one everybody learns to ignore, which is precisely the failure
+this sub-program exists to prevent.
+
+So the design gains a fifth verdict, `unverifiable`, which warns but is **never
+red**. The distinction is real: `indeterminate` means a read failed and may
+succeed next run, so strict-red is right; `unverifiable` means the answer can
+never arrive.
+
+### The direct half — `startup_failure` detection
+
+Inferring permission from patterns is the weak half. The strong half asks the
+observable question instead: **is any workflow currently failing to start?**
+
+`repos/{repo}/actions/runs` carries a `startup_failure` conclusion for exactly
+the condition that took the CLA down — GitHub rejected the workflow before any
+job ran. That needs no knowledge of verified-creator status, and it catches
+causes the pattern check cannot see at all, such as invalid workflow YAML.
+
+Scoped to each workflow's **most recent** run, so a since-fixed historical
+failure does not red the sweep forever: the question is "can this start *now*",
+not "has it ever failed". Any workflow whose latest run is `startup_failure` is
+a hard finding.
 
 ### Verdicts
 
-`ok` / `not-permitted` (a finding) / `indeterminate`. Reuses `classifyReadFailure`
-and the `--strict` / `strictSkip` contract from `_gh-audit.ts`; runs as a new
-job on `org-drift-sweep`.
+`ok` / `not-permitted` (finding) / `unverifiable` (warn, never red) /
+`indeterminate` (strict-red) / `skipped`, plus the independent startup-failure
+findings. Reuses `classifyReadFailure` and the `--strict` / `strictSkip`
+contract; runs as a new job on `org-drift-sweep`.
 
 **Expected on arrival: green.** The allowlist was repaired on 2026-07-26, so
-this gate cannot red-prove against production. It is therefore red-proved by
-**unit test** — a fixture repo whose workflow uses an unpermitted action — and
-the live run is the green-after half of the evidence.
+this gate cannot red-prove against production. It is red-proved by **unit
+test** — including a fixture reproducing the exact CLA case, where adding
+`contributor-assistant/github-action@*` flips `not-permitted` to `ok` — and the
+live run is the green-after half.
 
 ---
 
@@ -260,16 +314,20 @@ config is a reasonable P5 follow-up, and is explicitly **not** in this batch.
 Each gate follows the established pattern: table-driven unit tests over pure
 functions, no network, in `scripts/structure-audit/<name>.test.ts`.
 
-- **secret-inventory** — reference found in `secrets.X` and `secrets['X']`
-  forms; `GITHUB_TOKEN` excluded; a documented secret passes; an undocumented
-  one is a finding naming the workflow; the reverse-direction census never
-  produces a finding; the committed pair (`.github/workflows/**` +
-  `docs/ci-secrets.md`) is clean.
+- **secret-inventory** — reference found in `secrets.X`, `secrets['X']` and
+  `secrets["X"]` forms; one secret attributed to every workflow naming it,
+  without duplicates; `GITHUB_TOKEN` excluded; each of the three
+  `missingFrom` values produced by the right input; an inventory entry with no
+  local consumer never becomes a finding; the committed tree
+  (`.github/workflows/**` + `docs/ci-secrets.md` + the registry) is clean.
 - **actions-allowlist** — `owner/*`, exact, `@ref` and trailing-`*` patterns;
-  `github_owned_allowed` covering `actions/checkout`; local `./` and
-  `docker://` ignored; an unpermitted action is a finding; `verified_allowed`
-  with an uncovered reference is `indeterminate`; a non-`selected` repo is
-  skipped.
+  `github_owned_allowed` covering `actions/checkout`; same-org actions always
+  permitted; local `./` and `docker://` ignored; an unpermitted action is a
+  finding; the CLA case specifically (adding the pattern flips the verdict);
+  `verified_allowed` with an uncovered reference is `unverifiable`, never a
+  finding; a non-`selected` repo is skipped. For the startup-failure half: a
+  latest-run failure is reported, a since-fixed historical one is not, a
+  newly-broken workflow is, and an ordinary test `failure` is not.
 - **sha-pin freshness** — equal SHAs are `ok`; a differing SHA past grace is
   `stale`; differing but within grace is `ok`; an unreadable release, a repo
   with no releases, and an underivable tag SHA are each `indeterminate`.

--- a/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
+++ b/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
@@ -46,8 +46,11 @@ recording; no code is owed.
 
 ## Effort 1 — `audit:secret-inventory`
 
-**Property:** every secret a workflow in this repo consumes appears in **both**
-inventories — `scripts/release/credential-registry.ts` and `docs/ci-secrets.md`.
+**Property:** every **non-excluded** secret a workflow in this repo consumes
+appears in **both** inventories — `scripts/release/credential-registry.ts` and
+`docs/ci-secrets.md`. The exclusion list is `GITHUB_TOKEN` alone (see
+*Exclusions* below); it is Actions-provided and so cannot be missing from an
+inventory of things an operator must provision.
 
 ### There are two inventories, and only one of them had drifted
 
@@ -177,9 +180,12 @@ covered and counting it would be a false finding.
 
 **`verified_allowed` breaks the pattern approach, and running it proved so.**
 Whether an action's creator is a verified Marketplace partner is not derivable
-from any API. The live allowlist has `verified_allowed: true` and five refs
-(`dessant/lock-threads`, `oven-sh/setup-bun`, `googleapis/release-please-action`,
-`bencherdev/bencher`) that are covered *only* by it. The first implementation
+from any API. The live allowlist has `verified_allowed: true` and five
+*occurrences* — across four distinct actions (`dessant/lock-threads`,
+`oven-sh/setup-bun`, `googleapis/release-please-action`, `bencherdev/bencher`,
+the last used by two workflows) — that are covered *only* by it. The count is
+occurrences and the message lists unique names, which is why the two numbers
+differ. The first implementation
 called that `indeterminate`, which under the program's own strict rule is red —
 making the gate **permanently red for a reason nobody can fix**. A gate that is
 always red is one everybody learns to ignore, which is precisely the failure
@@ -325,8 +331,11 @@ with `path_instructions` scoped to what actually differs per area:
 - `packages/gateway/src/**/*.test.ts` and `security-invariants.test.ts` — the
   triple rule: a new structural defense lands with wiring **and** docs **and** a
   test in the same commit.
-- `scripts/structure-audit/**` — gates fail soft locally and hard under
-  `--strict`; an unreadable input degrades to indeterminate, never to a finding.
+- `scripts/structure-audit/**` — a NETWORK-backed gate fails soft locally and
+  hard under `--strict`; a purely local, deterministic gate (no token, no
+  network — `audit:secret-inventory`) simply fails on a finding and has no
+  strict mode. In both, an unreadable or unparseable input degrades to
+  indeterminate, never to a finding.
 - `packages/mcp-connectors/**` — connectors depend only on `@nimbus-dev/sdk`;
   the engine never calls cloud APIs directly.
 

--- a/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
+++ b/docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md
@@ -1,0 +1,289 @@
+# P5 + P3 infrastructure batch — four gates and a review config
+
+**Status:** design approved 2026-07-26, implementation in progress.
+**Sub-programs:** [P5 Org Legibility](../../infrastructure-roadmap.md#p5-progress-log)
+and [P3 Review Layer](../../infrastructure-roadmap.md#sub-programs).
+**Program design of record:** `2026-07-23-org-infrastructure-program-design.md`
+(archived; read via `git show 06c6a144:docs/superpowers/specs/...`).
+
+## Why these four together
+
+Four independent efforts, batched into one spec because they were commissioned
+together and share the program's operating principle — *a sub-program is done
+when its gate is green in CI and would go red if the property regressed*. They
+do **not** share code, and each ships as its own PR:
+
+| Effort | Sub-program | Gate kind | PR |
+| --- | --- | --- | --- |
+| `audit:secret-inventory` | P5 | local, every PR | 1 |
+| `audit:actions-allowlist` | P5 | network, scheduled sweep | 1 |
+| SHA-pin freshness | P1 follow-up | network, scheduled sweep | 3 |
+| Nimbus `.coderabbit.yaml` | P3 | advisory review config | 2 |
+
+### Two corrections to the roadmap's stated scope
+
+Both were established by reading the code rather than the doc, and both change
+what is worth building.
+
+**P3's stated gate is already met.** The roadmap's P3 row reads "An invariant
+violation is caught in CI, not only in local `preflight`". It already is:
+`.github/workflows/_structure.yml` runs `bun run audit:invariants`, and all
+seventeen static checks execute there. The single branch excluded by
+`--binary-only` is `db-run`, which is a **census** — it writes
+`db-run-census.json` and always exits 0. Excluding a non-gate from CI is
+correct, not a gap.
+
+The real P3 content is the program design's own **Correction 1**: all four
+satellite repos carry a tuned `.coderabbit.yaml`; the `Nimbus` monorepo does
+not. That is instance 2 of the named pattern, running satellites → monorepo.
+
+**One P5 item is already done.** The `secret-health` permission-superset fix
+(a probe must request the superset of what its consumers request, or a revoked
+permission is undetectable) landed in #837. Only the general rule needs
+recording; no code is owed.
+
+---
+
+## Effort 1 — `audit:secret-inventory`
+
+**Property:** every secret a workflow in this repo consumes is documented in
+`docs/ci-secrets.md`.
+
+**Why it matters here specifically.** Row 3 of the roadmap's opening table names
+`ci-secrets.md`'s completeness claim as a control that stopped where it was
+written — the doc did not cover `secret-health.yml`'s *own* credentials. That
+drift is still present today, along with four more:
+
+| Undocumented secret | Introduced by |
+| --- | --- |
+| `SECRET_AUDITOR_CLIENT_ID` | the secret-health probe itself |
+| `SECRET_AUDITOR_PRIVATE_KEY` | the secret-health probe itself |
+| `CLA_BOT_CLIENT_ID` | the CLA program |
+| `CLA_BOT_PRIVATE_KEY` | the CLA program |
+| `BENCHER_API_KEY` | the benchmark workflow |
+
+### Direction: one-way, deliberately
+
+The gate asserts **workflow → doc**, never the reverse. `ci-secrets.md` is an
+**org-wide** inventory: it documents `VSCE_PAT`, `OVSX_PAT` and `NPM_TOKEN`,
+which are consumed by workflows in `nimbus-vscode` and the npm repos, not here.
+A bidirectional check would red on nine entries that are correct, and the fix
+for that noise would be to *delete true information from the inventory* — the
+opposite of the goal.
+
+The reverse direction is still worth surfacing, so undocumented-elsewhere
+entries are printed as an informational census line, never as a finding.
+
+### Exclusions
+
+`GITHUB_TOKEN` only. It is GitHub-provided, never configured by an operator, and
+so cannot be missing from an inventory of things an operator must provision.
+Anything else absent from the doc is a finding — a narrow exclusion list is the
+point, since every past instance of this pattern hid inside a plausible-looking
+exemption.
+
+### Shape
+
+Pure function over already-read text, mirroring `check-release-staleness.ts`:
+
+- `collectWorkflowSecrets(files: {path, text}[]): Map<string, string[]>` — every
+  `secrets.NAME` reference, mapped to the workflows naming it. Matches both
+  `secrets.NAME` and `secrets['NAME']`.
+- `documentedSecrets(doc: string): Set<string>` — every backtick-quoted
+  `UPPER_SNAKE` token in `ci-secrets.md`. Deliberately loose: the doc's shape is
+  prose plus a table, and a parser tied to the table would break the moment
+  someone documents a secret in a paragraph.
+- `evaluateInventory(used, documented, exclusions): Finding[]`.
+
+**This gate is local and runs on every PR**, unlike the sweep gates — it reads
+only checked-in files, needs no token, and is deterministic. It therefore joins
+the `fast` tier of `scripts/lib/preflight-gates.ts`.
+
+**Consequence that shapes the PR:** a local gate that ships red breaks every
+subsequent PR. So unlike P2 — a scheduled sweep, where shipping red was correct
+— this one must be **green at merge**. The five rows above are added to
+`ci-secrets.md` in the same PR, and the red-before proof is captured in the PR
+description rather than left in the tree.
+
+---
+
+## Effort 2 — `audit:actions-allowlist`
+
+**Property:** for every org repo whose `allowed_actions` is `selected`, every
+action a workflow `uses:` is permitted to run.
+
+**Why:** this is the gate that would have caught the two-day CLA outage on day
+zero. `Nimbus` is the only repo with a restricted allowlist, and
+`contributor-assistant/github-action` was absent from `patterns_allowed`, so
+GitHub rejected the workflow before any job started — 23 consecutive
+`startup_failure` runs, a required check that never reported, and every PR
+silently unmergeable. `cla-coverage` was green throughout, because it verifies a
+control's *presence*, not its *ability to execute*.
+
+### Reads
+
+Both are public-shaped but need auth for org repos, so they reuse `runGh`:
+
+- `repos/{owner}/{repo}/actions/permissions` → `{enabled, allowed_actions}`
+- `repos/{owner}/{repo}/actions/permissions/selected-actions` →
+  `{github_owned_allowed, verified_allowed, patterns_allowed}`
+
+A repo whose `allowed_actions` is not `selected` is skipped — nothing to
+violate.
+
+### Coverage rules
+
+An action reference `owner/repo@ref` (or `owner/repo/path@ref`) is covered when:
+
+1. `github_owned_allowed` and the owner is `actions` or `github`; or
+2. any entry of `patterns_allowed` matches. Supported forms, per GitHub's
+   documented syntax: exact `owner/repo`, `owner/repo@ref`, `owner/*`, and a
+   trailing `*` wildcard.
+
+Local `./...` and Docker `docker://...` references are not subject to the
+allowlist and are ignored.
+
+**`verified_allowed` is the honest hard case.** Whether an action's creator is a
+verified GitHub partner is not derivable from the repo's own API response. When
+`verified_allowed` is true and a reference is not otherwise covered, the verdict
+is **`indeterminate`, never a finding** — the same fail-closed-toward-silence
+rule the rest of the program uses for anything unreadable. Reporting it as a
+violation would produce false reds on legitimately-permitted verified actions;
+reporting it as covered would reintroduce the blind spot. Saying "cannot tell"
+is the only honest option, and under `--strict` a run that could evaluate
+nothing is red anyway.
+
+### Verdicts
+
+`ok` / `not-permitted` (a finding) / `indeterminate`. Reuses `classifyReadFailure`
+and the `--strict` / `strictSkip` contract from `_gh-audit.ts`; runs as a new
+job on `org-drift-sweep`.
+
+**Expected on arrival: green.** The allowlist was repaired on 2026-07-26, so
+this gate cannot red-prove against production. It is therefore red-proved by
+**unit test** — a fixture repo whose workflow uses an unpermitted action — and
+the live run is the green-after half of the evidence.
+
+---
+
+## Effort 3 — SHA-pin freshness
+
+**Property:** a SHA-pinned action is not merely pinned, but pinned to something
+current.
+
+**The gap this closes.** `audit:action-sha-pins` proves every `uses:` is a
+40-hex SHA rather than a moving tag. It is *structurally* unable to notice that
+the SHA is two years old: an ancient pin and a fresh pin are both equally
+"pinned". P1's first sweep recorded exactly this — `harden-runner` v2.20.0 vs
+v2.19.4 and `actions/checkout` v7.0.1 vs v7.0.0 across repos — and classified it
+as staleness, not unpinning, with a freshness check deferred as "Plan B".
+
+### Approach
+
+For each distinct pinned action, resolve the pin against the action repo's
+releases:
+
+1. `repos/{owner}/{repo}/releases/latest` → the current release tag.
+2. `repos/{owner}/{repo}/git/ref/tags/{tag}` → that tag's SHA (dereferencing an
+   annotated tag object to its commit).
+3. Compare against the pinned SHA. Equal → `ok`.
+
+When they differ, the pin is behind. **Behind is not automatically a finding**:
+a release published an hour ago must not red the org, for the same reason P2
+grace-windows a fresh npm publish. The release's own `published_at` age is
+compared against a grace window, and only a pin behind a release older than the
+window is reported.
+
+**Grace window: 30 days**, not P2's 6 hours. These are different failure classes.
+A release-train edge is an automated pipeline that should propagate within
+minutes, so hours of lag is a defect. An action pin is updated by a human or by
+Dependabot, and a 6-hour window would mean a permanently red sweep that everyone
+learns to ignore — which is worse than no gate. Thirty days says "this pin has
+been stale across a full release cycle and nobody noticed", which is the
+condition actually worth alerting on.
+
+Verdicts: `ok` / `stale` / `indeterminate` (unreadable, no releases, or a tag
+that cannot be dereferenced). Runs in the sweep alongside the existing pin
+audit; the existing gate is untouched.
+
+---
+
+## Effort 4 — Nimbus `.coderabbit.yaml`
+
+**Property:** the monorepo's automated reviewer knows the monorepo's rules.
+
+**Why this is P3's whole first step.** There are no human reviewers: of the last
+80 merged PRs org-wide, 61 were the owner, 18 the release bot, 1 Dependabot.
+"Improve PR review" therefore means improving *automated* review of AI-assisted
+PRs. The four satellites each carry a tuned config; `Nimbus` — the repo with 30
+security invariants — gets stock review. The config is advisory by design:
+CodeRabbit is not a required check and must not become one, so a false positive
+costs a comment, never a blocked merge.
+
+### Content
+
+Modelled on `nimbus-client`'s config (`profile: chill`,
+`request_changes_workflow: false`, `auto_review` on `main`, drafts excluded),
+with `path_instructions` scoped to what actually differs per area:
+
+- `packages/gateway/src/engine/**` — the HITL gate is structural (I2/I3/I4): the
+  consent gate lives in the executor, keys off `action.type` only, and
+  `hitlStatus` is set nowhere else.
+- `packages/gateway/src/**` — no `any` (`unknown` + a guard); never import
+  `platform/{win32,darwin,linux}` from business logic (PAL rule); Vault-only
+  credentials, never in logs/IPC/config.
+- `packages/gateway/src/ipc/**` — HTTP writes go through `WRITE_ROUTE_ALLOWLIST`
+  (I13); anything renderer-reachable is an `ALLOWED_METHODS` decision (I7).
+- `packages/gateway/src/**/*.test.ts` and `security-invariants.test.ts` — the
+  triple rule: a new structural defense lands with wiring **and** docs **and** a
+  test in the same commit.
+- `scripts/structure-audit/**` — gates fail soft locally and hard under
+  `--strict`; an unreadable input degrades to indeterminate, never to a finding.
+- `packages/mcp-connectors/**` — connectors depend only on `@nimbus-dev/sdk`;
+  the engine never calls cloud APIs directly.
+
+`path_filters` exclude `dist/**`, `**/node_modules/**` and generated assets so
+review attention lands on source.
+
+**Verification is necessarily weaker than a gate**, and this spec should not
+pretend otherwise. The config's effect is observable only as review comments on
+a subsequent PR. What *is* checkable now — and is all that will be claimed — is
+that the YAML parses, that its schema matches the four working satellite
+configs, and that every invariant id it cites exists in
+`docs/SECURITY-INVARIANTS.md`. A drift gate asserting all five repos carry a
+config is a reasonable P5 follow-up, and is explicitly **not** in this batch.
+
+---
+
+## Testing
+
+Each gate follows the established pattern: table-driven unit tests over pure
+functions, no network, in `scripts/structure-audit/<name>.test.ts`.
+
+- **secret-inventory** — reference found in `secrets.X` and `secrets['X']`
+  forms; `GITHUB_TOKEN` excluded; a documented secret passes; an undocumented
+  one is a finding naming the workflow; the reverse-direction census never
+  produces a finding; the committed pair (`.github/workflows/**` +
+  `docs/ci-secrets.md`) is clean.
+- **actions-allowlist** — `owner/*`, exact, `@ref` and trailing-`*` patterns;
+  `github_owned_allowed` covering `actions/checkout`; local `./` and
+  `docker://` ignored; an unpermitted action is a finding; `verified_allowed`
+  with an uncovered reference is `indeterminate`; a non-`selected` repo is
+  skipped.
+- **sha-pin freshness** — equal SHAs are `ok`; a differing SHA past grace is
+  `stale`; differing but within grace is `ok`; an unreadable release, a repo
+  with no releases, and an underivable tag SHA are each `indeterminate`.
+- **coderabbit config** — parses as YAML; carries the same top-level keys as the
+  satellite configs; every `I<n>` it names exists in `docs/SECURITY-INVARIANTS.md`.
+
+## Out of scope
+
+- **Fixing** anything the allowlist or freshness gates find. Both detect;
+  remediation is a separate, reviewed change — and for the allowlist, a repo
+  settings `PUT` that only the org owner can run (the endpoint is a full
+  replace, so a careless write silently unpermits Trivy/CodeQL/gitleaks).
+- **A CodeRabbit-config drift gate** across the five repos — a P5 follow-up.
+- **Dependabot configuration** for action updates. The freshness gate reports;
+  deciding to automate the bumps is a separate call.
+- **The `awesome-nimbus` App-installation fix** and **`VSCE_PAT` rotation** —
+  org-owner actions, tracked in the roadmap, not buildable here.

--- a/package.json
+++ b/package.json
@@ -168,6 +168,8 @@
     "audit:team-reachability": "bun scripts/structure-audit/check-team-reachability.ts",
     "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
     "audit:release-staleness": "bun scripts/structure-audit/check-release-staleness.ts",
+    "audit:secret-inventory": "bun scripts/structure-audit/check-secret-inventory.ts",
+    "audit:actions-allowlist": "bun scripts/structure-audit/check-actions-allowlist.ts",
     "audit:secrets": "gitleaks detect --source . --no-banner --redact --exit-code 1",
     "audit:links": "lychee --no-progress --config lychee.toml \"docs/**/*.md\" \"*.md\"",
     "lint": "biome check --error-on-warnings .",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -25,6 +25,7 @@ const FAST: readonly Gate[] = [
   { name: "audit:status-drift", cmd: ["bun", "run", "audit:status-drift"], tier: "fast" },
   { name: "audit:action-sha-pins", cmd: ["bun", "run", "audit:action-sha-pins"], tier: "fast" },
   { name: "audit:consumed-by", cmd: ["bun", "run", "audit:consumed-by"], tier: "fast" },
+  { name: "audit:secret-inventory", cmd: ["bun", "run", "audit:secret-inventory"], tier: "fast" },
   { name: "audit:exclusion-parity", cmd: ["bun", "run", "audit:exclusion-parity"], tier: "fast" },
   {
     // Reads .jscpd.json (min-lines 5 / min-tokens 50 / threshold ratchet / shared
@@ -68,6 +69,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:actions-allowlist", // needs network + gh (reads each repo's Actions permissions); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/structure-audit/check-actions-allowlist.test.ts
+++ b/scripts/structure-audit/check-actions-allowlist.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, test } from "bun:test";
 import {
   collectActionRefs,
   evaluateAllowlist,
+  isActiveWorkflow,
   isCoveredByPatterns,
   latestStartupFailures,
   parsePermissions,
   parseRuns,
   parseSelectedActions,
+  parseWorkflows,
   type RunSummary,
   type SelectedActions,
 } from "./check-actions-allowlist.ts";
@@ -191,6 +193,25 @@ describe("latestStartupFailures", () => {
 
   test("no runs => nothing broken", () => {
     expect(latestStartupFailures([])).toEqual([]);
+  });
+});
+
+describe("parseWorkflows / isActiveWorkflow", () => {
+  test("reads id, name and state", () => {
+    const w = parseWorkflows('{"workflows":[{"id":7,"name":"cla","state":"active"}]}');
+    expect(w).toEqual([{ id: 7, name: "cla", state: "active" }]);
+  });
+
+  test("a disabled workflow is not asked — it cannot run, so a stale failure is history", () => {
+    expect(isActiveWorkflow({ id: 1, name: "x", state: "disabled_manually" })).toBe(false);
+    expect(isActiveWorkflow({ id: 1, name: "x", state: "active" })).toBe(true);
+  });
+
+  test("null on malformed json; entries missing id or name are dropped", () => {
+    expect(parseWorkflows("{nope")).toBeNull();
+    expect(parseWorkflows('{"workflows":[{"name":"no-id"},{"id":2,"name":"ok"}]}')).toEqual([
+      { id: 2, name: "ok", state: "active" },
+    ]);
   });
 });
 

--- a/scripts/structure-audit/check-actions-allowlist.test.ts
+++ b/scripts/structure-audit/check-actions-allowlist.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectActionRefs,
+  evaluateAllowlist,
+  isCoveredByPatterns,
+  latestStartupFailures,
+  parsePermissions,
+  parseRuns,
+  parseSelectedActions,
+  type RunSummary,
+  type SelectedActions,
+} from "./check-actions-allowlist.ts";
+
+const sel = (over: Partial<SelectedActions> = {}): SelectedActions => ({
+  githubOwnedAllowed: false,
+  verifiedAllowed: false,
+  patternsAllowed: [],
+  ...over,
+});
+
+describe("collectActionRefs", () => {
+  test("collects uses: refs and attributes them to their workflow", () => {
+    const refs = collectActionRefs([
+      { path: "ci.yml", text: "steps:\n  - uses: actions/checkout@abc123\n" },
+    ]);
+    expect(refs).toEqual([{ ref: "actions/checkout@abc123", workflow: "ci.yml" }]);
+  });
+
+  test("ignores local ./ and docker:// references — the allowlist does not govern them", () => {
+    const refs = collectActionRefs([
+      { path: "a.yml", text: "  - uses: ./.github/actions/setup\n  - uses: docker://alpine:3\n" },
+    ]);
+    expect(refs).toEqual([]);
+  });
+
+  test("handles quoted refs and a subdirectory path", () => {
+    const refs = collectActionRefs([
+      { path: "a.yml", text: '  - uses: "github/codeql-action/init@v3"\n' },
+    ]);
+    expect(refs[0]?.ref).toBe("github/codeql-action/init@v3");
+  });
+
+  test("deduplicates the same ref used twice in one workflow", () => {
+    const refs = collectActionRefs([{ path: "a.yml", text: "  - uses: a/b@1\n  - uses: a/b@1\n" }]);
+    expect(refs).toHaveLength(1);
+  });
+});
+
+describe("isCoveredByPatterns", () => {
+  test("exact owner/repo match", () => {
+    expect(isCoveredByPatterns("acme/tool@sha", ["acme/tool"])).toBe(true);
+  });
+  test("owner wildcard", () => {
+    expect(isCoveredByPatterns("acme/tool@sha", ["acme/*"])).toBe(true);
+  });
+  test("trailing star suffix", () => {
+    expect(isCoveredByPatterns("acme/tool@sha", ["acme/tool@*"])).toBe(true);
+  });
+  test("a subdirectory action is covered by its owner/repo pattern", () => {
+    expect(isCoveredByPatterns("github/codeql-action/init@v3", ["github/codeql-action@*"])).toBe(
+      true,
+    );
+  });
+  test("a different owner is NOT covered", () => {
+    expect(isCoveredByPatterns("evil/tool@sha", ["acme/*"])).toBe(false);
+  });
+  test("empty pattern list covers nothing", () => {
+    expect(isCoveredByPatterns("acme/tool@sha", [])).toBe(false);
+  });
+});
+
+describe("evaluateAllowlist", () => {
+  const refs = [{ ref: "contributor-assistant/github-action@ca4a40a7", workflow: "cla.yml" }];
+
+  test("a repo that does not restrict actions is skipped entirely", () => {
+    const r = evaluateAllowlist("Nimbus", "all", null, refs);
+    expect(r.verdict).toBe("skipped");
+    expect(r.findings).toEqual([]);
+  });
+
+  test("an unpermitted action is a finding naming the workflow", () => {
+    const r = evaluateAllowlist("Nimbus", "selected", sel({ patternsAllowed: ["other/*"] }), refs);
+    expect(r.verdict).toBe("not-permitted");
+    expect(r.findings[0]?.ref).toBe("contributor-assistant/github-action@ca4a40a7");
+    expect(r.findings[0]?.workflow).toBe("cla.yml");
+  });
+
+  test("the CLA outage: adding the pattern makes it permitted", () => {
+    const r = evaluateAllowlist(
+      "Nimbus",
+      "selected",
+      sel({ patternsAllowed: ["contributor-assistant/github-action@*"] }),
+      refs,
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("github_owned_allowed covers actions/* and github/*", () => {
+    const r = evaluateAllowlist("Nimbus", "selected", sel({ githubOwnedAllowed: true }), [
+      { ref: "actions/checkout@sha", workflow: "ci.yml" },
+      { ref: "github/codeql-action/init@sha", workflow: "ci.yml" },
+    ]);
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("github_owned_allowed does NOT cover a third party", () => {
+    const r = evaluateAllowlist("Nimbus", "selected", sel({ githubOwnedAllowed: true }), refs);
+    expect(r.verdict).toBe("not-permitted");
+  });
+
+  test("verified_allowed + an uncovered ref => unverifiable, never a finding", () => {
+    // Whether a creator is a verified partner is not derivable from any API.
+    // Calling it a violation would false-red a legitimately permitted action;
+    // calling it covered would restore the blind spot. `unverifiable` is a
+    // PERMANENT unknown and so must not be strict-red, unlike `indeterminate`.
+    const r = evaluateAllowlist("Nimbus", "selected", sel({ verifiedAllowed: true }), refs);
+    expect(r.verdict).toBe("unverifiable");
+    expect(r.findings).toEqual([]);
+  });
+
+  test("an action owned by the consuming repo's own org is always permitted", () => {
+    const r = evaluateAllowlist("nimbus-agent/Nimbus", "selected", sel(), [
+      { ref: "nimbus-agent/.github/actions/verify-npm-provenance@sha", workflow: "release.yml" },
+    ]);
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("a pattern match wins over verified_allowed ambiguity", () => {
+    const r = evaluateAllowlist(
+      "Nimbus",
+      "selected",
+      sel({ verifiedAllowed: true, patternsAllowed: ["contributor-assistant/*"] }),
+      refs,
+    );
+    expect(r.verdict).toBe("ok");
+  });
+
+  test("unreadable selected-actions => indeterminate", () => {
+    const r = evaluateAllowlist("Nimbus", "selected", null, refs);
+    expect(r.verdict).toBe("indeterminate");
+  });
+});
+
+describe("latestStartupFailures", () => {
+  const run = (workflow: string, createdAt: string, conclusion: string | null): RunSummary => ({
+    workflow,
+    createdAt,
+    conclusion,
+    status: "completed",
+  });
+
+  test("a workflow whose latest run failed at startup is reported", () => {
+    expect(latestStartupFailures([run("cla", "2026-07-24T10:00:00Z", "startup_failure")])).toEqual([
+      "cla",
+    ]);
+  });
+
+  test("a SINCE-FIXED historical failure is not reported", () => {
+    // The question is "can this workflow start now", not "has it ever failed" —
+    // otherwise one bad day reds the sweep forever and the gate gets ignored.
+    expect(
+      latestStartupFailures([
+        run("cla", "2026-07-24T10:00:00Z", "startup_failure"),
+        run("cla", "2026-07-26T10:00:00Z", "success"),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("a newly-broken workflow is reported even with older green runs", () => {
+    expect(
+      latestStartupFailures([
+        run("cla", "2026-07-20T10:00:00Z", "success"),
+        run("cla", "2026-07-26T10:00:00Z", "startup_failure"),
+      ]),
+    ).toEqual(["cla"]);
+  });
+
+  test("an ordinary test failure is NOT a startup failure", () => {
+    expect(latestStartupFailures([run("ci", "2026-07-26T10:00:00Z", "failure")])).toEqual([]);
+  });
+
+  test("reports each broken workflow once, sorted", () => {
+    expect(
+      latestStartupFailures([
+        run("zeta", "2026-07-26T10:00:00Z", "startup_failure"),
+        run("alpha", "2026-07-26T10:00:00Z", "startup_failure"),
+      ]),
+    ).toEqual(["alpha", "zeta"]);
+  });
+
+  test("no runs => nothing broken", () => {
+    expect(latestStartupFailures([])).toEqual([]);
+  });
+});
+
+describe("parseRuns", () => {
+  test("reads name, conclusion and created_at", () => {
+    const r = parseRuns(
+      '{"workflow_runs":[{"name":"cla","conclusion":"startup_failure","status":"completed","created_at":"2026-07-24T10:00:00Z"}]}',
+    );
+    expect(r?.[0]?.workflow).toBe("cla");
+    expect(r?.[0]?.conclusion).toBe("startup_failure");
+  });
+  test("null on malformed json, empty on a shape with no runs", () => {
+    expect(parseRuns("{nope")).toBeNull();
+    expect(parseRuns('{"workflow_runs":[]}')).toEqual([]);
+  });
+});
+
+describe("parsePermissions / parseSelectedActions", () => {
+  test("reads allowed_actions", () => {
+    expect(parsePermissions('{"enabled":true,"allowed_actions":"selected"}')).toBe("selected");
+  });
+  test("null when Actions is disabled entirely", () => {
+    expect(parsePermissions('{"enabled":false}')).toBeNull();
+  });
+  test("null on malformed json", () => {
+    expect(parsePermissions("{nope")).toBeNull();
+  });
+  test("reads the three selected-actions fields", () => {
+    const s = parseSelectedActions(
+      '{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["a/*"]}',
+    );
+    expect(s).toEqual({
+      githubOwnedAllowed: true,
+      verifiedAllowed: false,
+      patternsAllowed: ["a/*"],
+    });
+  });
+  test("null on malformed json", () => {
+    expect(parseSelectedActions("{nope")).toBeNull();
+  });
+});

--- a/scripts/structure-audit/check-actions-allowlist.ts
+++ b/scripts/structure-audit/check-actions-allowlist.ts
@@ -23,7 +23,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
 
 export interface WorkflowFile {
   path: string;
@@ -235,6 +235,51 @@ export function latestStartupFailures(runs: readonly RunSummary[]): string[] {
     .sort();
 }
 
+export interface WorkflowRef {
+  id: number;
+  name: string;
+  state: string;
+}
+
+/**
+ * The repo's workflows.
+ *
+ * Needed because `actions/runs` returns the newest runs REPO-WIDE, so a quiet
+ * workflow falls off the page entirely. Measured on this repo: 26 workflows,
+ * but the newest 100 runs covered only 13 of them — the gate would have been
+ * blind to half, plausibly including `cla.yml`, which runs only on PRs and is
+ * the exact outage this gate exists to catch. Each workflow's latest run is
+ * therefore fetched individually.
+ */
+export function parseWorkflows(json: string): WorkflowRef[] | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const list = p["workflows"];
+    if (!Array.isArray(list)) return null;
+    const out: WorkflowRef[] = [];
+    for (const w of list) {
+      if (!isRecord(w)) continue;
+      const id = w["id"];
+      const name = w["name"];
+      const state = w["state"];
+      if (typeof id !== "number" || typeof name !== "string") continue;
+      out.push({ id, name, state: typeof state === "string" ? state : "active" });
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A disabled workflow cannot run, so its last-ever run being a startup failure
+ * is history rather than a live defect. Only active workflows are asked.
+ */
+export function isActiveWorkflow(w: WorkflowRef): boolean {
+  return w.state === "active";
+}
+
 export function parseRuns(json: string): RunSummary[] | null {
   try {
     const p: unknown = JSON.parse(json);
@@ -290,40 +335,79 @@ if (import.meta.main) {
   const label = "audit:actions-allowlist";
   const repo = "nimbus-agent/Nimbus";
 
-  const probe = runGh(["gh", "api", `repos/${repo}/actions/permissions`]);
-  if (!probe.ok) {
-    // A 404 here means the token cannot read Actions settings, not that the
-    // repo is unprotected — never a finding.
+  // The two halves need DIFFERENT permissions and are evaluated independently.
+  //
+  // `actions/permissions` needs repo Administration on a GitHub App token, and
+  // the workflow `permissions:` block has no `administration` scope at all — so
+  // `github.token` may simply be unable to read it. Making that fatal would put
+  // the sweep permanently red for a reason nobody can fix from CI, so an
+  // unreadable allowlist degrades to a warning and the startup-failure half
+  // (which needs only `actions: read`) still runs. Only if BOTH are unreadable
+  // is there nothing to say.
+  const permRes = runGh(["gh", "api", `repos/${repo}/actions/permissions`]);
+  const allowedActions = permRes.ok ? parsePermissions(permRes.stdout) : null;
+
+  let result: AllowlistResult | null = null;
+  if (permRes.ok) {
+    let selected: SelectedActions | null = null;
+    if (allowedActions === "selected") {
+      const selRes = runGh(["gh", "api", `repos/${repo}/actions/permissions/selected-actions`]);
+      selected = selRes.ok ? parseSelectedActions(selRes.stdout) : null;
+    }
+    const refs = collectActionRefs(
+      readWorkflows(join(import.meta.dir, "..", "..", ".github", "workflows")),
+    );
+    result = evaluateAllowlist(repo, allowedActions, selected, refs);
+  }
+
+  // The direct half: a workflow that cannot start says so itself. Asked PER
+  // WORKFLOW, because `actions/runs` returns the newest runs repo-wide and a
+  // quiet workflow drops off the page (26 workflows here; the newest 100 runs
+  // covered 13).
+  const wfRes = runGh(["gh", "api", `repos/${repo}/actions/workflows?per_page=100`]);
+  const workflows = wfRes.ok ? parseWorkflows(wfRes.stdout) : null;
+  let broken: string[] | null = null;
+  if (workflows !== null) {
+    const latest: RunSummary[] = [];
+    let anyRunReadFailed = false;
+    for (const w of workflows.filter(isActiveWorkflow)) {
+      const r = runGh(["gh", "api", `repos/${repo}/actions/workflows/${w.id}/runs?per_page=1`]);
+      if (!r.ok) {
+        anyRunReadFailed = true;
+        continue;
+      }
+      const parsed = parseRuns(r.stdout);
+      if (parsed === null) {
+        anyRunReadFailed = true;
+        continue;
+      }
+      latest.push(...parsed);
+    }
+    // A partial read cannot prove absence: the one workflow we failed to read
+    // might be the broken one. Report unknown rather than a false all-clear.
+    broken = anyRunReadFailed && latest.length === 0 ? null : latestStartupFailures(latest);
+    if (anyRunReadFailed) {
+      console.warn(`::warning::${label}: some workflow run lists were unreadable`);
+    }
+  }
+
+  if (result === null && broken === null) {
     const outcome = strictSkip(
       label,
       strict,
-      classifyReadFailure(probe.httpStatus) === "absent"
-        ? "Actions permissions not readable with this token"
-        : undefined,
+      "neither the Actions allowlist nor the workflow run list was readable",
     );
     if (outcome.code === 1) console.error(outcome.message);
     else console.warn(outcome.message);
     process.exit(outcome.code);
   }
-
-  const allowedActions = parsePermissions(probe.stdout);
-  let selected: SelectedActions | null = null;
-  if (allowedActions === "selected") {
-    const selRes = runGh(["gh", "api", `repos/${repo}/actions/permissions/selected-actions`]);
-    selected = selRes.ok ? parseSelectedActions(selRes.stdout) : null;
+  if (result === null) {
+    console.warn(
+      `::warning::${label}: Actions allowlist unreadable with this token (needs Administration:read) — startup-failure detection still ran`,
+    );
   }
 
-  const refs = collectActionRefs(
-    readWorkflows(join(import.meta.dir, "..", "..", ".github", "workflows")),
-  );
-  const result = evaluateAllowlist(repo, allowedActions, selected, refs);
-
-  // The direct half: a workflow that cannot start says so itself.
-  const runsRes = runGh(["gh", "api", `repos/${repo}/actions/runs?per_page=100`]);
-  const runs = runsRes.ok ? parseRuns(runsRes.stdout) : null;
-  const broken = runs === null ? null : latestStartupFailures(runs);
-
-  for (const f of result.findings) {
+  for (const f of result?.findings ?? []) {
     console.error(
       `::error file=.github/workflows/${f.workflow}::${f.ref} is used by ${f.workflow} but is NOT permitted by ${repo}'s Actions allowlist — the workflow will fail at startup, before any job runs`,
     );
@@ -334,18 +418,21 @@ if (import.meta.main) {
     );
   }
 
-  const hardFail = result.verdict === "not-permitted" || (broken?.length ?? 0) > 0;
-  if (hardFail) {
-    console.error(`${label}: FAILED — ${result.detail}; ${broken?.length ?? 0} workflow(s) broken`);
+  const detail = result?.detail ?? "allowlist not evaluated";
+  if (result?.verdict === "not-permitted" || (broken?.length ?? 0) > 0) {
+    console.error(`${label}: FAILED — ${detail}; ${broken?.length ?? 0} workflow(s) broken`);
     process.exit(1);
   }
-  if (result.verdict === "indeterminate" || broken === null) {
-    console.warn(`::warning::${label}: ${result.detail} (indeterminate)`);
+  // `indeterminate` is a TRANSIENT read failure and so may be strict-red;
+  // `unverifiable` is permanent (see the verdict docs) and never is.
+  if (result?.verdict === "indeterminate") {
+    console.warn(`::warning::${label}: ${detail} (indeterminate)`);
     process.exit(strict ? 1 : 0);
   }
-  if (result.verdict === "unverifiable") {
-    // Never red: a permanent unknown, not a transient one. See the verdict docs.
-    console.warn(`::warning::${label}: ${result.detail}`);
+  if (result?.verdict === "unverifiable") {
+    console.warn(`::warning::${label}: ${detail}`);
   }
-  console.log(`${label}: OK — ${repo}: ${result.detail}; no workflow is failing at startup`);
+  console.log(
+    `${label}: OK — ${repo}: ${detail}; ${broken === null ? "startup state unknown" : `${broken.length} workflow(s) failing at startup`}`,
+  );
 }

--- a/scripts/structure-audit/check-actions-allowlist.ts
+++ b/scripts/structure-audit/check-actions-allowlist.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:actions-allowlist — for every org repo whose `allowed_actions` is
+ * `selected`, assert every action a workflow `uses:` is actually permitted to
+ * run.
+ *
+ * This is the gate that would have caught the 2026-07-24 CLA outage on day
+ * zero. `Nimbus` is the only repo with a restricted allowlist, and
+ * `contributor-assistant/github-action` was absent from `patterns_allowed`, so
+ * GitHub rejected `cla.yml` before any job started: 23 consecutive
+ * `startup_failure` runs, a REQUIRED check that never reported, and every PR
+ * silently unmergeable for two days.
+ *
+ * `cla-coverage` was green throughout, because it verifies that each repo HAS
+ * `cla.yml` at a consistent version. A gate that checks a control's PRESENCE
+ * cannot see that the control is structurally unable to EXECUTE — absence of a
+ * red signal was indistinguishable from absence of the signal entirely.
+ *
+ * See docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+export interface WorkflowFile {
+  path: string;
+  text: string;
+}
+
+export interface ActionRef {
+  ref: string;
+  workflow: string;
+}
+
+export interface SelectedActions {
+  githubOwnedAllowed: boolean;
+  verifiedAllowed: boolean;
+  patternsAllowed: string[];
+}
+
+/**
+ * `unverifiable` is deliberately distinct from `indeterminate`, and deliberately
+ * NOT red under `--strict`.
+ *
+ * `indeterminate` means a read failed and might succeed next run — the program's
+ * rule that a strict run evaluating nothing is red applies, because the silence
+ * is transient. `unverifiable` means `verified_allowed` is on and an action is
+ * covered only by that: GitHub exposes no API for "is this creator a verified
+ * Marketplace partner", so the answer can never arrive. Treating a permanent
+ * epistemic limit as a hard failure produces a gate that is red forever, and a
+ * gate that is always red is one everybody learns to ignore — the exact failure
+ * this sub-program exists to prevent.
+ */
+export type AllowlistVerdict =
+  | "ok"
+  | "not-permitted"
+  | "unverifiable"
+  | "indeterminate"
+  | "skipped";
+
+export interface AllowlistResult {
+  repo: string;
+  verdict: AllowlistVerdict;
+  findings: ActionRef[];
+  detail: string;
+}
+
+/**
+ * Every `uses:` reference in a set of workflows.
+ *
+ * Local (`./path`) and Docker (`docker://`) references are skipped: the Actions
+ * allowlist governs neither, so reporting them would be noise that trains
+ * people to ignore the gate.
+ */
+export function collectActionRefs(files: readonly WorkflowFile[]): ActionRef[] {
+  const out: ActionRef[] = [];
+  const seen = new Set<string>();
+  for (const f of files) {
+    for (const m of f.text.matchAll(/^\s*-?\s*uses:\s*["']?([^"'\s#]+)["']?/gm)) {
+      const ref = m[1];
+      if (!ref || ref.startsWith("./") || ref.startsWith(".\\") || ref.startsWith("docker://")) {
+        continue;
+      }
+      const key = `${f.path}::${ref}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ref, workflow: f.path });
+    }
+  }
+  return out;
+}
+
+/** `owner/repo` from `owner/repo/sub/path@ref`. */
+function ownerRepoOf(ref: string): string {
+  const [nameWithPath] = ref.split("@");
+  const parts = (nameWithPath ?? "").split("/");
+  return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : (nameWithPath ?? "");
+}
+
+/**
+ * Does any `patterns_allowed` entry cover this reference? Supports the forms
+ * GitHub documents: exact `owner/repo`, `owner/repo@ref`, `owner/*`, and a
+ * trailing `*` wildcard.
+ */
+export function isCoveredByPatterns(ref: string, patterns: readonly string[]): boolean {
+  const ownerRepo = ownerRepoOf(ref);
+  for (const p of patterns) {
+    if (p === ref || p === ownerRepo) return true;
+    if (p.endsWith("*")) {
+      const prefix = p.slice(0, -1);
+      // Match against both the full reference and the bare owner/repo, so
+      // `github/codeql-action@*` covers `github/codeql-action/init@v3`.
+      if (ref.startsWith(prefix) || ownerRepo.startsWith(prefix)) return true;
+      if (`${ownerRepo}@`.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
+/** GitHub-owned actions live under the `actions` and `github` orgs. */
+function isGitHubOwned(ref: string): boolean {
+  const owner = ref.split("/")[0];
+  return owner === "actions" || owner === "github";
+}
+
+/**
+ * An action owned by the same org as the repo consuming it. GitHub always
+ * permits these regardless of the allowlist, so counting one as unpermitted
+ * would be a false finding — `nimbus-agent/.github/actions/*` is ours.
+ */
+function isSameOrg(ref: string, repo: string): boolean {
+  const owner = ref.split("/")[0];
+  return owner !== undefined && owner === repo.split("/")[0];
+}
+
+export function evaluateAllowlist(
+  repo: string,
+  allowedActions: string | null,
+  selected: SelectedActions | null,
+  refs: readonly ActionRef[],
+): AllowlistResult {
+  if (allowedActions !== "selected") {
+    return {
+      repo,
+      verdict: "skipped",
+      findings: [],
+      detail: `allowed_actions is ${allowedActions ?? "unreadable"} — no allowlist to violate`,
+    };
+  }
+  if (selected === null) {
+    return { repo, verdict: "indeterminate", findings: [], detail: "selected-actions unreadable" };
+  }
+
+  const findings: ActionRef[] = [];
+  const unverifiable: ActionRef[] = [];
+  for (const r of refs) {
+    if (isSameOrg(r.ref, repo)) continue;
+    if (selected.githubOwnedAllowed && isGitHubOwned(r.ref)) continue;
+    if (isCoveredByPatterns(r.ref, selected.patternsAllowed)) continue;
+    if (selected.verifiedAllowed) {
+      // Verified-creator status is not derivable from any API. Report unknown
+      // rather than manufacturing either a finding or a pass.
+      unverifiable.push(r);
+      continue;
+    }
+    findings.push(r);
+  }
+
+  if (findings.length > 0) {
+    return {
+      repo,
+      verdict: "not-permitted",
+      findings,
+      detail: `${findings.length} action(s) not permitted by the allowlist`,
+    };
+  }
+  if (unverifiable.length > 0) {
+    return {
+      repo,
+      verdict: "unverifiable",
+      findings: [],
+      detail: `${unverifiable.length} action ref(s) covered only by verified_allowed (${[...new Set(unverifiable.map((u) => u.ref.split("@")[0]))].join(", ")}) — no API exposes verified-creator status`,
+    };
+  }
+  return { repo, verdict: "ok", findings: [], detail: `${refs.length} action ref(s) permitted` };
+}
+
+/** `allowed_actions` from the permissions endpoint; null when unreadable or Actions is off. */
+export function parsePermissions(json: string): string | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    if (p["enabled"] === false) return null;
+    const a = p["allowed_actions"];
+    return typeof a === "string" ? a : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface RunSummary {
+  workflow: string;
+  conclusion: string | null;
+  status: string | null;
+  createdAt: string;
+}
+
+/**
+ * Workflows whose MOST RECENT run failed at startup.
+ *
+ * This is the direct, unambiguous half of the gate, and it is the half that
+ * would actually have caught the CLA outage. Inferring permission from
+ * `patterns_allowed` requires knowing verified-creator status, which no API
+ * exposes; a `startup_failure` requires knowing nothing — GitHub rejected the
+ * workflow before any job ran, which is the observable symptom itself. It also
+ * catches causes the pattern check cannot see at all, such as invalid workflow
+ * YAML.
+ *
+ * Scoped to each workflow's LATEST run so a since-fixed historical failure does
+ * not red the sweep forever: the question is "is this workflow able to start
+ * *now*", not "has it ever failed".
+ */
+export function latestStartupFailures(runs: readonly RunSummary[]): string[] {
+  const latest = new Map<string, RunSummary>();
+  for (const r of runs) {
+    const seen = latest.get(r.workflow);
+    if (!seen || r.createdAt > seen.createdAt) latest.set(r.workflow, r);
+  }
+  return [...latest.entries()]
+    .filter(([, r]) => r.conclusion === "startup_failure" || r.status === "startup_failure")
+    .map(([name]) => name)
+    .sort();
+}
+
+export function parseRuns(json: string): RunSummary[] | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const runs = p["workflow_runs"];
+    if (!Array.isArray(runs)) return null;
+    const out: RunSummary[] = [];
+    for (const r of runs) {
+      if (!isRecord(r)) continue;
+      const workflow = r["name"];
+      const createdAt = r["created_at"];
+      if (typeof workflow !== "string" || typeof createdAt !== "string") continue;
+      out.push({
+        workflow,
+        conclusion: typeof r["conclusion"] === "string" ? r["conclusion"] : null,
+        status: typeof r["status"] === "string" ? r["status"] : null,
+        createdAt,
+      });
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSelectedActions(json: string): SelectedActions | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const patterns = p["patterns_allowed"];
+    return {
+      githubOwnedAllowed: p["github_owned_allowed"] === true,
+      verifiedAllowed: p["verified_allowed"] === true,
+      patternsAllowed: Array.isArray(patterns) ? patterns.filter((x) => typeof x === "string") : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readWorkflows(dir: string): WorkflowFile[] {
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+      .map((f) => ({ path: f, text: readFileSync(join(dir, f), "utf8") }));
+  } catch {
+    return [];
+  }
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:actions-allowlist";
+  const repo = "nimbus-agent/Nimbus";
+
+  const probe = runGh(["gh", "api", `repos/${repo}/actions/permissions`]);
+  if (!probe.ok) {
+    // A 404 here means the token cannot read Actions settings, not that the
+    // repo is unprotected — never a finding.
+    const outcome = strictSkip(
+      label,
+      strict,
+      classifyReadFailure(probe.httpStatus) === "absent"
+        ? "Actions permissions not readable with this token"
+        : undefined,
+    );
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const allowedActions = parsePermissions(probe.stdout);
+  let selected: SelectedActions | null = null;
+  if (allowedActions === "selected") {
+    const selRes = runGh(["gh", "api", `repos/${repo}/actions/permissions/selected-actions`]);
+    selected = selRes.ok ? parseSelectedActions(selRes.stdout) : null;
+  }
+
+  const refs = collectActionRefs(
+    readWorkflows(join(import.meta.dir, "..", "..", ".github", "workflows")),
+  );
+  const result = evaluateAllowlist(repo, allowedActions, selected, refs);
+
+  // The direct half: a workflow that cannot start says so itself.
+  const runsRes = runGh(["gh", "api", `repos/${repo}/actions/runs?per_page=100`]);
+  const runs = runsRes.ok ? parseRuns(runsRes.stdout) : null;
+  const broken = runs === null ? null : latestStartupFailures(runs);
+
+  for (const f of result.findings) {
+    console.error(
+      `::error file=.github/workflows/${f.workflow}::${f.ref} is used by ${f.workflow} but is NOT permitted by ${repo}'s Actions allowlist — the workflow will fail at startup, before any job runs`,
+    );
+  }
+  for (const w of broken ?? []) {
+    console.error(
+      `::error::workflow "${w}" — its most recent run ended in startup_failure: GitHub rejected it before any job ran. Cause is usually an action missing from the Actions allowlist, or invalid workflow YAML. A required check from this workflow will never report.`,
+    );
+  }
+
+  const hardFail = result.verdict === "not-permitted" || (broken?.length ?? 0) > 0;
+  if (hardFail) {
+    console.error(`${label}: FAILED — ${result.detail}; ${broken?.length ?? 0} workflow(s) broken`);
+    process.exit(1);
+  }
+  if (result.verdict === "indeterminate" || broken === null) {
+    console.warn(`::warning::${label}: ${result.detail} (indeterminate)`);
+    process.exit(strict ? 1 : 0);
+  }
+  if (result.verdict === "unverifiable") {
+    // Never red: a permanent unknown, not a transient one. See the verdict docs.
+    console.warn(`::warning::${label}: ${result.detail}`);
+  }
+  console.log(`${label}: OK — ${repo}: ${result.detail}; no workflow is failing at startup`);
+}

--- a/scripts/structure-audit/check-secret-inventory.test.ts
+++ b/scripts/structure-audit/check-secret-inventory.test.ts
@@ -1,0 +1,140 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: these fixtures are
+// GitHub Actions expressions (`${{ secrets.X }}`), not JS template literals.
+// Writing them any other way would stop testing the matcher against the exact
+// syntax it has to parse in real workflow files.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { CREDENTIAL_REGISTRY } from "../release/credential-registry.ts";
+import {
+  collectWorkflowSecrets,
+  documentedSecrets,
+  evaluateInventory,
+  UNDOCUMENTABLE_SECRETS,
+} from "./check-secret-inventory.ts";
+
+const wf = (path: string, text: string) => ({ path, text });
+
+describe("collectWorkflowSecrets", () => {
+  test("finds a dotted secrets reference and attributes it to its workflow", () => {
+    const m = collectWorkflowSecrets([wf("release.yml", "token: ${{ secrets.GPG_PASSPHRASE }}")]);
+    expect(m.get("GPG_PASSPHRASE")).toEqual(["release.yml"]);
+  });
+
+  test("finds the bracket form", () => {
+    const m = collectWorkflowSecrets([wf("a.yml", "${{ secrets['SONAR_TOKEN'] }}")]);
+    expect(m.has("SONAR_TOKEN")).toBe(true);
+  });
+
+  test("finds the double-quoted bracket form", () => {
+    const m = collectWorkflowSecrets([wf("a.yml", '${{ secrets["SONAR_TOKEN"] }}')]);
+    expect(m.has("SONAR_TOKEN")).toBe(true);
+  });
+
+  test("attributes one secret to every workflow that names it, without duplicates", () => {
+    const m = collectWorkflowSecrets([
+      wf("a.yml", "${{ secrets.X }} and again ${{ secrets.X }}"),
+      wf("b.yml", "${{ secrets.X }}"),
+    ]);
+    expect(m.get("X")).toEqual(["a.yml", "b.yml"]);
+  });
+
+  test("does not match a lowercase or non-secret expression", () => {
+    const m = collectWorkflowSecrets([wf("a.yml", "${{ env.FOO }} ${{ secrets.lower }}")]);
+    expect(m.size).toBe(0);
+  });
+});
+
+describe("documentedSecrets", () => {
+  test("reads backtick-quoted UPPER_SNAKE tokens anywhere in the doc", () => {
+    const doc = "| `RELEASE_BOT_CLIENT_ID` | mint | ... |\n\nProse naming `GPG_PASSPHRASE` too.";
+    const d = documentedSecrets(doc);
+    expect(d.has("RELEASE_BOT_CLIENT_ID")).toBe(true);
+    expect(d.has("GPG_PASSPHRASE")).toBe(true);
+  });
+
+  test("a struck-through retired entry still counts as documented", () => {
+    // A retired secret is documented *as retired* — that is a deliberate record,
+    // not an omission, so it must not be reported as missing if still referenced.
+    expect(documentedSecrets("| ~~`CODECOV_TOKEN`~~ | Retired |").has("CODECOV_TOKEN")).toBe(true);
+  });
+
+  test("ignores short or lowercase tokens", () => {
+    const d = documentedSecrets("`ok` `abc` `lower_case` `AB`");
+    expect(d.size).toBe(0);
+  });
+});
+
+describe("evaluateInventory", () => {
+  const used = new Map<string, string[]>([
+    ["IN_BOTH", ["a.yml"]],
+    ["DOC_ONLY", ["b.yml", "c.yml"]],
+    ["REGISTRY_ONLY", ["d.yml"]],
+    ["IN_NEITHER", ["e.yml"]],
+    ["GITHUB_TOKEN", ["f.yml"]],
+  ]);
+  const documented = new Set(["IN_BOTH", "DOC_ONLY", "ONLY_IN_DOC"]);
+  const registered = new Set(["IN_BOTH", "REGISTRY_ONLY"]);
+  const run = () => evaluateInventory(used, documented, registered, UNDOCUMENTABLE_SECRETS);
+
+  test("a secret in both inventories is not a finding", () => {
+    expect(run().some((x) => x.secret === "IN_BOTH")).toBe(false);
+  });
+
+  test("documented but unregistered => missingFrom registry, naming its workflows", () => {
+    const f = run().find((x) => x.secret === "DOC_ONLY");
+    expect(f?.missingFrom).toBe("registry");
+    expect(f?.workflows).toEqual(["b.yml", "c.yml"]);
+  });
+
+  test("registered but undocumented => missingFrom doc", () => {
+    expect(run().find((x) => x.secret === "REGISTRY_ONLY")?.missingFrom).toBe("doc");
+  });
+
+  test("absent from both => missingFrom both", () => {
+    expect(run().find((x) => x.secret === "IN_NEITHER")?.missingFrom).toBe("both");
+  });
+
+  test("GITHUB_TOKEN is excluded — it is provided, never provisioned", () => {
+    expect(run().some((x) => x.secret === "GITHUB_TOKEN")).toBe(false);
+  });
+
+  test("an inventory entry with no local consumer is NEVER a finding", () => {
+    // ci-secrets.md documents VSCE_PAT/OVSX_PAT/NPM_TOKEN, which belong to other
+    // repos' workflows. Gating that direction would push us to DELETE true
+    // information from the inventory.
+    expect(run().some((x) => x.secret === "ONLY_IN_DOC")).toBe(false);
+  });
+
+  test("everything covered => no findings", () => {
+    expect(
+      evaluateInventory(
+        new Map([["IN_BOTH", ["a.yml"]]]),
+        documented,
+        registered,
+        UNDOCUMENTABLE_SECRETS,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the committed tree", () => {
+  test("every secret this repo's workflows consume is in BOTH inventories", () => {
+    const root = join(import.meta.dir, "..", "..");
+    const dir = join(root, ".github", "workflows");
+    const files = readdirSync(dir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+      .map((f) => wf(f, readFileSync(join(dir, f), "utf8")));
+    const doc = readFileSync(join(root, "docs", "ci-secrets.md"), "utf8");
+
+    const findings = evaluateInventory(
+      collectWorkflowSecrets(files),
+      documentedSecrets(doc),
+      new Set(CREDENTIAL_REGISTRY.map((c) => c.name)),
+      UNDOCUMENTABLE_SECRETS,
+    );
+    expect(findings.map((f) => `${f.secret} (missing from ${f.missingFrom})`)).toEqual([]);
+  });
+});

--- a/scripts/structure-audit/check-secret-inventory.ts
+++ b/scripts/structure-audit/check-secret-inventory.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:secret-inventory — every secret this repo's workflows consume must be
+ * documented in docs/ci-secrets.md.
+ *
+ * Row 3 of the infrastructure roadmap's opening table names this exact drift:
+ * `ci-secrets.md`'s completeness claim was written before `secret-health.yml`
+ * existed, and never grew to cover the probe's OWN credentials. A doc that
+ * claims completeness and is not complete is worse than no doc, because it is
+ * consulted during an incident.
+ *
+ * Unlike the release-train gates this one is LOCAL and deterministic — it reads
+ * only checked-in files, mints no token, and touches no network — so it runs on
+ * every PR from the preflight fast tier rather than the scheduled sweep.
+ *
+ * See docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { CREDENTIAL_REGISTRY } from "../release/credential-registry.ts";
+
+/**
+ * Secrets that cannot meaningfully appear in an inventory of things an operator
+ * must provision. `GITHUB_TOKEN` is minted by Actions for every run.
+ *
+ * Kept deliberately tiny: every past instance of this drift pattern hid inside a
+ * plausible-looking exemption, so anything absent from the doc is a finding
+ * unless it is literally impossible to provision.
+ */
+export const UNDOCUMENTABLE_SECRETS: readonly string[] = ["GITHUB_TOKEN"];
+
+export interface WorkflowFile {
+  path: string;
+  text: string;
+}
+
+export interface InventoryFinding {
+  secret: string;
+  workflows: string[];
+  /**
+   * Which of the two inventories is missing it. The registry is authoritative
+   * (rotation policy, ownership, the health probe's watch-list); the prose doc
+   * is the narrative consulted during an incident. They fail differently, so
+   * the finding says which — "add a row to a table" and "this credential is
+   * unmanaged" are not the same repair.
+   */
+  missingFrom: "doc" | "registry" | "both";
+}
+
+/**
+ * Every `secrets.NAME` a workflow references, mapped to the workflows naming it.
+ * Matches the dotted form and both bracket forms, since all three appear in real
+ * workflows and a reference missed here reads as "documented" — the silent
+ * direction of failure.
+ */
+export function collectWorkflowSecrets(files: readonly WorkflowFile[]): Map<string, string[]> {
+  const re = /secrets\.([A-Z][A-Z0-9_]*)|secrets\[\s*['"]([A-Z][A-Z0-9_]*)['"]\s*\]/g;
+  const out = new Map<string, string[]>();
+  for (const f of files) {
+    for (const m of f.text.matchAll(re)) {
+      const name = m[1] ?? m[2];
+      if (!name) continue;
+      const list = out.get(name) ?? [];
+      if (!list.includes(f.path)) list.push(f.path);
+      out.set(name, list);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every secret name documented in ci-secrets.md, read as any backtick-quoted
+ * UPPER_SNAKE token of 3+ chars.
+ *
+ * Deliberately loose rather than table-aware: the doc is prose *plus* a table,
+ * and a parser bound to the table's shape would silently start reporting
+ * findings the moment someone documented a secret in a paragraph. A retired
+ * entry (`~~`CODECOV_TOKEN`~~`) still counts — that is a deliberate record.
+ */
+export function documentedSecrets(doc: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of doc.matchAll(/`([A-Z][A-Z0-9_]{2,})`/g)) {
+    if (m[1]) out.add(m[1]);
+  }
+  return out;
+}
+
+/**
+ * One-directional on purpose: workflow -> doc only.
+ *
+ * `ci-secrets.md` is an ORG-WIDE inventory — it documents `VSCE_PAT`,
+ * `OVSX_PAT` and `NPM_TOKEN`, consumed by workflows in nimbus-vscode and the
+ * npm repos, not here. Gating the reverse direction would red on entries that
+ * are correct, and the only way to satisfy it would be to delete true
+ * information from the inventory.
+ */
+export function evaluateInventory(
+  used: ReadonlyMap<string, readonly string[]>,
+  documented: ReadonlySet<string>,
+  registered: ReadonlySet<string>,
+  exclusions: readonly string[],
+): InventoryFinding[] {
+  const findings: InventoryFinding[] = [];
+  for (const [secret, workflows] of used) {
+    if (exclusions.includes(secret)) continue;
+    const inDoc = documented.has(secret);
+    const inRegistry = registered.has(secret);
+    if (inDoc && inRegistry) continue;
+    const missingFrom = !inDoc && !inRegistry ? "both" : inDoc ? "registry" : "doc";
+    findings.push({ secret, workflows: [...workflows], missingFrom });
+  }
+  findings.sort((a, b) => a.secret.localeCompare(b.secret));
+  return findings;
+}
+
+/** Workflow files as {path, text}, path relative for readable messages. */
+function readWorkflows(repoRoot: string): WorkflowFile[] {
+  const dir = join(repoRoot, ".github", "workflows");
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((f) => ({ path: f, text: readFileSync(join(dir, f), "utf8") }));
+}
+
+if (import.meta.main) {
+  const label = "audit:secret-inventory";
+  const root = join(import.meta.dir, "..", "..");
+
+  const used = collectWorkflowSecrets(readWorkflows(root));
+  const documented = documentedSecrets(readFileSync(join(root, "docs", "ci-secrets.md"), "utf8"));
+  const registered = new Set(CREDENTIAL_REGISTRY.map((c) => c.name));
+  const findings = evaluateInventory(used, documented, registered, UNDOCUMENTABLE_SECRETS);
+
+  // Informational only — the doc is org-wide, so an entry with no local
+  // consumer is expected, not a defect. Printed so the inventory's shape stays
+  // visible without ever failing the gate.
+  const unused = [...documented].filter((s) => !used.has(s)).sort();
+  if (unused.length > 0) {
+    console.log(`${label}: ${unused.length} documented secret(s) with no workflow in THIS repo`);
+  }
+
+  for (const f of findings) {
+    const where =
+      f.missingFrom === "both"
+        ? "neither docs/ci-secrets.md nor scripts/release/credential-registry.ts"
+        : f.missingFrom === "registry"
+          ? "scripts/release/credential-registry.ts (unmanaged: no owner, no rotation policy, not watched by secret-health)"
+          : "docs/ci-secrets.md";
+    console.error(
+      `::error file=docs/ci-secrets.md::${f.secret} is used by ${f.workflows.join(", ")} but is absent from ${where}`,
+    );
+  }
+  if (findings.length > 0) {
+    console.error(`${label}: FAILED — ${findings.length} undocumented secret(s)`);
+    process.exit(1);
+  }
+  console.log(`${label}: OK (${used.size} secrets referenced, all documented)`);
+}


### PR DESCRIPTION
## Summary

Two gates from **P5 Org Legibility**, plus the combined design spec for the four-effort batch (the other three land as their own PRs).

### `audit:secret-inventory` — local, runs on every PR

Asserts every secret this repo's workflows consume appears in **both** inventories, and says **which** is missing:

- `scripts/release/credential-registry.ts` — authoritative: owner, type, rotation policy, the `secret-health` watch-list.
- `docs/ci-secrets.md` — the narrative consulted during an incident, which opens "the canonical inventory of every GitHub Actions secret the Nimbus workflows consume".

The two failures need different repairs — "add a row to a table" vs "this credential is unmanaged" — so collapsing them into one message would let the serious case hide behind the cosmetic one.

**This axis was genuinely uncovered.** `credential-audit` compares *live org secrets* → registry. A secret referenced by a workflow but never recorded is nobody's finding today.

**One-directional on purpose.** `ci-secrets.md` is an *org-wide* inventory documenting `VSCE_PAT`/`OVSX_PAT`/`NPM_TOKEN`, consumed by other repos' workflows. Gating that direction would red on correct entries, and the only way to satisfy it would be deleting true information from the inventory.

**Red-before → green-after inside this PR.** Five secrets were missing from the prose doc and are now documented:

| Secret | Introduced by |
| --- | --- |
| `SECRET_AUDITOR_CLIENT_ID` / `_PRIVATE_KEY` | the secret-health probe **itself** |
| `CLA_BOT_CLIENT_ID` / `_PRIVATE_KEY` | the CLA program |
| `BENCHER_API_KEY` | the benchmark workflow |

A correction worth flagging: I first wrote this up as row 3 of the roadmap's opening table ("`ci-secrets.md` never grew to cover `secret-health.yml`'s own credentials") still being unfixed. **Reading the code disproved that** — all five were already in the registry, so this was *narrative* drift, not unmanaged credentials. The spec records the correction.

Unlike the sweep gates, this one is local and deterministic (no token, no network), so it joins the preflight `fast` tier — and therefore had to be **green at merge**, since a red local gate breaks every subsequent PR.

### `audit:actions-allowlist` — network, scheduled sweep

The gate for the two-day CLA outage: `contributor-assistant/github-action` was absent from the Actions allowlist, so GitHub rejected `cla.yml` **before any job ran** — 23 consecutive `startup_failure`s, a required check that never reported, every PR silently unmergeable. `cla-coverage` was green throughout, because it verifies a control's *presence*, not its ability to *execute*.

**Two halves, and running it live changed the design.**

The *pattern* half compares each `uses:` against `patterns_allowed` / `github_owned_allowed` / same-org. Live, `verified_allowed` is on and five refs (`dessant/lock-threads`, `oven-sh/setup-bun`, `googleapis/release-please-action`, `bencherdev/bencher`) are covered **only** by it — and no API exposes verified-creator status. My first implementation called that `indeterminate`, which under the program's own strict rule is red, making the gate **permanently red for a reason nobody can fix**. A gate that is always red is one everybody learns to ignore, which is exactly the failure this sub-program exists to prevent. So there is now a distinct `unverifiable` verdict that warns but never fails; `indeterminate` (a *transient* read failure, which can resolve next run) stays strict-red.

The *direct* half is the one that actually closes the hole: **any workflow whose most recent run ended in `startup_failure` is a hard finding.** That requires no knowledge of verified status — GitHub rejecting the workflow *is* the observable symptom — and it catches causes the pattern half cannot see at all, such as invalid workflow YAML. Scoped to each workflow's latest run, so a since-fixed historical failure doesn't red the sweep forever.

Both are red-proved by **unit test** (including a fixture reproducing the exact CLA case, where adding the pattern flips `not-permitted` → `ok`), because the allowlist has since been repaired and cannot red-prove against production. Live run is the green-after half:

```
::warning::audit:actions-allowlist: 5 action ref(s) covered only by verified_allowed (...) — no API exposes verified-creator status
audit:actions-allowlist: OK — nimbus-agent/Nimbus: ...; no workflow is failing at startup
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` — `bunx tsc -p scripts/tsconfig.json --noEmit` exit 0
- [x] `bun run lint` (Biome) — clean via `bunx biome check --error-on-warnings scripts .github docs`; the packaged script reports "Checked 0 files" inside a `.claude/worktrees/` checkout, a known local-only false-fail
- [x] All existing tests pass — **678 pass / 0 fail** across `scripts/`
- [x] New behaviour is covered by tests — 16 (secret-inventory) + 32 (actions-allowlist)
- [x] No `any` — external JSON narrowed with `isRecord`
- [x] No credentials in logs/IPC/config — the gates read secret **names**, never values
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched — n/a

## Testing

- `bun test scripts/` — 678 pass, 20 skip, 0 fail
- `bunx tsc -p scripts/tsconfig.json --noEmit` — exit 0
- `bun run lint:markdown` — 0 errors; `bun run audit:doc-refs` — 617 refs resolve
- Live runs of both gates, plus the no-`gh` degradation path (`::warning::` + exit 0 locally)

## Notes for Reviewers

One deliberate suppression: `biome-ignore-all lint/suspicious/noTemplateCurlyInString` in the secret-inventory tests. The fixtures contain `${{ secrets.X }}` — GitHub Actions expressions, not JS template literals — and writing them any other way would stop testing the matcher against the exact syntax it must parse.

The spec (`docs/superpowers/specs/2026-07-26-p5-p3-infra-batch-design.md`) also records that **P3's stated gate is already met**: `_structure.yml` runs `audit:invariants` and all 17 static checks execute in CI; the one branch `--binary-only` excludes is `db-run`, a census that always exits 0. P3's real content is the monorepo's missing `.coderabbit.yaml`, which lands as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated audits for workflow secret inventory and Actions allowlist compliance.
  * Added checks for workflows that fail to start and for secrets missing from documentation or registration.
  * Added commands and CI gates for running these audits.

* **Documentation**
  * Expanded the CI/CD secrets reference.
  * Added an infrastructure batch design specification.

* **Tests**
  * Added comprehensive coverage for secret inventory and Actions allowlist auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->