### PR TITLE
chore(ci): refresh three stale action pins + fix a pin-freshness blind spot

### DIFF
--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -40,7 +40,7 @@ runs:
     #
     # SKIPPED ON WINDOWS: Bun's monorepo layout under
     # `node_modules/.bun/<pkg>@<version>+<hash>/node_modules/<pkg>/` relies on
-    # NT junctions, which `actions/cache@v5`'s tar pack/restore does not preserve
+    # NT junctions, which this action's tar pack/restore does not preserve
     # correctly. A restored tree on Windows produces EPERM reads on `.bun/...`
     # paths and yields stripped-down ambient `@types/bun` / `@types/node`
     # declarations (e.g. `Response.text/ok/status` go missing), failing

--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -24,7 +24,7 @@ runs:
         bun-version: ${{ inputs.bun-version }}
 
     - name: Cache Bun package download cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -49,7 +49,7 @@ runs:
     # macOS (POSIX symlinks) and Linux are unaffected.
     - name: Cache node_modules
       if: runner.os != 'Windows'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           node_modules

--- a/.github/actions/setup-rust-tauri/action.yml
+++ b/.github/actions/setup-rust-tauri/action.yml
@@ -27,12 +27,12 @@ runs:
           libsecret-tools gnome-keyring
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       with:
         components: rustfmt, clippy
 
     - name: Rust cache (Tauri)
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,7 @@ jobs:
           run-checks: "false"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .playwright-browsers
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
@@ -616,7 +616,7 @@ jobs:
           run-checks: "false"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .playwright-browsers
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup Rust (Rust only)
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
         with:
           toolchain: "1.95.0"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           retention-days: 30
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
 
@@ -262,7 +262,7 @@ jobs:
           retention-days: 30
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -178,13 +178,13 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
         with:
           toolchain: "1.95.0"
 
       - name: Cache cargo-audit binary
         id: cargo-audit-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-0.22.1
@@ -220,7 +220,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (SHA-pinned; version driven by input below)
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
         with:
           toolchain: "1.95.0"
 

--- a/scripts/structure-audit/check-pin-freshness.test.ts
+++ b/scripts/structure-audit/check-pin-freshness.test.ts
@@ -115,6 +115,17 @@ describe("evaluatePin", () => {
     expect(r.verdict).toBe("stale");
   });
 
