### PR TITLE
fix(ci): retry the Rust toolchain install, drop the redundant one, and close #809/#810/#812

### DIFF
--- a/.github/actions/setup-rust-tauri/action.yml
+++ b/.github/actions/setup-rust-tauri/action.yml
@@ -26,10 +26,12 @@ runs:
           librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
           libsecret-tools gnome-keyring
 
+    # Was `dtolnay/rust-toolchain` with no `toolchain:` input, which defaults to
+    # `stable` — so this installed latest stable and then rust-toolchain.toml
+    # pulled 1.95.0 down a second time on the first `cargo fmt`. Two toolchains,
+    # two unretried downloads. The shared action installs the pinned one once.
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      with:
-        components: rustfmt, clippy
+      uses: ./.github/actions/setup-rust-toolchain
 
     - name: Rust cache (Tauri)
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -1,0 +1,111 @@
+name: Setup Rust toolchain
+description: >
+  Install the repo-pinned Rust toolchain, retrying the download. Channel and
+  components come from rust-toolchain.toml, the single source of truth.
+
+runs:
+  using: composite
+  steps:
+    # Why this exists rather than `dtolnay/rust-toolchain`:
+    #
+    #  1. Retry. `rustup toolchain install` is a single unretried fetch from
+    #     static.rust-lang.org. A TLS reset there ("Connection reset by peer",
+    #     os error 104) failed the whole `Cargo deny` job in run 30232465108 —
+    #     cargo-deny itself never ran. `continue-on-error` is not available to
+    #     composite-action steps, so the retry has to be in-script; this mirrors
+    #     the retry-once shape already used in ci.yml / _test-suite.yml / _perf.yml
+    #     and, like those, PROPAGATES the last attempt's exit code so a genuine
+    #     failure still fails the job.
+    #
+    #     Pre-warming and letting a second install no-op does NOT work: rustup
+    #     re-syncs the channel manifest on every `toolchain install`, even for an
+    #     already-installed pinned version. Verified by pointing RUSTUP_DIST_SERVER
+    #     at an unresolvable host with 1.95.0 already on disk — it still failed.
+    #
+    #  2. One place to bump the version. The 1.95.0 pin used to be copy-pasted
+    #     into codeql.yml and security.yml, and rust-toolchain.toml carried a
+    #     "when bumping this, also update ..." comment. Reading the file removes
+    #     the drift instead of documenting it.
+    - name: Install Rust toolchain (retry on transient download failure)
+      shell: bash
+      env:
+        # rustup falls back to copy+rename when a hardlink across filesystems
+        # fails, which is the norm on hosted runners. Carried over from dtolnay's
+        # action; without it the install can fail on Windows runners.
+        RUSTUP_PERMIT_COPY_RENAME: "1"
+      run: |
+        set -uo pipefail
+
+        toml="${GITHUB_WORKSPACE}/rust-toolchain.toml"
+        if [ ! -f "$toml" ]; then
+          echo "rust-toolchain.toml not found at $toml" >&2
+          exit 1
+        fi
+
+        # channel = "1.95.0"
+        channel="$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -n1)"
+        if [ -z "$channel" ]; then
+          echo "could not parse [toolchain].channel from $toml" >&2
+          exit 1
+        fi
+
+        # components = ["rustfmt", "clippy"] -> --component rustfmt --component clippy
+        #
+        # Installed up front on every caller, not just the ones that run fmt/clippy.
+        # rustup would otherwise materialise them lazily on the first in-repo cargo
+        # call — a second unretried download, which is the failure mode this action
+        # exists to remove.
+        comp_raw="$(sed -n 's/^[[:space:]]*components[[:space:]]*=[[:space:]]*\[\(.*\)\].*/\1/p' "$toml" |
+          head -n1 | sed 's/["[:space:]]//g')"
+        comp_flags=()
+        if [ -n "$comp_raw" ]; then
+          IFS=',' read -ra comps <<< "$comp_raw"
+          for c in "${comps[@]}"; do
+            [ -n "$c" ] && comp_flags+=(--component "$c")
+          done
+        fi
+
+        echo "Installing Rust $channel${comp_raw:+ (components: $comp_raw)}"
+
+        # Defensive: every GitHub-hosted runner image ships rustup, so this is a
+        # fallback for self-hosted. curl already retries here.
+        if ! command -v rustup >/dev/null 2>&1; then
+          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location \
+            --silent --show-error --fail https://sh.rustup.rs |
+            sh -s -- --default-toolchain none -y
+          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+          export PATH="$CARGO_HOME/bin:$PATH"
+        fi
+
+        for attempt in 1 2 3; do
+          rustup toolchain install "$channel" --profile minimal --no-self-update \
+            ${comp_flags[@]+"${comp_flags[@]}"}
+          code=$?
+          if [ "$code" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "All 3 attempts to install Rust $channel failed (exit $code)" >&2
+            exit "$code"
+          fi
+          delay=$((attempt * 10))
+          echo "Toolchain install attempt $attempt failed (exit $code), retrying in ${delay}s..."
+          sleep "$delay"
+        done
+
+        # Best-effort, exactly as upstream does it: in-repo commands already pick
+        # the pinned toolchain up from rust-toolchain.toml, so a failure here is
+        # not fatal. See dtolnay/rust-toolchain#127.
+        rustup default "$channel" || echo "rustup default failed (non-fatal)"
+
+        # Match upstream's environment so build behaviour and cache sizes do not
+        # change with this swap.
+        if [ -z "${CARGO_INCREMENTAL+set}" ]; then
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+        fi
+        if [ -z "${CARGO_TERM_COLOR+set}" ]; then
+          echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
+        fi
+
+        rustc "+$channel" --version --verbose

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,7 +57,6 @@ updates:
           - "actions/*"
           - "github/codeql-action"
           - "aquasecurity/trivy-action"
-          - "dtolnay/rust-toolchain"
           - "oven-sh/setup-bun"
           - "softprops/action-gh-release"
           - "dorny/test-reporter"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,9 +57,7 @@ jobs:
 
       - name: Setup Rust (Rust only)
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
-        with:
-          toolchain: "1.95.0"
+        uses: ./.github/actions/setup-rust-toolchain
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -178,9 +178,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
-        with:
-          toolchain: "1.95.0"
+        uses: ./.github/actions/setup-rust-toolchain
 
       - name: Cache cargo-audit binary
         id: cargo-audit-cache
@@ -219,11 +217,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable (SHA-pinned; version driven by input below)
-        with:
-          toolchain: "1.95.0"
-
+      # Deliberately no "Setup Rust" step here. cargo-deny-action is a *Docker*
+      # action (rust:1.85.0-alpine3.20) that brings its own cargo and resolves
+      # rust-toolchain.toml inside the container, so a host toolchain is never
+      # consulted. The host install was pure cost — and in run 30232465108 it was
+      # the step that failed (a static.rust-lang.org TLS reset), taking the job
+      # down before cargo-deny ever ran. Do not re-add it.
       - name: Run cargo deny
         # Pinned to v2.0.17 (cargo-deny 0.19.2). The previous pin at
         # e2f4ede (v2.0.4) bundled a cargo-deny version that couldn't

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -14,6 +14,11 @@ production = false
 timeout = 30000
 smol = false
 coverage = false
+# Runs before every test file — and before anything can import config.ts, whose `Config`
+# snapshots process.env once at first import. Blanks the developer's real credentials so no
+# test can inherit them and reach a live provider. See the file header and issue #812, where
+# a test suite made a real OAuth round-trip to Google with the developer's own client secret.
+preload = ["./scripts/test-preload/hermetic-credentials.ts"]
 
 [test.coverageThreshold]
 lines = 80

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,29 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-27 — Rust toolchain CI hardening, and two notification contracts pinned.**
+  The `Cargo deny` job died in `Setup Rust` on run 30232465108 — a TLS reset from
+  static.rust-lang.org on an unretried `rustup toolchain install`, of which there were four
+  copies. The failing one was **redundant**: `cargo-deny-action` is a Docker action on
+  `rust:1.85.0-alpine3.20` carrying its own cargo, so that step is deleted outright. The
+  three genuine ones now go through `.github/actions/setup-rust-toolchain`, which retries
+  three times with backoff and propagates the last exit code. Pre-warming was ruled out by
+  experiment, not assumption: rustup re-syncs the channel manifest on every
+  `toolchain install`, even for an already-installed pinned version. The action parses
+  `channel` and `components` from `rust-toolchain.toml`, so the 1.95.0 pin is no longer
+  copy-pasted into `codeql.yml` and `security.yml`; `setup-rust-tauri` also stops installing
+  `stable` and then pulling 1.95.0 down a second time. `dtolnay/rust-toolchain` is now unused
+  and its dependabot + pin-freshness entries are retired, with the pin-freshness test replaced
+  by one that fails when an override names an action the repo no longer pins.
+  **Notification contracts** (nimbus-agent/Nimbus#809, #810) are now recorded in
+  [`architecture.md`](./architecture.md) from the emit sites: `connector.configChanged`
+  carries the full post-mutation snapshot, and `workflow.run({ stream: true })` reuses the
+  **untagged** `agent.chunk` — the same method `engine.askStream` uses, so chunks cannot be
+  attributed to a run and a client must keep one streaming workflow per connection.
+  `@nimbus-dev/client` consumes both. Also fixes **#812**: the connector-auth OAuth suite
+  depended on winning a module-load race for `Config`'s env snapshot, and on a machine with
+  Google OAuth configured it fell through the fail-closed guard into a real PKCE round-trip.
+
 - **2026-07-26 — P2 Release Train Phase 2: dependency-DAG edges.** `audit:release-staleness`
   now also watches the npm propagation graph. A `<pkg>:publish` edge compares each upstream's
   component-prefixed release tag to npm `@latest`, catching a package that is tagged but never

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,16 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   `@nimbus-dev/client` consumes both. Also fixes **#812**: the connector-auth OAuth suite
   depended on winning a module-load race for `Config`'s env snapshot, and on a machine with
   Google OAuth configured it fell through the fail-closed guard into a real PKCE round-trip.
+  **Tests are now hermetic against real credentials by construction** — a `[test] preload`
+  (`scripts/test-preload/hermetic-credentials.ts`) blanks credential-shaped `NIMBUS_*` /
+  `OPENAI_*` / `ANTHROPIC_*` env vars before any test module loads, and therefore before
+  anything can import `config.ts` and freeze its snapshot. Per-file blanking cannot close that
+  class, because "am I the first file to load config.ts?" is not something a test file can
+  know; a preload is ordered ahead of all of them by construction. It announces the NAMES it
+  blanked (never values), so the next occurrence is visible rather than silent, and a wired-in
+  test asserts the preload actually ran. Tests that set a credential themselves are unaffected —
+  only inheritance from the developer's shell is removed, which no test may depend on since CI
+  has none set.
 
 - **2026-07-26 — P2 Release Train Phase 2: dependency-DAG edges.** `audit:release-staleness`
   now also watches the npm propagation graph. A `<pkg>:publish` edge compares each upstream's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1152,6 +1152,32 @@ const streamReq: JSONRPCRequest = {
 // Notification: { method: "engine.streamDone",  params: { streamId, meta } }
 // Notification: { method: "engine.streamError", params: { streamId, error } }
 
+// Streaming workflow run — `workflow.run({ stream: true })` reuses the SAME
+// `agent.chunk` notification as `engine.askStream`; there is no workflow-specific
+// chunk method. Emitted per step from `ipc/server/inline-handlers.ts`
+// (`sendAgentChunkIfStreaming`), which is a no-op when `stream` is falsy.
+// workflow.run(params: {
+//   name: string, triggeredBy?: string, dryRun?: boolean,
+//   stream?: boolean,                          // opt in to agent.chunk
+//   sessionId?: string, agent?: string,
+//   paramsOverride?: Record<string, Record<string, unknown>>  // keyed by step label
+// }) -> WorkflowRunResult
+// Notification: { method: "agent.chunk", params: { text: string } }
+//
+// Because the chunk method is shared, a client that runs a workflow and an ask
+// concurrently on ONE connection cannot attribute chunks to either. Clients that
+// need both at once should use separate connections until a stream id is added.
+
+// Connector config mutations — emitted from `ipc/connector-rpc-handlers/lifecycle.ts`
+// (`emitConfigChanged`) after setConfig / pause / resume / setInterval. Carries the
+// full post-mutation snapshot, so a client can reconcile a row without re-reading
+// `connector.listStatus`. Suppressed when the session registered no notify sink, or
+// when the service has no persisted status row yet.
+// Notification: { method: "connector.configChanged", params: {
+//   service: string, intervalMs: number,
+//   depth: "metadata_only" | "summary" | "full", enabled: boolean
+// } }
+
 // Session rehydration (Phase 4 WS6)
 // engine.getSessionTranscript(params: { sessionId, limit? }) -> { turns: AgentTurn[] }
 // engine.cancelStream(params: { streamId }) -> { ok: true }

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -270,8 +270,15 @@ client one, so none blocked the stage:
 - `connector.addMcp`'s consent payload reads `command`/`args`, which the
   `{ serviceId, commandLine }` params never populate — so the security prompt
   renders blank. Filed against the gateway.
-- `connector.configChanged` is emitted but not exposed; clients poll instead.
-- `workflow.run({ stream: true })` emits chunks that no public API surfaces.
+- ~~`connector.configChanged` is emitted but not exposed; clients poll instead.~~
+  **Closed.** Both payload contracts are pinned in `docs/architecture.md`, and
+  `@nimbus-dev/client` exposes `subscribeConnectorConfigChanged`.
+- ~~`workflow.run({ stream: true })` emits chunks that no public API surfaces.~~
+  **Closed — surfaced, not retired**, via `workflowRunStream`. One gateway-side
+  limitation remains and is the reason it is not a full `askStream` equivalent:
+  workflow chunks ride the UNTAGGED `agent.chunk`, so a client cannot attribute a
+  chunk to a run and must keep one streaming workflow per connection. Adding a
+  stream id to those chunks is the fix, and is gateway work.
 
 **Permanently out of bounds:** `vault.*` and `db.*` are gateway-internal and must
 never be surfaced to a client. Anything the gateway marks CLI-only stays CLI-only

--- a/packages/gateway/src/ipc/connector-rpc-handlers/auth.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/auth.test.ts
@@ -1,58 +1,63 @@
 /**
  * auth.test.ts — colocated coverage for connector-rpc-handlers/auth.ts.
  *
- * Focus: the OAuth-PKCE provider-config switch (`oauthClientConfigForProvider`, reached only via
- * `handleConnectorAuth` → `connectorAuthOAuthPkce`). Each OAuth provider's switch arm is exercised by
- * driving an auth for a service that maps to it; with NO OAuth client id configured, the flow fails
- * closed at the empty-client-id guard (BEFORE any network/PKCE), so the test never touches the real
- * OAuth flow.
+ * Focus: the OAuth-PKCE provider-config switch (`oauthClientConfigForProvider`) and the two
+ * fail-closed guards in `connectorAuthOAuthPkce` that stand in front of `runPKCEFlow`.
  *
- * Determinism: `Config` reads `NIMBUS_OAUTH_*_CLIENT_ID` from `process.env` at module-load. To stay
- * hermetic on a dev box that has some ids configured, we blank those env vars BEFORE importing the
- * modules (so the cached `Config` snapshot sees empty ids), then load `auth.ts`/`config.ts` lazily.
+ * Determinism (see issue #812). This suite used to drive both concerns through
+ * `handleConnectorAuth`, relying on every OAuth client id being empty so the flow would fail
+ * closed before any network. That premise is a property of the developer's environment, not of
+ * the code: `Config` snapshots `NIMBUS_OAUTH_*` ONCE at module load, so blanking those vars at
+ * the top of this file only worked while this file happened to be the first in the process to
+ * import `config.ts`. In `bun test packages/gateway/src/ipc/` a sibling gets there first, the
+ * blanking became a no-op, and on a machine with Google OAuth configured `google_drive` sailed
+ * past the guard into a real PKCE round-trip — a live redirect listener and a real request to
+ * Google with the developer's own credentials — which hung until the 5s timeout.
  *
- * NOTE (uncovered, deliberately): the PKCE success block (sharedKey mirror + token persistence) and
- * the `oauthScopesFromConnectorRequest`/`oauthRedirectPortFromRec` request-driven branches live AFTER
- * `runPKCEFlow`, which performs a real OAuth round-trip (network + a local redirect listener). There
- * is no DI seam to inject `runPKCEFlow`/`Config` into `handleConnectorAuth`, so those lines are not
- * reachable from a hermetic unit test without `mock.module` (which this suite avoids).
+ * A test that passes only because it never got far enough to try is exactly the failure this
+ * file exists to catch, so the ordering dependency is gone rather than papered over with a
+ * longer timeout:
+ *
+ *   - the switch arms are asserted DIRECTLY on the pure `oauthClientConfigForProvider`, which
+ *     needs no env and cannot reach the network;
+ *   - the guards are asserted through `handleConnectorAuth` with an INJECTED resolver
+ *     (`resolveOAuthClientConfig`), so "the client id is empty" is established by the test
+ *     instead of hoped for — and `runPKCEFlow` is unreachable by construction.
  *
  * Rules: no `any` (cast through `unknown`); no `mock.module`; real in-memory SQLite + mock vault.
  */
 
 import { Database } from "bun:sqlite";
-import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-// Blank every OAuth client-id / secret env var BEFORE the dynamic imports below read them. This makes
-// the empty-client-id guard fire deterministically regardless of the developer's local env. The
-// original values are captured so they can be restored after the suite — otherwise the mutation would
-// leak into unrelated tests sharing the worker and cause order-dependent failures.
-const oauthEnvBackup = new Map<string, string | undefined>();
-for (const k of Object.keys(process.env)) {
-  if (k.startsWith("NIMBUS_OAUTH_") && (k.endsWith("_CLIENT_ID") || k.endsWith("_CLIENT_SECRET"))) {
-    oauthEnvBackup.set(k, process.env[k]);
-    process.env[k] = "";
-  }
-}
-
-const { LocalIndex } = await import("../../index/local-index.ts");
-const { createMockVault } = await import("../../vault/mock.ts");
-const { ConnectorRpcError } = await import("../connector-rpc-shared.ts");
-const { handleConnectorAuth } = await import("./auth.ts");
-
-afterAll(() => {
-  for (const [k, v] of oauthEnvBackup) {
-    if (v === undefined) delete process.env[k];
-    else process.env[k] = v;
-  }
-});
-
-type NimbusVault = import("../../vault/nimbus-vault.ts").NimbusVault;
-type LocalIndexT = import("../../index/local-index.ts").LocalIndex;
-type ConnectorRpcHandlerContext = import("./context.ts").ConnectorRpcHandlerContext;
+import {
+  CANVA_OAUTH_CLIENT_ID_HELP,
+  FIGMA_OAUTH_CLIENT_ID_HELP,
+  GOOGLE_OAUTH_CLIENT_ID_HELP,
+  HUBSPOT_OAUTH_CLIENT_ID_HELP,
+  MENDELEY_OAUTH_CLIENT_ID_HELP,
+  MICROSOFT_OAUTH_CLIENT_ID_HELP,
+  MIRO_OAUTH_CLIENT_ID_HELP,
+  NOTION_OAUTH_CLIENT_ID_HELP,
+  NOTION_OAUTH_CLIENT_SECRET_HELP,
+  SALESFORCE_OAUTH_CLIENT_ID_HELP,
+  SLACK_OAUTH_CLIENT_ID_HELP,
+  WORKDAY_OAUTH_CLIENT_ID_HELP,
+  ZOOM_OAUTH_CLIENT_ID_HELP,
+} from "../../auth/oauth-env-help-messages.ts";
+import {
+  type ConnectorServiceId,
+  oauthProfileForService,
+} from "../../connectors/connector-catalog.ts";
+import { LocalIndex } from "../../index/local-index.ts";
+import { createMockVault } from "../../vault/mock.ts";
+import type { NimbusVault } from "../../vault/nimbus-vault.ts";
+import { ConnectorRpcError } from "../connector-rpc-shared.ts";
+import { handleConnectorAuth, oauthClientConfigForProvider } from "./auth.ts";
+import type { ConnectorRpcHandlerContext, OAuthClientConfigResolver } from "./context.ts";
 
 let db: Database;
-let localIndex: LocalIndexT;
+let localIndex: LocalIndex;
 let vault: NimbusVault;
 
 beforeEach(() => {
@@ -70,7 +75,7 @@ afterEach(() => {
   }
 });
 
-function ctxFor(service: string): ConnectorRpcHandlerContext {
+function ctxFor(service: string, resolve?: OAuthClientConfigResolver): ConnectorRpcHandlerContext {
   return {
     rec: { service },
     vault,
@@ -78,38 +83,94 @@ function ctxFor(service: string): ConnectorRpcHandlerContext {
     openUrl: async () => {},
     syncScheduler: undefined,
     connectorMesh: undefined,
+    ...(resolve === undefined ? {} : { resolveOAuthClientConfig: resolve }),
   };
 }
 
-describe("handleConnectorAuth — OAuth provider config switch arms", () => {
-  // Each service routes to a distinct OAuth provider arm in oauthClientConfigForProvider; with no
-  // client id configured, connectorAuthOAuthPkce throws the provider-specific empty-client-id help.
-  const oauthServices = [
-    "google_drive", // google
-    "onedrive", // microsoft
-    "slack", // slack
-    "notion", // notion
-    "zoom", // zoom
-    "hubspot", // hubspot
-    "miro", // miro
-    "canva", // canva
-    "figma", // figma
-    "salesforce", // salesforce
-    "mendeley", // mendeley
-  ] as const;
+/**
+ * One service per OAuth provider arm, with the help text that arm must return.
+ *
+ * The help constant is what identifies the arm: it is provider-specific and env-independent,
+ * so asserting it proves the switch routed correctly without asserting a client id that
+ * varies per machine.
+ */
+const PROVIDER_ARMS: ReadonlyArray<readonly [ConnectorServiceId, string]> = [
+  ["google_drive", GOOGLE_OAUTH_CLIENT_ID_HELP],
+  ["onedrive", MICROSOFT_OAUTH_CLIENT_ID_HELP],
+  ["slack", SLACK_OAUTH_CLIENT_ID_HELP],
+  ["notion", NOTION_OAUTH_CLIENT_ID_HELP],
+  ["zoom", ZOOM_OAUTH_CLIENT_ID_HELP],
+  ["hubspot", HUBSPOT_OAUTH_CLIENT_ID_HELP],
+  ["miro", MIRO_OAUTH_CLIENT_ID_HELP],
+  ["canva", CANVA_OAUTH_CLIENT_ID_HELP],
+  ["figma", FIGMA_OAUTH_CLIENT_ID_HELP],
+  ["salesforce", SALESFORCE_OAUTH_CLIENT_ID_HELP],
+  ["mendeley", MENDELEY_OAUTH_CLIENT_ID_HELP],
+  ["workday", WORKDAY_OAUTH_CLIENT_ID_HELP],
+];
 
-  for (const service of oauthServices) {
-    test(`${service} reaches its provider arm and fails closed on the empty client id`, async () => {
+describe("oauthClientConfigForProvider — one arm per OAuth provider", () => {
+  for (const [service, expectedHelp] of PROVIDER_ARMS) {
+    test(`${service} routes to its provider arm`, () => {
+      const config = oauthClientConfigForProvider(oauthProfileForService(service));
+      expect(config.emptyClientIdMessage).toBe(expectedHelp);
+    });
+  }
+
+  test("every arm is covered — the table tracks the provider list", () => {
+    // A new OAuth provider adds a switch arm that nothing above would exercise. The switch's
+    // `never` exhaustiveness check catches a MISSING arm at compile time; this catches an arm
+    // that exists but is untested.
+    const providers = new Set(
+      PROVIDER_ARMS.map(([service]) => oauthProfileForService(service).provider),
+    );
+    expect(providers.size).toBe(PROVIDER_ARMS.length);
+  });
+});
+
+describe("connectorAuthOAuthPkce — fail-closed before any PKCE round-trip", () => {
+  // Injected, so emptiness is established by the test rather than by the machine's env. If a
+  // guard ever stopped firing, the call would reach runPKCEFlow and this test would hang — which
+  // is the regression it is here to catch, and which it can now actually catch.
+  const emptyClientId: OAuthClientConfigResolver = () => ({
+    clientId: "",
+    emptyClientIdMessage: "no client id configured",
+  });
+
+  for (const [service] of PROVIDER_ARMS) {
+    test(`${service} fails closed on an empty client id`, async () => {
       let caught: unknown;
       try {
-        await handleConnectorAuth(ctxFor(service));
+        await handleConnectorAuth(ctxFor(service, emptyClientId));
       } catch (e) {
         caught = e;
       }
       expect(caught).toBeInstanceOf(ConnectorRpcError);
       expect((caught as InstanceType<typeof ConnectorRpcError>).rpcCode).toBe(-32602);
+      expect((caught as Error).message).toBe("no client id configured");
     });
   }
+
+  test("a provider whose client secret is required fails closed when only the id is set", async () => {
+    // The second guard. Only reachable with a NON-empty client id, so it was unreachable from
+    // the old env-driven suite on a machine with no Notion credentials — i.e. always.
+    const idButNoSecret: OAuthClientConfigResolver = () => ({
+      clientId: "set-but-secret-missing",
+      emptyClientIdMessage: NOTION_OAUTH_CLIENT_ID_HELP,
+      clientSecret: "",
+      clientSecretMissingHelp: NOTION_OAUTH_CLIENT_SECRET_HELP,
+    });
+
+    let caught: unknown;
+    try {
+      await handleConnectorAuth(ctxFor("notion", idButNoSecret));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ConnectorRpcError);
+    expect((caught as InstanceType<typeof ConnectorRpcError>).rpcCode).toBe(-32602);
+    expect((caught as Error).message).toBe(NOTION_OAUTH_CLIENT_SECRET_HELP);
+  });
 });
 
 describe("handleConnectorAuth — PAT handler routing", () => {

--- a/packages/gateway/src/ipc/connector-rpc-handlers/auth.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/auth.ts
@@ -650,7 +650,10 @@ async function connectorAuthOAuthPkce(
   vault: NimbusVault,
   localIndex: LocalIndex,
   openUrl: (url: string) => Promise<void>,
-  resolveClientConfig: OAuthClientConfigResolver = oauthClientConfigForProvider,
+  // Required, not defaulted. `handleConnectorAuth` is the only caller and already resolves the
+  // fallback; a default here would duplicate that and be permanently unreachable — dead code
+  // that reads like a safety net.
+  resolveClientConfig: OAuthClientConfigResolver,
 ): Promise<ConnectorRpcHit> {
   const profile = oauthProfileForService(id);
   const config = resolveClientConfig(profile);

--- a/packages/gateway/src/ipc/connector-rpc-handlers/auth.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/auth.ts
@@ -25,6 +25,7 @@ import { OAUTH_PROVIDERS } from "../../auth/oauth-registry.ts";
 import { type PKCEOptions, runPKCEFlow } from "../../auth/pkce.ts";
 import { Config } from "../../config.ts";
 import {
+  type ConnectorOAuthProfile,
   type ConnectorServiceId,
   defaultSyncIntervalMsForService,
   oauthProfileForService,
@@ -44,7 +45,12 @@ import {
   parseServiceArg,
   registerAtlassianApiConnectorAuth,
 } from "../connector-rpc-shared.ts";
-import type { ConnectorRpcHandlerContext, ConnectorRpcHit } from "./context.ts";
+import type {
+  ConnectorRpcHandlerContext,
+  ConnectorRpcHit,
+  OAuthClientConfig,
+  OAuthClientConfigResolver,
+} from "./context.ts";
 
 /** Returns the trimmed string value of `raw`, or `""` if it is not a non-empty string. */
 function extractStringField(raw: unknown): string {
@@ -540,18 +546,15 @@ async function connectorAuthBitbucket(
   return authSuccess("bitbucket");
 }
 
-interface OAuthClientConfig {
-  readonly clientId: string;
-  readonly emptyClientIdMessage: string;
-  /** Present when the provider has a config-driven client secret AND it is set. */
-  readonly clientSecret?: string;
-  /** Present when the provider's `clientSecret` is `required` (for the missing-secret error). */
-  readonly clientSecretMissingHelp?: string;
-}
-
-function oauthClientConfigForProvider(
-  profile: ReturnType<typeof oauthProfileForService>,
-): OAuthClientConfig {
+/**
+ * The `Config`-backed resolver: one arm per OAuth provider.
+ *
+ * Exported so the per-provider arms can be asserted directly. Reaching them through
+ * `handleConnectorAuth` instead means relying on every client id being empty, which is
+ * a property of the developer's environment rather than of this switch — and when it
+ * does not hold, the call falls through into a real PKCE round-trip (issue #812).
+ */
+export function oauthClientConfigForProvider(profile: ConnectorOAuthProfile): OAuthClientConfig {
   switch (profile.provider) {
     case "google":
       return {
@@ -647,9 +650,10 @@ async function connectorAuthOAuthPkce(
   vault: NimbusVault,
   localIndex: LocalIndex,
   openUrl: (url: string) => Promise<void>,
+  resolveClientConfig: OAuthClientConfigResolver = oauthClientConfigForProvider,
 ): Promise<ConnectorRpcHit> {
   const profile = oauthProfileForService(id);
-  const config = oauthClientConfigForProvider(profile);
+  const config = resolveClientConfig(profile);
   if (config.clientId === "") {
     throw new ConnectorRpcError(-32602, config.emptyClientIdMessage);
   }
@@ -764,5 +768,12 @@ export async function handleConnectorAuth(
   if (patHandler !== undefined) {
     return patHandler(ctx);
   }
-  return connectorAuthOAuthPkce(id, rec, vault, localIndex, openUrl);
+  return connectorAuthOAuthPkce(
+    id,
+    rec,
+    vault,
+    localIndex,
+    openUrl,
+    ctx.resolveOAuthClientConfig ?? oauthClientConfigForProvider,
+  );
 }

--- a/packages/gateway/src/ipc/connector-rpc-handlers/context.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/context.ts
@@ -1,12 +1,35 @@
 // Type-only module: NO executable runtime logic. It is exact-path-excluded from the coverage floor
 // in scripts/coverage-floor/exclusions.ts (a type-only file emits no SF: lcov record). Adding runtime
 // logic here would silently bypass the floor — put runtime logic in a separate, covered module.
+import type { ConnectorOAuthProfile } from "../../connectors/connector-catalog.ts";
 import type { LazyConnectorMesh } from "../../connectors/lazy-mesh/index.ts";
 import type { LocalIndex } from "../../index/local-index.ts";
 import type { SyncScheduler } from "../../sync/scheduler.ts";
 import type { NimbusVault } from "../../vault/nimbus-vault.ts";
 
 export type ConnectorRpcHit = { kind: "hit"; value: unknown };
+
+/** One OAuth provider's client credentials plus the help text shown when they are missing. */
+export interface OAuthClientConfig {
+  /** Empty string when unset — the fail-closed guard in `connectorAuthOAuthPkce` keys off exactly this. */
+  readonly clientId: string;
+  readonly emptyClientIdMessage: string;
+  /** Present when the provider has a config-driven client secret AND it is set. */
+  readonly clientSecret?: string;
+  /** Present when the provider's `clientSecret` is `required` (for the missing-secret error). */
+  readonly clientSecretMissingHelp?: string;
+}
+
+/**
+ * Resolves a provider's OAuth client config.
+ *
+ * Production uses the `Config`-backed resolver in `auth.ts`. Tests inject one so the
+ * fail-closed guards can be proven directly, instead of depending on `Config`'s
+ * module-load env snapshot — which is only blankable by the FIRST test file in a
+ * process to import `config.ts`, and therefore silently stops working in a combined
+ * run (see issue #812).
+ */
+export type OAuthClientConfigResolver = (profile: ConnectorOAuthProfile) => OAuthClientConfig;
 
 export type ConnectorRpcHandlerContext = {
   rec: Record<string, unknown> | undefined;
@@ -16,4 +39,9 @@ export type ConnectorRpcHandlerContext = {
   syncScheduler: SyncScheduler | undefined;
   connectorMesh: LazyConnectorMesh | undefined;
   notify?: (method: string, params: Record<string, unknown>) => void;
+  /**
+   * Test seam. Omitted in production, where `auth.ts` falls back to its
+   * `Config`-backed `oauthClientConfigForProvider`.
+   */
+  resolveOAuthClientConfig?: OAuthClientConfigResolver;
 };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,8 +5,10 @@
 # stabilized in Rust 1.85+. We pin 1.95 (April 2026 stable) to match the MSRV
 # declared in packages/ui/src-tauri/Cargo.toml.
 #
-# When bumping this, also update the `toolchain:` input in:
-#   .github/workflows/codeql.yml
-#   .github/workflows/security.yml
+# This file is the single source of truth for CI too: the shared
+# .github/actions/setup-rust-toolchain composite action parses `channel` and
+# `components` straight out of it, so bumping the version here is the whole
+# change. (It used to be copy-pasted into codeql.yml and security.yml, which is
+# what this comment used to remind you about.)
 channel = "1.95.0"
 components = ["rustfmt", "clippy"]

--- a/scripts/structure-audit/check-pin-freshness.test.ts
+++ b/scripts/structure-audit/check-pin-freshness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -215,11 +215,15 @@ describe("TRACKED_REF_OVERRIDES", () => {
 
     const dir = join(import.meta.dir, "..", "..", ".github");
     const files: WorkflowFile[] = [];
+    // `withFileTypes` so the directory test comes from the entry readdir already
+    // returned. A separate `statSync(full)` followed by `readFileSync(full)` is a
+    // check-then-use pair on the same path — CodeQL js/file-system-race, high.
     const walk = (d: string): void => {
-      for (const entry of readdirSync(d)) {
-        const full = join(d, entry);
-        if (statSync(full).isDirectory()) walk(full);
-        else if (entry.endsWith(".yml") || entry.endsWith(".yaml")) {
+      for (const entry of readdirSync(d, { withFileTypes: true })) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) {
           files.push({ path: full, text: readFileSync(full, "utf8") });
         }
       }

--- a/scripts/structure-audit/check-pin-freshness.test.ts
+++ b/scripts/structure-audit/check-pin-freshness.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   collectPinnedActions,
@@ -11,6 +13,7 @@ import {
   parseTagSha,
   summarize,
   TRACKED_REF_OVERRIDES,
+  type WorkflowFile,
 } from "./check-pin-freshness.ts";
 
 const pin = (over: Partial<PinnedAction> = {}): PinnedAction => ({
@@ -200,10 +203,33 @@ describe("TRACKED_REF_OVERRIDES", () => {
     expect(Object.keys(TRACKED_REF_OVERRIDES).length).toBeLessThanOrEqual(3);
   });
 
-  test("rust-toolchain is tracked against stable, the ref its pin comment names", () => {
-    // Its newest release `v1` sits behind the `stable` branch, so comparing
-    // against the release would demand moving the pin BACKWARDS to go green.
-    expect(TRACKED_REF_OVERRIDES["dtolnay/rust-toolchain"]).toBe("heads/stable");
+  test("every override names an action this repo still pins", () => {
+    // An override is a claim about an action we USE. When the Rust setup moved
+    // to the in-repo .github/actions/setup-rust-toolchain, the
+    // `dtolnay/rust-toolchain` entry became a claim about nothing — dead config
+    // that no other gate would have caught, because a stale override is silently
+    // never consulted. This asserts the map against the real .github tree so a
+    // retired action cannot leave one behind.
+    const keys = Object.keys(TRACKED_REF_OVERRIDES);
+    if (keys.length === 0) return;
+
+    const dir = join(import.meta.dir, "..", "..", ".github");
+    const files: WorkflowFile[] = [];
+    const walk = (d: string): void => {
+      for (const entry of readdirSync(d)) {
+        const full = join(d, entry);
+        if (statSync(full).isDirectory()) walk(full);
+        else if (entry.endsWith(".yml") || entry.endsWith(".yaml")) {
+          files.push({ path: full, text: readFileSync(full, "utf8") });
+        }
+      }
+    };
+    walk(dir);
+
+    const pinned = new Set(collectPinnedActions(files).map((p) => p.ownerRepo));
+    for (const k of keys) {
+      expect(pinned.has(k), `${k} is in TRACKED_REF_OVERRIDES but no longer pinned`).toBe(true);
+    }
   });
 });
 

--- a/scripts/structure-audit/check-pin-freshness.ts
+++ b/scripts/structure-audit/check-pin-freshness.ts
@@ -40,20 +40,21 @@ export const DEFAULT_GRACE_DAYS = 30;
  * Actions whose pin deliberately tracks a named REF rather than a release.
  *
  * "Latest release" is the right yardstick for most actions and the wrong one
- * for some. `dtolnay/rust-toolchain` is pinned here against its `stable`
- * branch (the trailing `# stable` comment says so), and its newest *release*,
- * `v1`, currently sits **12 commits behind** that branch — so measuring the pin
- * against `v1` would report a correctly-updated pin as stale, and "fixing" it
+ * for some — an action pinned to a branch whose newest *release* sits behind
+ * that branch would be reported stale while correctly updated, and "fixing" it
  * would move the pin backwards in code age to satisfy the gate.
  *
  * A gate that can only be satisfied by making the repo worse is a broken gate,
  * so these are compared against the ref they actually track. Keep the map tiny:
  * an entry here is a claim about intent, and the trailing comment in the
  * workflow must agree with it.
+ *
+ * Currently empty. Its only entry was `dtolnay/rust-toolchain` (pinned to
+ * `heads/stable`), retired when the Rust setup moved to the in-repo
+ * `.github/actions/setup-rust-toolchain`. The mechanism stays because the
+ * branch-pinned case it handles is a recurring one, not because it is in use.
  */
-export const TRACKED_REF_OVERRIDES: Readonly<Record<string, string>> = {
-  "dtolnay/rust-toolchain": "heads/stable",
-};
+export const TRACKED_REF_OVERRIDES: Readonly<Record<string, string>> = {};
 
 export interface PinnedAction {
   ownerRepo: string;

--- a/scripts/test-preload/hermetic-credentials.test.ts
+++ b/scripts/test-preload/hermetic-credentials.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { blankCredentialEnv, isCredentialEnvName } from "./hermetic-credentials.ts";
+
+describe("isCredentialEnvName", () => {
+  test("matches the credentials that actually leaked", () => {
+    // The pair from #812 — a real Google OAuth desktop client on the developer's box.
+    expect(isCredentialEnvName("NIMBUS_OAUTH_GOOGLE_CLIENT_ID")).toBe(true);
+    expect(isCredentialEnvName("NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET")).toBe(true);
+    expect(isCredentialEnvName("NIMBUS_GITHUB_PAT")).toBe(true);
+    expect(isCredentialEnvName("OPENAI_API_KEY")).toBe(true);
+    expect(isCredentialEnvName("ANTHROPIC_API_KEY")).toBe(true);
+    expect(isCredentialEnvName("NIMBUS_AWS_SECRET_ACCESS_KEY")).toBe(true);
+  });
+
+  test("leaves settings alone — a model name or a host is not a secret", () => {
+    // Blanking these would change behaviour under test rather than protect anything.
+    expect(isCredentialEnvName("NIMBUS_AGENT_MODEL")).toBe(false);
+    expect(isCredentialEnvName("NIMBUS_OPENAI_CLASSIFIER_MODEL")).toBe(false);
+    expect(isCredentialEnvName("NIMBUS_WORKDAY_TENANT_HOST")).toBe(false);
+    expect(isCredentialEnvName("NIMBUS_CONFIG_DIR")).toBe(false);
+  });
+
+  test("requires an owned prefix — foreign credentials are not ours to clear", () => {
+    // SONAR_TOKEN / CODACY_API_TOKEN belong to CI tooling, not to the gateway. Clearing
+    // them inside `bun test` would protect nothing and could break a tool that reads them.
+    expect(isCredentialEnvName("SONAR_TOKEN")).toBe(false);
+    expect(isCredentialEnvName("CODACY_API_TOKEN")).toBe(false);
+    expect(isCredentialEnvName("GITHUB_TOKEN")).toBe(false);
+  });
+});
+
+describe("blankCredentialEnv", () => {
+  test("blanks to empty string rather than deleting", () => {
+    // Config reads `processEnvGet(x) ?? ""`, so "" and absent are equivalent to it — but ""
+    // additionally survives code that only tests `in process.env`.
+    const env: Record<string, string | undefined> = {
+      NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET: "real-secret",
+      NIMBUS_AGENT_MODEL: "some-model",
+    };
+    const blanked = blankCredentialEnv(env);
+
+    expect(blanked).toEqual(["NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET"]);
+    expect(env["NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET"]).toBe("");
+    expect("NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET" in env).toBe(true);
+    expect(env["NIMBUS_AGENT_MODEL"]).toBe("some-model");
+  });
+
+  test("reports names only — a value must never reach the return path", () => {
+    const secret = "GOCSPX-not-a-real-one";
+    const env: Record<string, string | undefined> = { NIMBUS_OAUTH_GOOGLE_CLIENT_SECRET: secret };
+    const blanked = blankCredentialEnv(env);
+    expect(blanked.join(",")).not.toContain(secret);
+  });
+
+  test("ignores already-empty and undefined entries", () => {
+    const env: Record<string, string | undefined> = {
+      NIMBUS_GITHUB_PAT: "",
+      NIMBUS_SLACK_TOKEN: undefined,
+    };
+    expect(blankCredentialEnv(env)).toEqual([]);
+  });
+});
+
+describe("the preload is actually wired", () => {
+  test("credential vars are blank in this very process", () => {
+    // The load-bearing assertion. The unit tests above prove the predicate; this proves the
+    // preload RAN — the failure mode in #812 was a blanking step that was correct in isolation
+    // and never took effect. Reads process.env directly: if bunfig's `preload` were dropped,
+    // a developer with credentials configured would go red here instead of silently making
+    // live API calls from the test suite.
+    for (const name of Object.keys(process.env)) {
+      if (isCredentialEnvName(name)) {
+        expect(process.env[name], `${name} survived the preload`).toBe("");
+      }
+    }
+  });
+});

--- a/scripts/test-preload/hermetic-credentials.ts
+++ b/scripts/test-preload/hermetic-credentials.ts
@@ -1,0 +1,77 @@
+/**
+ * Test preload — blank the developer's real credentials before any test module loads.
+ *
+ * Registered as `[test] preload` in bunfig.toml, so it runs before EVERY test file and,
+ * critically, before anything can import `packages/gateway/src/config.ts` — whose `Config`
+ * is a module-level literal that snapshots `process.env` exactly once, at first import.
+ *
+ * Why this exists. Issue #812: the connector-auth suite blanked `NIMBUS_OAUTH_*` at its own
+ * top level and imported lazily, which only worked while it happened to be the FIRST file in
+ * the process to load `config.ts`. In a combined run a sibling got there first, the blanking
+ * became a silent no-op, and on a machine with Google OAuth configured the suite walked past
+ * its fail-closed guard into a real PKCE round-trip — a live local redirect listener and a
+ * real request to Google carrying the developer's own client id and secret. It passed alone,
+ * hung in the combined run, and was invisible in CI, which has no credentials to leak.
+ *
+ * Per-file blanking cannot fix that class, because "am I first?" is not something a test file
+ * can know. A preload can: it is ordered before all of them by construction.
+ *
+ * Blanked, not deleted. `Config` reads `processEnvGet(x) ?? ""`, so an empty string and an
+ * absent var are equivalent to it, and an empty string additionally survives code that only
+ * checks `in process.env`.
+ *
+ * This does NOT stop a test from setting a credential itself — several legitimately do
+ * (`mendeley-access-token.test.ts`, `notion-access-token.test.ts`). Those assignments happen
+ * after preload and are untouched. The only thing removed is INHERITANCE from the developer's
+ * shell, which no test may depend on: CI has none of these set, so any test that needed one
+ * would already be failing there.
+ */
+
+/** Prefixes we own, or that name a paid API a test must never reach for real. */
+const CREDENTIAL_PREFIXES = ["NIMBUS_", "OPENAI_", "ANTHROPIC_"] as const;
+
+/** Name shapes that denote a secret rather than a setting (a model name or a host is fine). */
+const CREDENTIAL_SUFFIXES = [
+  "_CLIENT_ID",
+  "_CLIENT_SECRET",
+  "_SECRET",
+  "_TOKEN",
+  "_PAT",
+  "_API_KEY",
+  "_KEY",
+  "_ACCESS_KEY_ID",
+  "_SECRET_ACCESS_KEY",
+  "_PASSWORD",
+] as const;
+
+/**
+ * Pattern-matched rather than enumerated: the credential surface is ~80 connectors wide and a
+ * hand-maintained list would drift out of date exactly when a new connector is added — which
+ * is the moment it would matter.
+ */
+export function isCredentialEnvName(name: string): boolean {
+  if (!CREDENTIAL_PREFIXES.some((p) => name.startsWith(p))) return false;
+  return CREDENTIAL_SUFFIXES.some((s) => name.endsWith(s));
+}
+
+/** Blanks matching keys in `env`; returns the NAMES blanked (never the values). */
+export function blankCredentialEnv(env: Record<string, string | undefined>): string[] {
+  const blanked: string[] = [];
+  for (const name of Object.keys(env)) {
+    if (env[name] !== undefined && env[name] !== "" && isCredentialEnvName(name)) {
+      env[name] = "";
+      blanked.push(name);
+    }
+  }
+  return blanked.sort();
+}
+
+const blanked = blankCredentialEnv(process.env);
+if (blanked.length > 0 && process.env["NIMBUS_TEST_PRELOAD_QUIET"] !== "1") {
+  // Names only — printing a value here would put the very secret this guard exists to contain
+  // into CI logs and terminal scrollback. Announced rather than silent so the behaviour is
+  // discoverable: #812 was hard to read precisely because the leak was invisible.
+  console.error(
+    `[test-preload] blanked ${blanked.length} credential env var(s) for hermetic tests: ${blanked.join(", ")}`,
+  );
+}


### PR DESCRIPTION
Addresses the failure in [run 30232465108](https://github.com/nimbus-agent/Nimbus/actions/runs/30232465108) and the repo's open issues. Closes #809, #810, #812. (#854 is a bot release-health alert — every row `ok` except the already-tracked `VSCE_PAT` 2026-09-20 deadline; nothing to fix in code.)

## 1. The CI failure

`Cargo deny` died in **`Setup Rust`** — cargo-deny itself never ran. `rustup toolchain install 1.95.0` took a TLS reset from `static.rust-lang.org` (`Connection reset by peer`, os error 104). Harden Runner is on `egress-policy: audit` here, so nothing was blocked; it was simply an unretried single point of failure, and there were **four** copies of it.

**The failing step did not need to exist.** `cargo-deny-action` is a *Docker* action on `rust:1.85.0-alpine3.20` that brings its own cargo and resolves `rust-toolchain.toml` inside the container — the host toolchain is never consulted. That step is deleted, with a comment so it does not come back.

The three genuine host installs now go through `.github/actions/setup-rust-toolchain`: three attempts, 10s then 20s backoff, propagating the last exit code so a real failure still fails.

Two things were settled by experiment rather than assumption:

- **Pre-warming does not work.** rustup re-syncs the channel manifest on *every* `toolchain install`, even for an already-installed pinned version — verified by pointing `RUSTUP_DIST_SERVER` at an unresolvable host with 1.95.0 already on disk; it still failed. So the retry must wrap the install itself.
- **`continue-on-error` is unavailable to composite-action steps**, which is why the retry is in-script rather than the usual two-step wrapper.

Fallout worth noting:

- `rust-toolchain.toml` is now the single source of truth — the action parses `channel` and `components` from it, so the 1.95.0 pin is no longer copy-pasted into `codeql.yml` and `security.yml`, and that file's "when bumping this, also update …" comment describes something that can no longer drift.
- `setup-rust-tauri` passed no `toolchain:`, so it installed **`stable`** and then `rust-toolchain.toml` pulled 1.95.0 down a *second* time on the first `cargo fmt` — two toolchains, two unretried downloads. Now one.
- `dtolnay/rust-toolchain` is unused, so its dependabot group entry and `TRACKED_REF_OVERRIDES` pin-freshness entry are retired. A stale override is dead config no gate would catch (an override for an unpinned action is silently never consulted), so the test asserting the dtolnay entry is replaced by one asserting **every** override still names an action the repo actually pins, checked against the real `.github` tree.

**Live proof:** dispatched `security.yml` on this branch — [run 30280225651](https://github.com/nimbus-agent/Nimbus/actions/runs/30280225651) is fully green, and the `Cargo audit` log shows `Installing Rust 1.95.0 (components: rustfmt,clippy)` parsed from the TOML.

## 2. #812 — the connector-auth suite depended on winning a race

`… google_drive …` timed out at 5000ms in the combined `packages/gateway/src/ipc/` run and passed in ~190ms alone. Not a timer leak and not `mock.module` — a premise that only holds when the file wins a race.

`Config` is a module-level literal, so it snapshots every `NIMBUS_OAUTH_*` var **once, at first import**. The suite blanked those vars then imported lazily, which only works if it is the first file in the process to load `config.ts`. A sibling gets there first, the blanking becomes a no-op, and `Config.oauthGoogleClientId` keeps whatever the developer has configured. `google_drive` then walks past the `clientId === ""` guard into `runPKCEFlow` — **a live local redirect listener and a real request to Google using the developer's own credentials** — and hangs. Only google failed because it is the only provider most machines configure; CI never failed because CI has no client id at all.

Proven, not inferred: adding only `NIMBUS_OAUTH_GOOGLE_CLIENT_ID=""` to the outer environment takes the combined run from 1341 pass / 1 fail to **1342 / 0**.

The issue asks for the masking to be fixed rather than the timeout raised, so the ordering dependency is removed: provider arms are asserted directly on the now-exported, pure `oauthClientConfigForProvider`, and the fail-closed guards are asserted through `handleConnectorAuth` with an **injected** `resolveOAuthClientConfig`, so emptiness is established *by the test*. `runPKCEFlow` is unreachable from this suite by construction, on any machine.

Net coverage change: the empty-client-id guard is now exercised for **all 12** providers instead of only those a given box leaves unconfigured; `workday` gains an arm test it never had; and the client-secret-required guard is covered for the first time — it needs a *non-empty* client id, so the old env-driven suite could never reach it. 14 tests → 29. The env-blanking preamble and its `afterAll` restore are gone, removing this file's own process-wide `process.env` mutation — the same hazard class the failure came from.

## 3. #809 / #810 — notification contracts

Both were filed against the gateway because *which* notifications are public contract is a gateway decision. Payload shapes are now recorded in `docs/architecture.md`, read off the emit sites:

- `connector.configChanged` carries the full post-mutation snapshot `{ service, intervalMs, depth, enabled }`.
- `workflow.run({ stream: true })` has **no chunk method of its own** — it reuses the untagged `agent.chunk { text }`, the same notification `engine.askStream` emits. #810 asked for surface-vs-retire; **surfaced**, since the emission already works.

The consequence bounds what any client can offer and is stated explicitly: those chunks carry no stream id, so a caller cannot attribute a chunk to a run. Adding one is gateway work and stays open in the ecosystem roadmap.

Client half: **nimbus-agent/nimbus-client#39** (green), adding `subscribeConnectorConfigChanged` and `workflowRunStream`.

## Verification

Full gateway suite **8832 pass / 0 fail** across 665 files. Typecheck, biome (via `bunx biome check packages scripts` — `bun run lint` reports 0 files inside `.claude/worktrees`), `audit:invariants`, `structure`, `boundaries`, `any`, `cross-platform`, `exclusion-parity`, `openapi-drift`, `readme-cli`, `package-readmes`, `svg-assets`, `consumed-by`, `release-please`, `action-sha-pins`, `actions-allowlist`, `doc-refs` (622 refs), markdownlint, and lychee (1008 OK / 0 errors, whole branch) all clean.

Both new guards red-proven: mis-routing the google arm fails the arm test, and deleting the empty-client-id guard fails the fail-closed test for **every** provider. The retry loop was red-proven to exhaust 3 attempts and propagate the exit code, and the action script was run end-to-end against a simulated GHA environment.

**One gate I could not run locally:** `audit:coverage-floor` is Linux-authoritative via Docker, and Docker is not running on this machine. `auth.ts` is not in the baseline (it already clears both floors) and the change only adds covered paths, so it should be unaffected — but CI is the authority here, not that reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)