### PR TITLE
feat(review): give the monorepo a tuned CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,126 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/configure/
+#
+# The four satellite repos (nimbus-sdk, nimbus-client, nimbus-vscode,
+# nimbus-web-clipper) have each carried a tuned config since they were created.
+# This monorepo — the one with 30 security invariants and a structural HITL gate
+# — got stock review until now. That is instance 2 of the pattern named at the
+# top of docs/infrastructure-roadmap.md, running satellites -> monorepo.
+#
+# ADVISORY BY DESIGN. CodeRabbit is not a required check and must not become
+# one: a false positive should cost a comment, never a blocked merge. The
+# machine-checked rules live in `bun run preflight` and
+# scripts/structure-audit/*; this file tells the reviewer what the repo's
+# invariants MEAN so its prose comments are useful rather than generic.
+#
+# Invariant ids below refer to docs/SECURITY-INVARIANTS.md (I1-I30; I28 is
+# reserved). Keep them in sync — scripts/structure-audit/check-coderabbit-config.test.ts
+# fails if this file cites an invariant that does not exist there.
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!**/dist/**"
+    - "!**/node_modules/**"
+    - "!**/*.lock"
+    - "!bun.lock"
+    - "!packages/docs/dist/**"
+    - "!**/__snapshots__/**"
+  path_instructions:
+    - path: "packages/gateway/src/engine/**"
+      instructions: >-
+        The HITL (human-in-the-loop) consent gate is STRUCTURAL, not a
+        convention. Flag anything that: adds an action type to the executor's
+        gated path without adding it to the frozen HITL_REQUIRED_BACKING set
+        (I2); branches on `payload.mcpToolId` rather than `action.type` when
+        deciding whether to gate (I3) — the tool id is caller-influenced and
+        must never drive the decision; assigns `hitlStatus` anywhere except the
+        consent gate itself (I4); or makes the gate configurable, bypassable, or
+        conditional on a flag. Also flag any new `connectors.dispatch` call site
+        outside executor.ts — every gated action appends one egress-ledger row
+        BEFORE dispatch, and an append failure must ABORT rather than dispatch
+        (I29). LLM-facing tool results go through `wrapToolOutput` (I11); a raw
+        result reaching the model is a prompt-injection regression.
+    - path: "packages/gateway/src/ipc/**"
+      instructions: >-
+        Every HTTP POST/PUT/DELETE must be in WRITE_ROUTE_ALLOWLIST with bearer
+        auth (I13) — the local HTTP API is read-only apart from sanctioned
+        carve-outs. Flag a new write route that skips the allowlist, and flag any
+        method exposed to the renderer without a deliberate note about the Tauri
+        ALLOWED_METHODS decision (I7): renderer-reachable RCE-class methods
+        (`vault.*`, `extension.install`) are the exact chain a single allowlist
+        mistake opened before. Federated/LAN-reachable methods need the same
+        scrutiny — answering a peer happens only through the query gate (I17).
+    - path: "packages/gateway/src/**"
+      instructions: >-
+        No `any` — use `unknown` for external data plus a type guard; TypeScript
+        strict is non-negotiable. Credentials live in the Vault ONLY and must
+        never reach logs, IPC payloads, config files, or test fixtures. Never
+        import `platform/win32`, `platform/darwin`, or `platform/linux` from
+        business logic: OS-specific code is reached through `PlatformServices`
+        (the PAL rule), so flag a raw `process.platform` branch outside
+        `platform/`. SQLite writes go through `dbRun`/`dbExec`/`dbStmtRun` with
+        bound parameters; identifiers via `escapeIdentifier` (I9, I14). Compare
+        hashes, MACs, pairing codes and tokens with the constant-time helper
+        (I10), never `===`.
+    - path: "packages/gateway/src/**/*.test.ts"
+      instructions: >-
+        Enforce the TRIPLE RULE for any structural defense: production wiring,
+        a row in docs/SECURITY-INVARIANTS.md, and an enforcement test in
+        security-invariants.test.ts all land in the SAME commit — a defense
+        defined but never wired looks identical to one that works, and an audit
+        previously found three of those. When a guard asserts on source text,
+        check it cannot pass on a leftover import: assert the CALL
+        (`helper(`), not the bare name. Prefer dependency injection over
+        `mock.module`, which is process-global and leaks across files in the
+        combined CI run.
+    - path: "packages/mcp-connectors/**"
+      instructions: >-
+        Connectors are first-party MCP servers whose only dependency is the
+        published `@nimbus-dev/sdk` — flag a new runtime dependency, and flag
+        any import from the gateway. The engine must never call a cloud API
+        directly; that is what these exist for. Write-capable tools must be
+        declared so the HITL gate and the federated invoke gate can see them
+        (I26): a peer must never be able to trigger a connector write.
+    - path: "scripts/structure-audit/**"
+      instructions: >-
+        These are the org's gates, so their failure modes matter more than their
+        happy paths. A gate must fail SOFT locally and hard under `--strict` /
+        GITHUB_ACTIONS. Any unreadable or unparseable input degrades to
+        `indeterminate` — never to a finding: a transient 5xx must not
+        manufacture drift. Distinguish a 404 ("absent", a real finding) from any
+        other read failure via `classifyReadFailure`. Flag a comparison that can
+        throw on malformed input (`Bun.semver.order` throws; use the wrapper
+        that returns null). Flag a new gate that is not registered in
+        scripts/lib/preflight-gates.ts or CI_ONLY_GATES — the drift test exists
+        because an unregistered gate silently never runs.
+    - path: ".github/workflows/**"
+      instructions: >-
+        Every `uses:` must be pinned to a full 40-character commit SHA with the
+        version in a trailing comment. Flag a moving tag. Remember an action
+        must also be permitted by the repo's Actions allowlist, which is set to
+        `selected` here — an unpermitted action fails the workflow at STARTUP,
+        before any job runs, so a required check from it never reports. Flag a
+        step that captures `gh api` output and tests it with `-z`: gh writes its
+        error body to stdout, so a failed call leaves the variable non-empty.
+    - path: "packages/ui/src-tauri/**"
+      instructions: >-
+        ALLOWED_METHODS is a security boundary (I7) — adding a method here
+        exposes it to the renderer. RCE-class methods must stay out. The renderer
+        CSP must not gain `unsafe-inline` or `unsafe-eval` (I8).
+    - path: "docs/**"
+      instructions: >-
+        Status lines, invariant counts, schema versions and release numbers go
+        stale across releases. When a doc states a version, phase, or invariant
+        ceiling, check it against the change in the same PR. CLAUDE.md and
+        GEMINI.md mirror each other — a change to commands, roadmap rows, or
+        non-negotiables belongs in both.
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -92,10 +92,15 @@ reviews:
     - path: "scripts/structure-audit/**"
       instructions: >-
         These are the org's gates, so their failure modes matter more than their