+  test("an EMPTY publishedAt yields stale — which is why a caller must never fabricate one", () => {
+    // `daysSince("")` fails closed to +Infinity, so handing evaluatePin a
+    // dated result built from a FAILED read would manufacture a `stale` finding
+    // out of a transient error. The tracked-ref branch therefore builds
+    // `latest` only once both the ref read and the commit-date read succeed,
+    // and otherwise passes null so this path reports indeterminate instead.
+    const r = evaluatePin(pin({ sha }), { tag: "stable", publishedAt: "" }, "b".repeat(40), 30);
+    expect(r.verdict).toBe("stale");
+    expect(evaluatePin(pin({ sha }), null, "b".repeat(40), 30).verdict).toBe("indeterminate");
+  });
+
   test("a timestamp with no timezone also fails closed", () => {
     const r = evaluatePin(
       pin({ sha }),

--- a/scripts/structure-audit/check-pin-freshness.test.ts
+++ b/scripts/structure-audit/check-pin-freshness.test.ts
@@ -10,6 +10,7 @@ import {
   parseTagObjectType,
   parseTagSha,
   summarize,
+  TRACKED_REF_OVERRIDES,
 } from "./check-pin-freshness.ts";
 
 const pin = (over: Partial<PinnedAction> = {}): PinnedAction => ({
@@ -172,6 +173,26 @@ describe("parseLatestRelease / parseTagSha", () => {
   test("reads an annotated tag's object type so it can be dereferenced", () => {
     expect(parseTagObjectType(`{"object":{"sha":"x","type":"tag"}}`)).toBe("tag");
     expect(parseTagObjectType(`{"object":{"sha":"x","type":"commit"}}`)).toBe("commit");
+  });
+});
+
+describe("TRACKED_REF_OVERRIDES", () => {
+  test("every override names a git ref namespace, not a bare branch name", () => {
+    // The value is spliced into `git/ref/<value>`, so `stable` alone would 404
+    // and silently degrade the pin to indeterminate rather than checking it.
+    for (const ref of Object.values(TRACKED_REF_OVERRIDES)) {
+      expect(ref).toMatch(/^(heads|tags)\//);
+    }
+  });
+
+  test("the map stays small — an entry is a claim about intent, not a mute button", () => {
+    expect(Object.keys(TRACKED_REF_OVERRIDES).length).toBeLessThanOrEqual(3);
+  });
+
+  test("rust-toolchain is tracked against stable, the ref its pin comment names", () => {
+    // Its newest release `v1` sits behind the `stable` branch, so comparing
+    // against the release would demand moving the pin BACKWARDS to go green.
+    expect(TRACKED_REF_OVERRIDES["dtolnay/rust-toolchain"]).toBe("heads/stable");
   });
 });
 

--- a/scripts/structure-audit/check-pin-freshness.ts
+++ b/scripts/structure-audit/check-pin-freshness.ts
@@ -313,15 +313,23 @@ if (import.meta.main) {
       if (trackedRef !== undefined) {
         // Compare against the ref the pin actually tracks. No release exists to
         // date it, so the ref's own head commit supplies `availableSince`.
+        //
+        // BOTH reads must succeed before a dated result is built. Passing an
+        // empty `publishedAt` through would make `daysSince` fail closed to
+        // +Infinity and turn a transient read failure into a manufactured
+        // `stale` — an unreadable input must degrade to `indeterminate`, never
+        // to a finding.
         const refRes = runGh(["gh", "api", `repos/${pin.ownerRepo}/git/ref/${trackedRef}`]);
         const sha = refRes.ok ? parseTagSha(refRes.stdout) : null;
-        let since = "";
-        if (sha !== null) {
-          const c = runGh(["gh", "api", `repos/${pin.ownerRepo}/commits/${sha}`]);
-          since = (c.ok ? parseCommitDate(c.stdout) : null) ?? "";
-        }
-        entry =
+        const since =
           sha === null
+            ? null
+            : (() => {
+                const c = runGh(["gh", "api", `repos/${pin.ownerRepo}/commits/${sha}`]);
+                return c.ok ? parseCommitDate(c.stdout) : null;
+              })();
+        entry =
+          sha === null || since === null
             ? { latest: null, sha: null }
             : { latest: { tag: trackedRef.replace(/^heads\//, ""), publishedAt: since }, sha };
         cache.set(pin.ownerRepo, entry);

--- a/scripts/structure-audit/check-pin-freshness.ts
+++ b/scripts/structure-audit/check-pin-freshness.ts
@@ -36,6 +36,25 @@ import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_g
  */
 export const DEFAULT_GRACE_DAYS = 30;
 
+/**
+ * Actions whose pin deliberately tracks a named REF rather than a release.
+ *
+ * "Latest release" is the right yardstick for most actions and the wrong one
+ * for some. `dtolnay/rust-toolchain` is pinned here against its `stable`
+ * branch (the trailing `# stable` comment says so), and its newest *release*,
+ * `v1`, currently sits **12 commits behind** that branch — so measuring the pin
+ * against `v1` would report a correctly-updated pin as stale, and "fixing" it
+ * would move the pin backwards in code age to satisfy the gate.
+ *
+ * A gate that can only be satisfied by making the repo worse is a broken gate,
+ * so these are compared against the ref they actually track. Keep the map tiny:
+ * an entry here is a claim about intent, and the trailing comment in the
+ * workflow must agree with it.
+ */
+export const TRACKED_REF_OVERRIDES: Readonly<Record<string, string>> = {
+  "dtolnay/rust-toolchain": "heads/stable",
+};
+
 export interface PinnedAction {
   ownerRepo: string;
   sha: string;
@@ -290,6 +309,25 @@ if (import.meta.main) {
   for (const pin of collectPinnedActions(files)) {
     let entry = cache.get(pin.ownerRepo);
     if (!entry) {
+      const trackedRef = TRACKED_REF_OVERRIDES[pin.ownerRepo];
+      if (trackedRef !== undefined) {
+        // Compare against the ref the pin actually tracks. No release exists to
+        // date it, so the ref's own head commit supplies `availableSince`.
+        const refRes = runGh(["gh", "api", `repos/${pin.ownerRepo}/git/ref/${trackedRef}`]);
+        const sha = refRes.ok ? parseTagSha(refRes.stdout) : null;
+        let since = "";
+        if (sha !== null) {
+          const c = runGh(["gh", "api", `repos/${pin.ownerRepo}/commits/${sha}`]);
+          since = (c.ok ? parseCommitDate(c.stdout) : null) ?? "";
+        }
+        entry =
+          sha === null
+            ? { latest: null, sha: null }
+            : { latest: { tag: trackedRef.replace(/^heads\//, ""), publishedAt: since }, sha };
+        cache.set(pin.ownerRepo, entry);
+        results.push(evaluatePin(pin, entry.latest, entry.sha, DEFAULT_GRACE_DAYS));
+        continue;
+      }
       const relRes = runGh(["gh", "api", `repos/${pin.ownerRepo}/releases/latest`]);
       if (!relRes.ok && classifyReadFailure(relRes.httpStatus) === "absent") {
         // The repo publishes no releases at all (our own `nimbus-agent/.github`


### PR DESCRIPTION
## Summary

Clears the three findings `audit:pin-freshness` shipped red on in #847 — and one of them turned out to be a flaw in **my gate**, not a stale pin.

| Action | Change | Risk |
| --- | --- | --- |
| `actions/cache` | v5.0.5 → **v6.1.0** (6 call sites) | Major — see below |
| `actions/attest-build-provenance` | v4.1.0 → **v4.1.1** (2 sites) | Patch, none |
| `dtolnay/rust-toolchain` | → current `stable` head (3 sites) | See below |

Gate after: **`audit:pin-freshness: OK (30/30 pins current)`**.

## The `actions/cache` major bump deserves a sentence

v6.0.0 is *"Update packages, migrate to ESM"* — a packaging/runtime change, not caching semantics. That matters here because `.github/actions/setup-nimbus-ci/action.yml` carries an explicit note about `actions/cache@v5`'s tar pack/restore not preserving **Windows NT junctions**. Upstream doesn't list that behaviour as changed, so I bumped rather than pinned back — but CI is the proof, and the Windows cache steps on this PR are the thing to watch.

## `dtolnay/rust-toolchain` — the gate was wrong, not the pin

The pin is commented `# stable` and deliberately tracks that **branch**. My gate measured it against the newest **release**, `v1` — and `v1` currently sits **12 commits behind `stable`**:

```
compare(stable...v1) → { ahead: 0, behind: 12 }
```

So taking the gate at its word would have moved the pin **backwards in code age** purely to turn a check green. That's the failure mode this whole batch has been avoiding: a gate that can only be satisfied by making the repo worse is a broken gate.

Fix: actions that deliberately track a named ref are compared against **that ref**, via a deliberately tiny `TRACKED_REF_OVERRIDES` map. Three tests keep it honest:

- every value must be a real ref namespace (`heads/…`/`tags/…`) — a bare `stable` would 404 and silently degrade the pin to `indeterminate`, i.e. a mute button dressed as a check;
- the map is **size-capped**, so it cannot quietly grow into a general suppression list;
- the rust-toolchain entry asserts it matches the ref its own pin comment names.

This is the third instance in this batch of the same underlying lesson — *don't let a gate report a permanent mismatch as a fixable failure* (cf. `unverifiable` in #845 and the no-releases skip in #847).

## Testing

- `bun test scripts/` — **753 pass, 20 skip, 0 fail** (3 new)
- `bunx tsc -p scripts/tsconfig.json --noEmit` — exit 0
- biome — clean
- `audit:action-sha-pins` — OK (every bumped ref is still a full 40-hex SHA with a version comment)
- `audit:secret-inventory` — OK
- Live `audit:pin-freshness` — 30/30 current

## Type of Change

- [x] CI / tooling
- [x] Bug fix (the gate blind spot)

## Non-Negotiables Checklist

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` (Biome) — clean
- [x] All existing tests pass — 753
- [x] New behaviour is covered by tests — 3
- [x] No `any` introduced
- [x] No credentials in logs/IPC/config
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched — n/a

## Notes for Reviewers

This unblocks the **P2 sweep proof**: with the pins current, a dispatched `org-drift-sweep` should be green across every job, which is the program's definition of *done* for Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI, security, and release automation to newer verified revisions, including refreshed build provenance attestation tooling.
  - Improved caching for JavaScript/Rust tooling and Playwright E2E browsers, and refreshed pinned Rust toolchain action revisions across workflows.
- **Tests**
  - Enhanced structure audit coverage for tracked ref pins, including stricter validation and correctness checks for freshness verdicts.
- **Security**
  - Updated Rust security scan workflow tooling pins used for cargo auditing and denial checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->