### PR TITLE
chore(deps): @nimbus-dev/client 0.5.0 → 0.12.1 in packages/cli

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
       "dependencies": {
         "@clack/prompts": "^1.5.1",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@nimbus-dev/client": "^0.5.0",
+        "@nimbus-dev/client": "^0.12.1",
         "@nimbus-dev/sdk": "^1.5.0",
         "ink": "^7.0.6",
         "ink-text-input": "^6.0.0",
@@ -1815,7 +1815,7 @@
 
     "@nimbus-dev/admin-console": ["@nimbus-dev/admin-console@workspace:packages/admin-console"],
 
-    "@nimbus-dev/client": ["@nimbus-dev/client@0.5.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.3.0" } }, "sha512-DqIhRNGfwwNNUS9eqc2w3ggGhMB36xMYz4kh6TKut0rDDcOut/XNvIJIm7uqRbTfzMAuZQ9QAdTVGSMcy7uw1A=="],
+    "@nimbus-dev/client": ["@nimbus-dev/client@0.12.1", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-6vAzHfEH1mR2L4TJP8fjkBbS9O1vrxTu13Ss+0nI5OEAyUgJYrlG8m8vmdY2NHX2u6H9cf0CIjEdAsKjcgiP9A=="],
 
     "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.6.0", "", {}, "sha512-dHPSNP7GuNgM6oo0el4oZhqx1Xbtbwi+2XSKLmBfUcBj4zDTIKyqX9JQpmmSU9eaQcZgQNC7u9o5CmQTa8g1qA=="],
 
@@ -4150,8 +4150,6 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
-
-    "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.3.0", "", {}, "sha512-mCVlMLbYUowRLsw1dAcDp61AyoLSW6hrfbdrJim7ho3kg78rJlS0DYrKpqQxbng6E83NscJkUHlIFanxp0hp5g=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@clack/prompts": "^1.5.1",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@nimbus-dev/client": "^0.5.0",
+    "@nimbus-dev/client": "^0.12.1",
     "@nimbus-dev/sdk": "^1.5.0",
     "ink": "^7.0.6",
     "ink-text-input": "^6.0.0",


### PR DESCRIPTION
## Summary

Clears the **last red edge** from the P2 Release Train Phase 2 gate (#843), which found the CLI resolving `@nimbus-dev/client` **0.5.0** against a published **0.12.1** — seven minors of drift accumulated across the narrow-waist work, which nothing detected until the gate existed. Owner-confirmed as drift, not a deliberate pin.

**This needed a manifest edit, not a lockfile refresh.** A caret on a `0.x` version pins the **minor**, so `^0.5.0` could never resolve past `0.5.x` — the range was itself the blocker. That asymmetry is precisely why the Phase 2 gate reads the **lockfile** rather than the declared range: a range misleads in both directions (`^1.2.0` permits a newer `1.3.0`; `^0.5.0` forbids `0.12.1`).

Contrast the sdk bumps in #843 / nimbus-client#38 / nimbus-vscode#58, which were caret-on-`1.x` and needed only `bun install`.

## Why it turned out small

Seven minors on a `0.x` is nominally high-risk, which is why I checked call sites before assuming. The CLI's surface use is narrow — `IPCClient`, `MockClient`, `NimbusClient` — and `IPCClient` grew method **count** (15 → 32 across those releases) rather than changing shape. Nothing needed adapting, including `packages/cli/src/tui/test-helpers/stub-client.ts`, which *implements* the interface and was the most likely breakage.

## Testing

- **Full monorepo typecheck** — exit 0 (all packages)
- **biome** — clean
- `bun test packages/cli/src` — **1792 pass / 8 fail before AND after the bump**, a zero delta

### About those 8 failures

They are **pre-existing and Windows-local**, not caused by this change. I verified rather than assumed: stashed the bump, re-ran on clean `main`, and got the identical 14 pass / 8 fail in the same file.

They are all in `runUpdate dispatcher` (`packages/cli/src/commands/update.test.ts`), and they fail in isolation too — so this is *not* the known `mock.module` cross-file contamination. The mock records **zero** IPC calls, meaning `withGatewayIpc` bails before dispatch, consistent with the named-pipe socket path on Windows. There is no platform guard on the file and it is not excluded from CI, so Ubuntu CI should show them green.

Unrelated to a dependency bump, so out of scope here — but worth its own look, since a Windows-only failure in a TTY/socket path is exactly the class the cross-platform non-negotiable exists to catch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — dependency drift
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` — exit 0 across the monorepo
- [x] `bun run lint` (Biome) — clean
- [x] All existing tests pass — zero delta vs `main` (see above)
- [x] New behaviour is covered by tests — n/a, dependency bump with no source change
- [x] No `any` introduced — no source change
- [x] No credentials in logs/IPC/config
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched

## Notes for Reviewers

After this and the three sdk bumps land, **every P2 Phase 2 edge should be green**, which unblocks the sweep proof that Phase 2's definition of *done* requires (`org-drift-sweep.yml`, then record the run number in the P2 progress log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)