-        happy paths. A gate must fail SOFT locally and hard under `--strict` /
-        GITHUB_ACTIONS. Any unreadable or unparseable input degrades to
-        `indeterminate` — never to a finding: a transient 5xx must not
-        manufacture drift. Distinguish a 404 ("absent", a real finding) from any
+        happy paths. A NETWORK-backed gate must fail SOFT locally and hard under
+        `--strict` / GITHUB_ACTIONS. A purely local, deterministic gate — no
+        token, no network, reading only checked-in files — simply fails on a
+        finding and has no strict mode; do not ask for one. Any unreadable or
+        unparseable input degrades to `indeterminate` — never to a finding: a
+        transient 5xx must not manufacture drift. Distinguish a PERMANENT
+        unknown (no API can answer) from a TRANSIENT one (a read failed): only
+        the transient kind may be strict-red, or the gate is red forever and
+        everybody learns to ignore it. Distinguish a 404 ("absent", a real finding) from any
         other read failure via `classifyReadFailure`. Flag a comparison that can
         throw on malformed input (`Bun.semver.order` throws; use the wrapper
         that returns null). Flag a new gate that is not registered in

--- a/scripts/structure-audit/check-coderabbit-config.test.ts
+++ b/scripts/structure-audit/check-coderabbit-config.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { parse } from "yaml";
+
+/**
+ * The CodeRabbit config's effect — better review comments — is not machine
+ * checkable, and this file does not pretend otherwise. What IS checkable is
+ * that the config parses, carries the shape the four working satellite configs
+ * share, and does not cite an invariant that has since been renumbered or
+ * retired. That last one is the real risk: the config is prose instructions,
+ * so a stale `I29` would silently teach the reviewer something false forever.
+ */
+
+const ROOT = join(import.meta.dir, "..", "..");
+const CONFIG = join(ROOT, ".coderabbit.yaml");
+
+function loadConfig(): Record<string, unknown> {
+  const parsed: unknown = parse(readFileSync(CONFIG, "utf8"));
+  if (typeof parsed !== "object" || parsed === null) throw new Error("config is not a mapping");
+  return parsed as Record<string, unknown>;
+}
+
+describe("the monorepo's .coderabbit.yaml", () => {
+  test("exists — the four satellites have one and this repo carries the invariants", () => {
+    expect(existsSync(CONFIG)).toBe(true);
+  });
+
+  test("parses as YAML and carries the satellite shape", () => {
+    const c = loadConfig();
+    expect(c["language"]).toBe("en-US");
+    const reviews = c["reviews"] as Record<string, unknown>;
+    expect(reviews["profile"]).toBe("chill");
+    // Advisory by design: CodeRabbit is not a required check, and a false
+    // positive must never block a merge.
+    expect(reviews["request_changes_workflow"]).toBe(false);
+    expect(Array.isArray(reviews["path_instructions"])).toBe(true);
+  });
+
+  test("every path_instructions entry has a real path and non-trivial instructions", () => {
+    const reviews = loadConfig()["reviews"] as Record<string, unknown>;
+    const entries = reviews["path_instructions"] as { path: string; instructions: string }[];
+    expect(entries.length).toBeGreaterThan(0);
+    for (const e of entries) {
+      expect(typeof e.path).toBe("string");
+      expect(e.instructions.length).toBeGreaterThan(80);
+      // The glob's first literal segment must exist on disk, so a renamed
+      // directory cannot leave an instruction silently matching nothing.
+      const literal = e.path.split("/**")[0]?.split("/*")[0] ?? "";
+      if (literal && !literal.includes("*")) {
+        expect(existsSync(join(ROOT, literal))).toBe(true);
+      }
+    }
+  });
+
+  test("every invariant it cites exists in docs/SECURITY-INVARIANTS.md", () => {
+    const text = readFileSync(CONFIG, "utf8");
+    const doc = readFileSync(join(ROOT, "docs", "SECURITY-INVARIANTS.md"), "utf8");
+
+    // Real invariants are `## I<n> — ...` headings. Mentions elsewhere in the
+    // doc include a worked example for adding the NEXT invariant, which must
+    // not count as existing.
+    const defined = new Set(
+      [...doc.matchAll(/^##\s+(I\d+)\b/gm)].map((m) => m[1]).filter((x): x is string => !!x),
+    );
+    expect(defined.size).toBeGreaterThan(20);
+
+    const cited = new Set(
+      [...text.matchAll(/\(([I\d, ]*I\d+)\)/g)]
+        .flatMap((m) => (m[1] ?? "").split(/[,\s]+/))
+        .filter((s) => /^I\d+$/.test(s)),
+    );
+    expect(cited.size).toBeGreaterThan(0);
+
+    const unknown = [...cited].filter((i) => !defined.has(i));
+    expect(unknown).toEqual([]);
+  });
+
+  test("no path_instruction tells the reviewer to enforce the reserved I28", () => {
+    // I28 is reserved for a parked branch, not a live defense. The file's header
+    // comment may SAY that (it is useful context for whoever edits this next);
+    // what must not happen is an instruction asking the reviewer to enforce it.
+    const reviews = loadConfig()["reviews"] as Record<string, unknown>;
+    const entries = reviews["path_instructions"] as { instructions: string }[];
+    const offending = entries.filter((e) => /\bI28\b/.test(e.instructions));
+    expect(offending).toEqual([]);
+  });
+});

--- a/scripts/structure-audit/check-coderabbit-config.test.ts
+++ b/scripts/structure-audit/check-coderabbit-config.test.ts
@@ -22,6 +22,16 @@ function loadConfig(): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
+interface InstructionEntry {
+  path: string;
+  instructions: string;
+}
+
+function instructionEntries(): InstructionEntry[] {
+  const reviews = loadConfig()["reviews"] as Record<string, unknown>;
+  return reviews["path_instructions"] as InstructionEntry[];
+}
+
 describe("the monorepo's .coderabbit.yaml", () => {
   test("exists — the four satellites have one and this repo carries the invariants", () => {
     expect(existsSync(CONFIG)).toBe(true);
@@ -39,11 +49,14 @@ describe("the monorepo's .coderabbit.yaml", () => {
   });
 
   test("every path_instructions entry has a real path and non-trivial instructions", () => {
-    const reviews = loadConfig()["reviews"] as Record<string, unknown>;
-    const entries = reviews["path_instructions"] as { path: string; instructions: string }[];
+    const entries = instructionEntries();
     expect(entries.length).toBeGreaterThan(0);
     for (const e of entries) {
       expect(typeof e.path).toBe("string");
+      // `typeof` before `.length`: the TS cast is erased at runtime, and an
+      // ARRAY of 80+ elements would satisfy a bare length check while being an
+      // invalid CodeRabbit instruction value.
+      expect(typeof e.instructions).toBe("string");
       expect(e.instructions.length).toBeGreaterThan(80);
       // The glob's first literal segment must exist on disk, so a renamed
       // directory cannot leave an instruction silently matching nothing.
@@ -54,8 +67,7 @@ describe("the monorepo's .coderabbit.yaml", () => {
     }
   });
 
-  test("every invariant it cites exists in docs/SECURITY-INVARIANTS.md", () => {
-    const text = readFileSync(CONFIG, "utf8");
+  test("every invariant cited in an instruction exists in docs/SECURITY-INVARIANTS.md", () => {
     const doc = readFileSync(join(ROOT, "docs", "SECURITY-INVARIANTS.md"), "utf8");
 
     // Real invariants are `## I<n> — ...` headings. Mentions elsewhere in the
@@ -66,10 +78,16 @@ describe("the monorepo's .coderabbit.yaml", () => {
     );
     expect(defined.size).toBeGreaterThan(20);
 
+    // Scan the PARSED instruction values with a bare `\bI\d+\b`, not the raw
+    // YAML for parenthesised ids. The narrower form only saw `(I2)` and would
+    // have let `enforce I31` or `(I30/I31)` through — precisely the stale
+    // guidance this test exists to catch. Parsing also scopes the scan to
+    // instructions, so the file's header comment (which legitimately mentions
+    // the I1-I30 range and the reserved I28) is not swept in.
     const cited = new Set(
-      [...text.matchAll(/\(([I\d, ]*I\d+)\)/g)]
-        .flatMap((m) => (m[1] ?? "").split(/[,\s]+/))
-        .filter((s) => /^I\d+$/.test(s)),
+      instructionEntries().flatMap((e) =>
+        [...e.instructions.matchAll(/\bI\d+\b/g)].map((m) => m[0]),
+      ),
     );
     expect(cited.size).toBeGreaterThan(0);
 
@@ -81,9 +99,7 @@ describe("the monorepo's .coderabbit.yaml", () => {
     // I28 is reserved for a parked branch, not a live defense. The file's header
     // comment may SAY that (it is useful context for whoever edits this next);
     // what must not happen is an instruction asking the reviewer to enforce it.
-    const reviews = loadConfig()["reviews"] as Record<string, unknown>;
-    const entries = reviews["path_instructions"] as { instructions: string }[];
-    const offending = entries.filter((e) => /\bI28\b/.test(e.instructions));
+    const offending = instructionEntries().filter((e) => /\bI28\b/.test(e.instructions));
     expect(offending).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

**P3 Review Layer, first step.** All four satellites (`nimbus-sdk`, `nimbus-client`, `nimbus-vscode`, `nimbus-web-clipper`) have carried a tuned `.coderabbit.yaml` since they were created. This monorepo — the one with **30 security invariants**, a structural HITL gate and a PAL import ban — got **stock review**.

That is instance 2 of the pattern named at the top of `docs/infrastructure-roadmap.md`, and specifically the one running **satellites → monorepo**, which is why that section can claim the org has no propagation mechanism in *either* direction rather than merely a lagging periphery.

### P3's stated gate was already met — this is the real gap

Worth stating up front, since it changes what this PR is. The roadmap's P3 row reads *"An invariant violation is caught in CI, not only in local `preflight`"*. **It already is:** `.github/workflows/_structure.yml` runs `bun run audit:invariants`, and all seventeen static checks execute there. The single branch `--binary-only` excludes is `db-run`, which is a **census** — it writes `db-run-census.json` and always exits 0. Excluding a non-gate is correct, not a gap.

So this PR implements the program design's own **Correction 1** instead, which identifies the missing config as P3's first step and notes it makes P3 materially cheaper: a large share of Nimbus-aware review is reachable by writing the monorepo a config whose `path_instructions` encode the invariants.

### What the instructions encode

Things the machine gates cannot express — what the invariants *mean*:

| Area | Encoded |
| --- | --- |
| `engine/**` | HITL keys off `action.type`, never `payload.mcpToolId` (I2/I3/I4); `connectors.dispatch` only in `executor.ts`, ledger append **aborts** rather than dispatches (I29); `wrapToolOutput` on LLM-facing results (I11) |
| `ipc/**` | `WRITE_ROUTE_ALLOWLIST` + bearer auth (I13); renderer exposure is an `ALLOWED_METHODS` decision (I7); peers answered only via the query gate (I17) |
| `gateway/src/**` | no `any`; Vault-only credentials; no `platform/{win32,darwin,linux}` import from business logic; bound-param SQL (I9/I14); constant-time compares (I10) |
| tests | the **triple rule** — wiring + docs + test in the same commit; assert the *call* (`helper(`) not the bare name; DI over `mock.module` |
| `scripts/structure-audit/**` | fail soft locally / hard under `--strict`; unreadable input → `indeterminate`, never a finding; register the gate or it silently never runs |
| `.github/workflows/**` | SHA-pin everything; an unpermitted action fails at **startup**; `gh` writes errors to **stdout**, so `-z` on captured output lies |

**Advisory by design.** CodeRabbit is not a required check and must not become one — a false positive should cost a comment, never a blocked merge.

## Testing

The config's actual effect is only observable as review comments on a later PR, and the test does not pretend otherwise. It asserts what *is* checkable:

- parses as YAML and matches the satellite shape (`profile: chill`, `request_changes_workflow: false`)
- every `path_instructions` glob's literal prefix **exists on disk**, so a renamed directory can't leave an instruction silently matching nothing
- **every invariant cited is a real `## I<n>` heading** in `SECURITY-INVARIANTS.md` — the live risk being a renumbered id that silently teaches the reviewer something false forever. The scan deliberately ignores the doc's worked example for adding the *next* invariant (`I31`), which is illustrative, not real.
- no instruction cites the **reserved I28**

That last test caught a bug in itself during development: a naive `\bI28\b` scan flagged the file's own header comment explaining *that* I28 is reserved — useful context, not a citation. Scoped to instruction bodies.

- `bun test scripts/` — **635 pass, 20 skip, 0 fail**
- `bunx tsc -p scripts/tsconfig.json --noEmit` — exit 0
- biome — clean

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` (Biome) — clean (validated via `bunx biome check`; the packaged script false-fails inside `.claude/worktrees/`)
- [x] All existing tests pass — 635 scripts tests
- [x] New behaviour is covered by tests — 5
- [x] No `any` introduced
- [x] No credentials in logs/IPC/config/fixtures
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched — n/a (this PR only *describes* it to the reviewer)

## Notes for Reviewers

A follow-up worth considering, deliberately **not** in this PR: a drift gate asserting all five repos carry a `.coderabbit.yaml`. Without it, this fix is itself subject to the pattern it closes — a control that stops where it was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CodeRabbit review configuration with repository-specific review guidance and security checks.
  * Enabled automatic reviews for changes targeting the main branch and chat-based replies.

* **Tests**
  * Added validation to ensure review configuration paths, instructions, and referenced security invariants remain accurate.
  * Added safeguards preventing use of a reserved security invariant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->