### PR TITLE
feat(audit): P4b — measure CI latency before tuning anything

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -210,6 +210,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bun scripts/structure-audit/check-pin-freshness.ts --strict
 
+  ci-latency:
+    name: ci-latency
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # `actions: read` is all the Actions API needs for runs + jobs. Every
+      # audited repo is public, so the default github.token reaches them.
+      - name: Audit CI latency
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/ci-latency/check.ts --strict
+
   actions-allowlist:
     name: actions-allowlist
     runs-on: ubuntu-24.04

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -319,17 +319,22 @@ moves to P6).
   is DAG-free contention and the DAG cost is recorded separately. Contention is
   real but concentrated almost entirely on **macOS** runners.
 - **Tolerance is a per-key noise band, not a constant.** Measured spreads
-  (`p90 − median`) over 11 samples: `Static — ubuntu` 0.2, `Unit + Coverage —
-  ubuntu` 0.29, `Unit + Coverage — windows` **10.77**. No global constant fits
-  both, so the baseline stores each job's own spread and the gate allows
-  `max(1min, spread)`. A job whose spread exceeds half its median is reported
-  `unstable` — observed, never failed, since flakiness is not caused by the
-  contributor's change.
-- **Baseline coverage:** the generated baseline contains **194 keys from 1806
+  (`p90 − median`) in the committed baseline: `Static — ubuntu` 0.15, `Unit +
+  Coverage — ubuntu` 0.22, `Unit + Coverage — windows` **10.48**. No global
+  constant fits both, so the baseline stores each job's own spread and the gate
+  allows `max(1min, spread)`. A job whose spread exceeds half its median is
+  reported `unstable` — observed, never failed, since flakiness is not caused
+  by the contributor's change.
+- **Baseline coverage:** the generated baseline contains **197 keys from 1778
   observations across 6 repos**. Three of the nine audited repos (`linux-repo`,
   `homebrew-tap`, `scoop-bucket`) contribute nothing because they have zero
   successful `push`-event runs — their automation is dispatch-triggered. This is
-  expected, not a gap.
+  expected, not a gap. An earlier collection paged only the first 100 jobs of
+  each run, which silently dropped every job past that cutoff — including all
+  three `E2E Desktop` legs, exactly the deepest-DAG, longest-tail jobs the gate
+  exists to watch. The collector now pages through `total_count`, capped at
+  `MAX_JOB_PAGES` (5) per run, and `Nimbus :: CI :: E2E Desktop — {ubuntu,macos,
+  windows}` now appear in the baseline.
 - **The gate ships green by construction:** the baseline is generated from the
   same window the check reads, so nothing can exceed it on the first run. The
   red-proof is the unit test in `scripts/ci-latency/evaluate.test.ts`, not the

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -320,7 +320,7 @@ moves to P6).
   real but concentrated almost entirely on **macOS** runners.
 - **Tolerance is a per-key noise band, not a constant.** Measured spreads
   (`p90 − median`) over 11 samples: `Static — ubuntu` 0.2, `Unit + Coverage —
-  ubuntu` 2.0min, `Unit + Coverage — windows` **10.77**. No global constant fits
+  ubuntu` 0.29, `Unit + Coverage — windows` **10.77**. No global constant fits
   both, so the baseline stores each job's own spread and the gate allows
   `max(1min, spread)`. A job whose spread exceeds half its median is reported
   `unstable` — observed, never failed, since flakiness is not caused by the

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -79,7 +79,7 @@ Design of record:
 | P2 | Release Train | ✅ done (Phase 1 run 30210246814) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, or when a release phantoms (manifest bumped, nothing built). Red-proved on a real phantom and green after (`OK (5 edges current)`). Phase 2 adds npm publish-phantom + consumer-lag edges. |
 | P3 | Review Layer | ⬜ not started | An invariant violation is caught in CI, not only in local `preflight` |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
-| P4b | Latency | ⬜ not started | Per-job wall-clock tracked; regressions visible |
+| P4b | Latency | 🔨 measurement shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning is deliberately NOT in this slice — the first measurement showed execution is not the binding constraint. |
 | P5 | Org Legibility | ⬜ not started | `audit:secret-inventory` fails on any workflow secret missing from `ci-secrets.md`. **Second gate added 2026-07-26:** an Actions-allowlist check that fails when a required workflow's action is not permitted to run |
 | P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
 
@@ -298,6 +298,44 @@ moves to P6).
   scheduled harness, which Phase 2 cannot show while it is legitimately red;
   dispatch `org-drift-sweep.yml` after the consumer bumps land and record the
   run number here, same as Phase 1.
+
+### P4b progress log
+
+- **Delivered (measurement, 2026-07-27):** `audit:ci-latency` collects per-job
+  timings from the Actions API across all 9 org repos and gates execution
+  against a committed baseline (`docs/structure-audit/ci-latency-baseline.json`),
+  mirroring `audit:coverage-floor`.
+- **The first measurement contradicted the design of record's hunch.** That
+  document proposed cache tuning, matrix sharding and finer path filters. On the
+  slowest sampled run (73.8min) the longest single job *executed* for 12.3min,
+  while the longest DAG wait was 33.9min and the longest runner queue 31.6min —
+  so execution is not the binding constraint, and sharding would worsen it by
+  adding jobs to the same contended pool. Principle #3 ("only against
+  measurement, never against a hunch") earned its keep on first use.
+- **An earlier revision of the design claimed "~80% of wall-clock is queueing".
+  That was wrong** and the design review caught it: it measured
+  `started_at − run_started_at`, which charges a job for its *dependencies'*
+  execution. A job's `created_at` tracks eligibility, so `started_at − created_at`
+  is DAG-free contention and the DAG cost is recorded separately. Contention is
+  real but concentrated almost entirely on **macOS** runners.
+- **Tolerance is a per-key noise band, not a constant.** Measured spreads
+  (`p90 − median`) over 11 samples: `Static — ubuntu` 0.2, `Unit + Coverage —
+  ubuntu` 2.0min, `Unit + Coverage — windows` **10.77**. No global constant fits
+  both, so the baseline stores each job's own spread and the gate allows
+  `max(1min, spread)`. A job whose spread exceeds half its median is reported
+  `unstable` — observed, never failed, since flakiness is not caused by the
+  contributor's change.
+- **Baseline coverage:** the generated baseline contains **194 keys from 1806
+  observations across 6 repos**. Three of the nine audited repos (`linux-repo`,
+  `homebrew-tap`, `scoop-bucket`) contribute nothing because they have zero
+  successful `push`-event runs — their automation is dispatch-triggered. This is
+  expected, not a gap.
+- **The gate ships green by construction:** the baseline is generated from the
+  same window the check reads, so nothing can exceed it on the first run. The
+  red-proof is the unit test in `scripts/ci-latency/evaluate.test.ts`, not the
+  live run.
+- **Remaining:** the tuning slice itself, which must be justified against this
+  data. The clearest lead is macOS runner contention.
 
 ### P5 progress log
 

--- a/docs/structure-audit/ci-latency-baseline.json
+++ b/docs/structure-audit/ci-latency-baseline.json
@@ -1,0 +1,782 @@
+{
+  "version": 1,
+  "generated_at": "2026-07-27T16:23:22.420Z",
+  "entries": {
+    ".github :: CI :: Test composite actions": {
+      "execMedian": 0.23,
+      "execSpread": 0.05
+    },
+    "Nimbus :: CI :: CI — Rust/Tauri (macos-15)": {
+      "execMedian": 1.17,
+      "execSpread": 0.17
+    },
+    "Nimbus :: CI :: CI — Rust/Tauri (ubuntu-24.04)": {
+      "execMedian": 1.27,
+      "execSpread": 0.42
+    },
+    "Nimbus :: CI :: CI — Rust/Tauri (windows-2025)": {
+      "execMedian": 1.72,
+      "execSpread": 0.28
+    },
+    "Nimbus :: CI :: CI — Structure audit / structure": {
+      "execMedian": 0.83,
+      "execSpread": 0.06
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Agents (macos-15)": {
+      "execMedian": 1.28,
+      "execSpread": 0.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Config (macos-15)": {
+      "execMedian": 1.18,
+      "execSpread": 0.16
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — DB layer (macos-15)": {
+      "execMedian": 1.31,
+      "execSpread": 0.19
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Deployment (macos-15)": {
+      "execMedian": 1.27,
+      "execSpread": 0.17
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Doctor (macos-15)": {
+      "execMedian": 1.22,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Embedding (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.23
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Engine (macos-15)": {
+      "execMedian": 1.28,
+      "execSpread": 0.1
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Extensions (macos-15)": {
+      "execMedian": 1.25,
+      "execSpread": 0.15
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Health (macos-15)": {
+      "execMedian": 1.21,
+      "execSpread": 0.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — LAN (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.23
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — MCP (macos-15)": {
+      "execMedian": 1.26,
+      "execSpread": 0.13
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Metrics (macos-15)": {
+      "execMedian": 1.35,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — People (macos-15)": {
+      "execMedian": 1.13,
+      "execSpread": 0.13
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Perf (macos-15)": {
+      "execMedian": 1.32,
+      "execSpread": 0.15
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Preflight (macos-15)": {
+      "execMedian": 1.29,
+      "execSpread": 0.42
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Rate limiter (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.17
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Sandbox (macos-15)": {
+      "execMedian": 1.25,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Sync scheduler (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.27
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — TUI (macos-15)": {
+      "execMedian": 1.33,
+      "execSpread": 0.15
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Telemetry (macos-15)": {
+      "execMedian": 1.25,
+      "execSpread": 0.1
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Updater (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.3
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Vault (macos-15)": {
+      "execMedian": 1.26,
+      "execSpread": 0.16
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Watcher (macos-15)": {
+      "execMedian": 1.31,
+      "execSpread": 0.24
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Workflow (macos-15)": {
+      "execMedian": 1.24,
+      "execSpread": 0.22
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / E2E CLI — macos-15": {
+      "execMedian": 1.36,
+      "execSpread": 0.21
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / E2E Gateway — macos-15": {
+      "execMedian": 1.3,
+      "execSpread": 0.22
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Integration — macos-15": {
+      "execMedian": 1.28,
+      "execSpread": 0.43
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Static — macos-15": {
+      "execMedian": 4.53,
+      "execSpread": 0.76
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Unit + Coverage — macos-15": {
+      "execMedian": 4.91,
+      "execSpread": 0.24
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Agents (ubuntu-24.04)": {
+      "execMedian": 0.79,
+      "execSpread": 0.04
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Config (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — DB layer (ubuntu-24.04)": {
+      "execMedian": 0.78,
+      "execSpread": 0.07
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Deployment (ubuntu-24.04)": {
+      "execMedian": 0.78,
+      "execSpread": 0.05
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Doctor (ubuntu-24.04)": {
+      "execMedian": 0.72,
+      "execSpread": 0.05
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Embedding (ubuntu-24.04)": {
+      "execMedian": 0.75,
+      "execSpread": 0.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Engine (ubuntu-24.04)": {
+      "execMedian": 0.71,
+      "execSpread": 0.11
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Extensions (ubuntu-24.04)": {
+      "execMedian": 0.72,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Health (ubuntu-24.04)": {
+      "execMedian": 0.62,
+      "execSpread": 0.18
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — LAN (ubuntu-24.04)": {
+      "execMedian": 0.85,
+      "execSpread": 0.03
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — MCP (ubuntu-24.04)": {
+      "execMedian": 0.69,
+      "execSpread": 0.14
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Metrics (ubuntu-24.04)": {
+      "execMedian": 0.72,
+      "execSpread": 0.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — People (ubuntu-24.04)": {
+      "execMedian": 0.77,
+      "execSpread": 0.03
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Perf (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.17
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Preflight (ubuntu-24.04)": {
+      "execMedian": 0.7,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Rate limiter (ubuntu-24.04)": {
+      "execMedian": 0.7,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Sandbox (ubuntu-24.04)": {
+      "execMedian": 0.88,
+      "execSpread": 0.18
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Sync scheduler (ubuntu-24.04)": {
+      "execMedian": 0.67,
+      "execSpread": 0.18
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — TUI (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Telemetry (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.11
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Updater (ubuntu-24.04)": {
+      "execMedian": 0.77,
+      "execSpread": 0.03
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Vault (ubuntu-24.04)": {
+      "execMedian": 1.08,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Watcher (ubuntu-24.04)": {
+      "execMedian": 0.63,
+      "execSpread": 0.15
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Workflow (ubuntu-24.04)": {
+      "execMedian": 0.71,
+      "execSpread": 0.06
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / E2E CLI — ubuntu-24.04": {
+      "execMedian": 1.08,
+      "execSpread": 0.38
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / E2E Gateway — ubuntu-24.04": {
+      "execMedian": 1.18,
+      "execSpread": 0.27
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Integration — ubuntu-24.04": {
+      "execMedian": 1.14,
+      "execSpread": 0.26
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Packaging — ubuntu-24.04": {
+      "execMedian": 1.32,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Static — ubuntu-24.04": {
+      "execMedian": 4.57,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Unit + Coverage — ubuntu-24.04": {
+      "execMedian": 12.26,
+      "execSpread": 0.29
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Agents (windows-2025)": {
+      "execMedian": 2.38,
+      "execSpread": 0.23
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Config (windows-2025)": {
+      "execMedian": 2.45,
+      "execSpread": 1.08
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — DB layer (windows-2025)": {
+      "execMedian": 2.86,
+      "execSpread": 1.17
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Deployment (windows-2025)": {
+      "execMedian": 2.16,
+      "execSpread": 0.44
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Doctor (windows-2025)": {
+      "execMedian": 2.03,
+      "execSpread": 0.45
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Embedding (windows-2025)": {
+      "execMedian": 2.39,
+      "execSpread": 0.83
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Engine (windows-2025)": {
+      "execMedian": 2.08,
+      "execSpread": 0.28
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Extensions (windows-2025)": {
+      "execMedian": 2.23,
+      "execSpread": 0.34
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Health (windows-2025)": {
+      "execMedian": 2.2,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — LAN (windows-2025)": {
+      "execMedian": 2.13,
+      "execSpread": 0.75
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — MCP (windows-2025)": {
+      "execMedian": 2.27,
+      "execSpread": 0.18
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Metrics (windows-2025)": {
+      "execMedian": 2.32,
+      "execSpread": 0.67
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — People (windows-2025)": {
+      "execMedian": 2.16,
+      "execSpread": 0.44
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Perf (windows-2025)": {
+      "execMedian": 2.25,
+      "execSpread": 0.22
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Preflight (windows-2025)": {
+      "execMedian": 2.35,
+      "execSpread": 0.47
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Rate limiter (windows-2025)": {
+      "execMedian": 2.18,
+      "execSpread": 0.78
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Sandbox (windows-2025)": {
+      "execMedian": 2.17,
+      "execSpread": 0.42
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Sync scheduler (windows-2025)": {
+      "execMedian": 2.22,
+      "execSpread": 0.53
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — TUI (windows-2025)": {
+      "execMedian": 2.19,
+      "execSpread": 0.26
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Telemetry (windows-2025)": {
+      "execMedian": 2.14,
+      "execSpread": 0.39
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Updater (windows-2025)": {
+      "execMedian": 2.35,
+      "execSpread": 0.55
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Vault (windows-2025)": {
+      "execMedian": 2.22,
+      "execSpread": 0.28
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Watcher (windows-2025)": {
+      "execMedian": 2.23,
+      "execSpread": 0.1
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Workflow (windows-2025)": {
+      "execMedian": 2.13,
+      "execSpread": 0.34
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / E2E CLI — windows-2025": {
+      "execMedian": 2.53,
+      "execSpread": 0.12
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / E2E Gateway — windows-2025": {
+      "execMedian": 2.26,
+      "execSpread": 0.96
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Integration — windows-2025": {
+      "execMedian": 2.92,
+      "execSpread": 0.52
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Static — windows-2025": {
+      "execMedian": 6.81,
+      "execSpread": 0.99
+    },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Unit + Coverage — windows-2025": {
+      "execMedian": 12.87,
+      "execSpread": 10.77
+    },
+    "Nimbus :: CI :: Detect changes": {
+      "execMedian": 0.25,
+      "execSpread": 0.02
+    },
+    "Nimbus :: CodeQL :: Analyze (javascript-typescript)": {
+      "execMedian": 3.52,
+      "execSpread": 0.2
+    },
+    "Nimbus :: CodeQL :: Analyze (rust)": {
+      "execMedian": 1.8,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Docs Quality :: Bencher Report": {
+      "execMedian": 0,
+      "execSpread": 0
+    },
+    "Nimbus :: Docs Quality :: Cast transcript tripwire": {
+      "execMedian": 0.7,
+      "execSpread": 0.05
+    },
+    "Nimbus :: Docs Quality :: OG card render": {
+      "execMedian": 0.68,
+      "execSpread": 0.02
+    },
+    "Nimbus :: Docs Quality :: Package READMEs audit": {
+      "execMedian": 0.57,
+      "execSpread": 0.14
+    },
+    "Nimbus :: Docs Quality :: README CLI-command tripwire": {
+      "execMedian": 0.65,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Docs Quality :: SVG asset audit": {
+      "execMedian": 0.68,
+      "execSpread": 0.11
+    },
+    "Nimbus :: Docs Quality :: Starlight build test": {
+      "execMedian": 0.64,
+      "execSpread": 0.09
+    },
+    "Nimbus :: Docs Quality :: lychee link check": {
+      "execMedian": 0.67,
+      "execSpread": 0.17
+    },
+    "Nimbus :: Docs Quality :: markdownlint-cli2": {
+      "execMedian": 0.62,
+      "execSpread": 0.12
+    },
+    "Nimbus :: Performance Benchmarks :: Bench (macos-15)": {
+      "execMedian": 32.58,
+      "execSpread": 4.34
+    },
+    "Nimbus :: Performance Benchmarks :: Bench (ubuntu-24.04)": {
+      "execMedian": 11.77,
+      "execSpread": 0.12
+    },
+    "Nimbus :: Performance Benchmarks :: Bench (windows-2025)": {
+      "execMedian": 26.98,
+      "execSpread": 0.99
+    },
+    "Nimbus :: Performance Benchmarks :: Decide whether to run the bench matrix": {
+      "execMedian": 0.05,
+      "execSpread": 0.02
+    },
+    "Nimbus :: Release :: Build .msi (Windows)": {
+      "execMedian": 1.27,
+      "execSpread": 0.01
+    },
+    "Nimbus :: Release :: Build .pkg (macOS)": {
+      "execMedian": 0.69,
+      "execSpread": 0.06
+    },
+    "Nimbus :: Release :: Build CLI — linux": {
+      "execMedian": 0.69,
+      "execSpread": 0.11
+    },
+    "Nimbus :: Release :: Build CLI — macos": {
+      "execMedian": 2,
+      "execSpread": 0.43
+    },
+    "Nimbus :: Release :: Build CLI — macos-arm64": {
+      "execMedian": 1.33,
+      "execSpread": 0.23
+    },
+    "Nimbus :: Release :: Build CLI — windows": {
+      "execMedian": 2.33,
+      "execSpread": 0.46
+    },
+    "Nimbus :: Release :: Build Gateway — linux": {
+      "execMedian": 0.84,
+      "execSpread": 0.04
+    },
+    "Nimbus :: Release :: Build Gateway — macos": {
+      "execMedian": 2.63,
+      "execSpread": 1.08
+    },
+    "Nimbus :: Release :: Build Gateway — macos-arm64": {
+      "execMedian": 1.22,
+      "execSpread": 0.15
+    },
+    "Nimbus :: Release :: Build Gateway — windows": {
+      "execMedian": 2.13,
+      "execSpread": 0.08
+    },
+    "Nimbus :: Release :: Publish GitHub Release": {
+      "execMedian": 2.75,
+      "execSpread": 0.12
+    },
+    "Nimbus :: Release :: Publish updater manifest": {
+      "execMedian": 0.78,
+      "execSpread": 0.1
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Agents (ubuntu-24.04)": {
+      "execMedian": 0.78,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Config (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.05
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — DB layer (ubuntu-24.04)": {
+      "execMedian": 0.85,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Deployment (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.06
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Doctor (ubuntu-24.04)": {
+      "execMedian": 0.71,
+      "execSpread": 0.23
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Embedding (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Engine (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.13
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Extensions (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.09
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Health (ubuntu-24.04)": {
+      "execMedian": 0.63,
+      "execSpread": 0.03
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — LAN (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.06
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — MCP (ubuntu-24.04)": {
+      "execMedian": 0.83,
+      "execSpread": 0.03
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Metrics (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.08
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — People (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.14
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Perf (ubuntu-24.04)": {
+      "execMedian": 0.78,
+      "execSpread": 0.1
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Preflight (ubuntu-24.04)": {
+      "execMedian": 0.79,
+      "execSpread": 0.06
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Rate limiter (ubuntu-24.04)": {
+      "execMedian": 0.74,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Sandbox (ubuntu-24.04)": {
+      "execMedian": 0.93,
+      "execSpread": 0.13
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Sync scheduler (ubuntu-24.04)": {
+      "execMedian": 0.75,
+      "execSpread": 0.08
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — TUI (ubuntu-24.04)": {
+      "execMedian": 0.92,
+      "execSpread": 0.03
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Telemetry (ubuntu-24.04)": {
+      "execMedian": 0.73,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Updater (ubuntu-24.04)": {
+      "execMedian": 0.67,
+      "execSpread": 0.32
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Vault (ubuntu-24.04)": {
+      "execMedian": 1.09,
+      "execSpread": 0.06
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Watcher (ubuntu-24.04)": {
+      "execMedian": 0.68,
+      "execSpread": 0.12
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Coverage — Workflow (ubuntu-24.04)": {
+      "execMedian": 0.64,
+      "execSpread": 0.14
+    },
+    "Nimbus :: Release :: Test suite (release gate) / E2E CLI — ubuntu-24.04": {
+      "execMedian": 1.02,
+      "execSpread": 0.21
+    },
+    "Nimbus :: Release :: Test suite (release gate) / E2E Gateway — ubuntu-24.04": {
+      "execMedian": 1.12,
+      "execSpread": 0.85
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Integration — ubuntu-24.04": {
+      "execMedian": 1.23,
+      "execSpread": 0.02
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Static — ubuntu-24.04": {
+      "execMedian": 4.48,
+      "execSpread": 0.17
+    },
+    "Nimbus :: Release :: Test suite (release gate) / Unit + Coverage — ubuntu-24.04": {
+      "execMedian": 14.72,
+      "execSpread": 3.58
+    },
+    "Nimbus :: Release :: Validate": {
+      "execMedian": 4.17,
+      "execSpread": 0.05
+    },
+    "Nimbus :: Scorecard supply-chain security :: Bencher Report": {
+      "execMedian": 0,
+      "execSpread": 0
+    },
+    "Nimbus :: Scorecard supply-chain security :: Scorecard analysis": {
+      "execMedian": 0.68,
+      "execSpread": 0.18
+    },
+    "Nimbus :: Security :: Cargo audit (Tauri)": {
+      "execMedian": 0.53,
+      "execSpread": 0.04
+    },
+    "Nimbus :: Security :: Cargo deny (licenses + advisories + bans)": {
+      "execMedian": 1.05,
+      "execSpread": 0.05
+    },
+    "Nimbus :: Security :: Dependency audit": {
+      "execMedian": 0.66,
+      "execSpread": 0.07
+    },
+    "Nimbus :: Security :: Gateway audit JSON + connector.remove vault restore": {
+      "execMedian": 0.65,
+      "execSpread": 0.12
+    },
+    "Nimbus :: Security :: Gitleaks secret scan": {
+      "execMedian": 0.33,
+      "execSpread": 0.03
+    },
+    "Nimbus :: Security :: JS license compliance": {
+      "execMedian": 0.68,
+      "execSpread": 0.03
+    },
+    "Nimbus :: Security :: Trivy vulnerability scan": {
+      "execMedian": 0.91,
+      "execSpread": 0.13
+    },
+    "Nimbus :: release-please :: Bencher Report": {
+      "execMedian": 0,
+      "execSpread": 0
+    },
+    "Nimbus :: release-please :: release-please": {
+      "execMedian": 0.47,
+      "execSpread": 1.75
+    },
+    "nimbus-client :: CI :: build-test (macos-latest)": {
+      "execMedian": 0.47,
+      "execSpread": 0.08
+    },
+    "nimbus-client :: CI :: build-test (ubuntu-24.04)": {
+      "execMedian": 0.36,
+      "execSpread": 0.11
+    },
+    "nimbus-client :: CI :: build-test (windows-latest)": {
+      "execMedian": 1.03,
+      "execSpread": 0.53
+    },
+    "nimbus-client :: CodeQL :: Analyze (javascript-typescript)": {
+      "execMedian": 1.21,
+      "execSpread": 0.04
+    },
+    "nimbus-client :: Release :: publish": {
+      "execMedian": 0.88,
+      "execSpread": 0.77
+    },
+    "nimbus-client :: Release :: release-please": {
+      "execMedian": 0.32,
+      "execSpread": 0.13
+    },
+    "nimbus-client :: SonarQube Cloud :: SonarQube Cloud analysis": {
+      "execMedian": 1.18,
+      "execSpread": 0.1
+    },
+    "nimbus-sdk :: CI :: build-test": {
+      "execMedian": 0.31,
+      "execSpread": 0.13
+    },
+    "nimbus-sdk :: CI :: build-test (macos-15)": {
+      "execMedian": 0.36,
+      "execSpread": 0.03
+    },
+    "nimbus-sdk :: CI :: build-test (ubuntu-24.04)": {
+      "execMedian": 0.29,
+      "execSpread": 0.04
+    },
+    "nimbus-sdk :: CI :: build-test (windows-2025)": {
+      "execMedian": 0.82,
+      "execSpread": 0.12
+    },
+    "nimbus-sdk :: CI :: ci-complete": {
+      "execMedian": 0.22,
+      "execSpread": 0.05
+    },
+    "nimbus-sdk :: CI :: node-smoke (macos-15, 22)": {
+      "execMedian": 0.33,
+      "execSpread": 0
+    },
+    "nimbus-sdk :: CI :: node-smoke (macos-15, 24)": {
+      "execMedian": 0.31,
+      "execSpread": 0.02
+    },
+    "nimbus-sdk :: CI :: node-smoke (ubuntu-24.04, 22)": {
+      "execMedian": 0.25,
+      "execSpread": 0.07
+    },
+    "nimbus-sdk :: CI :: node-smoke (ubuntu-24.04, 24)": {
+      "execMedian": 0.25,
+      "execSpread": 0.05
+    },
+    "nimbus-sdk :: CI :: node-smoke (windows-2025, 22)": {
+      "execMedian": 0.58,
+      "execSpread": 0.1
+    },
+    "nimbus-sdk :: CI :: node-smoke (windows-2025, 24)": {
+      "execMedian": 0.62,
+      "execSpread": 0.68
+    },
+    "nimbus-sdk :: CodeQL :: Analyze (javascript-typescript)": {
+      "execMedian": 1.38,
+      "execSpread": 0.06
+    },
+    "nimbus-sdk :: Release :: publish": {
+      "execMedian": 1.05,
+      "execSpread": 0.63
+    },
+    "nimbus-sdk :: Release :: release-please": {
+      "execMedian": 0.28,
+      "execSpread": 0.14
+    },
+    "nimbus-sdk :: SonarQube Cloud :: SonarQube Cloud analysis": {
+      "execMedian": 1.18,
+      "execSpread": 0.05
+    },
+    "nimbus-vscode :: CI :: build-test": {
+      "execMedian": 0.48,
+      "execSpread": 0.03
+    },
+    "nimbus-vscode :: CI :: windows-check": {
+      "execMedian": 1.38,
+      "execSpread": 0.21
+    },
+    "nimbus-vscode :: CodeQL :: Analyze (javascript-typescript)": {
+      "execMedian": 1.48,
+      "execSpread": 0.17
+    },
+    "nimbus-vscode :: Publish VS Code Extension :: Mirror .vsix on GitHub Release": {
+      "execMedian": 0.23,
+      "execSpread": 0.11
+    },
+    "nimbus-vscode :: Publish VS Code Extension :: Publish to VS Code Marketplace + Open VSX": {
+      "execMedian": 0.78,
+      "execSpread": 0.32
+    },
+    "nimbus-vscode :: SonarQube Cloud :: SonarQube Cloud analysis": {
+      "execMedian": 1.51,
+      "execSpread": 0.13
+    },
+    "nimbus-vscode :: release-please :: release-please": {
+      "execMedian": 0.3,
+      "execSpread": 0.12
+    },
+    "nimbus-web-clipper :: CI :: build-test": {
+      "execMedian": 0.47,
+      "execSpread": 0.05
+    },
+    "nimbus-web-clipper :: CodeQL :: Analyze (javascript-typescript)": {
+      "execMedian": 1.35,
+      "execSpread": 0.07
+    },
+    "nimbus-web-clipper :: SonarQube Cloud :: SonarQube Cloud analysis": {
+      "execMedian": 1.36,
+      "execSpread": 0.11
+    }
+  }
+}

--- a/docs/structure-audit/ci-latency-baseline.json
+++ b/docs/structure-audit/ci-latency-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-07-27T16:23:22.420Z",
+  "generated_at": "2026-07-27T17:00:53.202Z",
   "entries": {
     ".github :: CI :: Test composite actions": {
       "execMedian": 0.23,
@@ -11,8 +11,8 @@
       "execSpread": 0.17
     },
     "Nimbus :: CI :: CI — Rust/Tauri (ubuntu-24.04)": {
-      "execMedian": 1.27,
-      "execSpread": 0.42
+      "execMedian": 1.25,
+      "execSpread": 0.25
     },
     "Nimbus :: CI :: CI — Rust/Tauri (windows-2025)": {
       "execMedian": 1.72,
@@ -20,195 +20,195 @@
     },
     "Nimbus :: CI :: CI — Structure audit / structure": {
       "execMedian": 0.83,
-      "execSpread": 0.06
+      "execSpread": 0.05
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Agents (macos-15)": {
       "execMedian": 1.28,
-      "execSpread": 0.08
+      "execSpread": 0.03
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Config (macos-15)": {
-      "execMedian": 1.18,
-      "execSpread": 0.16
-    },
-    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — DB layer (macos-15)": {
-      "execMedian": 1.31,
-      "execSpread": 0.19
-    },
-    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Deployment (macos-15)": {
-      "execMedian": 1.27,
+      "execMedian": 1.17,
       "execSpread": 0.17
     },
-    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Doctor (macos-15)": {
-      "execMedian": 1.22,
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — DB layer (macos-15)": {
+      "execMedian": 1.3,
       "execSpread": 0.2
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Deployment (macos-15)": {
+      "execMedian": 1.25,
+      "execSpread": 0.1
+    },
+    "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Doctor (macos-15)": {
+      "execMedian": 1.23,
+      "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Embedding (macos-15)": {
       "execMedian": 1.23,
       "execSpread": 0.23
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Engine (macos-15)": {
-      "execMedian": 1.28,
-      "execSpread": 0.1
+      "execMedian": 1.27,
+      "execSpread": 0.07
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Extensions (macos-15)": {
       "execMedian": 1.25,
       "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Health (macos-15)": {
-      "execMedian": 1.21,
+      "execMedian": 1.2,
       "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — LAN (macos-15)": {
       "execMedian": 1.23,
-      "execSpread": 0.23
+      "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — MCP (macos-15)": {
-      "execMedian": 1.26,
-      "execSpread": 0.13
+      "execMedian": 1.25,
+      "execSpread": 0.12
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Metrics (macos-15)": {
-      "execMedian": 1.35,
-      "execSpread": 0.2
+      "execMedian": 1.3,
+      "execSpread": 0.25
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — People (macos-15)": {
-      "execMedian": 1.13,
-      "execSpread": 0.13
+      "execMedian": 1.12,
+      "execSpread": 0.12
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Perf (macos-15)": {
       "execMedian": 1.32,
       "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Preflight (macos-15)": {
-      "execMedian": 1.29,
-      "execSpread": 0.42
+      "execMedian": 1.28,
+      "execSpread": 0.3
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Rate limiter (macos-15)": {
-      "execMedian": 1.23,
-      "execSpread": 0.17
+      "execMedian": 1.22,
+      "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Sandbox (macos-15)": {
-      "execMedian": 1.25,
-      "execSpread": 0.2
+      "execMedian": 1.27,
+      "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Sync scheduler (macos-15)": {
       "execMedian": 1.23,
-      "execSpread": 0.27
+      "execSpread": 0.2
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — TUI (macos-15)": {
-      "execMedian": 1.33,
-      "execSpread": 0.15
+      "execMedian": 1.32,
+      "execSpread": 0.17
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Telemetry (macos-15)": {
-      "execMedian": 1.25,
-      "execSpread": 0.1
+      "execMedian": 1.27,
+      "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Updater (macos-15)": {
-      "execMedian": 1.23,
-      "execSpread": 0.3
+      "execMedian": 1.22,
+      "execSpread": 0.32
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Vault (macos-15)": {
-      "execMedian": 1.26,
-      "execSpread": 0.16
+      "execMedian": 1.25,
+      "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Watcher (macos-15)": {
-      "execMedian": 1.31,
-      "execSpread": 0.24
+      "execMedian": 1.3,
+      "execSpread": 0.25
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Coverage — Workflow (macos-15)": {
-      "execMedian": 1.24,
-      "execSpread": 0.22
+      "execMedian": 1.23,
+      "execSpread": 0.23
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / E2E CLI — macos-15": {
-      "execMedian": 1.36,
-      "execSpread": 0.21
+      "execMedian": 1.43,
+      "execSpread": 0.13
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / E2E Gateway — macos-15": {
-      "execMedian": 1.3,
-      "execSpread": 0.22
+      "execMedian": 1.27,
+      "execSpread": 0.23
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Integration — macos-15": {
-      "execMedian": 1.28,
-      "execSpread": 0.43
+      "execMedian": 1.3,
+      "execSpread": 0.42
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Static — macos-15": {
-      "execMedian": 4.53,
-      "execSpread": 0.76
+      "execMedian": 4.3,
+      "execSpread": 0.98
     },
     "Nimbus :: CI :: CI — TS/Bun (macos-15) / Unit + Coverage — macos-15": {
-      "execMedian": 4.91,
-      "execSpread": 0.24
+      "execMedian": 4.9,
+      "execSpread": 0.25
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Agents (ubuntu-24.04)": {
-      "execMedian": 0.79,
-      "execSpread": 0.04
+      "execMedian": 0.78,
+      "execSpread": 0.05
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Config (ubuntu-24.04)": {
       "execMedian": 0.68,
-      "execSpread": 0.12
+      "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — DB layer (ubuntu-24.04)": {
-      "execMedian": 0.78,
-      "execSpread": 0.07
+      "execMedian": 0.75,
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Deployment (ubuntu-24.04)": {
       "execMedian": 0.78,
-      "execSpread": 0.05
+      "execSpread": 0.02
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Doctor (ubuntu-24.04)": {
-      "execMedian": 0.72,
-      "execSpread": 0.05
+      "execMedian": 0.73,
+      "execSpread": 0.03
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Embedding (ubuntu-24.04)": {
-      "execMedian": 0.75,
-      "execSpread": 0.08
+      "execMedian": 0.73,
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Engine (ubuntu-24.04)": {
-      "execMedian": 0.71,
-      "execSpread": 0.11
+      "execMedian": 0.68,
+      "execSpread": 0.13
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Extensions (ubuntu-24.04)": {
       "execMedian": 0.72,
-      "execSpread": 0.12
+      "execSpread": 0.07
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Health (ubuntu-24.04)": {
       "execMedian": 0.62,
       "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — LAN (ubuntu-24.04)": {
-      "execMedian": 0.85,
-      "execSpread": 0.03
+      "execMedian": 0.83,
+      "execSpread": 0.05
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — MCP (ubuntu-24.04)": {
-      "execMedian": 0.69,
-      "execSpread": 0.14
+      "execMedian": 0.68,
+      "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Metrics (ubuntu-24.04)": {
-      "execMedian": 0.72,
-      "execSpread": 0.08
+      "execMedian": 0.73,
+      "execSpread": 0.07
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — People (ubuntu-24.04)": {
       "execMedian": 0.77,
       "execSpread": 0.03
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Perf (ubuntu-24.04)": {
-      "execMedian": 0.73,
-      "execSpread": 0.17
+      "execMedian": 0.75,
+      "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Preflight (ubuntu-24.04)": {
-      "execMedian": 0.7,
-      "execSpread": 0.12
+      "execMedian": 0.68,
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Rate limiter (ubuntu-24.04)": {
-      "execMedian": 0.7,
-      "execSpread": 0.12
+      "execMedian": 0.68,
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Sandbox (ubuntu-24.04)": {
       "execMedian": 0.88,
-      "execSpread": 0.18
+      "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Sync scheduler (ubuntu-24.04)": {
-      "execMedian": 0.67,
-      "execSpread": 0.18
+      "execMedian": 0.65,
+      "execSpread": 0.2
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — TUI (ubuntu-24.04)": {
       "execMedian": 0.73,
@@ -216,35 +216,35 @@
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Telemetry (ubuntu-24.04)": {
       "execMedian": 0.68,
-      "execSpread": 0.11
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Updater (ubuntu-24.04)": {
-      "execMedian": 0.77,
-      "execSpread": 0.03
+      "execMedian": 0.75,
+      "execSpread": 0.05
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Vault (ubuntu-24.04)": {
-      "execMedian": 1.08,
-      "execSpread": 0.12
+      "execMedian": 1.05,
+      "execSpread": 0.13
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Watcher (ubuntu-24.04)": {
       "execMedian": 0.63,
       "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Coverage — Workflow (ubuntu-24.04)": {
-      "execMedian": 0.71,
-      "execSpread": 0.06
+      "execMedian": 0.68,
+      "execSpread": 0.08
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / E2E CLI — ubuntu-24.04": {
-      "execMedian": 1.08,
-      "execSpread": 0.38
+      "execMedian": 1.15,
+      "execSpread": 0.3
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / E2E Gateway — ubuntu-24.04": {
-      "execMedian": 1.18,
-      "execSpread": 0.27
+      "execMedian": 1.22,
+      "execSpread": 0.23
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Integration — ubuntu-24.04": {
-      "execMedian": 1.14,
-      "execSpread": 0.26
+      "execMedian": 1.17,
+      "execSpread": 0.23
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Packaging — ubuntu-24.04": {
       "execMedian": 1.32,
@@ -252,47 +252,47 @@
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Static — ubuntu-24.04": {
       "execMedian": 4.57,
-      "execSpread": 0.2
+      "execSpread": 0.15
     },
     "Nimbus :: CI :: CI — TS/Bun (ubuntu-24.04) / Unit + Coverage — ubuntu-24.04": {
-      "execMedian": 12.26,
-      "execSpread": 0.29
+      "execMedian": 12.22,
+      "execSpread": 0.22
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Agents (windows-2025)": {
       "execMedian": 2.38,
-      "execSpread": 0.23
+      "execSpread": 0.22
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Config (windows-2025)": {
-      "execMedian": 2.45,
-      "execSpread": 1.08
+      "execMedian": 2.5,
+      "execSpread": 1.03
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — DB layer (windows-2025)": {
-      "execMedian": 2.86,
-      "execSpread": 1.17
+      "execMedian": 2.77,
+      "execSpread": 1.18
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Deployment (windows-2025)": {
-      "execMedian": 2.16,
-      "execSpread": 0.44
-    },
-    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Doctor (windows-2025)": {
-      "execMedian": 2.03,
+      "execMedian": 2.15,
       "execSpread": 0.45
     },
+    "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Doctor (windows-2025)": {
+      "execMedian": 2.05,
+      "execSpread": 0.43
+    },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Embedding (windows-2025)": {
-      "execMedian": 2.39,
-      "execSpread": 0.83
+      "execMedian": 2.43,
+      "execSpread": 0.78
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Engine (windows-2025)": {
-      "execMedian": 2.08,
-      "execSpread": 0.28
+      "execMedian": 2.2,
+      "execSpread": 0.17
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Extensions (windows-2025)": {
-      "execMedian": 2.23,
-      "execSpread": 0.34
+      "execMedian": 2.2,
+      "execSpread": 0.35
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Health (windows-2025)": {
       "execMedian": 2.2,
-      "execSpread": 0.12
+      "execSpread": 0.1
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — LAN (windows-2025)": {
       "execMedian": 2.13,
@@ -303,88 +303,100 @@
       "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Metrics (windows-2025)": {
-      "execMedian": 2.32,
-      "execSpread": 0.67
+      "execMedian": 2.48,
+      "execSpread": 0.5
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — People (windows-2025)": {
-      "execMedian": 2.16,
-      "execSpread": 0.44
+      "execMedian": 2.13,
+      "execSpread": 0.47
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Perf (windows-2025)": {
       "execMedian": 2.25,
-      "execSpread": 0.22
+      "execSpread": 0.3
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Preflight (windows-2025)": {
-      "execMedian": 2.35,
-      "execSpread": 0.47
+      "execMedian": 2.28,
+      "execSpread": 0.37
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Rate limiter (windows-2025)": {
       "execMedian": 2.18,
       "execSpread": 0.78
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Sandbox (windows-2025)": {
-      "execMedian": 2.17,
-      "execSpread": 0.42
+      "execMedian": 2.22,
+      "execSpread": 0.37
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Sync scheduler (windows-2025)": {
-      "execMedian": 2.22,
-      "execSpread": 0.53
+      "execMedian": 2.27,
+      "execSpread": 0.48
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — TUI (windows-2025)": {
-      "execMedian": 2.19,
-      "execSpread": 0.26
+      "execMedian": 2.18,
+      "execSpread": 0.27
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Telemetry (windows-2025)": {
-      "execMedian": 2.14,
-      "execSpread": 0.39
+      "execMedian": 2.13,
+      "execSpread": 0.4
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Updater (windows-2025)": {
       "execMedian": 2.35,
       "execSpread": 0.55
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Vault (windows-2025)": {
-      "execMedian": 2.22,
-      "execSpread": 0.28
+      "execMedian": 2.18,
+      "execSpread": 0.18
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Watcher (windows-2025)": {
-      "execMedian": 2.23,
-      "execSpread": 0.1
+      "execMedian": 2.2,
+      "execSpread": 0.13
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Coverage — Workflow (windows-2025)": {
-      "execMedian": 2.13,
-      "execSpread": 0.34
+      "execMedian": 2.12,
+      "execSpread": 0.35
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / E2E CLI — windows-2025": {
-      "execMedian": 2.53,
-      "execSpread": 0.12
+      "execMedian": 2.52,
+      "execSpread": 0.13
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / E2E Gateway — windows-2025": {
-      "execMedian": 2.26,
-      "execSpread": 0.96
+      "execMedian": 2.25,
+      "execSpread": 0.22
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Integration — windows-2025": {
-      "execMedian": 2.92,
-      "execSpread": 0.52
+      "execMedian": 2.95,
+      "execSpread": 0.48
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Static — windows-2025": {
-      "execMedian": 6.81,
-      "execSpread": 0.99
+      "execMedian": 6.73,
+      "execSpread": 1.07
     },
     "Nimbus :: CI :: CI — TS/Bun (windows-2025) / Unit + Coverage — windows-2025": {
-      "execMedian": 12.87,
-      "execSpread": 10.77
+      "execMedian": 13.15,
+      "execSpread": 10.48
     },
     "Nimbus :: CI :: Detect changes": {
       "execMedian": 0.25,
       "execSpread": 0.02
+    },
+    "Nimbus :: CI :: E2E Desktop — macos-15": {
+      "execMedian": 4.72,
+      "execSpread": 1.1
+    },
+    "Nimbus :: CI :: E2E Desktop — ubuntu-24.04": {
+      "execMedian": 7.45,
+      "execSpread": 0.5
+    },
+    "Nimbus :: CI :: E2E Desktop — windows-2025": {
+      "execMedian": 12.97,
+      "execSpread": 0.42
     },
     "Nimbus :: CodeQL :: Analyze (javascript-typescript)": {
       "execMedian": 3.52,
       "execSpread": 0.2
     },
     "Nimbus :: CodeQL :: Analyze (rust)": {
-      "execMedian": 1.8,
-      "execSpread": 0.07
+      "execMedian": 1.83,
+      "execSpread": 0.04
     },
     "Nimbus :: Docs Quality :: Bencher Report": {
       "execMedian": 0,
@@ -395,31 +407,31 @@
       "execSpread": 0.05
     },
     "Nimbus :: Docs Quality :: OG card render": {
-      "execMedian": 0.68,
-      "execSpread": 0.02
+      "execMedian": 0.65,
+      "execSpread": 0.05
     },
     "Nimbus :: Docs Quality :: Package READMEs audit": {
-      "execMedian": 0.57,
-      "execSpread": 0.14
+      "execMedian": 0.64,
+      "execSpread": 0.08
     },
     "Nimbus :: Docs Quality :: README CLI-command tripwire": {
-      "execMedian": 0.65,
-      "execSpread": 0.07
+      "execMedian": 0.64,
+      "execSpread": 0.08
     },
     "Nimbus :: Docs Quality :: SVG asset audit": {
       "execMedian": 0.68,
       "execSpread": 0.11
     },
     "Nimbus :: Docs Quality :: Starlight build test": {
-      "execMedian": 0.64,
-      "execSpread": 0.09
+      "execMedian": 0.63,
+      "execSpread": 0.1
     },
     "Nimbus :: Docs Quality :: lychee link check": {
-      "execMedian": 0.67,
-      "execSpread": 0.17
+      "execMedian": 0.66,
+      "execSpread": 0.18
     },
     "Nimbus :: Docs Quality :: markdownlint-cli2": {
-      "execMedian": 0.62,
+      "execMedian": 0.61,
       "execSpread": 0.12
     },
     "Nimbus :: Performance Benchmarks :: Bench (macos-15)": {
@@ -611,24 +623,24 @@
       "execSpread": 0
     },
     "Nimbus :: Scorecard supply-chain security :: Scorecard analysis": {
-      "execMedian": 0.68,
-      "execSpread": 0.18
+      "execMedian": 0.65,
+      "execSpread": 0.22
     },
     "Nimbus :: Security :: Cargo audit (Tauri)": {
-      "execMedian": 0.53,
-      "execSpread": 0.04
-    },
-    "Nimbus :: Security :: Cargo deny (licenses + advisories + bans)": {
-      "execMedian": 1.05,
+      "execMedian": 0.52,
       "execSpread": 0.05
     },
-    "Nimbus :: Security :: Dependency audit": {
-      "execMedian": 0.66,
+    "Nimbus :: Security :: Cargo deny (licenses + advisories + bans)": {
+      "execMedian": 1.03,
       "execSpread": 0.07
     },
-    "Nimbus :: Security :: Gateway audit JSON + connector.remove vault restore": {
+    "Nimbus :: Security :: Dependency audit": {
       "execMedian": 0.65,
-      "execSpread": 0.12
+      "execSpread": 0.08
+    },
+    "Nimbus :: Security :: Gateway audit JSON + connector.remove vault restore": {
+      "execMedian": 0.63,
+      "execSpread": 0.13
     },
     "Nimbus :: Security :: Gitleaks secret scan": {
       "execMedian": 0.33,
@@ -639,16 +651,16 @@
       "execSpread": 0.03
     },
     "Nimbus :: Security :: Trivy vulnerability scan": {
-      "execMedian": 0.91,
-      "execSpread": 0.13
+      "execMedian": 0.88,
+      "execSpread": 0.15
     },
     "Nimbus :: release-please :: Bencher Report": {
       "execMedian": 0,
       "execSpread": 0
     },
     "Nimbus :: release-please :: release-please": {
-      "execMedian": 0.47,
-      "execSpread": 1.75
+      "execMedian": 0.48,
+      "execSpread": 1.73
     },
     "nimbus-client :: CI :: build-test (macos-latest)": {
       "execMedian": 0.47,
@@ -667,8 +679,8 @@
       "execSpread": 0.04
     },
     "nimbus-client :: Release :: publish": {
-      "execMedian": 0.88,
-      "execSpread": 0.77
+      "execMedian": 1.27,
+      "execSpread": 0.5
     },
     "nimbus-client :: Release :: release-please": {
       "execMedian": 0.32,

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review-response.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review-response.md
@@ -1,0 +1,141 @@
+# P4b implementation-plan review — response
+
+Response to [`2026-07-27-p4b-ci-latency-review.md`](./2026-07-27-p4b-ci-latency-review.md).
+
+| # | Finding | Outcome |
+| --- | --- | --- |
+| 1 | Does `created_at` track eligibility or run creation? | **Verified — hypothesis disproved**, plus a guard added so the assumption cannot rot silently |
+| 2 | API volume / rate-limit handling | **Fixed** — bounded fetches + partial-collection detection |
+| 3 | `MIN_SAMPLES_FOR_RATCHET = 5` too low | **Fixed, but the threshold was not the problem** — the sampling window was |
+
+---
+
+## 1. `created_at` — verified against the live API, hypothesis disproved
+
+The review proposes that GitHub "creates all jobs in the run database at the very
+start", which would make `dagWait` always 0 and silently collapse `queue` back
+into the conflated metric this design exists to avoid. That would be fatal, so it
+was measured rather than argued.
+
+**Across 8 CI runs (301 jobs): 203 jobs have `created_at` shifted more than a
+minute after `run_started_at`; 98 sit at ~0.** If the review's model were right,
+all 301 would sit at ~0.
+
+The split is not random — it is exactly the DAG:
+
+| job | `created_at` offset | `needs` in `ci.yml` |
+| --- | --- | --- |
+| `PR quality — TS/Bun (ubuntu-24.04)` | 2.5 min | `needs: filter` |
+| `PR quality — Rust/Tauri (ubuntu-24.04)` | 2.5 min | `needs: filter` |
+| `PR quality — Duplication scan` | 2.5 min | `needs: filter` |
+| `PR quality — required gates` | 2.5 min | `needs: [filter, …]` |
+| `E2E Desktop (PR) — ubuntu-24.04` | 2.5 min | `needs: [filter, pr-quality-ts, pr-quality-rust]` |
+| every root job | 0.0 min | none |
+
+The `filter` job takes 2.5 minutes, and **every** dependent is created at exactly
+2.5 minutes. `created_at` tracks eligibility. The metric stands, and the review's
+fallback — reconstructing the DAG from workflow YAML — is not needed.
+
+### But the caution was right, so the assumption is now guarded
+
+This is undocumented API behaviour that a GitHub change could alter silently, and
+the failure would be invisible: `dagWait` would quietly go to zero everywhere and
+`queue` would re-absorb dependency execution, with no error anywhere.
+
+**Added to the plan (Task 5 + Task 6):** if the whole collection produces
+**zero** observations with a non-zero `dagWait` while at least one sampled
+workflow declares `needs:`, the shell emits
+`::warning::ci-latency: dagWait is zero everywhere — the created_at eligibility
+assumption may have changed; queue figures may now include dependency execution`.
+
+A warning rather than a failure, deliberately: an upstream API change is not
+something a contributor's PR can fix. Same rule as `queue` itself.
+
+---
+
+## 2. API volume — fixed, and finding 3 forced the shape of the fix
+
+The arithmetic in the review is right (~279 requests), and the robustness point
+is right: `runGh` already degrades to `ok: false` rather than throwing, so
+nothing crashes — but a **partial** collection is the real hazard. If half a
+repo's job fetches fail, the survivors still produce medians, and those medians
+could be biased toward whichever runs happened to succeed. The gate would then
+compare a thin, skewed sample against the baseline and could manufacture a
+regression.
+
+**Fixed:**
+
+- `collectAll` now returns `{ observations, readFailures }` instead of a bare
+  array.
+- Any read failure emits a warning naming the count.
+- If read failures exceed **25%** of attempted job fetches, the run **skips
+  gating entirely** via `strictSkip` rather than gating on a degraded sample —
+  an unreliable read is `indeterminate`, never a finding.
+
+Note the interaction with finding 3: the fix there *widens* the window, which
+would have pushed this toward ~900 requests. That is resolved by capping job
+fetches **per workflow** rather than per repo (below), which keeps the total in
+the same ~300 range while multiplying per-key depth.
+
+---
+
+## 3. Ratchet threshold — the number was not the problem
+
+The instinct is right — 5 is a small sample — but both the suggested values would
+have made the mechanism **dead**, and measuring showed my own 5 was already
+nearly dead.
+
+With the planned 30-run window, over 161 distinct keys:
+
+| threshold | keys that qualify |
+| --- | --- |
+| ≥3 (gating) | 114 (71%) |
+| ≥5 (planned ratchet) | **4 (2%)** |
+| ≥7 (suggested) | **0** |
+| ≥10 (suggested) | **0** |
+
+### Root cause: the window, not the threshold
+
+`MAX_RUNS_PER_REPO = 30` counts runs **across all workflows in the repo**. Those
+30 push runs span 8 workflows, so `CI` itself gets only **4** — and no CI job can
+ever have more than 4 samples. Raising the threshold against that window cannot
+help; it can only disable the ratchet.
+
+Measured at a wider window:
+
+| window | runs for `CI` |
+| --- | --- |
+| `per_page=30` | 4 |
+| `per_page=100` | **12** |
+
+**Fixed by re-shaping sampling:**
+
+- `RUN_LIST_PAGE = 100` — fetch the run *list* at the API maximum (1 request).
+- `MAX_RUNS_PER_WORKFLOW = 12` — cap the expensive *job* fetches per workflow,
+  not per repo.
+
+This lifts achievable depth for a stable CI job from ≤4 to ~12 while keeping
+total requests in the same ballpark as before (the cap binds where the volume
+is), which is what makes finding 2's fix and finding 3's fix compatible.
+
+**With ~12 samples reachable, the review's suggestion becomes affordable, so it
+is adopted: `MIN_SAMPLES_FOR_RATCHET = 7`** (up from 5). Lowering a bound now
+requires more than half of a full window's evidence, and unlike the original
+proposal it is a threshold that keys can actually meet.
+
+`MIN_SAMPLES` stays at 3 for gating: 71% of keys qualify, and requiring more
+would silently stop watching most of the org.
+
+---
+
+## Net changes to the plan
+
+- **Task 1** — `MAX_RUNS_PER_REPO` replaced by `RUN_LIST_PAGE` (100) +
+  `MAX_RUNS_PER_WORKFLOW` (12); `MIN_SAMPLES_FOR_RATCHET` 5 → 7;
+  `MAX_READ_FAILURE_RATIO` (0.25) added.
+- **Task 5** — group runs by workflow and cap per workflow; return
+  `{ observations, readFailures, attempted, sawNeedsWorkflow }`; new tests for
+  the per-workflow cap and for failure counting.
+- **Task 6** — warn on read failures, skip gating past the failure ratio, and
+  emit the `dagWait`-is-zero-everywhere guard.
+- **Task 3** — the ratchet test updates to 7.

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review-response.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review-response.md
@@ -43,8 +43,7 @@ the failure would be invisible: `dagWait` would quietly go to zero everywhere an
 `queue` would re-absorb dependency execution, with no error anywhere.
 
 **Added to the plan (Task 5 + Task 6):** if the whole collection produces
-**zero** observations with a non-zero `dagWait` while at least one sampled
-workflow declares `needs:`, the shell emits
+**zero** observations with a non-zero `dagWait`, the shell emits
 `::warning::ci-latency: dagWait is zero everywhere — the created_at eligibility
 assumption may have changed; queue figures may now include dependency execution`.
 
@@ -134,7 +133,7 @@ would silently stop watching most of the org.
   `MAX_RUNS_PER_WORKFLOW` (12); `MIN_SAMPLES_FOR_RATCHET` 5 → 7;
   `MAX_READ_FAILURE_RATIO` (0.25) added.
 - **Task 5** — group runs by workflow and cap per workflow; return
-  `{ observations, readFailures, attempted, sawNeedsWorkflow }`; new tests for
+  `{ observations, readFailures, attempted, sawNonZeroDagWait }`; new tests for
   the per-workflow cap and for failure counting.
 - **Task 6** — warn on read failures, skip gating past the failure ratio, and
   emit the `dagWait`-is-zero-everywhere guard.

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency-review.md
@@ -1,0 +1,62 @@
+# P4b — CI latency Implementation Plan: Review
+
+## 1. Job `created_at` behavior in GitHub Actions API
+
+The plan relies on:
+
+```ts
+const queue = minutesBetween(j["started_at"], j["created_at"]);
+const dagWait = minutesBetween(j["created_at"], runStartedAt);
+```
+
+### Open Question
+
+Does the GitHub Actions API set `created_at` for a job when it is *eligible* to run (after dependencies are resolved), or when the *workflow run* itself is created?
+
+In GitHub Actions, the workflow run engine generally creates all jobs in the run database at the very start of the workflow execution. Therefore, `j["created_at"]` is typically identical (or very close) to the workflow run's `run_started_at` for all jobs, including downstream ones.
+
+If this is the case:
+
+- `dagWait` will evaluate to `0` for all jobs.
+- `queue` will evaluate to `started_at - run_started_at`, which still includes the execution time of all upstream dependencies.
+
+### Recommendation
+
+- **Verification**: Run a manual query or check existing API responses for a workflow run with dependencies to verify whether `created_at` differs for downstream jobs.
+- **Alternative**: If `created_at` is indeed fixed to the run start time, we may need to reconstruct/parse the DAG dependencies (e.g. from workflow YAML or by finding the completion time of the jobs listed in `needs`) to calculate true queue/concurrency wait vs. DAG wait.
+
+---
+
+## 2. API Call Performance and Rate Limits
+
+The collector walks 9 repositories, fetches the last 30 runs for each, and then fetches the jobs for each of those runs:
+
+- `9` repos × `1` run list query = `9` requests.
+- `9` repos × `30` runs × `1` jobs query = `270` requests.
+- Total API calls = `279` requests.
+
+### Suggestions
+
+- **Sequential Latency**: Executing 279 sequential `gh api` calls will take around 1–3 minutes depending on network latency. Since this runs in a background sweep (`org-drift-sweep`), this is acceptable, but sequential execution could be optimized.
+- **Rate Limit Safety**: The default GITHUB_TOKEN has a rate limit of 1,000 requests per hour per repository (for GitHub Actions). 279 requests is well within this limit, but if more repos or runs are added, it could approach the limit.
+- **Recommendation**: Ensure the collector handles rate limit headers gracefully or exits early with a clear warning instead of throwing unhandled exceptions if rate limits are hit.
+
+---
+
+## 3. Ratchet Stability on Small Sample Sets
+
+In `baseline.ts`:
+
+```ts
+if (prev && s.execMedian < prev.execMedian && s.samples < MIN_SAMPLES_FOR_RATCHET) {
+  entries.set(key, prev);
+  continue;
+}
+```
+
+If `s.samples >= MIN_SAMPLES_FOR_RATCHET` (5 samples), the baseline is aggressively ratcheted down.
+
+### Suggestions
+
+- A sample size of 5 is still relatively small. A single run with an exceptionally fast runner or hot caches might bias the median downwards.
+- **Recommendation**: Consider setting `MIN_SAMPLES_FOR_RATCHET` to a slightly higher value (e.g., 7 or 10) to ensure a highly stable improved baseline before ratcheting down.

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
@@ -827,7 +827,7 @@ git commit -m "feat(audit): ci-latency evaluate — per-key band, exec-only gati
 **Interfaces:**
 
 - Consumes: `runGh`, `isRecord` from `../structure-audit/_gh-audit.ts`; `RUN_LIST_PAGE`, `MAX_RUNS_PER_WORKFLOW`, `SAMPLE_EVENT`, `AUDITED_REPOS`.
-- Produces: `parseRunMeta(json: string): RunMeta[]`, `selectRuns(runs: readonly RunMeta[]): RunMeta[]`, `parseJobObservations(json, repo, workflow, runStartedAt): JobObservation[]`, `collectRepo(repo: string): CollectResult`, `collectAll(repos?: readonly string[]): CollectResult`, and `interface CollectResult { observations: JobObservation[]; attempted: number; readFailures: number; sawNeedsWorkflow: boolean }`.
+- Produces: `parseRunMeta(json: string): RunMeta[]`, `selectRuns(runs: readonly RunMeta[]): RunMeta[]`, `parseJobObservations(json, repo, workflow, runStartedAt): JobObservation[]`, `collectRepo(repo: string): CollectResult`, `collectAll(repos?: readonly string[]): CollectResult`, and `interface CollectResult { observations: JobObservation[]; attempted: number; readFailures: number; sawNonZeroDagWait: boolean }`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -978,7 +978,7 @@ export interface CollectResult {
   attempted: number;
   readFailures: number;
   /** True once any observation carried a non-zero dagWait — the created_at guard. */
-  sawNeedsWorkflow: boolean;
+  sawNonZeroDagWait: boolean;
 }
 
 export function parseRunMeta(json: string): RunMeta[] {
@@ -1075,7 +1075,7 @@ export function collectRepo(repo: string): CollectResult {
     observations: [],
     attempted: 0,
     readFailures: 0,
-    sawNeedsWorkflow: false,
+    sawNonZeroDagWait: false,
   };
   const res = runGh([
     "gh",
@@ -1087,7 +1087,7 @@ export function collectRepo(repo: string): CollectResult {
   const out: JobObservation[] = [];
   let attempted = 0;
   let readFailures = 0;
-  let sawNeedsWorkflow = false;
+  let sawNonZeroDagWait = false;
 
   for (const run of selectRuns(parseRunMeta(res.stdout))) {
     attempted++;
@@ -1101,10 +1101,10 @@ export function collectRepo(repo: string): CollectResult {
       continue;
     }
     const obs = parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt);
-    if (obs.some((o) => o.dagWait > 0)) sawNeedsWorkflow = true;
+    if (obs.some((o) => o.dagWait > 0)) sawNonZeroDagWait = true;
     out.push(...obs);
   }
-  return { observations: out, attempted, readFailures, sawNeedsWorkflow };
+  return { observations: out, attempted, readFailures, sawNonZeroDagWait };
 }
 
 export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectResult {
@@ -1112,14 +1112,14 @@ export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectRes
     observations: [],
     attempted: 0,
     readFailures: 0,
-    sawNeedsWorkflow: false,
+    sawNonZeroDagWait: false,
   };
   for (const repo of repos) {
     const r = collectRepo(repo);
     merged.observations.push(...r.observations);
     merged.attempted += r.attempted;
     merged.readFailures += r.readFailures;
-    merged.sawNeedsWorkflow ||= r.sawNeedsWorkflow;
+    merged.sawNonZeroDagWait ||= r.sawNonZeroDagWait;
   }
   return merged;
 }
@@ -1197,7 +1197,7 @@ if (import.meta.main) {
   const label = "audit:ci-latency";
 
   const collected = collectAll();
-  const { observations, attempted, readFailures, sawNeedsWorkflow } = collected;
+  const { observations, attempted, readFailures, sawNonZeroDagWait } = collected;
 
   if (observations.length === 0) {
     // Nothing readable at all: no gh, no auth, or a total API outage.
@@ -1227,7 +1227,7 @@ if (import.meta.main) {
   // ever changes, dagWait silently goes to zero everywhere and `queue` quietly
   // re-absorbs dependency execution — with no error anywhere. Warn, never fail:
   // an upstream API change is not something a contributor's PR can fix.
-  if (!sawNeedsWorkflow) {
+  if (!sawNonZeroDagWait) {
     console.warn(
       `::warning::${label}: dagWait is zero for every observation — the created_at eligibility assumption may have changed; queue figures may now include dependency execution`,
     );
@@ -1449,7 +1449,7 @@ git commit -m "docs(infra): record P4b — CI latency measurement shipped"
 - Per-key noise band replacing a flat tolerance → Task 3 stores `execSpread`, Task 4 applies `max(MIN_ABSOLUTE_DELTA, spread)`. ✓
 - `MIN_ABSOLUTE_DELTA` floor for sub-minute jobs → Task 4 test. ✓
 - `unstable` observation at `UNSTABLE_SPREAD_RATIO` → Task 4. ✓
-- Ratchet down needs `MIN_SAMPLES_FOR_RATCHET` (5) vs 3 to gate → Task 3 test. ✓
+- Ratchet down needs `MIN_SAMPLES_FOR_RATCHET` (7) vs 3 to gate → Task 3 test. ✓
 - Spread travels down with the median → Task 3 test. ✓
 - Stale baseline entry / new key are never failures → Task 4 tests. ✓
 - Org-wide, 9 repos → Task 1 `AUDITED_REPOS` (mirrors the sha-pins matrix). ✓

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
@@ -1,0 +1,1321 @@
+# P4b — CI latency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track per-job CI execution, runner queue and DAG wait across all 9 org repos, and fail when a job's execution regresses beyond its own measured noise band.
+
+**Architecture:** Mirrors `audit:coverage-floor`. Pure functions (`summarize`, `baseline`, `evaluate`) do all the reasoning and are table-tested offline; one impure collector walks the Actions API; one `import.meta.main` shell wires them and supports `--update-baseline`. The committed baseline lives beside `coverage-baseline.json`.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6 strict, `gh` CLI via the existing `runGh`, Biome. No new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md`](../specs/2026-07-27-p4b-ci-latency-design.md) (+ its review and review-response).
+
+## Global Constraints
+
+- **Runtime:** Bun v1.2+, TypeScript 6.x strict. **No `any`** — narrow external JSON with `isRecord` from `_gh-audit.ts`.
+- **`exactOptionalPropertyTypes: true`** — an optional field needs an explicit `?: T | undefined`.
+- **Linter:** run `bunx biome check scripts .github docs` — **NOT** `bun run lint`, which reports "Checked 0 files" and exits 1 inside a `.claude/worktrees/` checkout.
+- **Branch:** all work on `dev/asafgolombek/p4b-latency` in the worktree `.claude/worktrees/p4b-latency`. Never commit on `main`; verify with `git rev-parse --abbrev-ref HEAD`.
+- **Gate contract:** fail-soft locally, hard under `--strict` / `GITHUB_ACTIONS`. Reuse `isStrict` / `strictSkip` / `classifyReadFailure` from `_gh-audit.ts`.
+- **Never write files with Python on Windows** — it emits CRLF and biome's formatter rejects it. Use the Write/Edit tools, or `open(p,"wb")` with explicit `\n`.
+- **Markdown:** every heading, list and fenced block needs a blank line around it, fences need a language, no trailing spaces (`lint:markdown` enforces MD022/MD031/MD032/MD040/MD009).
+- **Pre-push:** `bun test scripts/` and `bunx tsc -p scripts/tsconfig.json --noEmit` must pass.
+
+## Constants (single source of truth — `scripts/ci-latency/constants.ts`)
+
+| Constant | Value | Why |
+| --- | --- | --- |
+| `MIN_SAMPLES` | 3 | fewer observations is `insufficient-data`, skipped not failed |
+| `MIN_SAMPLES_FOR_RATCHET` | 5 | lowering a bound demands more evidence than enforcing one |
+| `MIN_ABSOLUTE_DELTA_MIN` | 1 | ratios are meaningless on a 0.3-min job |
+| `UNSTABLE_SPREAD_RATIO` | 0.5 | spread > 50% of median ⇒ reported `unstable`, never failed |
+| `MAX_RUNS_PER_REPO` | 30 | bounds API cost to ~250 requests |
+| `SAMPLE_EVENT` | `"push"` | PR runs execute a different job set; mixing compares unlike things |
+
+---
+
+## File Structure
+
+- **Create** `scripts/ci-latency/constants.ts` — the table above. Exists separately so tests and the shell cannot drift apart.
+- **Create** `scripts/ci-latency/types.ts` — `JobObservation`, `KeySummary`, `BaselineEntry`, `LatencyBaseline`, `Finding`, `CheckResult`.
+- **Create** `scripts/ci-latency/summarize.ts` — **pure**: `JobObservation[]` → `Map<key, KeySummary>` (median exec/queue/dagWait + p90 spread + sample count).
+- **Create** `scripts/ci-latency/baseline.ts` — **pure**: `parseBaseline`, `serializeBaseline`, `computeUpdatedBaseline`.
+- **Create** `scripts/ci-latency/evaluate.ts` — **pure**: summaries + baseline → `Finding[]`.
+- **Create** `scripts/ci-latency/collect.ts` — **impure**: Actions API → `JobObservation[]`.
+- **Create** `scripts/ci-latency/check.ts` — the `import.meta.main` shell + `--update-baseline`.
+- **Create** the four test files alongside (`summarize.test.ts`, `baseline.test.ts`, `evaluate.test.ts`, `collect.test.ts`).
+- **Create** `docs/structure-audit/ci-latency-baseline.json` — generated in Task 6, committed.
+- **Modify** `package.json` — `audit:ci-latency` + `audit:ci-latency:update-baseline`.
+- **Modify** `scripts/lib/preflight-gates.ts` — add to `CI_ONLY_GATES` (network-backed; never the local FAST tier).
+- **Modify** `.github/workflows/org-drift-sweep.yml` — a new `ci-latency` job.
+- **Modify** `docs/infrastructure-roadmap.md` — record the delivery.
+
+---
+
+## Task 1: Constants and types
+
+**Files:**
+
+- Create: `scripts/ci-latency/constants.ts`, `scripts/ci-latency/types.ts`
+
+**Interfaces:**
+
+- Produces: every constant in the table above, and the types every later task consumes.
+
+- [ ] **Step 1: Create the constants**
+
+```ts
+/**
+ * Tuning constants for `audit:ci-latency`, kept in one module so the tests and
+ * the gate can never drift apart. Every value here was chosen against measured
+ * data — see docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md.
+ */
+
+/** Below this many samples a key is `insufficient-data`: skipped, never failed. */
+export const MIN_SAMPLES = 3;
+
+/**
+ * Lowering a baseline needs MORE evidence than enforcing one: three consecutive
+ * hot-cache runs is a plausible window, and the cost of a wrongly-low bound is a
+ * permanently red gate.
+ */
+export const MIN_SAMPLES_FOR_RATCHET = 5;
+
+/** Ratios and small noise bands are both meaningless on a sub-minute job. */
+export const MIN_ABSOLUTE_DELTA_MIN = 1;
+
+/** spread > this × median ⇒ reported `unstable` (observed, never failed). */
+export const UNSTABLE_SPREAD_RATIO = 0.5;
+
+/** Bounds API cost: ~1 + MAX_RUNS_PER_REPO requests per repo. */
+export const MAX_RUNS_PER_REPO = 30;
+
+/** PR runs execute a different job set with different cache state. */
+export const SAMPLE_EVENT = "push";
+
+/** The org repos audited, mirroring the sha-pins matrix in org-drift-sweep.yml. */
+export const AUDITED_REPOS: readonly string[] = [
+  "Nimbus",
+  "nimbus-client",
+  "nimbus-sdk",
+  "nimbus-vscode",
+  "nimbus-web-clipper",
+  ".github",
+  "linux-repo",
+  "homebrew-tap",
+  "scoop-bucket",
+];
+```
+
+- [ ] **Step 2: Create the types**
+
+```ts
+/** One successful job from one run. Minutes throughout — never milliseconds. */
+export interface JobObservation {
+  repo: string;
+  workflow: string;
+  job: string;
+  exec: number;
+  queue: number;
+  dagWait: number;
+}
+
+/** A key is `<repo> :: <workflow> :: <job>`. */
+export interface KeySummary {
+  key: string;
+  samples: number;
+  execMedian: number;
+  /** p90 − median of exec: the job's own noise band. */
+  execSpread: number;
+  queueMedian: number;
+  dagWaitMedian: number;
+}
+
+export interface BaselineEntry {
+  execMedian: number;
+  execSpread: number;
+}
+
+export interface LatencyBaseline {
+  version: 1;
+  generated_at: string;
+  entries: Map<string, BaselineEntry>;
+}
+
+export type FindingKind =
+  | "regression"
+  | "insufficient-data"
+  | "unstable"
+  | "new-key"
+  | "stale-baseline-entry";
+
+export interface Finding {
+  key: string;
+  kind: FindingKind;
+  detail: string;
+}
+
+export interface CheckResult {
+  findings: Finding[];
+  /** Only `regression` findings can fail the gate. */
+  regressions: Finding[];
+}
+```
+
+- [ ] **Step 3: Typecheck and commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/ci-latency/constants.ts scripts/ci-latency/types.ts
+git commit -m "feat(audit): ci-latency constants + types"
+```
+
+---
+
+## Task 2: `summarize` — observations to per-key medians
+
+**Files:**
+
+- Create: `scripts/ci-latency/summarize.ts`, `scripts/ci-latency/summarize.test.ts`
+
+**Interfaces:**
+
+- Consumes: `JobObservation`, `KeySummary` from `types.ts`.
+- Produces: `observationKey(o: JobObservation): string`, `median(xs: readonly number[]): number`, `p90(xs: readonly number[]): number`, `summarize(obs: readonly JobObservation[]): Map<string, KeySummary>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { median, observationKey, p90, summarize } from "./summarize.ts";
+import type { JobObservation } from "./types.ts";
+
+const obs = (over: Partial<JobObservation> = {}): JobObservation => ({
+  repo: "Nimbus",
+  workflow: "CI",
+  job: "Unit + Coverage",
+  exec: 10,
+  queue: 1,
+  dagWait: 0,
+  ...over,
+});
+
+describe("median", () => {
+  test("odd count takes the middle value", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+  test("even count averages the two middle values", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+  test("a single outlier cannot drag it (this is why not a mean)", () => {
+    // mean would be 12.6; the median ignores the contended 58-minute run.
+    expect(median([3, 3, 4, 4, 58])).toBe(4);
+  });
+  test("empty is 0", () => {
+    expect(median([])).toBe(0);
+  });
+});
+
+describe("p90", () => {
+  test("picks the 90th-percentile value", () => {
+    expect(p90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(10);
+  });
+  test("small samples fall back to the max", () => {
+    expect(p90([2, 5])).toBe(5);
+  });
+  test("empty is 0", () => {
+    expect(p90([])).toBe(0);
+  });
+});
+
+describe("observationKey", () => {
+  test("keys on repo, workflow and job so matrix legs stay distinct", () => {
+    expect(observationKey(obs({ job: "Static — windows-2025" }))).toBe(
+      "Nimbus :: CI :: Static — windows-2025",
+    );
+  });
+});
+
+describe("summarize", () => {
+  test("groups by key and counts samples", () => {
+    const m = summarize([obs({ exec: 10 }), obs({ exec: 12 }), obs({ exec: 14 })]);
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.samples).toBe(3);
+    expect(s?.execMedian).toBe(12);
+  });
+
+  test("execSpread is p90 minus median — the job's own noise band", () => {
+    const m = summarize([2, 2, 2, 2, 2, 2, 2, 2, 2, 20].map((e) => obs({ exec: e })));
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.execMedian).toBe(2);
+    expect(s?.execSpread).toBe(18);
+  });
+
+  test("a stable job has a near-zero spread", () => {
+    const m = summarize([12, 12.2, 12.1].map((e) => obs({ exec: e })));
+    expect(m.get("Nimbus :: CI :: Unit + Coverage")?.execSpread).toBeLessThan(0.5);
+  });
+
+  test("queue and dagWait are summarised independently of exec", () => {
+    const m = summarize([
+      obs({ exec: 10, queue: 30, dagWait: 5 }),
+      obs({ exec: 10, queue: 2, dagWait: 5 }),
+      obs({ exec: 10, queue: 2, dagWait: 5 }),
+    ]);
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.queueMedian).toBe(2);
+    expect(s?.dagWaitMedian).toBe(5);
+  });
+
+  test("different repos never share a key", () => {
+    const m = summarize([obs(), obs({ repo: "nimbus-sdk" })]);
+    expect(m.size).toBe(2);
+  });
+
+  test("no observations yields an empty map", () => {
+    expect(summarize([]).size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/ci-latency/summarize.test.ts`
+Expected: FAIL — module `./summarize.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Pure reduction from raw observations to per-key statistics.
+ *
+ * Medians everywhere, never means: a single contended run produced a 58-minute
+ * observation in the sample that motivated this gate, and a mean would let that
+ * one outlier redefine the job.
+ */
+
+import type { JobObservation, KeySummary } from "./types.ts";
+
+export function observationKey(o: JobObservation): string {
+  return `${o.repo} :: ${o.workflow} :: ${o.job}`;
+}
+
+export function median(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  if (s.length % 2 === 1) return s[mid] as number;
+  return (((s[mid - 1] as number) + (s[mid] as number)) / 2);
+}
+
+/**
+ * 90th percentile by nearest-rank. On a small sample this collapses to the max,
+ * which is the honest answer: with three observations there is no distinguishing
+ * a p90 from a maximum.
+ */
+export function p90(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const rank = Math.ceil(0.9 * s.length);
+  return s[Math.min(rank, s.length) - 1] as number;
+}
+
+export function summarize(obs: readonly JobObservation[]): Map<string, KeySummary> {
+  const grouped = new Map<string, JobObservation[]>();
+  for (const o of obs) {
+    const k = observationKey(o);
+    const list = grouped.get(k) ?? [];
+    list.push(o);
+    grouped.set(k, list);
+  }
+
+  const out = new Map<string, KeySummary>();
+  for (const [key, list] of grouped) {
+    const execs = list.map((o) => o.exec);
+    const execMedian = median(execs);
+    out.set(key, {
+      key,
+      samples: list.length,
+      execMedian,
+      execSpread: Math.max(0, p90(execs) - execMedian),
+      queueMedian: median(list.map((o) => o.queue)),
+      dagWaitMedian: median(list.map((o) => o.dagWait)),
+    });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/ci-latency/summarize.test.ts`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/ci-latency/summarize.ts scripts/ci-latency/summarize.test.ts
+git commit -m "feat(audit): ci-latency summarize — per-key medians + noise band"
+```
+
+---
+
+## Task 3: `baseline` — parse, serialise, ratchet
+
+**Files:**
+
+- Create: `scripts/ci-latency/baseline.ts`, `scripts/ci-latency/baseline.test.ts`
+
+**Interfaces:**
+
+- Consumes: `LatencyBaseline`, `BaselineEntry`, `KeySummary`; `MIN_SAMPLES_FOR_RATCHET`.
+- Produces: `parseBaseline(json: string): LatencyBaseline`, `serializeBaseline(b: LatencyBaseline): string`, `computeUpdatedBaseline(current: LatencyBaseline, summaries: ReadonlyMap<string, KeySummary>, now: string): LatencyBaseline`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
+import type { KeySummary, LatencyBaseline } from "./types.ts";
+
+const sum = (over: Partial<KeySummary> & { key: string }): KeySummary => ({
+  samples: 10,
+  execMedian: 10,
+  execSpread: 1,
+  queueMedian: 0,
+  dagWaitMedian: 0,
+  ...over,
+});
+
+const base = (entries: Record<string, { execMedian: number; execSpread: number }>): LatencyBaseline => ({
+  version: 1,
+  generated_at: "2026-07-27T00:00:00Z",
+  entries: new Map(Object.entries(entries)),
+});
+
+describe("parseBaseline / serializeBaseline", () => {
+  test("round-trips entries", () => {
+    const json = serializeBaseline(base({ "a :: b :: c": { execMedian: 5, execSpread: 1 } }));
+    const back = parseBaseline(json);
+    expect(back.entries.get("a :: b :: c")).toEqual({ execMedian: 5, execSpread: 1 });
+  });
+  test("an empty baseline parses to an empty map, not a throw", () => {
+    expect(parseBaseline('{"version":1,"generated_at":"x","entries":{}}').entries.size).toBe(0);
+  });
+  test("malformed JSON throws with a message naming the file's purpose", () => {
+    expect(() => parseBaseline("{nope")).toThrow(/ci-latency baseline/i);
+  });
+  test("serialised output ends with a newline so the file is diff-clean", () => {
+    expect(serializeBaseline(base({})).endsWith("\n")).toBe(true);
+  });
+  test("entries serialise sorted, so a re-run never reorders the diff", () => {
+    const json = serializeBaseline(
+      base({ "z :: z :: z": { execMedian: 1, execSpread: 0 }, "a :: a :: a": { execMedian: 1, execSpread: 0 } }),
+    );
+    expect(json.indexOf("a :: a :: a")).toBeLessThan(json.indexOf("z :: z :: z"));
+  });
+});
+
+describe("computeUpdatedBaseline", () => {
+  const now = "2026-07-28T00:00:00Z";
+
+  test("records a key seen for the first time", () => {
+    const next = computeUpdatedBaseline(base({}), new Map([["k", sum({ key: "k", execMedian: 8 })]]), now);
+    expect(next.entries.get("k")?.execMedian).toBe(8);
+  });
+
+  test("ratchets DOWN when a job gets faster", () => {
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+      new Map([["k", sum({ key: "k", execMedian: 6, execSpread: 1 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(6);
+    // the band travels with the median, so the lowered bound stays achievable
+    expect(next.entries.get("k")?.execSpread).toBe(1);
+  });
+
+  test("does NOT ratchet down on too few samples", () => {
+    // Three hot-cache runs is a plausible window; lowering demands more evidence
+    // than gating does.
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+      new Map([["k", sum({ key: "k", execMedian: 6, samples: 4 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(10);
+  });
+
+  test("raises the baseline when a job legitimately got slower", () => {
+    // --update-baseline is an explicit human action accepting the new reality.
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 5, execSpread: 1 } }),
+      new Map([["k", sum({ key: "k", execMedian: 9, execSpread: 2 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(9);
+  });
+
+  test("drops a key that no longer appears (renamed or deleted job)", () => {
+    const next = computeUpdatedBaseline(base({ gone: { execMedian: 5, execSpread: 1 } }), new Map(), now);
+    expect(next.entries.has("gone")).toBe(false);
+  });
+
+  test("ignores a key with too few samples to be trusted at all", () => {
+    const next = computeUpdatedBaseline(base({}), new Map([["k", sum({ key: "k", samples: 1 })]]), now);
+    expect(next.entries.has("k")).toBe(false);
+  });
+
+  test("stamps generated_at", () => {
+    expect(computeUpdatedBaseline(base({}), new Map(), now).generated_at).toBe(now);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/ci-latency/baseline.test.ts`
+Expected: FAIL — module `./baseline.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * The committed baseline: one `execMedian` + `execSpread` per key.
+ *
+ * The spread is stored, not recomputed at check time, because the gate compares
+ * today's median against the noise band the baseline was TAKEN with. Recomputing
+ * it from the current window would let a job that is becoming erratic widen its
+ * own tolerance, which is exactly backwards.
+ */
+
+import { MIN_SAMPLES, MIN_SAMPLES_FOR_RATCHET } from "./constants.ts";
+import type { BaselineEntry, KeySummary, LatencyBaseline } from "./types.ts";
+
+interface RawBaseline {
+  version?: unknown;
+  generated_at?: unknown;
+  entries?: unknown;
+}
+
+export function parseBaseline(json: string): LatencyBaseline {
+  let raw: RawBaseline;
+  try {
+    raw = JSON.parse(json) as RawBaseline;
+  } catch {
+    throw new Error("ci-latency baseline: file is not valid JSON");
+  }
+  const entries = new Map<string, BaselineEntry>();
+  const rawEntries = raw.entries;
+  if (typeof rawEntries === "object" && rawEntries !== null) {
+    for (const [k, v] of Object.entries(rawEntries as Record<string, unknown>)) {
+      if (typeof v !== "object" || v === null) continue;
+      const e = v as { execMedian?: unknown; execSpread?: unknown };
+      if (typeof e.execMedian !== "number" || typeof e.execSpread !== "number") continue;
+      entries.set(k, { execMedian: e.execMedian, execSpread: e.execSpread });
+    }
+  }
+  return {
+    version: 1,
+    generated_at: typeof raw.generated_at === "string" ? raw.generated_at : "",
+    entries,
+  };
+}
+
+export function serializeBaseline(b: LatencyBaseline): string {
+  // Sorted so a regenerated baseline produces a minimal, reviewable diff.
+  const obj: Record<string, BaselineEntry> = {};
+  for (const k of [...b.entries.keys()].sort()) {
+    const e = b.entries.get(k);
+    if (e) obj[k] = { execMedian: round2(e.execMedian), execSpread: round2(e.execSpread) };
+  }
+  return `${JSON.stringify({ version: 1, generated_at: b.generated_at, entries: obj }, null, 2)}\n`;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * The ratchet. Raising is unconditional (an explicit `--update-baseline` accepts
+ * the new reality); LOWERING requires `MIN_SAMPLES_FOR_RATCHET` observations,
+ * because a wrongly-low bound produces a permanently red gate and three
+ * consecutive hot-cache runs is a plausible window.
+ *
+ * A key absent from the current window is dropped: it was renamed or deleted,
+ * and keeping it would strand a baseline entry nothing can ever satisfy.
+ */
+export function computeUpdatedBaseline(
+  current: LatencyBaseline,
+  summaries: ReadonlyMap<string, KeySummary>,
+  now: string,
+): LatencyBaseline {
+  const entries = new Map<string, BaselineEntry>();
+  for (const [key, s] of summaries) {
+    if (s.samples < MIN_SAMPLES) continue;
+    const prev = current.entries.get(key);
+    if (prev && s.execMedian < prev.execMedian && s.samples < MIN_SAMPLES_FOR_RATCHET) {
+      entries.set(key, prev);
+      continue;
+    }
+    entries.set(key, { execMedian: s.execMedian, execSpread: s.execSpread });
+  }
+  return { version: 1, generated_at: now, entries };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/ci-latency/baseline.test.ts`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/ci-latency/baseline.ts scripts/ci-latency/baseline.test.ts
+git commit -m "feat(audit): ci-latency baseline + evidence-asymmetric ratchet"
+```
+
+---
+
+## Task 4: `evaluate` — the gate decision
+
+**Files:**
+
+- Create: `scripts/ci-latency/evaluate.ts`, `scripts/ci-latency/evaluate.test.ts`
+
+**Interfaces:**
+
+- Consumes: `KeySummary`, `LatencyBaseline`, `Finding`, `CheckResult`; `MIN_SAMPLES`, `MIN_ABSOLUTE_DELTA_MIN`, `UNSTABLE_SPREAD_RATIO`.
+- Produces: `evaluate(summaries: ReadonlyMap<string, KeySummary>, baseline: LatencyBaseline): CheckResult`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { evaluate } from "./evaluate.ts";
+import type { KeySummary, LatencyBaseline } from "./types.ts";
+
+const sum = (over: Partial<KeySummary> & { key: string }): KeySummary => ({
+  samples: 10,
+  execMedian: 10,
+  execSpread: 1,
+  queueMedian: 0,
+  dagWaitMedian: 0,
+  ...over,
+});
+const base = (e: Record<string, { execMedian: number; execSpread: number }>): LatencyBaseline => ({
+  version: 1,
+  generated_at: "x",
+  entries: new Map(Object.entries(e)),
+});
+const kinds = (r: { findings: { key: string; kind: string }[] }, key: string) =>
+  r.findings.filter((f) => f.key === key).map((f) => f.kind);
+
+describe("evaluate", () => {
+  test("a job within its noise band is not a finding", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 10.5 })]]),
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a regression beyond the band fails", () => {
+    // Ubuntu Unit+Coverage: median 12.2, spread 2.0 — a 4-minute regression must
+    // fail. Under a flat 50% tolerance it needed 6.1 and would have passed.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 16.2 })]]),
+      base({ k: { execMedian: 12.2, execSpread: 2 } }),
+    );
+    expect(r.regressions.map((f) => f.key)).toEqual(["k"]);
+    expect(r.regressions[0]?.detail).toContain("12.2");
+  });
+
+  test("a noisy job gets its own wide band, not a global constant", () => {
+    // Windows Unit+Coverage: median 13.2, spread 14.5. A 10-minute swing is this
+    // job's normal behaviour and must NOT fail; a global 3-minute cap would.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 23.2 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 14.5 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("MIN_ABSOLUTE_DELTA floors the band on a sub-minute job", () => {
+    // 0.3 -> 0.5 is +67% but irrelevant; the 1-minute floor absorbs it.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 0.5 })]]),
+      base({ k: { execMedian: 0.3, execSpread: 0 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("too few samples is insufficient-data, never a regression", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 99, samples: 2 })]]),
+      base({ k: { execMedian: 1, execSpread: 0 } }),
+    );
+    expect(kinds(r, "k")).toContain("insufficient-data");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a key absent from the baseline is new-key, never a regression", () => {
+    const r = evaluate(new Map([["k", sum({ key: "k" })]]), base({}));
+    expect(kinds(r, "k")).toContain("new-key");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a baseline entry with no observations is stale, never a regression", () => {
+    const r = evaluate(new Map(), base({ gone: { execMedian: 5, execSpread: 1 } }));
+    expect(kinds(r, "gone")).toContain("stale-baseline-entry");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("an erratic job is reported unstable but never failed for it", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 13.2, execSpread: 14.5 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 14.5 } }),
+    );
+    expect(kinds(r, "k")).toContain("unstable");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a stable job is not reported unstable", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 12, execSpread: 1 })]]),
+      base({ k: { execMedian: 12, execSpread: 1 } }),
+    );
+    expect(kinds(r, "k")).not.toContain("unstable");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/ci-latency/evaluate.test.ts`
+Expected: FAIL — module `./evaluate.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * The gate decision. ONLY `regression` can fail the run.
+ *
+ * `queue`, `dagWait` and `unstable` are deliberately observation-only: none is
+ * caused by the change under test. Queue wait moves with how many PRs happen to
+ * be open, and a flaky job is flaky regardless of the diff — failing a
+ * contributor for either would report a condition they cannot fix, which the
+ * infrastructure roadmap names as the way a gate becomes one everybody ignores.
+ */
+
+import { MIN_ABSOLUTE_DELTA_MIN, MIN_SAMPLES, UNSTABLE_SPREAD_RATIO } from "./constants.ts";
+import type { CheckResult, Finding, KeySummary, LatencyBaseline } from "./types.ts";
+
+const r1 = (n: number): string => n.toFixed(1);
+
+export function evaluate(
+  summaries: ReadonlyMap<string, KeySummary>,
+  baseline: LatencyBaseline,
+): CheckResult {
+  const findings: Finding[] = [];
+
+  for (const [key, s] of summaries) {
+    if (s.execSpread > s.execMedian * UNSTABLE_SPREAD_RATIO && s.execMedian > 0) {
+      findings.push({
+        key,
+        kind: "unstable",
+        detail: `spread ${r1(s.execSpread)}m on a ${r1(s.execMedian)}m median — flaky, not a regression`,
+      });
+    }
+
+    if (s.samples < MIN_SAMPLES) {
+      findings.push({
+        key,
+        kind: "insufficient-data",
+        detail: `${s.samples} sample(s), need ${MIN_SAMPLES} — skipped, and no retry creates more history`,
+      });
+      continue;
+    }
+
+    const prev = baseline.entries.get(key);
+    if (!prev) {
+      findings.push({
+        key,
+        kind: "new-key",
+        detail: `not in the baseline (median ${r1(s.execMedian)}m) — recorded on the next --update-baseline`,
+      });
+      continue;
+    }
+
+    const allowed = Math.max(MIN_ABSOLUTE_DELTA_MIN, prev.execSpread);
+    if (s.execMedian > prev.execMedian + allowed) {
+      findings.push({
+        key,
+        kind: "regression",
+        detail: `${r1(s.execMedian)}m vs baseline ${r1(prev.execMedian)}m (+${r1(s.execMedian - prev.execMedian)}m, allowed +${r1(allowed)}m)`,
+      });
+    }
+  }
+
+  for (const key of baseline.entries.keys()) {
+    if (!summaries.has(key)) {
+      findings.push({
+        key,
+        kind: "stale-baseline-entry",
+        detail: "in the baseline but not observed — renamed or deleted; fix with --update-baseline",
+      });
+    }
+  }
+
+  return { findings, regressions: findings.filter((f) => f.kind === "regression") };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/ci-latency/evaluate.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/ci-latency/evaluate.ts scripts/ci-latency/evaluate.test.ts
+git commit -m "feat(audit): ci-latency evaluate — per-key band, exec-only gating"
+```
+
+---
+
+## Task 5: `collect` — the Actions API reader
+
+**Files:**
+
+- Create: `scripts/ci-latency/collect.ts`, `scripts/ci-latency/collect.test.ts`
+
+**Interfaces:**
+
+- Consumes: `runGh`, `isRecord` from `../structure-audit/_gh-audit.ts`; `MAX_RUNS_PER_REPO`, `SAMPLE_EVENT`, `AUDITED_REPOS`.
+- Produces: `parseRunIds(json: string): string[]`, `parseJobObservations(json: string, repo: string, workflow: string, runStartedAt: string): JobObservation[]`, `collectRepo(repo: string): JobObservation[]`, `collectAll(repos?: readonly string[]): JobObservation[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { parseJobObservations, parseRunIds } from "./collect.ts";
+
+describe("parseRunIds", () => {
+  test("reads ids from the runs payload", () => {
+    expect(parseRunIds('{"workflow_runs":[{"id":1},{"id":2}]}')).toEqual(["1", "2"]);
+  });
+  test("empty on malformed JSON — an unreadable list is never a finding", () => {
+    expect(parseRunIds("{nope")).toEqual([]);
+  });
+  test("skips entries with no numeric id", () => {
+    expect(parseRunIds('{"workflow_runs":[{"id":"x"},{"id":7}]}')).toEqual(["7"]);
+  });
+});
+
+describe("parseJobObservations", () => {
+  const t0 = "2026-07-27T10:00:00Z";
+  const job = (over: Record<string, unknown> = {}) => ({
+    name: "Unit + Coverage",
+    conclusion: "success",
+    created_at: "2026-07-27T10:00:00Z",
+    started_at: "2026-07-27T10:02:00Z",
+    completed_at: "2026-07-27T10:12:00Z",
+    ...over,
+  });
+  const payload = (jobs: unknown[]) => JSON.stringify({ jobs });
+
+  test("exec is completed minus started", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.exec).toBe(10);
+  });
+
+  test("queue is started minus CREATED — DAG-free contention", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.queue).toBe(2);
+  });
+
+  test("dagWait is created minus run start, so a needs-blocked job is not charged as queue", () => {
+    // A job gated by `needs` is CREATED only once its dependencies finish, so
+    // charging created-minus-run-start to queue would bill it for their work.
+    const [o] = parseJobObservations(
+      payload([job({ created_at: "2026-07-27T10:20:00Z", started_at: "2026-07-27T10:21:00Z", completed_at: "2026-07-27T10:26:00Z" })]),
+      "Nimbus",
+      "CI",
+      t0,
+    );
+    expect(o?.dagWait).toBe(20);
+    expect(o?.queue).toBe(1);
+    expect(o?.exec).toBe(5);
+  });
+
+  test("a root job has zero dagWait", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.dagWait).toBe(0);
+  });
+
+  test("skips jobs that did not succeed — a failed job's duration is meaningless", () => {
+    expect(parseJobObservations(payload([job({ conclusion: "failure" })]), "Nimbus", "CI", t0)).toEqual([]);
+  });
+
+  test("skips jobs with a missing timestamp rather than emitting NaN", () => {
+    expect(parseJobObservations(payload([job({ completed_at: null })]), "Nimbus", "CI", t0)).toEqual([]);
+  });
+
+  test("empty on malformed JSON", () => {
+    expect(parseJobObservations("{nope", "Nimbus", "CI", t0)).toEqual([]);
+  });
+
+  test("carries repo and workflow through onto every observation", () => {
+    const [o] = parseJobObservations(payload([job()]), "nimbus-sdk", "Release", t0);
+    expect(o?.repo).toBe("nimbus-sdk");
+    expect(o?.workflow).toBe("Release");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test scripts/ci-latency/collect.test.ts`
+Expected: FAIL — module `./collect.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * The only impure module: walks the Actions API and returns raw observations.
+ * Every parser is exported and pure so the whole shape is table-tested offline.
+ *
+ * Restricted to `push` on the default branch: PR runs execute a different job
+ * set against different cache state, so mixing them compares unlike things.
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { AUDITED_REPOS, MAX_RUNS_PER_REPO, SAMPLE_EVENT } from "./constants.ts";
+import type { JobObservation } from "./types.ts";
+
+const MS_PER_MIN = 60_000;
+
+export function parseRunIds(json: string): string[] {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["workflow_runs"])) return [];
+    const out: string[] = [];
+    for (const r of p["workflow_runs"]) {
+      if (isRecord(r) && typeof r["id"] === "number") out.push(String(r["id"]));
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function minutesBetween(later: unknown, earlier: unknown): number | null {
+  if (typeof later !== "string" || typeof earlier !== "string") return null;
+  const a = new Date(later).getTime();
+  const b = new Date(earlier).getTime();
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return (a - b) / MS_PER_MIN;
+}
+
+export function parseJobObservations(
+  json: string,
+  repo: string,
+  workflow: string,
+  runStartedAt: string,
+): JobObservation[] {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["jobs"])) return [];
+    const out: JobObservation[] = [];
+    for (const j of p["jobs"]) {
+      if (!isRecord(j)) continue;
+      if (j["conclusion"] !== "success") continue;
+      const name = j["name"];
+      if (typeof name !== "string") continue;
+      const exec = minutesBetween(j["completed_at"], j["started_at"]);
+      const queue = minutesBetween(j["started_at"], j["created_at"]);
+      const dagWait = minutesBetween(j["created_at"], runStartedAt);
+      if (exec === null || queue === null || dagWait === null) continue;
+      out.push({
+        repo,
+        workflow,
+        job: name,
+        exec,
+        queue: Math.max(0, queue),
+        dagWait: Math.max(0, dagWait),
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+interface RunMeta {
+  id: string;
+  name: string;
+  runStartedAt: string;
+}
+
+function parseRunMeta(json: string): RunMeta[] {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["workflow_runs"])) return [];
+    const out: RunMeta[] = [];
+    for (const r of p["workflow_runs"]) {
+      if (!isRecord(r)) continue;
+      const id = r["id"];
+      const name = r["name"];
+      const started = r["run_started_at"];
+      if (typeof id !== "number" || typeof name !== "string" || typeof started !== "string") continue;
+      out.push({ id: String(id), name, runStartedAt: started });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/** All observations for one repo. An unreadable repo yields none — never a finding. */
+export function collectRepo(repo: string): JobObservation[] {
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/nimbus-agent/${repo}/actions/runs?per_page=${MAX_RUNS_PER_REPO}&event=${SAMPLE_EVENT}&status=success`,
+  ]);
+  if (!res.ok) return [];
+  const out: JobObservation[] = [];
+  for (const run of parseRunMeta(res.stdout)) {
+    const jobs = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+    ]);
+    if (!jobs.ok) continue;
+    out.push(...parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt));
+  }
+  return out;
+}
+
+export function collectAll(repos: readonly string[] = AUDITED_REPOS): JobObservation[] {
+  return repos.flatMap((r) => collectRepo(r));
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test scripts/ci-latency/collect.test.ts`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts
+git add scripts/ci-latency/collect.ts scripts/ci-latency/collect.test.ts
+git commit -m "feat(audit): ci-latency collector — DAG-free queue via job created_at"
+```
+
+---
+
+## Task 6: The shell, the generated baseline, and registration
+
+**Files:**
+
+- Create: `scripts/ci-latency/check.ts`, `docs/structure-audit/ci-latency-baseline.json`
+- Modify: `package.json`, `scripts/lib/preflight-gates.ts`, `.github/workflows/org-drift-sweep.yml`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1–5.
+- Produces: no new exports — the shell is `import.meta.main` only.
+
+- [ ] **Step 1: Write the shell**
+
+Create `scripts/ci-latency/check.ts`:
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * audit:ci-latency — per-job CI execution, runner queue and DAG wait across the
+ * org, gated against a committed baseline.
+ *
+ * ONLY execution regressions fail. Queue wait, DAG wait and job instability are
+ * reported and never gated: none is caused by the change under test, and a gate
+ * that reports a condition nobody can fix is one everybody learns to ignore.
+ *
+ * See docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
+import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
+import { collectAll } from "./collect.ts";
+import { evaluate } from "./evaluate.ts";
+import { summarize } from "./summarize.ts";
+
+const BASELINE_PATH = join(import.meta.dir, "..", "..", "docs", "structure-audit", "ci-latency-baseline.json");
+
+function readBaselineFile(): string {
+  try {
+    return readFileSync(BASELINE_PATH, "utf8");
+  } catch {
+    return '{"version":1,"generated_at":"","entries":{}}';
+  }
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const strict = isStrict(argv, process.env);
+  const updateMode = argv.includes("--update-baseline");
+  const label = "audit:ci-latency";
+
+  const observations = collectAll();
+  if (observations.length === 0) {
+    // Nothing readable at all: no gh, no auth, or a total API outage.
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const summaries = summarize(observations);
+  const baseline = parseBaseline(readBaselineFile());
+
+  if (updateMode) {
+    const next = computeUpdatedBaseline(baseline, summaries, new Date().toISOString());
+    writeFileSync(BASELINE_PATH, serializeBaseline(next));
+    console.log(`${label}: baseline updated — ${next.entries.size} key(s) from ${observations.length} observation(s)`);
+    process.exit(0);
+  }
+
+  const result = evaluate(summaries, baseline);
+
+  // Observational lines first, so a red is read in context.
+  const worstQueue = [...summaries.values()].sort((a, b) => b.queueMedian - a.queueMedian)[0];
+  if (worstQueue && worstQueue.queueMedian > 1) {
+    console.warn(
+      `::warning::${label}: worst median runner queue ${worstQueue.queueMedian.toFixed(1)}m on "${worstQueue.key}" — contention, not a code regression`,
+    );
+  }
+  for (const f of result.findings) {
+    if (f.kind === "regression") continue;
+    console.warn(`::warning::${label}: ${f.key}: ${f.detail} (${f.kind})`);
+  }
+  for (const f of result.regressions) {
+    console.error(`::error::${label}: ${f.key}: ${f.detail}`);
+  }
+
+  if (result.regressions.length > 0) {
+    console.error(`${label}: FAILED — ${result.regressions.length} job(s) slower than baseline`);
+    process.exit(1);
+  }
+  console.log(`${label}: OK (${summaries.size} key(s), ${observations.length} observation(s))`);
+}
+```
+
+- [ ] **Step 2: Register the scripts**
+
+In `package.json`, immediately after the `"audit:pin-freshness"` line:
+
+```json
+    "audit:ci-latency": "bun scripts/ci-latency/check.ts",
+    "audit:ci-latency:update-baseline": "bun scripts/ci-latency/check.ts --update-baseline",
+```
+
+In `scripts/lib/preflight-gates.ts`, add both to `CI_ONLY_GATES` immediately after the `"audit:pin-freshness"` entry:
+
+```ts
+  "audit:ci-latency", // needs network + gh (Actions API across 9 repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:ci-latency:update-baseline", // explicit human action that rewrites the committed baseline; never a gate
+```
+
+- [ ] **Step 3: Generate and inspect the baseline**
+
+Run: `GH_TOKEN=$(gh auth token) bun run audit:ci-latency:update-baseline`
+Expected: `baseline updated — N key(s) from M observation(s)`, and `docs/structure-audit/ci-latency-baseline.json` now exists.
+
+Open the file and sanity-check it before trusting it:
+
+- every `execMedian` is a plausible number of **minutes** (not seconds, not ms);
+- `Nimbus :: CI :: ...` keys are present;
+- `Unit + Coverage — windows-2025` carries a large `execSpread` (~14) while
+  `Static — ubuntu-24.04` carries a small one (~1). If both are ~0 the sample
+  collapsed to one run and the baseline is not trustworthy — investigate rather
+  than commit.
+
+- [ ] **Step 4: Run the gate against the fresh baseline**
+
+Run: `GH_TOKEN=$(gh auth token) bun run audit:ci-latency`
+Expected: **exit 0**, `OK (N key(s), M observation(s))`, plus a `::warning::` naming the worst median runner queue and any `unstable` / `insufficient-data` keys.
+
+Green is correct here and is not evidence the gate works — the baseline was just generated from this same data, so nothing can exceed it by construction. The red-proof is the unit test in Task 4 (`a regression beyond the band fails`).
+
+- [ ] **Step 5: Verify the degradation path**
+
+Run: `BUNDIR=$(dirname "$(which bun)"); env -u GH_TOKEN -u GITHUB_TOKEN PATH="$BUNDIR" "$BUNDIR/bun" scripts/ci-latency/check.ts`
+Expected: a soft `::warning::` skip and **exit 0** — never a stack trace.
+
+Then: `... scripts/ci-latency/check.ts --strict`
+Expected: `::error::` and **exit 1**.
+
+- [ ] **Step 6: Add the sweep job**
+
+In `.github/workflows/org-drift-sweep.yml`, after the `pin-freshness` job:
+
+```yaml
+  ci-latency:
+    name: ci-latency
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # `actions: read` is all the Actions API needs for runs + jobs. Every
+      # audited repo is public, so the default github.token reaches them.
+      - name: Audit CI latency
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/ci-latency/check.ts --strict
+```
+
+- [ ] **Step 7: Full verification**
+
+Run: `bun test scripts/ && bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check scripts .github docs && bun run audit:action-sha-pins`
+Expected: all pass. The sha-pin audit matters because Step 6 added two `uses:` refs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/ci-latency/check.ts docs/structure-audit/ci-latency-baseline.json package.json scripts/lib/preflight-gates.ts .github/workflows/org-drift-sweep.yml
+git commit -F - <<'EOF'
+feat(audit): audit:ci-latency — per-job exec gate, queue observed
+
+Only execution regressions fail. Queue wait, DAG wait and job instability are
+reported and never gated: none is caused by the change under test, so failing a
+PR for them would report a condition the contributor cannot fix.
+EOF
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+
+- Modify: `docs/infrastructure-roadmap.md`
+
+- [ ] **Step 1: Update the P4b row**
+
+In the sub-programs table, replace the P4b row with:
+
+```markdown
+| P4b | Latency | 🔨 measurement shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning is deliberately NOT in this slice — the first measurement showed execution is not the binding constraint. |
+```
+
+- [ ] **Step 2: Add the P4b progress log**
+
+Add a new `### P4b progress log` section immediately before `### P5 progress log`:
+
+```markdown
+### P4b progress log
+
+- **Delivered (measurement, 2026-07-27):** `audit:ci-latency` collects per-job
+  timings from the Actions API across all 9 org repos and gates execution
+  against a committed baseline (`docs/structure-audit/ci-latency-baseline.json`),
+  mirroring `audit:coverage-floor`.
+- **The first measurement contradicted the design of record's hunch.** That
+  document proposed cache tuning, matrix sharding and finer path filters. On the
+  slowest sampled run (73.8min) the longest single job *executed* for 12.3min,
+  while the longest DAG wait was 33.9min and the longest runner queue 31.6min —
+  so execution is not the binding constraint, and sharding would worsen it by
+  adding jobs to the same contended pool. Principle #3 ("only against
+  measurement, never against a hunch") earned its keep on first use.
+- **An earlier revision of the design claimed "~80% of wall-clock is queueing".
+  That was wrong** and the design review caught it: it measured
+  `started_at − run_started_at`, which charges a job for its *dependencies'*
+  execution. A job's `created_at` tracks eligibility, so `started_at − created_at`
+  is DAG-free contention and the DAG cost is recorded separately. Contention is
+  real but concentrated almost entirely on **macOS** runners.
+- **Tolerance is a per-key noise band, not a constant.** Measured spreads over 11
+  samples: `Static — ubuntu` 0.7min, `Unit + Coverage — ubuntu` 2.0min,
+  `Unit + Coverage — windows` **14.5min**. No global constant fits both, so the
+  baseline stores each job's own spread and the gate allows
+  `max(1min, spread)`. A job whose spread exceeds half its median is reported
+  `unstable` — observed, never failed, since flakiness is not caused by the
+  contributor's change.
+- **Remaining:** the tuning slice itself, which must be justified against this
+  data. The clearest lead is macOS runner contention.
+```
+
+- [ ] **Step 3: Validate the docs**
+
+Run: `bun run lint:markdown && bun run audit:doc-refs && "$HOME/.cargo/bin/lychee" --offline --no-progress --config lychee.toml 'docs/**/*.md' '*.md'`
+Expected: 0 markdown errors, all refs resolve, 0 link errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/infrastructure-roadmap.md
+git commit -m "docs(infra): record P4b — CI latency measurement shipped"
+```
+
+---
+
+## Post-implementation (not a task — for the PR author)
+
+- **PR description:** state plainly that the gate ships **green by construction**
+  (the baseline is generated from the same window it is checked against), so the
+  red-proof is the unit test in Task 4 rather than a live finding. Paste the
+  Task 6 Step 4 output.
+- **Sweep proof:** after merge, dispatch `org-drift-sweep.yml` and record the run
+  number in the P4b progress log, matching how P2 and P5 were closed.
+- **The tuning slice is the follow-up**, and macOS contention is its first lead.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Three metrics, exec/queue/dagWait separated → Task 5 `parseJobObservations` + Task 2 `summarize`. ✓
+- Only exec gated; queue/dagWait/unstable observed → Task 4 `evaluate` + Task 6 shell. ✓
+- `queue = started_at − created_at` (DAG-free) → Task 5, with a test asserting a `needs`-blocked job is not charged. ✓
+- Sparse sampling → `MIN_SAMPLES`, `insufficient-data` skipped not failed → Tasks 1, 4. ✓
+- Single event class (`push`) → Task 1 `SAMPLE_EVENT`, Task 5 query string. ✓
+- Per-key noise band replacing a flat tolerance → Task 3 stores `execSpread`, Task 4 applies `max(MIN_ABSOLUTE_DELTA, spread)`. ✓
+- `MIN_ABSOLUTE_DELTA` floor for sub-minute jobs → Task 4 test. ✓
+- `unstable` observation at `UNSTABLE_SPREAD_RATIO` → Task 4. ✓
+- Ratchet down needs `MIN_SAMPLES_FOR_RATCHET` (5) vs 3 to gate → Task 3 test. ✓
+- Spread travels down with the median → Task 3 test. ✓
+- Stale baseline entry / new key are never failures → Task 4 tests. ✓
+- Org-wide, 9 repos → Task 1 `AUDITED_REPOS` (mirrors the sha-pins matrix). ✓
+- Sweep job, `--strict`, not the fast tier → Task 6 Steps 2 and 6. ✓
+- Fail-soft locally / hard strict → Task 6 Step 5. ✓
+- Ships green by construction; red-proof is a unit test → Task 6 Step 4 + Task 4. ✓
+- No tuning in scope → nothing in any task changes a workflow's execution; the only workflow edit adds a job. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step carries complete code. ✓
+
+**Type consistency:** `JobObservation`, `KeySummary`, `BaselineEntry`, `LatencyBaseline`, `Finding`, `FindingKind`, `CheckResult` are each defined once in Task 1 and referenced with identical shapes throughout. `summarize` / `parseBaseline` / `serializeBaseline` / `computeUpdatedBaseline` / `evaluate` / `collectAll` keep one signature across tasks. `execSpread` is named identically in the summary, the baseline entry and the evaluator. ✓

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
@@ -376,7 +376,7 @@ export function summarize(obs: readonly JobObservation[]): Map<string, KeySummar
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `bun test scripts/ci-latency/summarize.test.ts`
-Expected: PASS, 13 tests.
+Expected: PASS, 14 tests.
 
 - [ ] **Step 5: Commit**
 
@@ -1128,7 +1128,7 @@ export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectRes
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `bun test scripts/ci-latency/collect.test.ts`
-Expected: PASS, 15 tests.
+Expected: PASS, 14 tests.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
+++ b/docs/superpowers/plans/2026-07-27-p4b-ci-latency.md
@@ -25,12 +25,21 @@
 
 | Constant | Value | Why |
 | --- | --- | --- |
-| `MIN_SAMPLES` | 3 | fewer observations is `insufficient-data`, skipped not failed |
-| `MIN_SAMPLES_FOR_RATCHET` | 5 | lowering a bound demands more evidence than enforcing one |
+| `MIN_SAMPLES` | 3 | fewer observations is `insufficient-data`, skipped not failed; 71% of keys qualify |
+| `MIN_SAMPLES_FOR_RATCHET` | 7 | lowering a bound demands more evidence than enforcing one |
 | `MIN_ABSOLUTE_DELTA_MIN` | 1 | ratios are meaningless on a 0.3-min job |
 | `UNSTABLE_SPREAD_RATIO` | 0.5 | spread > 50% of median ⇒ reported `unstable`, never failed |
-| `MAX_RUNS_PER_REPO` | 30 | bounds API cost to ~250 requests |
+| `RUN_LIST_PAGE` | 100 | one cheap list request at the API maximum |
+| `MAX_RUNS_PER_WORKFLOW` | 12 | caps the *expensive* job fetches where the volume is |
+| `MAX_READ_FAILURE_RATIO` | 0.25 | past this the sample is degraded — skip gating, never gate on it |
 | `SAMPLE_EVENT` | `"push"` | PR runs execute a different job set; mixing compares unlike things |
+
+**Why the window is per-workflow, not per-repo.** An earlier revision capped 30
+runs per *repo*. Measured: those 30 push runs span 8 workflows, so `CI` itself
+got only **4** — and no CI job could ever exceed 4 samples, which left just
+**2% of keys** able to ratchet and made any threshold above 5 unreachable. At a
+100-run list, `CI` gets **12**. Capping the job fetches per workflow buys that
+depth without the ~900 requests a flat 100-per-repo would have cost.
 
 ---
 
@@ -75,11 +84,15 @@
 export const MIN_SAMPLES = 3;
 
 /**
- * Lowering a baseline needs MORE evidence than enforcing one: three consecutive
+ * Lowering a baseline needs MORE evidence than enforcing one: a few consecutive
  * hot-cache runs is a plausible window, and the cost of a wrongly-low bound is a
  * permanently red gate.
+ *
+ * 7 is affordable only because sampling is capped per WORKFLOW rather than per
+ * repo — under the old per-repo window a stable CI job could reach at most 4
+ * samples, which made every threshold above 5 unreachable and the ratchet dead.
  */
-export const MIN_SAMPLES_FOR_RATCHET = 5;
+export const MIN_SAMPLES_FOR_RATCHET = 7;
 
 /** Ratios and small noise bands are both meaningless on a sub-minute job. */
 export const MIN_ABSOLUTE_DELTA_MIN = 1;
@@ -87,8 +100,21 @@ export const MIN_ABSOLUTE_DELTA_MIN = 1;
 /** spread > this × median ⇒ reported `unstable` (observed, never failed). */
 export const UNSTABLE_SPREAD_RATIO = 0.5;
 
-/** Bounds API cost: ~1 + MAX_RUNS_PER_REPO requests per repo. */
-export const MAX_RUNS_PER_REPO = 30;
+/** One cheap list request at the API maximum. */
+export const RUN_LIST_PAGE = 100;
+
+/**
+ * Caps the EXPENSIVE per-run job fetches, and does so per workflow so a busy
+ * workflow cannot starve a quiet one out of the sample.
+ */
+export const MAX_RUNS_PER_WORKFLOW = 12;
+
+/**
+ * Past this share of failed job reads the sample is degraded: the survivors are
+ * whichever runs happened to succeed, so their median could be biased and the
+ * gate could manufacture a regression. Skip gating instead.
+ */
+export const MAX_READ_FAILURE_RATIO = 0.25;
 
 /** PR runs execute a different job set with different cache state. */
 export const SAMPLE_EVENT = "push";
@@ -439,11 +465,11 @@ describe("computeUpdatedBaseline", () => {
   });
 
   test("does NOT ratchet down on too few samples", () => {
-    // Three hot-cache runs is a plausible window; lowering demands more evidence
-    // than gating does.
+    // A few hot-cache runs is a plausible window; lowering demands more evidence
+    // than gating does. 6 < MIN_SAMPLES_FOR_RATCHET (7).
     const next = computeUpdatedBaseline(
       base({ k: { execMedian: 10, execSpread: 2 } }),
-      new Map([["k", sum({ key: "k", execMedian: 6, samples: 4 })]]),
+      new Map([["k", sum({ key: "k", execMedian: 6, samples: 6 })]]),
       now,
     );
     expect(next.entries.get("k")?.execMedian).toBe(10);
@@ -800,25 +826,55 @@ git commit -m "feat(audit): ci-latency evaluate — per-key band, exec-only gati
 
 **Interfaces:**
 
-- Consumes: `runGh`, `isRecord` from `../structure-audit/_gh-audit.ts`; `MAX_RUNS_PER_REPO`, `SAMPLE_EVENT`, `AUDITED_REPOS`.
-- Produces: `parseRunIds(json: string): string[]`, `parseJobObservations(json: string, repo: string, workflow: string, runStartedAt: string): JobObservation[]`, `collectRepo(repo: string): JobObservation[]`, `collectAll(repos?: readonly string[]): JobObservation[]`.
+- Consumes: `runGh`, `isRecord` from `../structure-audit/_gh-audit.ts`; `RUN_LIST_PAGE`, `MAX_RUNS_PER_WORKFLOW`, `SAMPLE_EVENT`, `AUDITED_REPOS`.
+- Produces: `parseRunMeta(json: string): RunMeta[]`, `selectRuns(runs: readonly RunMeta[]): RunMeta[]`, `parseJobObservations(json, repo, workflow, runStartedAt): JobObservation[]`, `collectRepo(repo: string): CollectResult`, `collectAll(repos?: readonly string[]): CollectResult`, and `interface CollectResult { observations: JobObservation[]; attempted: number; readFailures: number; sawNeedsWorkflow: boolean }`.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```ts
 import { describe, expect, test } from "bun:test";
 
-import { parseJobObservations, parseRunIds } from "./collect.ts";
+import { parseJobObservations, parseRunMeta, selectRuns } from "./collect.ts";
 
-describe("parseRunIds", () => {
-  test("reads ids from the runs payload", () => {
-    expect(parseRunIds('{"workflow_runs":[{"id":1},{"id":2}]}')).toEqual(["1", "2"]);
+describe("parseRunMeta", () => {
+  test("reads id, workflow name and run_started_at", () => {
+    const m = parseRunMeta(
+      '{"workflow_runs":[{"id":1,"name":"CI","run_started_at":"2026-07-27T10:00:00Z"}]}',
+    );
+    expect(m).toEqual([{ id: "1", name: "CI", runStartedAt: "2026-07-27T10:00:00Z" }]);
   });
   test("empty on malformed JSON — an unreadable list is never a finding", () => {
-    expect(parseRunIds("{nope")).toEqual([]);
+    expect(parseRunMeta("{nope")).toEqual([]);
   });
-  test("skips entries with no numeric id", () => {
-    expect(parseRunIds('{"workflow_runs":[{"id":"x"},{"id":7}]}')).toEqual(["7"]);
+  test("skips entries missing any required field", () => {
+    expect(parseRunMeta('{"workflow_runs":[{"id":"x","name":"CI","run_started_at":"t"}]}')).toEqual(
+      [],
+    );
+  });
+});
+
+describe("selectRuns", () => {
+  const run = (name: string, i: number) => ({ id: `${name}-${i}`, name, runStartedAt: "t" });
+
+  test("caps per WORKFLOW, so a busy workflow cannot starve a quiet one", () => {
+    // The whole reason this exists: a flat per-repo cap gave CI only 4 of 30
+    // runs, which made every ratchet threshold above 5 unreachable.
+    const runs = [
+      ...Array.from({ length: 40 }, (_, i) => run("Scorecard", i)),
+      ...Array.from({ length: 40 }, (_, i) => run("CI", i)),
+    ];
+    const sel = selectRuns(runs);
+    expect(sel.filter((r) => r.name === "CI")).toHaveLength(12);
+    expect(sel.filter((r) => r.name === "Scorecard")).toHaveLength(12);
+  });
+
+  test("keeps every run of a workflow that has fewer than the cap", () => {
+    expect(selectRuns([run("CI", 1), run("CI", 2)])).toHaveLength(2);
+  });
+
+  test("preserves API order (newest first) within a workflow", () => {
+    const sel = selectRuns(Array.from({ length: 20 }, (_, i) => run("CI", i)));
+    expect(sel[0]?.id).toBe("CI-0");
   });
 });
 
@@ -900,23 +956,69 @@ Expected: FAIL — module `./collect.ts` does not exist.
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { AUDITED_REPOS, MAX_RUNS_PER_REPO, SAMPLE_EVENT } from "./constants.ts";
+import {
+  AUDITED_REPOS,
+  MAX_RUNS_PER_WORKFLOW,
+  RUN_LIST_PAGE,
+  SAMPLE_EVENT,
+} from "./constants.ts";
 import type { JobObservation } from "./types.ts";
 
 const MS_PER_MIN = 60_000;
 
-export function parseRunIds(json: string): string[] {
+export interface RunMeta {
+  id: string;
+  name: string;
+  runStartedAt: string;
+}
+
+export interface CollectResult {
+  observations: JobObservation[];
+  /** Job-list fetches attempted, for the failure-ratio check. */
+  attempted: number;
+  readFailures: number;
+  /** True once any observation carried a non-zero dagWait — the created_at guard. */
+  sawNeedsWorkflow: boolean;
+}
+
+export function parseRunMeta(json: string): RunMeta[] {
   try {
     const p: unknown = JSON.parse(json);
     if (!isRecord(p) || !Array.isArray(p["workflow_runs"])) return [];
-    const out: string[] = [];
+    const out: RunMeta[] = [];
     for (const r of p["workflow_runs"]) {
-      if (isRecord(r) && typeof r["id"] === "number") out.push(String(r["id"]));
+      if (!isRecord(r)) continue;
+      const id = r["id"];
+      const name = r["name"];
+      const started = r["run_started_at"];
+      if (typeof id !== "number" || typeof name !== "string" || typeof started !== "string") {
+        continue;
+      }
+      out.push({ id: String(id), name, runStartedAt: started });
     }
     return out;
   } catch {
     return [];
   }
+}
+
+/**
+ * Keep at most `MAX_RUNS_PER_WORKFLOW` runs of each workflow.
+ *
+ * Capping per workflow rather than per repo is the whole point: a flat per-repo
+ * cap let the noisiest workflow consume the window, leaving `CI` with 4 of 30
+ * runs and every ratchet threshold above 5 permanently unreachable.
+ */
+export function selectRuns(runs: readonly RunMeta[]): RunMeta[] {
+  const seen = new Map<string, number>();
+  const out: RunMeta[] = [];
+  for (const r of runs) {
+    const n = seen.get(r.name) ?? 0;
+    if (n >= MAX_RUNS_PER_WORKFLOW) continue;
+    seen.set(r.name, n + 1);
+    out.push(r);
+  }
+  return out;
 }
 
 function minutesBetween(later: unknown, earlier: unknown): number | null {
@@ -961,61 +1063,72 @@ export function parseJobObservations(
   }
 }
 
-interface RunMeta {
-  id: string;
-  name: string;
-  runStartedAt: string;
-}
-
-function parseRunMeta(json: string): RunMeta[] {
-  try {
-    const p: unknown = JSON.parse(json);
-    if (!isRecord(p) || !Array.isArray(p["workflow_runs"])) return [];
-    const out: RunMeta[] = [];
-    for (const r of p["workflow_runs"]) {
-      if (!isRecord(r)) continue;
-      const id = r["id"];
-      const name = r["name"];
-      const started = r["run_started_at"];
-      if (typeof id !== "number" || typeof name !== "string" || typeof started !== "string") continue;
-      out.push({ id: String(id), name, runStartedAt: started });
-    }
-    return out;
-  } catch {
-    return [];
-  }
-}
-
-/** All observations for one repo. An unreadable repo yields none — never a finding. */
-export function collectRepo(repo: string): JobObservation[] {
+/**
+ * All observations for one repo. An unreadable repo yields none — never a
+ * finding — but read failures are COUNTED, because a partial sample is more
+ * dangerous than no sample: the survivors are whichever runs happened to
+ * succeed, so their median can be biased and the gate could manufacture a
+ * regression from it.
+ */
+export function collectRepo(repo: string): CollectResult {
+  const empty: CollectResult = {
+    observations: [],
+    attempted: 0,
+    readFailures: 0,
+    sawNeedsWorkflow: false,
+  };
   const res = runGh([
     "gh",
     "api",
-    `repos/nimbus-agent/${repo}/actions/runs?per_page=${MAX_RUNS_PER_REPO}&event=${SAMPLE_EVENT}&status=success`,
+    `repos/nimbus-agent/${repo}/actions/runs?per_page=${RUN_LIST_PAGE}&event=${SAMPLE_EVENT}&status=success`,
   ]);
-  if (!res.ok) return [];
+  if (!res.ok) return empty;
+
   const out: JobObservation[] = [];
-  for (const run of parseRunMeta(res.stdout)) {
+  let attempted = 0;
+  let readFailures = 0;
+  let sawNeedsWorkflow = false;
+
+  for (const run of selectRuns(parseRunMeta(res.stdout))) {
+    attempted++;
     const jobs = runGh([
       "gh",
       "api",
       `repos/nimbus-agent/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
     ]);
-    if (!jobs.ok) continue;
-    out.push(...parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt));
+    if (!jobs.ok) {
+      readFailures++;
+      continue;
+    }
+    const obs = parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt);
+    if (obs.some((o) => o.dagWait > 0)) sawNeedsWorkflow = true;
+    out.push(...obs);
   }
-  return out;
+  return { observations: out, attempted, readFailures, sawNeedsWorkflow };
 }
 
-export function collectAll(repos: readonly string[] = AUDITED_REPOS): JobObservation[] {
-  return repos.flatMap((r) => collectRepo(r));
+export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectResult {
+  const merged: CollectResult = {
+    observations: [],
+    attempted: 0,
+    readFailures: 0,
+    sawNeedsWorkflow: false,
+  };
+  for (const repo of repos) {
+    const r = collectRepo(repo);
+    merged.observations.push(...r.observations);
+    merged.attempted += r.attempted;
+    merged.readFailures += r.readFailures;
+    merged.sawNeedsWorkflow ||= r.sawNeedsWorkflow;
+  }
+  return merged;
 }
 ```
 
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `bun test scripts/ci-latency/collect.test.ts`
-Expected: PASS, 11 tests.
+Expected: PASS, 15 tests.
 
 - [ ] **Step 5: Commit**
 
@@ -1061,6 +1174,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
+import { MAX_READ_FAILURE_RATIO } from "./constants.ts";
 import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
 import { collectAll } from "./collect.ts";
 import { evaluate } from "./evaluate.ts";
@@ -1082,13 +1196,41 @@ if (import.meta.main) {
   const updateMode = argv.includes("--update-baseline");
   const label = "audit:ci-latency";
 
-  const observations = collectAll();
+  const collected = collectAll();
+  const { observations, attempted, readFailures, sawNeedsWorkflow } = collected;
+
   if (observations.length === 0) {
     // Nothing readable at all: no gh, no auth, or a total API outage.
     const outcome = strictSkip(label, strict);
     if (outcome.code === 1) console.error(outcome.message);
     else console.warn(outcome.message);
     process.exit(outcome.code);
+  }
+
+  if (readFailures > 0) {
+    console.warn(`::warning::${label}: ${readFailures}/${attempted} job-list read(s) failed`);
+  }
+  // A partial sample is worse than none: the survivors are whichever runs
+  // happened to succeed, so gating on their median could manufacture a
+  // regression. Degrade to a skip rather than gate on degraded data.
+  if (attempted > 0 && readFailures / attempted > MAX_READ_FAILURE_RATIO) {
+    const outcome = strictSkip(
+      label,
+      strict,
+      `${readFailures}/${attempted} job reads failed — sample too degraded to gate on`,
+    );
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+  // The created_at eligibility assumption is undocumented API behaviour. If it
+  // ever changes, dagWait silently goes to zero everywhere and `queue` quietly
+  // re-absorbs dependency execution — with no error anywhere. Warn, never fail:
+  // an upstream API change is not something a contributor's PR can fix.
+  if (!sawNeedsWorkflow) {
+    console.warn(
+      `::warning::${label}: dagWait is zero for every observation — the created_at eligibility assumption may have changed; queue figures may now include dependency execution`,
+    );
   }
 
   const summaries = summarize(observations);

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review-response.md
@@ -118,8 +118,9 @@ verification") was already the design.
 **But the residual risk is real** and worth closing: `MIN_SAMPLES` is 3, and
 three consecutive hot-cache runs is an entirely plausible window. Two changes:
 
-- Ratcheting **down** requires `MIN_SAMPLES_FOR_RATCHET` (5) samples — more than
-  the 3 needed to *gate*. Lowering a threshold should demand more evidence than
+- Ratcheting **down** requires `MIN_SAMPLES_FOR_RATCHET` samples — more than the
+  3 needed to *gate*. (Shipped as **7**, raised from the 5 proposed here once the
+  per-workflow sampling window made that depth reachable.) Lowering a threshold should demand more evidence than
   enforcing one, since the cost of a wrong lower bound is a permanently red gate.
 - The recorded `spread` travels down with the median, so a newly-lowered
   baseline keeps its noise band and cannot become unachievable by construction.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review-response.md
@@ -1,0 +1,140 @@
+# P4b design review — response
+
+Response to [`2026-07-27-p4b-ci-latency-design-review.md`](./2026-07-27-p4b-ci-latency-design-review.md).
+
+**All three findings are valid.** Two of them changed the design materially, and
+the first one corrected a factual claim in the spec's own headline. Each was
+checked against the live API rather than reasoned about, because two of the three
+have answers that only measurement can give.
+
+| # | Finding | Outcome |
+| --- | --- | --- |
+| 1 | DAG `needs` inflates `queue` | **Fixed** — and it corrected the spec's headline |
+| 2 | 50% tolerance too loose for long jobs | **Fixed**, but by a different mechanism than suggested |
+| 3 | Ratchet can lock in an anomalous fast run | **Partly pre-existing, residual risk fixed** |
+
+---
+
+## 1. DAG dependencies — fixed, and it corrected the headline
+
+**The finding is right.** `queue = started_at − run_started_at` charges a
+dependent job for its dependencies' execution. `ci.yml` uses `needs:` in ten
+places, so this was not hypothetical.
+
+The review's first suggestion — *"investigate if the API has a field indicating
+when the job was actually unlocked"* — is exactly the right question, and the
+answer is **yes**. The jobs API exposes a per-job `created_at`, and it tracks
+**eligibility**, not run start: root jobs are created at `run_started_at`, while
+jobs gated by `needs` are created only once their dependencies finish (verified
+live — some jobs in a sampled run have `created_at` more than a minute after
+`run_started_at`, while all root jobs sit at exactly 0.0).
+
+So the metric becomes, with no documented limitation needed:
+
+```ts
+queue = job.started_at − job.created_at   // pure runner contention, DAG-free
+dagWait = job.created_at − run.run_started_at  // time blocked by `needs`
+```
+
+### This invalidated the spec's central claim
+
+The spec led with *"~80% of the wall-clock is queueing, not computing."* That
+figure came from `started_at − run_started_at`, i.e. the conflated metric this
+finding is about. Recomputed on the same run (30215198584, 73.8 min total):
+
+| | old (conflated) | corrected |
+| --- | --- | --- |
+| max "wait" | 58.7 min | — |
+| max **DAG wait** | — | 33.9 min |
+| max **runner queue** | — | 31.6 min |
+| max exec | 12.3 min | 12.3 min |
+
+DAG wait is **not idle time** — it is dependencies doing real work. Counting it
+as queueing overstated the contention case. Contention is still substantial
+(~30 min, and concentrated almost entirely on **macOS** jobs, which is a
+specific and actionable signal), but the headline is now stated correctly.
+
+The spec's conclusion survives: execution is not the binding constraint, so the
+design of record's proposed levers still miss. But it survives on a smaller
+margin than the original text claimed, and `dagWait` is now a third recorded
+metric — because "this run was slow because the DAG is deep" and "because
+runners were scarce" have completely different fixes.
+
+---
+
+## 2. Tolerance — fixed, but neither suggested mechanism works
+
+**The finding is right**: at 50%, a 15-minute job needs a 7.5-minute regression
+to fail, which is absurd.
+
+Both suggested fixes were tested against measured variance and **both fail**.
+Eleven samples per job on `push`-to-default:
+
+| job | median | observed spread (max−min) |
+| --- | --- | --- |
+| `Static — ubuntu-24.04` | 4.6 min | **0.7 min** |
+| `Unit + Coverage — ubuntu-24.04` | 12.2 min | **2.0 min** |
+| `Unit + Coverage — windows-2025` | 13.2 min | **14.5 min** |
+
+A global cap (the review's `MAX_ABSOLUTE_LIMIT ≈ 3 min`) would make
+`Unit + Coverage — windows-2025` fire constantly: its honest run-to-run spread
+is 14.5 minutes. A lower global tolerance (0.25) has the same problem from the
+other side. **No single global constant fits both a job that varies by 0.7
+minutes and one that varies by 14.5.**
+
+### Resolution: per-key noise band, measured rather than guessed
+
+The collector already gathers N samples per key, so the baseline records the
+job's own noise band alongside its median:
+
+```ts
+allowedIncrease = max(MIN_ABSOLUTE_DELTA, baseline.spread)
+fail when observedMedian > baseline.median + allowedIncrease
+```
+
+where `spread` is the p90−median of the baseline window. This is tight exactly
+where the data is tight (Ubuntu Unit+Coverage: ~+2 min, so a 4-minute regression
+fails — under the old rule it needed 6.1) and lenient exactly where the job is
+genuinely noisy, without a hand-picked constant that is wrong for one of them.
+
+`MIN_ABSOLUTE_DELTA` (1 min) survives as the floor, for the reason it existed:
+ratios and small bands are both meaningless on a 0.3-minute job.
+
+**Added observation, not a gate:** a key whose spread exceeds 50% of its median
+is reported as `unstable`. `Unit + Coverage — windows-2025` qualifies today
+(14.5 / 13.2). A job that unpredictable is a real problem — but it is a
+*flakiness* problem, and failing a PR for it would punish a contributor for
+something their change did not cause. Same rule as `queue`.
+
+---
+
+## 3. Ratchet — premise partly incorrect, residual risk real
+
+**Partly pre-existing.** The spec already ratchets to a *median over the sample
+window*, not to a single run, so "a single atypical speedup" cannot by itself
+move the baseline — the review's own first suggestion ("require multi-sample
+verification") was already the design.
+
+**But the residual risk is real** and worth closing: `MIN_SAMPLES` is 3, and
+three consecutive hot-cache runs is an entirely plausible window. Two changes:
+
+- Ratcheting **down** requires `MIN_SAMPLES_FOR_RATCHET` (5) samples — more than
+  the 3 needed to *gate*. Lowering a threshold should demand more evidence than
+  enforcing one, since the cost of a wrong lower bound is a permanently red gate.
+- The recorded `spread` travels down with the median, so a newly-lowered
+  baseline keeps its noise band and cannot become unachievable by construction.
+
+The review's second suggestion — manual approval for large drops — is
+**deferred**, not rejected. `--update-baseline` is already an explicit human
+action producing a reviewable diff, so a second approval step inside a manual
+command adds ceremony without adding a check. If a bad ratchet is ever observed
+in practice, a `--max-drop` guard is the cheap follow-up.
+
+---
+
+## Not changed
+
+The review's "Strengths" section (exec/queue separation, medians over means,
+sparse-sample skipping) needs no response beyond confirming those are load-
+bearing and unchanged. The exec/queue split in particular is now *more*
+load-bearing, since finding 1 splits it three ways.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design-review.md
@@ -1,0 +1,71 @@
+# P4b — CI latency: design review
+
+## 1. DAG Job Dependencies and Queue Metrics
+
+The current formula for the `queue` metric is defined as:
+
+```text
+queue = job.started_at − run.run_started_at
+```
+
+### Problem
+
+In GitHub Actions workflows, jobs can have logical execution dependencies using the `needs` keyword (e.g., `test` depends on `build`). If `build` takes 5 minutes to run, the `test` job cannot start until minute 5.
+
+Under the proposed definition, `test` will record at least 5 minutes of `queue` time, even if there is zero runner queue contention and the runner starts it immediately. This conflates logical DAG execution time with queue/runner contention, leading to misleading queue observations for all downstream jobs.
+
+### Suggestions
+
+- **API Check**: Investigate if the GitHub API job object has a field indicating when the job was actually unlocked/queued versus when it started (e.g., if there is a `started_at` and `created_at` that shifts for dependent jobs, or a queue time in the workflow run events).
+- **Document/Acknowledge Limitation**: If the GitHub Actions API does not expose the unlocked timestamp, explicitly document that downstream jobs in a DAG will show inflated `queue` times that reflect the execution time of their dependencies.
+- **Alternative (Future)**: Filter or group queue metrics by root jobs (jobs with no `needs` dependencies) to get an accurate representation of actual runner contention.
+
+---
+
+## 2. High Tolerance for Long-Running Jobs
+
+The gate criteria requires:
+
+- `median > baseline × (1 + TOLERANCE)` (where `TOLERANCE = 0.5`) AND
+- `absolute_delta > MIN_ABSOLUTE_DELTA` (where `MIN_ABSOLUTE_DELTA = 1 minute`)
+
+### Problem
+
+While a 50% tolerance is highly effective at preventing noise/flakiness on short jobs, it becomes very loose for long-running jobs:
+
+- A 2-minute job requires a 1-minute increase to fail (reasonable).
+- A 15-minute job requires a **7.5-minute** increase to fail. A 7-minute regression in the main test suite is massive, yet it would bypass this gate.
+
+### Suggestions
+
+- **Sliding or Capped Tolerance**: Implement a tolerance that scales down for longer baselines, or cap the maximum allowed absolute increase. For example:
+
+  ```ts
+  const maxAllowedIncrease = Math.min(baseline * TOLERANCE, MAX_ABSOLUTE_LIMIT); // e.g., MAX_ABSOLUTE_LIMIT = 3 minutes
+  ```
+
+- **Grade-Based Tolerance**: Use a lower `TOLERANCE` (e.g., 0.25) combined with the absolute minimum floor to protect against short-job noise, while keeping a tighter rein on longer jobs.
+
+---
+
+## 3. Ratchet Mechanics & Baseline Drift
+
+The design specifies that the baseline ratchets down immediately in the improving direction:
+> "If a job gets faster, the baseline drops to the new median on the next `--update-baseline`"
+
+### Problem
+
+If a single run experiences an atypical speedup (e.g., due to an exceptionally hot cache, a partial run, or a temporary runner speedup), `--update-baseline` will lock in this abnormally fast execution time as the new baseline. Subsequent normal runs will then fail the gate as regressions.
+
+### Suggestions
+
+- **Require Multi-Sample Verification**: Ensure that the improved baseline is also calculated over a median of multiple recent runs (e.g., `MIN_SAMPLES` runs of the faster version), rather than a single run or a temporary state.
+- **Conservative Ratcheting**: Allow a buffer when ratcheting down, or require manual verification/approval for significant baseline drops to avoid setting an unachievable threshold.
+
+---
+
+## 4. Strengths of the Design
+
+- **Separation of Exec vs. Queue**: Decoupling the two metrics is excellent and prevents PR contributors from being penalized for runner pool congestion.
+- **Median vs. Mean**: Using medians correctly avoids outlier distortion.
+- **Sparse Sampling Handling**: Skipping keys with `< 3` samples prevents false positives due to matrix/conditional job noise.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
@@ -19,23 +19,29 @@ slowest recent `CI` run (30215198584, push, 2026-07-27):
 | --- | --- |
 | Total wall-clock | **73.8 min** |
 | Longest single job **execution** | **12.3 min** |
-| Longest job **wait for a runner** | **58.7 min** |
-| Summed execution across all jobs | 166.5 min |
+| Longest **DAG wait** (blocked by `needs`) | **33.9 min** |
+| Longest **runner queue** (true contention) | **31.6 min** |
 
-**About 80% of the wall-clock is queueing, not computing.** Cache tuning and
-finer path filters shorten execution, which is not the binding constraint.
-Matrix *sharding* would actively make it worse: more jobs contending for the
-same runner pool. The binding constraint is total queued job-minutes against
-available concurrency.
+**Execution is not the binding constraint.** Cache tuning and finer path filters
+shorten execution, which is already only ~12 min on the critical path. Matrix
+*sharding* would actively make it worse: more jobs contending for the same
+runner pool.
 
-Two caveats stated up front, because a single number must not become its own
+Three caveats stated up front, because a single number must not become its own
 hunch:
 
-1. That run happened during a burst with seven PRs in flight, so contention was
+1. **An earlier revision of this spec claimed "~80% of wall-clock is queueing".
+   That was wrong**, and the design review caught it. It measured
+   `started_at − run_started_at`, which charges a job for its *dependencies'
+   execution* as though it were idle waiting. Decomposed correctly, the 73.8 min
+   splits into DAG wait (dependencies doing real work) and genuine runner
+   contention. The conclusion holds — execution is not the constraint — but on a
+   smaller margin than first stated.
+2. Contention is concentrated almost entirely on **macOS** jobs, which is a
+   specific and actionable signal for the eventual tuning slice.
+3. That run happened during a burst with seven PRs in flight, so contention was
    atypically high. One sample cannot separate "slow" from "congested" — which
    is exactly why P4b's gate is *tracking*, not a one-off tune.
-2. Run-level admission queueing is **zero** (`run_started_at == created_at` on
-   every sampled run). The waiting is per-*job*, waiting for a runner.
 
 ## Goal
 
@@ -46,15 +52,25 @@ after measurement, and the numbers above show why that ordering was right.
 
 ## What is measured
 
-Two metrics per job, kept **separate**, because they have different causes and
-different fixes:
+**Three** metrics per job, kept separate, because each has a different cause and
+a different fix:
 
 | Metric | Definition | Cause of a regression |
 | --- | --- | --- |
 | **exec** | `job.completed_at − job.started_at` | slower code, tests, or install |
-| **queue** | `job.started_at − run.run_started_at` | more concurrent jobs, or less concurrency |
+| **queue** | `job.started_at − job.created_at` | more concurrent jobs, or less concurrency |
+| **dagWait** | `job.created_at − run.run_started_at` | a deeper or slower dependency chain |
 
-Conflating them is what produced the misleading "CI takes 74 minutes" reading.
+The third metric and the corrected `queue` definition both come from the design
+review. A job's `created_at` tracks **eligibility**, not run start: root jobs are
+created at `run_started_at`, while a job gated by `needs` is created only once
+its dependencies finish (verified live). So `started_at − created_at` is pure
+runner contention with the DAG excluded, and the DAG cost is recorded separately
+rather than silently folded into "queue".
+
+This matters because the naive definition (`started_at − run_started_at`)
+charges every downstream job for its dependencies' execution, which is what
+produced the incorrect "80% is queueing" headline above.
 
 ### Only `exec` is gated — `queue` is observed
 
@@ -97,21 +113,44 @@ cache states, so mixing them compares unlike things.
 
 ### 2. Runner variance
 
-Even trivial jobs vary **1.3–1.9×** run-to-run (measured over the same window).
-A percentage threshold tight enough to catch a real 20% regression would fire
-constantly on noise, and a flaky gate is an ignored gate.
+Variance is wildly uneven across jobs, so **no single global constant works.**
+Eleven samples per job on `push`-to-default:
 
-**Resolution.** A key fails only when **both** conditions hold:
+| job | median | observed spread (max−min) |
+| --- | --- | --- |
+| `Static — ubuntu-24.04` | 4.6 min | **0.7 min** |
+| `Unit + Coverage — ubuntu-24.04` | 12.2 min | **2.0 min** |
+| `Unit + Coverage — windows-2025` | 13.2 min | **14.5 min** |
 
-- the observed median exceeds `baseline × (1 + TOLERANCE)` (TOLERANCE = 0.5), and
-- the absolute increase exceeds `MIN_ABSOLUTE_DELTA` (1 minute).
+An earlier revision used a flat 50% tolerance. The review correctly flagged it as
+far too loose for long jobs — a 15-minute job would need a 7.5-minute regression
+to fail. But the obvious fixes fail too: a global absolute cap (~3 min) would
+make `Unit + Coverage — windows-2025` fire constantly, since its *honest*
+run-to-run spread is 14.5 minutes.
 
-The absolute floor exists because ratios are meaningless on fast jobs: a
-0.3 min → 0.5 min job is +67% and completely irrelevant. Requiring both means the
-gate fires on "this job got materially slower", not on "this job jittered".
+**Resolution — a per-key noise band, measured rather than guessed.** The
+collector already gathers N samples per key, so the baseline stores the job's own
+spread alongside its median:
 
-Medians, never means: a single 58-minute outlier from a contended run would drag
-a mean past any threshold.
+```ts
+allowedIncrease = max(MIN_ABSOLUTE_DELTA, baseline.spread)   // spread = p90 − median
+fail when observedMedian > baseline.median + allowedIncrease
+```
+
+Tight exactly where the data is tight (Ubuntu Unit+Coverage: ~+2 min, so a
+4-minute regression now fails — under the flat rule it needed 6.1) and lenient
+exactly where the job is genuinely noisy. `MIN_ABSOLUTE_DELTA` (1 min) survives
+as the floor, because both ratios and small bands are meaningless on a
+0.3-minute job.
+
+Medians, never means: a single outlier from a contended run would drag a mean
+past any threshold.
+
+**Instability is observed, not gated.** A key whose spread exceeds 50% of its
+median is reported as `unstable` — `Unit + Coverage — windows-2025` qualifies
+today. A job that unpredictable is a real problem, but it is a *flakiness*
+problem; failing a PR for it would punish a contributor for something their
+change did not cause. Same rule as `queue`.
 
 ## Shape
 
@@ -132,6 +171,16 @@ baseline drops to the new median on the next `--update-baseline`, so a later
 regression from the improved state is caught. It never rises automatically —
 that would let latency drift upward one tolerated step at a time, which is the
 failure mode a ratchet exists to prevent.
+
+**Lowering demands more evidence than enforcing.** Ratcheting *down* requires
+`MIN_SAMPLES_FOR_RATCHET` (5) samples, versus the 3 needed to gate: three
+consecutive hot-cache runs is a plausible window, and the cost of a wrongly-low
+bound is a permanently red gate. The recorded `spread` travels down with the
+median, so a newly-lowered baseline keeps its noise band and cannot become
+unachievable by construction. (A `--max-drop` guard is the cheap follow-up if a
+bad ratchet is ever observed; `--update-baseline` is already an explicit human
+action producing a reviewable diff, so a second in-command approval step would
+add ceremony without adding a check.)
 
 ### Scope: org-wide from the start
 

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
@@ -217,7 +217,23 @@ Unchanged from the rest of the program, and fail-closed in the same direction:
 - A key observed but absent from the baseline → recorded on the next
   `--update-baseline`; never a failure on first sight.
 - Under `--strict`, a run where nothing was evaluable is red (the existing
-  team-reachability rule).
+  team-reachability rule) — except when every read SUCCEEDED and the window
+  simply held no eligible job. That is reported as "no CI activity to measure,
+  not an auth failure", because the default wording blames the token and would
+  send whoever reads the sweep hunting a credential that is fine.
+- **A partial sample is worse than no sample.** Failed job-list reads are
+  counted, not merely tolerated: the survivors of a partial collection are
+  whichever runs happened to succeed, so their median can be biased and the gate
+  could manufacture a regression from it. Past `MAX_READ_FAILURE_RATIO` (25% of
+  attempts) the run **skips gating entirely** rather than gate on degraded data.
+  A failed run-*list* read counts as one attempt and one failure, so losing a
+  whole repo can trip the guard.
+- **The `created_at` eligibility assumption is monitored, not assumed.** If no
+  observation anywhere carries a non-zero `dagWait`, the run warns that the
+  assumption may have changed. It cannot prove this — it observes the signal
+  (zero `dagWait` everywhere), not the cause (whether any sampled workflow
+  declares `needs:`), and it warns rather than fails, because an upstream API
+  change is not something a contributor can fix.
 
 ## Expected outcome on arrival
 
@@ -230,10 +246,19 @@ fixture whose median exceeds baseline past both thresholds must fail, and one
 that exceeds only the ratio or only the absolute delta must pass. The live run
 is the green-after half only.
 
-The first genuinely useful output is the **queue observation**, which already
-has a finding to report: ~80% of wall-clock is contention, which is an
-owner-actionable signal (raise concurrency or cut job count) and the input the
-eventual tuning slice must be justified against.
+The first genuinely useful output is the **queue and DAG-wait observations**,
+which already have a finding to report: on the sampled 73.8-minute run the
+longest runner queue was 31.6 min and the longest DAG wait 33.9 min, against a
+longest single-job execution of 12.3 min. Both are owner-actionable in different
+ways — contention says raise concurrency or cut job count, DAG wait says shorten
+the dependency chain — and together they are the input the eventual tuning slice
+must be justified against.
+
+(An earlier revision summarised this as "~80% of wall-clock is contention".
+That restated the same error the caveat at the top of this document corrects:
+it folds DAG wait, which is dependencies doing real work, into contention. The
+two maxima belong to different jobs and cannot be added, so no single percentage
+describes the run.)
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
@@ -1,0 +1,192 @@
+# P4b — CI latency: measure before tuning
+
+**Status:** design approved 2026-07-27, not yet implemented.
+**Sub-program:** [P4b Latency](../../infrastructure-roadmap.md#sub-programs) — the
+last un-started entry in the program.
+**Program design of record:** `2026-07-23-org-infrastructure-program-design.md`
+(archived; `git show 06c6a144:docs/superpowers/specs/...`).
+
+## The measurement that reframed this
+
+The program's guiding principle #3 is *"reduce latency — but only against
+measurement, never against a hunch."* The design of record then offered a hunch:
+*"Options: cache tuning, matrix sharding, finer path filters."*
+
+The first real measurement says all three would have missed. Breaking down the
+slowest recent `CI` run (30215198584, push, 2026-07-27):
+
+| | |
+| --- | --- |
+| Total wall-clock | **73.8 min** |
+| Longest single job **execution** | **12.3 min** |
+| Longest job **wait for a runner** | **58.7 min** |
+| Summed execution across all jobs | 166.5 min |
+
+**About 80% of the wall-clock is queueing, not computing.** Cache tuning and
+finer path filters shorten execution, which is not the binding constraint.
+Matrix *sharding* would actively make it worse: more jobs contending for the
+same runner pool. The binding constraint is total queued job-minutes against
+available concurrency.
+
+Two caveats stated up front, because a single number must not become its own
+hunch:
+
+1. That run happened during a burst with seven PRs in flight, so contention was
+   atypically high. One sample cannot separate "slow" from "congested" — which
+   is exactly why P4b's gate is *tracking*, not a one-off tune.
+2. Run-level admission queueing is **zero** (`run_started_at == created_at` on
+   every sampled run). The waiting is per-*job*, waiting for a runner.
+
+## Goal
+
+Per the sub-program's stated gate: **per-job wall-clock tracked; regressions
+visible.** This slice delivers the measurement layer and the regression gate. It
+deliberately delivers **no tuning** — the design of record puts optimisation
+after measurement, and the numbers above show why that ordering was right.
+
+## What is measured
+
+Two metrics per job, kept **separate**, because they have different causes and
+different fixes:
+
+| Metric | Definition | Cause of a regression |
+| --- | --- | --- |
+| **exec** | `job.completed_at − job.started_at` | slower code, tests, or install |
+| **queue** | `job.started_at − run.run_started_at` | more concurrent jobs, or less concurrency |
+
+Conflating them is what produced the misleading "CI takes 74 minutes" reading.
+
+### Only `exec` is gated — `queue` is observed
+
+This is the load-bearing decision of the design.
+
+Queue wait is **not a property of the change under test**. It moves with how many
+PRs happen to be open at that moment. A contributor cannot shorten it from their
+PR, so gating it would produce reds nobody can action — the failure mode the
+infrastructure roadmap now names as an operating rule (*a gate must never report
+a permanent mismatch as a fixable failure*), hit four times in the previous
+batch.
+
+So `queue` is reported as an informational line and written to the trend file,
+where a sustained rise is a signal to the **org owner** (raise concurrency, cut
+job count) rather than a red on someone's PR. `exec` is the half that is
+genuinely attributable to a change, and only it can fail the gate.
+
+## The two hard problems
+
+Neither is "call the API". Both were found by measuring.
+
+### 1. Sparse sampling
+
+Across the 30 most recent successful runs there are **145 distinct
+`workflow::job` keys, of which only 21 have ≥3 samples.** Matrix jobs carry the
+OS in their name, and conditional jobs appear only when their path filter fires.
+A baseline built from one sweep would be mostly single-sample noise — and worse,
+the *slow* jobs that actually matter (Unit + Coverage, ~12 min) are among the
+sparse ones.
+
+**Resolution.** A key is gated only when it has at least `MIN_SAMPLES` (3)
+successful observations in the window. Keys below that are reported as
+`insufficient-data` and **skipped, not failed** — the same permanent-vs-transient
+rule as above: too few samples is not a regression, and no amount of retrying
+this run creates more history.
+
+To make samples comparable the window is restricted to a **single event class**:
+`push` on the default branch. PR runs execute a different job set with different
+cache states, so mixing them compares unlike things.
+
+### 2. Runner variance
+
+Even trivial jobs vary **1.3–1.9×** run-to-run (measured over the same window).
+A percentage threshold tight enough to catch a real 20% regression would fire
+constantly on noise, and a flaky gate is an ignored gate.
+
+**Resolution.** A key fails only when **both** conditions hold:
+
+- the observed median exceeds `baseline × (1 + TOLERANCE)` (TOLERANCE = 0.5), and
+- the absolute increase exceeds `MIN_ABSOLUTE_DELTA` (1 minute).
+
+The absolute floor exists because ratios are meaningless on fast jobs: a
+0.3 min → 0.5 min job is +67% and completely irrelevant. Requiring both means the
+gate fires on "this job got materially slower", not on "this job jittered".
+
+Medians, never means: a single 58-minute outlier from a contended run would drag
+a mean past any threshold.
+
+## Shape
+
+Mirrors `audit:coverage-floor`, which the repo already knows:
+
+- `scripts/ci-latency/collect.ts` — impure: walks the Actions API for each repo,
+  returns raw `JobObservation[]`.
+- `scripts/ci-latency/summarize.ts` — **pure**: observations → per-key median
+  exec/queue + sample count.
+- `scripts/ci-latency/baseline.ts` — **pure**: load/serialise the committed
+  baseline, and `computeUpdatedBaseline` (the ratchet).
+- `scripts/ci-latency/check.ts` — the `import.meta.main` shell + `--update-baseline`.
+- `docs/structure-audit/ci-latency-baseline.json` — the committed baseline,
+  alongside the existing `coverage-baseline.json`.
+
+**The ratchet runs in the improving direction.** If a job gets faster, the
+baseline drops to the new median on the next `--update-baseline`, so a later
+regression from the improved state is caught. It never rises automatically —
+that would let latency drift upward one tolerated step at a time, which is the
+failure mode a ratchet exists to prevent.
+
+### Scope: org-wide from the start
+
+All 8 public org repos, keyed `(repo, workflow, job)`. The roadmap's founding
+observation is that controls stop where they were written, and a Nimbus-only
+latency gate would be the fifth instance of exactly that. API cost is bounded:
+one `runs` call per repo plus one `jobs` call per sampled run, capped at
+`MAX_RUNS_PER_REPO` (30), so ~250 requests against a 5000/hr authenticated
+limit.
+
+### Where it runs
+
+A new `ci-latency` job on `org-drift-sweep`, `--strict`, reusing the
+`_gh-audit.ts` contract (fail soft locally, hard in CI, `classifyReadFailure`
+for reads). Not in the preflight fast tier: it needs network and says nothing
+about the diff under test.
+
+## Failure model
+
+Unchanged from the rest of the program, and fail-closed in the same direction:
+
+- Unreadable run or job list → `indeterminate`, never a finding.
+- Fewer than `MIN_SAMPLES` observations → `insufficient-data`, skipped.
+- A key in the baseline that no longer appears (a renamed or deleted job) →
+  reported as `stale-baseline-entry`, **not** a failure; the fix is
+  `--update-baseline`, not a red on an unrelated PR.
+- A key observed but absent from the baseline → recorded on the next
+  `--update-baseline`; never a failure on first sight.
+- Under `--strict`, a run where nothing was evaluable is red (the existing
+  team-reachability rule).
+
+## Expected outcome on arrival
+
+**Green, with an informational queue line.** Unlike the P2 and pin-freshness
+gates there is no pre-existing drift to catch: the baseline is generated from
+current reality, so by construction nothing exceeds it on day one.
+
+That makes the red-proof a **unit-test** obligation rather than a live one: a
+fixture whose median exceeds baseline past both thresholds must fail, and one
+that exceeds only the ratio or only the absolute delta must pass. The live run
+is the green-after half only.
+
+The first genuinely useful output is the **queue observation**, which already
+has a finding to report: ~80% of wall-clock is contention, which is an
+owner-actionable signal (raise concurrency or cut job count) and the input the
+eventual tuning slice must be justified against.
+
+## Out of scope
+
+- **Any tuning.** Cache changes, sharding, path filters, concurrency limits.
+  The design of record puts these after measurement; this slice *is* the
+  measurement. Acting now would be the hunch the principle forbids.
+- **A latency dashboard** — that is P5's remaining half, and it should render
+  this data rather than collect its own.
+- **Per-step timings.** Job granularity is enough to locate a regression; step
+  granularity multiplies API cost and baseline churn for little gain.
+- **Self-hosted runners** as a concurrency fix — a real option, but a
+  cost/security decision for the owner, not a gate.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md
@@ -1,6 +1,6 @@
 # P4b — CI latency: measure before tuning
 
-**Status:** design approved 2026-07-27, not yet implemented.
+**Status:** implemented and shipped 2026-07-27 (`audit:ci-latency`).
 **Sub-program:** [P4b Latency](../../infrastructure-roadmap.md#sub-programs) — the
 last un-started entry in the program.
 **Program design of record:** `2026-07-23-org-infrastructure-program-design.md`
@@ -114,19 +114,20 @@ cache states, so mixing them compares unlike things.
 ### 2. Runner variance
 
 Variance is wildly uneven across jobs, so **no single global constant works.**
-Eleven samples per job on `push`-to-default:
+From the shipped, committed baseline (`docs/structure-audit/ci-latency-baseline.json`,
+regenerated 2026-07-27), `push`-to-default:
 
-| job | median | observed spread (max−min) |
+| job | median | observed spread (p90 − median) |
 | --- | --- | --- |
-| `Static — ubuntu-24.04` | 4.6 min | **0.7 min** |
-| `Unit + Coverage — ubuntu-24.04` | 12.2 min | **2.0 min** |
-| `Unit + Coverage — windows-2025` | 13.2 min | **14.5 min** |
+| `Static — ubuntu-24.04` | 4.6 min | **0.15 min** |
+| `Unit + Coverage — ubuntu-24.04` | 12.2 min | **0.22 min** |
+| `Unit + Coverage — windows-2025` | 13.2 min | **10.48 min** |
 
 An earlier revision used a flat 50% tolerance. The review correctly flagged it as
 far too loose for long jobs — a 15-minute job would need a 7.5-minute regression
 to fail. But the obvious fixes fail too: a global absolute cap (~3 min) would
 make `Unit + Coverage — windows-2025` fire constantly, since its *honest*
-run-to-run spread is 14.5 minutes.
+run-to-run spread is over 10 minutes.
 
 **Resolution — a per-key noise band, measured rather than guessed.** The
 collector already gathers N samples per key, so the baseline stores the job's own
@@ -137,11 +138,11 @@ allowedIncrease = max(MIN_ABSOLUTE_DELTA, baseline.spread)   // spread = p90 −
 fail when observedMedian > baseline.median + allowedIncrease
 ```
 
-Tight exactly where the data is tight (Ubuntu Unit+Coverage: ~+2 min, so a
-4-minute regression now fails — under the flat rule it needed 6.1) and lenient
-exactly where the job is genuinely noisy. `MIN_ABSOLUTE_DELTA` (1 min) survives
-as the floor, because both ratios and small bands are meaningless on a
-0.3-minute job.
+Tight exactly where the data is tight (Ubuntu Unit+Coverage: spread 0.22 min,
+floored to the 1-minute `MIN_ABSOLUTE_DELTA`, so a 4-minute regression now
+fails — under the flat rule it needed 6.1) and lenient exactly where the job is
+genuinely noisy. `MIN_ABSOLUTE_DELTA` (1 min) survives as the floor, because
+both ratios and small bands are meaningless on a 0.3-minute job.
 
 Medians, never means: a single outlier from a contended run would drag a mean
 past any threshold.
@@ -173,23 +174,29 @@ that would let latency drift upward one tolerated step at a time, which is the
 failure mode a ratchet exists to prevent.
 
 **Lowering demands more evidence than enforcing.** Ratcheting *down* requires
-`MIN_SAMPLES_FOR_RATCHET` (5) samples, versus the 3 needed to gate: three
-consecutive hot-cache runs is a plausible window, and the cost of a wrongly-low
-bound is a permanently red gate. The recorded `spread` travels down with the
-median, so a newly-lowered baseline keeps its noise band and cannot become
-unachievable by construction. (A `--max-drop` guard is the cheap follow-up if a
-bad ratchet is ever observed; `--update-baseline` is already an explicit human
-action producing a reviewable diff, so a second in-command approval step would
-add ceremony without adding a check.)
+`MIN_SAMPLES_FOR_RATCHET` (7) samples, versus the 3 needed to gate — 7 is
+affordable only because sampling is capped per WORKFLOW rather than per repo
+(a flat per-repo cap left `CI` with 4 of 30 runs and made every threshold above
+5 unreachable). Lowering demands more evidence than gating because the cost of
+a wrongly-low bound is a permanently red gate. The recorded `spread` travels
+down with the median, so a newly-lowered baseline keeps its noise band and
+cannot become unachievable by construction. (A `--max-drop` guard is the cheap
+follow-up if a bad ratchet is ever observed; `--update-baseline` is already an
+explicit human action producing a reviewable diff, so a second in-command
+approval step would add ceremony without adding a check.)
 
 ### Scope: org-wide from the start
 
-All 8 public org repos, keyed `(repo, workflow, job)`. The roadmap's founding
-observation is that controls stop where they were written, and a Nimbus-only
-latency gate would be the fifth instance of exactly that. API cost is bounded:
-one `runs` call per repo plus one `jobs` call per sampled run, capped at
-`MAX_RUNS_PER_REPO` (30), so ~250 requests against a 5000/hr authenticated
-limit.
+All 9 audited org repos (the 8-repo `sha-pins` matrix in `org-drift-sweep.yml`
+plus `Nimbus` itself, which that matrix excludes only because it is the
+checkout host for the other jobs, not an audit target), keyed
+`(repo, workflow, job)`. The roadmap's founding observation is that controls
+stop where they were written, and a Nimbus-only latency gate would be the
+fifth instance of exactly that. API cost is bounded: one `runs` call per repo
+(`RUN_LIST_PAGE` = 100, the API max in one page) plus one or more `jobs` calls
+per sampled run, capped at `MAX_RUNS_PER_WORKFLOW` (12) runs per workflow —
+capping per workflow rather than per repo is what makes `MIN_SAMPLES_FOR_RATCHET`
+(7) reachable at all.
 
 ### Where it runs
 

--- a/package.json
+++ b/package.json
@@ -163,6 +163,8 @@
     "audit:status-drift": "bun scripts/structure-audit/check-status-drift.ts",
     "audit:action-sha-pins": "bun scripts/structure-audit/check-action-sha-pins.ts",
     "audit:pin-freshness": "bun scripts/structure-audit/check-pin-freshness.ts",
+    "audit:ci-latency": "bun scripts/ci-latency/check.ts",
+    "audit:ci-latency:update-baseline": "bun scripts/ci-latency/check.ts --update-baseline",
     "audit:consumed-by": "bun scripts/structure-audit/check-consumed-by.ts",
     "audit:ruleset-drift": "bun scripts/structure-audit/check-ruleset-drift.ts",
     "audit:org-settings-drift": "bun scripts/structure-audit/check-org-settings-drift.ts",

--- a/scripts/ci-latency/baseline.test.ts
+++ b/scripts/ci-latency/baseline.test.ts
@@ -108,6 +108,38 @@ describe("computeUpdatedBaseline", () => {
     expect(next.entries.has("k")).toBe(false);
   });
 
+  test("a NARROWER spread cannot tighten the gate without ratchet evidence", () => {
+    // The evidence rule guards the EFFECTIVE threshold
+    // (median + max(1, spread)), not the median alone. Here the median is
+    // unchanged but the spread halves, which would drop the threshold from
+    // 10 + 4 = 14 to 10 + 2 = 12 — a real tightening. A median-only check
+    // would let it through, since 10 < 10 is false.
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 4 } }),
+      new Map([["k", sum({ key: "k", execMedian: 10, execSpread: 2, samples: 4 })]]),
+      now,
+    );
+    expect(next.entries.get("k")).toEqual({ execMedian: 10, execSpread: 4 });
+  });
+
+  test("a narrower spread IS accepted once the evidence threshold is met", () => {
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 4 } }),
+      new Map([["k", sum({ key: "k", execMedian: 10, execSpread: 2, samples: 9 })]]),
+      now,
+    );
+    expect(next.entries.get("k")).toEqual({ execMedian: 10, execSpread: 2 });
+  });
+
+  test("a WIDER spread is accepted unconditionally — loosening needs no evidence", () => {
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+      new Map([["k", sum({ key: "k", execMedian: 10, execSpread: 6, samples: 4 })]]),
+      now,
+    );
+    expect(next.entries.get("k")).toEqual({ execMedian: 10, execSpread: 6 });
+  });
+
   test("a sparse key retains its existing entry rather than being deleted", () => {
     // A rarely-run workflow (e.g. Release) can be legitimately observed but
     // sparse in any given window. Deleting it here would let it come back as

--- a/scripts/ci-latency/baseline.test.ts
+++ b/scripts/ci-latency/baseline.test.ts
@@ -108,6 +108,27 @@ describe("computeUpdatedBaseline", () => {
     expect(next.entries.has("k")).toBe(false);
   });
 
+  test("a sparse key retains its existing entry rather than being deleted", () => {
+    // A rarely-run workflow (e.g. Release) can be legitimately observed but
+    // sparse in any given window. Deleting it here would let it come back as
+    // an ungated `new-key` on the next check — a false green.
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 5, execSpread: 1 } }),
+      new Map([["k", sum({ key: "k", samples: 1, execMedian: 99 })]]),
+      now,
+    );
+    expect(next.entries.get("k")).toEqual({ execMedian: 5, execSpread: 1 });
+  });
+
+  test("a sparse key with no existing entry is still not added", () => {
+    const next = computeUpdatedBaseline(
+      base({}),
+      new Map([["k", sum({ key: "k", samples: 1, execMedian: 99 })]]),
+      now,
+    );
+    expect(next.entries.has("k")).toBe(false);
+  });
+
   test("stamps generated_at", () => {
     expect(computeUpdatedBaseline(base({}), new Map(), now).generated_at).toBe(now);
   });

--- a/scripts/ci-latency/baseline.test.ts
+++ b/scripts/ci-latency/baseline.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
+import type { KeySummary, LatencyBaseline } from "./types.ts";
+
+const sum = (over: Partial<KeySummary> & { key: string }): KeySummary => ({
+  samples: 10,
+  execMedian: 10,
+  execSpread: 1,
+  queueMedian: 0,
+  dagWaitMedian: 0,
+  ...over,
+});
+
+const base = (
+  entries: Record<string, { execMedian: number; execSpread: number }>,
+): LatencyBaseline => ({
+  version: 1,
+  generated_at: "2026-07-27T00:00:00Z",
+  entries: new Map(Object.entries(entries)),
+});
+
+describe("parseBaseline / serializeBaseline", () => {
+  test("round-trips entries", () => {
+    const json = serializeBaseline(base({ "a :: b :: c": { execMedian: 5, execSpread: 1 } }));
+    const back = parseBaseline(json);
+    expect(back.entries.get("a :: b :: c")).toEqual({ execMedian: 5, execSpread: 1 });
+  });
+  test("an empty baseline parses to an empty map, not a throw", () => {
+    expect(parseBaseline('{"version":1,"generated_at":"x","entries":{}}').entries.size).toBe(0);
+  });
+  test("malformed JSON throws with a message naming the file's purpose", () => {
+    expect(() => parseBaseline("{nope")).toThrow(/ci-latency baseline/i);
+  });
+  test("serialised output ends with a newline so the file is diff-clean", () => {
+    expect(serializeBaseline(base({})).endsWith("\n")).toBe(true);
+  });
+  test("entries serialise sorted, so a re-run never reorders the diff", () => {
+    const json = serializeBaseline(
+      base({
+        "z :: z :: z": { execMedian: 1, execSpread: 0 },
+        "a :: a :: a": { execMedian: 1, execSpread: 0 },
+      }),
+    );
+    expect(json.indexOf("a :: a :: a")).toBeLessThan(json.indexOf("z :: z :: z"));
+  });
+});
+
+describe("computeUpdatedBaseline", () => {
+  const now = "2026-07-28T00:00:00Z";
+
+  test("records a key seen for the first time", () => {
+    const next = computeUpdatedBaseline(
+      base({}),
+      new Map([["k", sum({ key: "k", execMedian: 8 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(8);
+  });
+
+  test("ratchets DOWN when a job gets faster", () => {
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+      new Map([["k", sum({ key: "k", execMedian: 6, execSpread: 1 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(6);
+    // the band travels with the median, so the lowered bound stays achievable
+    expect(next.entries.get("k")?.execSpread).toBe(1);
+  });
+
+  test("does NOT ratchet down on too few samples", () => {
+    // A few hot-cache runs is a plausible window; lowering demands more evidence
+    // than gating does. 6 < MIN_SAMPLES_FOR_RATCHET (7).
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+      new Map([["k", sum({ key: "k", execMedian: 6, samples: 6 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(10);
+  });
+
+  test("raises the baseline when a job legitimately got slower", () => {
+    // --update-baseline is an explicit human action accepting the new reality.
+    const next = computeUpdatedBaseline(
+      base({ k: { execMedian: 5, execSpread: 1 } }),
+      new Map([["k", sum({ key: "k", execMedian: 9, execSpread: 2 })]]),
+      now,
+    );
+    expect(next.entries.get("k")?.execMedian).toBe(9);
+  });
+
+  test("drops a key that no longer appears (renamed or deleted job)", () => {
+    const next = computeUpdatedBaseline(
+      base({ gone: { execMedian: 5, execSpread: 1 } }),
+      new Map(),
+      now,
+    );
+    expect(next.entries.has("gone")).toBe(false);
+  });
+
+  test("ignores a key with too few samples to be trusted at all", () => {
+    const next = computeUpdatedBaseline(
+      base({}),
+      new Map([["k", sum({ key: "k", samples: 1 })]]),
+      now,
+    );
+    expect(next.entries.has("k")).toBe(false);
+  });
+
+  test("stamps generated_at", () => {
+    expect(computeUpdatedBaseline(base({}), new Map(), now).generated_at).toBe(now);
+  });
+});

--- a/scripts/ci-latency/baseline.ts
+++ b/scripts/ci-latency/baseline.ts
@@ -60,8 +60,16 @@ function round2(n: number): number {
  * because a wrongly-low bound produces a permanently red gate and three
  * consecutive hot-cache runs is a plausible window.
  *
- * A key absent from the current window is dropped: it was renamed or deleted,
- * and keeping it would strand a baseline entry nothing can ever satisfy.
+ * A key OBSERVED but too sparse to trust (`samples < MIN_SAMPLES`) retains its
+ * existing baseline entry rather than being deleted — a quiet-fortnight
+ * regeneration of a rarely-run workflow (e.g. `Release`) must not make that key
+ * vanish and come back as an ungated `new-key`, which is a false green in the
+ * ratchet's own favour. A sparse key with no prior entry has nothing to
+ * preserve and is still omitted.
+ *
+ * A key ABSENT from the current window entirely is dropped: it was renamed or
+ * deleted, and keeping it would strand a baseline entry nothing can ever
+ * satisfy.
  */
 export function computeUpdatedBaseline(
   current: LatencyBaseline,
@@ -70,8 +78,11 @@ export function computeUpdatedBaseline(
 ): LatencyBaseline {
   const entries = new Map<string, BaselineEntry>();
   for (const [key, s] of summaries) {
-    if (s.samples < MIN_SAMPLES) continue;
     const prev = current.entries.get(key);
+    if (s.samples < MIN_SAMPLES) {
+      if (prev) entries.set(key, prev);
+      continue;
+    }
     if (prev && s.execMedian < prev.execMedian && s.samples < MIN_SAMPLES_FOR_RATCHET) {
       entries.set(key, prev);
       continue;

--- a/scripts/ci-latency/baseline.ts
+++ b/scripts/ci-latency/baseline.ts
@@ -7,7 +7,7 @@
  * own tolerance, which is exactly backwards.
  */
 
-import { MIN_SAMPLES, MIN_SAMPLES_FOR_RATCHET } from "./constants.ts";
+import { MIN_ABSOLUTE_DELTA_MIN, MIN_SAMPLES, MIN_SAMPLES_FOR_RATCHET } from "./constants.ts";
 import type { BaselineEntry, KeySummary, LatencyBaseline } from "./types.ts";
 
 interface RawBaseline {
@@ -71,6 +71,16 @@ function round2(n: number): number {
  * deleted, and keeping it would strand a baseline entry nothing can ever
  * satisfy.
  */
+/**
+ * The threshold a key is actually judged against: `evaluate` fails a key when
+ * its median exceeds `execMedian + max(MIN_ABSOLUTE_DELTA_MIN, execSpread)`.
+ * The ratchet must reason about this number rather than the median alone,
+ * because a narrower spread tightens the gate just as a lower median does.
+ */
+function effectiveLimit(e: { execMedian: number; execSpread: number }): number {
+  return e.execMedian + Math.max(MIN_ABSOLUTE_DELTA_MIN, e.execSpread);
+}
+
 export function computeUpdatedBaseline(
   current: LatencyBaseline,
   summaries: ReadonlyMap<string, KeySummary>,
@@ -83,7 +93,13 @@ export function computeUpdatedBaseline(
       if (prev) entries.set(key, prev);
       continue;
     }
-    if (prev && s.execMedian < prev.execMedian && s.samples < MIN_SAMPLES_FOR_RATCHET) {
+    // The evidence rule guards the EFFECTIVE gate threshold, not the median
+    // alone. The threshold a key is judged against is
+    // `execMedian + max(MIN_ABSOLUTE_DELTA_MIN, execSpread)`, so a run with an
+    // unchanged median but a NARROWER spread also tightens the gate — and would
+    // slip through a median-only check. Any decrease in the effective limit
+    // needs `MIN_SAMPLES_FOR_RATCHET` evidence; raising it stays unconditional.
+    if (prev && s.samples < MIN_SAMPLES_FOR_RATCHET && effectiveLimit(s) < effectiveLimit(prev)) {
       entries.set(key, prev);
       continue;
     }

--- a/scripts/ci-latency/baseline.ts
+++ b/scripts/ci-latency/baseline.ts
@@ -1,0 +1,82 @@
+/**
+ * The committed baseline: one `execMedian` + `execSpread` per key.
+ *
+ * The spread is stored, not recomputed at check time, because the gate compares
+ * today's median against the noise band the baseline was TAKEN with. Recomputing
+ * it from the current window would let a job that is becoming erratic widen its
+ * own tolerance, which is exactly backwards.
+ */
+
+import { MIN_SAMPLES, MIN_SAMPLES_FOR_RATCHET } from "./constants.ts";
+import type { BaselineEntry, KeySummary, LatencyBaseline } from "./types.ts";
+
+interface RawBaseline {
+  version?: unknown;
+  generated_at?: unknown;
+  entries?: unknown;
+}
+
+export function parseBaseline(json: string): LatencyBaseline {
+  let raw: RawBaseline;
+  try {
+    raw = JSON.parse(json) as RawBaseline;
+  } catch {
+    throw new Error("ci-latency baseline: file is not valid JSON");
+  }
+  const entries = new Map<string, BaselineEntry>();
+  const rawEntries = raw.entries;
+  if (typeof rawEntries === "object" && rawEntries !== null) {
+    for (const [k, v] of Object.entries(rawEntries as Record<string, unknown>)) {
+      if (typeof v !== "object" || v === null) continue;
+      const e = v as { execMedian?: unknown; execSpread?: unknown };
+      if (typeof e.execMedian !== "number" || typeof e.execSpread !== "number") continue;
+      entries.set(k, { execMedian: e.execMedian, execSpread: e.execSpread });
+    }
+  }
+  return {
+    version: 1,
+    generated_at: typeof raw.generated_at === "string" ? raw.generated_at : "",
+    entries,
+  };
+}
+
+export function serializeBaseline(b: LatencyBaseline): string {
+  // Sorted so a regenerated baseline produces a minimal, reviewable diff.
+  const obj: Record<string, BaselineEntry> = {};
+  for (const k of [...b.entries.keys()].sort()) {
+    const e = b.entries.get(k);
+    if (e) obj[k] = { execMedian: round2(e.execMedian), execSpread: round2(e.execSpread) };
+  }
+  return `${JSON.stringify({ version: 1, generated_at: b.generated_at, entries: obj }, null, 2)}\n`;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * The ratchet. Raising is unconditional (an explicit `--update-baseline` accepts
+ * the new reality); LOWERING requires `MIN_SAMPLES_FOR_RATCHET` observations,
+ * because a wrongly-low bound produces a permanently red gate and three
+ * consecutive hot-cache runs is a plausible window.
+ *
+ * A key absent from the current window is dropped: it was renamed or deleted,
+ * and keeping it would strand a baseline entry nothing can ever satisfy.
+ */
+export function computeUpdatedBaseline(
+  current: LatencyBaseline,
+  summaries: ReadonlyMap<string, KeySummary>,
+  now: string,
+): LatencyBaseline {
+  const entries = new Map<string, BaselineEntry>();
+  for (const [key, s] of summaries) {
+    if (s.samples < MIN_SAMPLES) continue;
+    const prev = current.entries.get(key);
+    if (prev && s.execMedian < prev.execMedian && s.samples < MIN_SAMPLES_FOR_RATCHET) {
+      entries.set(key, prev);
+      continue;
+    }
+    entries.set(key, { execMedian: s.execMedian, execSpread: s.execSpread });
+  }
+  return { version: 1, generated_at: now, entries };
+}

--- a/scripts/ci-latency/check.ts
+++ b/scripts/ci-latency/check.ts
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
 import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
 import { collectAll } from "./collect.ts";
-import { MAX_READ_FAILURE_RATIO } from "./constants.ts";
+import { MAX_READ_FAILURE_RATIO, MIN_REPORTED_QUEUE_MIN } from "./constants.ts";
 import { evaluate } from "./evaluate.ts";
 import { summarize } from "./summarize.ts";
 
@@ -45,7 +45,7 @@ if (import.meta.main) {
   const label = "audit:ci-latency";
 
   const collected = collectAll();
-  const { observations, attempted, readFailures, sawNeedsWorkflow } = collected;
+  const { observations, attempted, readFailures, sawNonZeroDagWait } = collected;
 
   if (observations.length === 0) {
     // Nothing readable at all: no gh, no auth, or a total API outage.
@@ -74,10 +74,12 @@ if (import.meta.main) {
   // The created_at eligibility assumption is undocumented API behaviour. If it
   // ever changes, dagWait silently goes to zero everywhere and `queue` quietly
   // re-absorbs dependency execution — with no error anywhere. Warn, never fail:
-  // an upstream API change is not something a contributor's PR can fix.
-  if (!sawNeedsWorkflow) {
+  // an upstream API change is not something a contributor's PR can fix. A
+  // window sampling only root jobs (no `needs:` anywhere in it) would ALSO show
+  // this, so the wording only reports the observation, not a conclusion.
+  if (!sawNonZeroDagWait) {
     console.warn(
-      `::warning::${label}: dagWait is zero for every observation — the created_at eligibility assumption may have changed; queue figures may now include dependency execution`,
+      `::warning::${label}: no observation carried a non-zero dagWait — if any sampled workflow uses \`needs:\`, the created_at eligibility assumption may have changed`,
     );
   }
 
@@ -97,9 +99,15 @@ if (import.meta.main) {
 
   // Observational lines first, so a red is read in context.
   const worstQueue = [...summaries.values()].sort((a, b) => b.queueMedian - a.queueMedian)[0];
-  if (worstQueue && worstQueue.queueMedian > 1) {
+  if (worstQueue && worstQueue.queueMedian > MIN_REPORTED_QUEUE_MIN) {
     console.warn(
       `::warning::${label}: worst median runner queue ${worstQueue.queueMedian.toFixed(1)}m on "${worstQueue.key}" — contention, not a code regression`,
+    );
+  }
+  const worstDagWait = [...summaries.values()].sort((a, b) => b.dagWaitMedian - a.dagWaitMedian)[0];
+  if (worstDagWait && worstDagWait.dagWaitMedian > MIN_REPORTED_QUEUE_MIN) {
+    console.warn(
+      `::warning::${label}: worst median DAG wait ${worstDagWait.dagWaitMedian.toFixed(1)}m on "${worstDagWait.key}" — dependency chain depth, not a code regression`,
     );
   }
   for (const f of result.findings) {

--- a/scripts/ci-latency/check.ts
+++ b/scripts/ci-latency/check.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:ci-latency — per-job CI execution, runner queue and DAG wait across the
+ * org, gated against a committed baseline.
+ *
+ * ONLY execution regressions fail. Queue wait, DAG wait and job instability are
+ * reported and never gated: none is caused by the change under test, and a gate
+ * that reports a condition nobody can fix is one everybody learns to ignore.
+ *
+ * See docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
+import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
+import { collectAll } from "./collect.ts";
+import { MAX_READ_FAILURE_RATIO } from "./constants.ts";
+import { evaluate } from "./evaluate.ts";
+import { summarize } from "./summarize.ts";
+
+const BASELINE_PATH = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "docs",
+  "structure-audit",
+  "ci-latency-baseline.json",
+);
+
+function readBaselineFile(): string {
+  try {
+    return readFileSync(BASELINE_PATH, "utf8");
+  } catch {
+    return '{"version":1,"generated_at":"","entries":{}}';
+  }
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const strict = isStrict(argv, process.env);
+  const updateMode = argv.includes("--update-baseline");
+  const label = "audit:ci-latency";
+
+  const collected = collectAll();
+  const { observations, attempted, readFailures, sawNeedsWorkflow } = collected;
+
+  if (observations.length === 0) {
+    // Nothing readable at all: no gh, no auth, or a total API outage.
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  if (readFailures > 0) {
+    console.warn(`::warning::${label}: ${readFailures}/${attempted} job-list read(s) failed`);
+  }
+  // A partial sample is worse than none: the survivors are whichever runs
+  // happened to succeed, so gating on their median could manufacture a
+  // regression. Degrade to a skip rather than gate on degraded data.
+  if (attempted > 0 && readFailures / attempted > MAX_READ_FAILURE_RATIO) {
+    const outcome = strictSkip(
+      label,
+      strict,
+      `${readFailures}/${attempted} job reads failed — sample too degraded to gate on`,
+    );
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+  // The created_at eligibility assumption is undocumented API behaviour. If it
+  // ever changes, dagWait silently goes to zero everywhere and `queue` quietly
+  // re-absorbs dependency execution — with no error anywhere. Warn, never fail:
+  // an upstream API change is not something a contributor's PR can fix.
+  if (!sawNeedsWorkflow) {
+    console.warn(
+      `::warning::${label}: dagWait is zero for every observation — the created_at eligibility assumption may have changed; queue figures may now include dependency execution`,
+    );
+  }
+
+  const summaries = summarize(observations);
+  const baseline = parseBaseline(readBaselineFile());
+
+  if (updateMode) {
+    const next = computeUpdatedBaseline(baseline, summaries, new Date().toISOString());
+    writeFileSync(BASELINE_PATH, serializeBaseline(next));
+    console.log(
+      `${label}: baseline updated — ${next.entries.size} key(s) from ${observations.length} observation(s)`,
+    );
+    process.exit(0);
+  }
+
+  const result = evaluate(summaries, baseline);
+
+  // Observational lines first, so a red is read in context.
+  const worstQueue = [...summaries.values()].sort((a, b) => b.queueMedian - a.queueMedian)[0];
+  if (worstQueue && worstQueue.queueMedian > 1) {
+    console.warn(
+      `::warning::${label}: worst median runner queue ${worstQueue.queueMedian.toFixed(1)}m on "${worstQueue.key}" — contention, not a code regression`,
+    );
+  }
+  for (const f of result.findings) {
+    if (f.kind === "regression") continue;
+    console.warn(`::warning::${label}: ${f.key}: ${f.detail} (${f.kind})`);
+  }
+  for (const f of result.regressions) {
+    console.error(`::error::${label}: ${f.key}: ${f.detail}`);
+  }
+
+  if (result.regressions.length > 0) {
+    console.error(`${label}: FAILED — ${result.regressions.length} job(s) slower than baseline`);
+    process.exit(1);
+  }
+  console.log(`${label}: OK (${summaries.size} key(s), ${observations.length} observation(s))`);
+}

--- a/scripts/ci-latency/check.ts
+++ b/scripts/ci-latency/check.ts
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
 import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
 import { collectAll } from "./collect.ts";
-import { MAX_READ_FAILURE_RATIO, MIN_REPORTED_QUEUE_MIN } from "./constants.ts";
+import { MAX_READ_FAILURE_RATIO, MIN_REPORTED_QUEUE_MIN, SAMPLE_EVENT } from "./constants.ts";
 import { evaluate } from "./evaluate.ts";
 import { summarize } from "./summarize.ts";
 
@@ -48,8 +48,20 @@ if (import.meta.main) {
   const { observations, attempted, readFailures, sawNonZeroDagWait } = collected;
 
   if (observations.length === 0) {
-    // Nothing readable at all: no gh, no auth, or a total API outage.
-    const outcome = strictSkip(label, strict);
+    // Two very different causes reach zero observations, and `strictSkip`'s
+    // default message names only one of them ("could not authenticate — the App
+    // token or a required permission is broken"). If every read SUCCEEDED there
+    // is nothing wrong with the token: the window simply held no eligible
+    // successful `push` job. Reporting that as an auth failure would send
+    // whoever reads the sweep hunting a credential that is fine.
+    const readsSucceeded = attempted > 0 && readFailures === 0;
+    const outcome = strictSkip(
+      label,
+      strict,
+      readsSucceeded
+        ? `all ${attempted} read(s) succeeded but no eligible successful ${SAMPLE_EVENT} job was found in the window — no CI activity to measure, not an auth failure`
+        : undefined,
+    );
     if (outcome.code === 1) console.error(outcome.message);
     else console.warn(outcome.message);
     process.exit(outcome.code);

--- a/scripts/ci-latency/collect.test.ts
+++ b/scripts/ci-latency/collect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseJobObservations, parseRunMeta, selectRuns } from "./collect.ts";
+
+describe("parseRunMeta", () => {
+  test("reads id, workflow name and run_started_at", () => {
+    const m = parseRunMeta(
+      '{"workflow_runs":[{"id":1,"name":"CI","run_started_at":"2026-07-27T10:00:00Z"}]}',
+    );
+    expect(m).toEqual([{ id: "1", name: "CI", runStartedAt: "2026-07-27T10:00:00Z" }]);
+  });
+  test("empty on malformed JSON — an unreadable list is never a finding", () => {
+    expect(parseRunMeta("{nope")).toEqual([]);
+  });
+  test("skips entries missing any required field", () => {
+    expect(parseRunMeta('{"workflow_runs":[{"id":"x","name":"CI","run_started_at":"t"}]}')).toEqual(
+      [],
+    );
+  });
+});
+
+describe("selectRuns", () => {
+  const run = (name: string, i: number) => ({ id: `${name}-${i}`, name, runStartedAt: "t" });
+
+  test("caps per WORKFLOW, so a busy workflow cannot starve a quiet one", () => {
+    // The whole reason this exists: a flat per-repo cap gave CI only 4 of 30
+    // runs, which made every ratchet threshold above 5 unreachable.
+    const runs = [
+      ...Array.from({ length: 40 }, (_, i) => run("Scorecard", i)),
+      ...Array.from({ length: 40 }, (_, i) => run("CI", i)),
+    ];
+    const sel = selectRuns(runs);
+    expect(sel.filter((r) => r.name === "CI")).toHaveLength(12);
+    expect(sel.filter((r) => r.name === "Scorecard")).toHaveLength(12);
+  });
+
+  test("keeps every run of a workflow that has fewer than the cap", () => {
+    expect(selectRuns([run("CI", 1), run("CI", 2)])).toHaveLength(2);
+  });
+
+  test("preserves API order (newest first) within a workflow", () => {
+    const sel = selectRuns(Array.from({ length: 20 }, (_, i) => run("CI", i)));
+    expect(sel[0]?.id).toBe("CI-0");
+  });
+});
+
+describe("parseJobObservations", () => {
+  const t0 = "2026-07-27T10:00:00Z";
+  const job = (over: Record<string, unknown> = {}) => ({
+    name: "Unit + Coverage",
+    conclusion: "success",
+    created_at: "2026-07-27T10:00:00Z",
+    started_at: "2026-07-27T10:02:00Z",
+    completed_at: "2026-07-27T10:12:00Z",
+    ...over,
+  });
+  const payload = (jobs: unknown[]) => JSON.stringify({ jobs });
+
+  test("exec is completed minus started", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.exec).toBe(10);
+  });
+
+  test("queue is started minus CREATED — DAG-free contention", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.queue).toBe(2);
+  });
+
+  test("dagWait is created minus run start, so a needs-blocked job is not charged as queue", () => {
+    // A job gated by `needs` is CREATED only once its dependencies finish, so
+    // charging created-minus-run-start to queue would bill it for their work.
+    const [o] = parseJobObservations(
+      payload([
+        job({
+          created_at: "2026-07-27T10:20:00Z",
+          started_at: "2026-07-27T10:21:00Z",
+          completed_at: "2026-07-27T10:26:00Z",
+        }),
+      ]),
+      "Nimbus",
+      "CI",
+      t0,
+    );
+    expect(o?.dagWait).toBe(20);
+    expect(o?.queue).toBe(1);
+    expect(o?.exec).toBe(5);
+  });
+
+  test("a root job has zero dagWait", () => {
+    const [o] = parseJobObservations(payload([job()]), "Nimbus", "CI", t0);
+    expect(o?.dagWait).toBe(0);
+  });
+
+  test("skips jobs that did not succeed — a failed job's duration is meaningless", () => {
+    expect(
+      parseJobObservations(payload([job({ conclusion: "failure" })]), "Nimbus", "CI", t0),
+    ).toEqual([]);
+  });
+
+  test("skips jobs with a missing timestamp rather than emitting NaN", () => {
+    expect(
+      parseJobObservations(payload([job({ completed_at: null })]), "Nimbus", "CI", t0),
+    ).toEqual([]);
+  });
+
+  test("empty on malformed JSON", () => {
+    expect(parseJobObservations("{nope", "Nimbus", "CI", t0)).toEqual([]);
+  });
+
+  test("carries repo and workflow through onto every observation", () => {
+    const [o] = parseJobObservations(payload([job()]), "nimbus-sdk", "Release", t0);
+    expect(o?.repo).toBe("nimbus-sdk");
+    expect(o?.workflow).toBe("Release");
+  });
+});

--- a/scripts/ci-latency/collect.test.ts
+++ b/scripts/ci-latency/collect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseJobObservations, parseRunMeta, selectRuns } from "./collect.ts";
+import { parseJobObservations, parseJobsTotalCount, parseRunMeta, selectRuns } from "./collect.ts";
 
 describe("parseRunMeta", () => {
   test("reads id, workflow name and run_started_at", () => {
@@ -111,5 +111,44 @@ describe("parseJobObservations", () => {
     const [o] = parseJobObservations(payload([job()]), "nimbus-sdk", "Release", t0);
     expect(o?.repo).toBe("nimbus-sdk");
     expect(o?.workflow).toBe("Release");
+  });
+
+  test("clamps a negative exec (clock skew) to zero, same as queue and dagWait", () => {
+    const [o] = parseJobObservations(
+      payload([job({ started_at: "2026-07-27T10:12:00Z", completed_at: "2026-07-27T10:02:00Z" })]),
+      "Nimbus",
+      "CI",
+      t0,
+    );
+    expect(o?.exec).toBe(0);
+  });
+});
+
+describe("parseJobsTotalCount", () => {
+  test("reads total_count off a jobs page", () => {
+    expect(parseJobsTotalCount('{"total_count":105,"jobs":[]}')).toBe(105);
+  });
+
+  test("null on malformed JSON — never mistaken for a real zero", () => {
+    expect(parseJobsTotalCount("{nope")).toBeNull();
+  });
+
+  test("null when total_count is missing or the wrong type", () => {
+    expect(parseJobsTotalCount('{"jobs":[]}')).toBeNull();
+    expect(parseJobsTotalCount('{"total_count":"105","jobs":[]}')).toBeNull();
+  });
+
+  test("a page reporting more jobs than it returned is the collector's paging trigger", () => {
+    // Confirmed live: Nimbus run 30232465196 reports total_count 105 but a
+    // single per_page=100 page returns only 100 — the collector must page
+    // again whenever total_count exceeds what came back on the page.
+    const page = JSON.stringify({
+      total_count: 105,
+      jobs: Array.from({ length: 100 }, () => ({ conclusion: "success" })),
+    });
+    const total = parseJobsTotalCount(page);
+    const returned = (JSON.parse(page) as { jobs: unknown[] }).jobs.length;
+    expect(total).toBe(105);
+    expect(returned).toBeLessThan(total as number);
   });
 });

--- a/scripts/ci-latency/collect.ts
+++ b/scripts/ci-latency/collect.ts
@@ -1,0 +1,171 @@
+/**
+ * The only impure module: walks the Actions API and returns raw observations.
+ * Every parser is exported and pure so the whole shape is table-tested offline.
+ *
+ * Restricted to `push` on the default branch: PR runs execute a different job
+ * set against different cache state, so mixing them compares unlike things.
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { AUDITED_REPOS, MAX_RUNS_PER_WORKFLOW, RUN_LIST_PAGE, SAMPLE_EVENT } from "./constants.ts";
+import type { JobObservation } from "./types.ts";
+
+const MS_PER_MIN = 60_000;
+
+export interface RunMeta {
+  id: string;
+  name: string;
+  runStartedAt: string;
+}
+
+export interface CollectResult {
+  observations: JobObservation[];
+  /** Job-list fetches attempted, for the failure-ratio check. */
+  attempted: number;
+  readFailures: number;
+  /** True once any observation carried a non-zero dagWait — the created_at guard. */
+  sawNeedsWorkflow: boolean;
+}
+
+export function parseRunMeta(json: string): RunMeta[] {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["workflow_runs"])) return [];
+    const out: RunMeta[] = [];
+    for (const r of p["workflow_runs"]) {
+      if (!isRecord(r)) continue;
+      const id = r["id"];
+      const name = r["name"];
+      const started = r["run_started_at"];
+      if (typeof id !== "number" || typeof name !== "string" || typeof started !== "string") {
+        continue;
+      }
+      out.push({ id: String(id), name, runStartedAt: started });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Keep at most `MAX_RUNS_PER_WORKFLOW` runs of each workflow.
+ *
+ * Capping per workflow rather than per repo is the whole point: a flat per-repo
+ * cap let the noisiest workflow consume the window, leaving `CI` with 4 of 30
+ * runs and every ratchet threshold above 5 permanently unreachable.
+ */
+export function selectRuns(runs: readonly RunMeta[]): RunMeta[] {
+  const seen = new Map<string, number>();
+  const out: RunMeta[] = [];
+  for (const r of runs) {
+    const n = seen.get(r.name) ?? 0;
+    if (n >= MAX_RUNS_PER_WORKFLOW) continue;
+    seen.set(r.name, n + 1);
+    out.push(r);
+  }
+  return out;
+}
+
+function minutesBetween(later: unknown, earlier: unknown): number | null {
+  if (typeof later !== "string" || typeof earlier !== "string") return null;
+  const a = new Date(later).getTime();
+  const b = new Date(earlier).getTime();
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return (a - b) / MS_PER_MIN;
+}
+
+export function parseJobObservations(
+  json: string,
+  repo: string,
+  workflow: string,
+  runStartedAt: string,
+): JobObservation[] {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["jobs"])) return [];
+    const out: JobObservation[] = [];
+    for (const j of p["jobs"]) {
+      if (!isRecord(j)) continue;
+      if (j["conclusion"] !== "success") continue;
+      const name = j["name"];
+      if (typeof name !== "string") continue;
+      const exec = minutesBetween(j["completed_at"], j["started_at"]);
+      const queue = minutesBetween(j["started_at"], j["created_at"]);
+      const dagWait = minutesBetween(j["created_at"], runStartedAt);
+      if (exec === null || queue === null || dagWait === null) continue;
+      out.push({
+        repo,
+        workflow,
+        job: name,
+        exec,
+        queue: Math.max(0, queue),
+        dagWait: Math.max(0, dagWait),
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * All observations for one repo. An unreadable repo yields none — never a
+ * finding — but read failures are COUNTED, because a partial sample is more
+ * dangerous than no sample: the survivors are whichever runs happened to
+ * succeed, so their median can be biased and the gate could manufacture a
+ * regression from it.
+ */
+export function collectRepo(repo: string): CollectResult {
+  const empty: CollectResult = {
+    observations: [],
+    attempted: 0,
+    readFailures: 0,
+    sawNeedsWorkflow: false,
+  };
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/nimbus-agent/${repo}/actions/runs?per_page=${RUN_LIST_PAGE}&event=${SAMPLE_EVENT}&status=success`,
+  ]);
+  if (!res.ok) return empty;
+
+  const out: JobObservation[] = [];
+  let attempted = 0;
+  let readFailures = 0;
+  let sawNeedsWorkflow = false;
+
+  for (const run of selectRuns(parseRunMeta(res.stdout))) {
+    attempted++;
+    const jobs = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+    ]);
+    if (!jobs.ok) {
+      readFailures++;
+      continue;
+    }
+    const obs = parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt);
+    if (obs.some((o) => o.dagWait > 0)) sawNeedsWorkflow = true;
+    out.push(...obs);
+  }
+  return { observations: out, attempted, readFailures, sawNeedsWorkflow };
+}
+
+export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectResult {
+  const merged: CollectResult = {
+    observations: [],
+    attempted: 0,
+    readFailures: 0,
+    sawNeedsWorkflow: false,
+  };
+  for (const repo of repos) {
+    const r = collectRepo(repo);
+    merged.observations.push(...r.observations);
+    merged.attempted += r.attempted;
+    merged.readFailures += r.readFailures;
+    merged.sawNeedsWorkflow ||= r.sawNeedsWorkflow;
+  }
+  return merged;
+}

--- a/scripts/ci-latency/collect.ts
+++ b/scripts/ci-latency/collect.ts
@@ -7,7 +7,13 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { AUDITED_REPOS, MAX_RUNS_PER_WORKFLOW, RUN_LIST_PAGE, SAMPLE_EVENT } from "./constants.ts";
+import {
+  AUDITED_REPOS,
+  MAX_JOB_PAGES,
+  MAX_RUNS_PER_WORKFLOW,
+  RUN_LIST_PAGE,
+  SAMPLE_EVENT,
+} from "./constants.ts";
 import type { JobObservation } from "./types.ts";
 
 const MS_PER_MIN = 60_000;
@@ -24,7 +30,7 @@ export interface CollectResult {
   attempted: number;
   readFailures: number;
   /** True once any observation carried a non-zero dagWait — the created_at guard. */
-  sawNeedsWorkflow: boolean;
+  sawNonZeroDagWait: boolean;
 }
 
 export function parseRunMeta(json: string): RunMeta[] {
@@ -98,7 +104,7 @@ export function parseJobObservations(
         repo,
         workflow,
         job: name,
-        exec,
+        exec: Math.max(0, exec),
         queue: Math.max(0, queue),
         dagWait: Math.max(0, dagWait),
       });
@@ -110,6 +116,34 @@ export function parseJobObservations(
 }
 
 /**
+ * Pulls `total_count` off a `jobs` page. `per_page=100` truncates silently —
+ * confirmed live on a 105-job run — and this is how the collector knows more
+ * pages remain. Returns `null` rather than 0 on malformed JSON so a paging
+ * loop can tell "nothing there" from "unreadable" and refuse to page forever.
+ */
+export function parseJobsTotalCount(json: string): number | null {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p)) return null;
+    const tc = p["total_count"];
+    return typeof tc === "number" ? tc : null;
+  } catch {
+    return null;
+  }
+}
+
+/** How many `jobs` entries one page actually returned, success or not. */
+function parseJobsPageCount(json: string): number {
+  try {
+    const p: unknown = JSON.parse(json);
+    if (!isRecord(p) || !Array.isArray(p["jobs"])) return 0;
+    return p["jobs"].length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * All observations for one repo. An unreadable repo yields none — never a
  * finding — but read failures are COUNTED, because a partial sample is more
  * dangerous than no sample: the survivors are whichever runs happened to
@@ -117,40 +151,61 @@ export function parseJobObservations(
  * regression from it.
  */
 export function collectRepo(repo: string): CollectResult {
-  const empty: CollectResult = {
-    observations: [],
-    attempted: 0,
-    readFailures: 0,
-    sawNeedsWorkflow: false,
-  };
   const res = runGh([
     "gh",
     "api",
     `repos/nimbus-agent/${repo}/actions/runs?per_page=${RUN_LIST_PAGE}&event=${SAMPLE_EVENT}&status=success`,
   ]);
-  if (!res.ok) return empty;
+  if (!res.ok) {
+    // A failed run-LIST read must still count against the degradation guard:
+    // losing a whole repo silently is worse than losing one run within it.
+    return { observations: [], attempted: 1, readFailures: 1, sawNonZeroDagWait: false };
+  }
 
   const out: JobObservation[] = [];
   let attempted = 0;
   let readFailures = 0;
-  let sawNeedsWorkflow = false;
+  let sawNonZeroDagWait = false;
 
   for (const run of selectRuns(parseRunMeta(res.stdout))) {
     attempted++;
-    const jobs = runGh([
+    const firstPage = runGh([
       "gh",
       "api",
       `repos/nimbus-agent/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
     ]);
-    if (!jobs.ok) {
+    if (!firstPage.ok) {
       readFailures++;
       continue;
     }
-    const obs = parseJobObservations(jobs.stdout, repo, run.name, run.runStartedAt);
-    if (obs.some((o) => o.dagWait > 0)) sawNeedsWorkflow = true;
+    const obs = parseJobObservations(firstPage.stdout, repo, run.name, run.runStartedAt);
+    if (obs.some((o) => o.dagWait > 0)) sawNonZeroDagWait = true;
     out.push(...obs);
+
+    // Page through until every job is retrieved. Bounded by MAX_JOB_PAGES so a
+    // bad/wildly-wrong total_count can never spin the loop forever.
+    const total = parseJobsTotalCount(firstPage.stdout);
+    let fetched = parseJobsPageCount(firstPage.stdout);
+    let page = 1;
+    while (total !== null && fetched < total && page < MAX_JOB_PAGES) {
+      page++;
+      attempted++;
+      const nextPage = runGh([
+        "gh",
+        "api",
+        `repos/nimbus-agent/${repo}/actions/runs/${run.id}/jobs?per_page=100&page=${page}`,
+      ]);
+      if (!nextPage.ok) {
+        readFailures++;
+        break;
+      }
+      const more = parseJobObservations(nextPage.stdout, repo, run.name, run.runStartedAt);
+      if (more.some((o) => o.dagWait > 0)) sawNonZeroDagWait = true;
+      out.push(...more);
+      fetched += parseJobsPageCount(nextPage.stdout);
+    }
   }
-  return { observations: out, attempted, readFailures, sawNeedsWorkflow };
+  return { observations: out, attempted, readFailures, sawNonZeroDagWait };
 }
 
 export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectResult {
@@ -158,14 +213,14 @@ export function collectAll(repos: readonly string[] = AUDITED_REPOS): CollectRes
     observations: [],
     attempted: 0,
     readFailures: 0,
-    sawNeedsWorkflow: false,
+    sawNonZeroDagWait: false,
   };
   for (const repo of repos) {
     const r = collectRepo(repo);
     merged.observations.push(...r.observations);
     merged.attempted += r.attempted;
     merged.readFailures += r.readFailures;
-    merged.sawNeedsWorkflow ||= r.sawNeedsWorkflow;
+    merged.sawNonZeroDagWait ||= r.sawNonZeroDagWait;
   }
   return merged;
 }

--- a/scripts/ci-latency/constants.ts
+++ b/scripts/ci-latency/constants.ts
@@ -34,6 +34,14 @@ export const RUN_LIST_PAGE = 100;
 export const MAX_RUNS_PER_WORKFLOW = 12;
 
 /**
+ * Caps how many `jobs` pages a single run's job list can page through. A run
+ * with >100 jobs (a wide matrix) needs more than one page to be fully counted,
+ * but a bad or wildly wrong `total_count` from the API must not spin the
+ * collector forever — 5 pages (500 jobs) is far beyond any real run.
+ */
+export const MAX_JOB_PAGES = 5;
+
+/**
  * Past this share of failed job reads the sample is degraded: the survivors are
  * whichever runs happened to succeed, so their median could be biased and the
  * gate could manufacture a regression. Skip gating instead.
@@ -43,7 +51,15 @@ export const MAX_READ_FAILURE_RATIO = 0.25;
 /** PR runs execute a different job set with different cache state. */
 export const SAMPLE_EVENT = "push";
 
-/** The org repos audited, mirroring the sha-pins matrix in org-drift-sweep.yml. */
+/** Below this many minutes a worst-observed line is not worth printing. */
+export const MIN_REPORTED_QUEUE_MIN = 1;
+
+/**
+ * The org repos audited: the 8-repo `sha-pins` matrix in `org-drift-sweep.yml`
+ * plus `Nimbus` itself — that matrix excludes Nimbus because it is the checkout
+ * host for the other jobs, not an audit target, but a latency gate that skipped
+ * the repo it exists to protect would miss most of what motivates it.
+ */
 export const AUDITED_REPOS: readonly string[] = [
   "Nimbus",
   "nimbus-client",

--- a/scripts/ci-latency/constants.ts
+++ b/scripts/ci-latency/constants.ts
@@ -1,0 +1,57 @@
+/**
+ * Tuning constants for `audit:ci-latency`, kept in one module so the tests and
+ * the gate can never drift apart. Every value here was chosen against measured
+ * data — see docs/superpowers/specs/2026-07-27-p4b-ci-latency-design.md.
+ */
+
+/** Below this many samples a key is `insufficient-data`: skipped, never failed. */
+export const MIN_SAMPLES = 3;
+
+/**
+ * Lowering a baseline needs MORE evidence than enforcing one: a few consecutive
+ * hot-cache runs is a plausible window, and the cost of a wrongly-low bound is a
+ * permanently red gate.
+ *
+ * 7 is affordable only because sampling is capped per WORKFLOW rather than per
+ * repo — under the old per-repo window a stable CI job could reach at most 4
+ * samples, which made every threshold above 5 unreachable and the ratchet dead.
+ */
+export const MIN_SAMPLES_FOR_RATCHET = 7;
+
+/** Ratios and small noise bands are both meaningless on a sub-minute job. */
+export const MIN_ABSOLUTE_DELTA_MIN = 1;
+
+/** spread > this × median ⇒ reported `unstable` (observed, never failed). */
+export const UNSTABLE_SPREAD_RATIO = 0.5;
+
+/** One cheap list request at the API maximum. */
+export const RUN_LIST_PAGE = 100;
+
+/**
+ * Caps the EXPENSIVE per-run job fetches, and does so per workflow so a busy
+ * workflow cannot starve a quiet one out of the sample.
+ */
+export const MAX_RUNS_PER_WORKFLOW = 12;
+
+/**
+ * Past this share of failed job reads the sample is degraded: the survivors are
+ * whichever runs happened to succeed, so their median could be biased and the
+ * gate could manufacture a regression. Skip gating instead.
+ */
+export const MAX_READ_FAILURE_RATIO = 0.25;
+
+/** PR runs execute a different job set with different cache state. */
+export const SAMPLE_EVENT = "push";
+
+/** The org repos audited, mirroring the sha-pins matrix in org-drift-sweep.yml. */
+export const AUDITED_REPOS: readonly string[] = [
+  "Nimbus",
+  "nimbus-client",
+  "nimbus-sdk",
+  "nimbus-vscode",
+  "nimbus-web-clipper",
+  ".github",
+  "linux-repo",
+  "homebrew-tap",
+  "scoop-bucket",
+];

--- a/scripts/ci-latency/evaluate.test.ts
+++ b/scripts/ci-latency/evaluate.test.ts
@@ -89,6 +89,31 @@ describe("evaluate", () => {
     expect(r.regressions).toEqual([]);
   });
 
+  test("an unstable key CAN still regress — the label is not an exemption", () => {
+    // Deliberate, and the opposite rule would be worse: exempting unstable keys
+    // would hand permanent immunity to the slowest jobs in the repo (the real
+    // `Unit + Coverage — windows-2025` carries a ~10min band and qualifies as
+    // unstable). Because the band is its own historical spread, reaching a
+    // regression means it got MORE than ~10 minutes slower — exactly when it
+    // should fail. Unstable: 20 > 0.5 × 30. Regression: 30 > 13.2 + max(1, 10.5).
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 30, execSpread: 20 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 10.5 } }),
+    );
+    expect(kinds(r, "k")).toContain("unstable");
+    expect(r.regressions.map((f) => f.key)).toEqual(["k"]);
+  });
+
+  test("an unstable key inside its wide band does NOT regress", () => {
+    // The contrast case: +8min on a 10.5min band is normal noise for this job.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 21, execSpread: 12 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 10.5 } }),
+    );
+    expect(kinds(r, "k")).toContain("unstable");
+    expect(r.regressions).toEqual([]);
+  });
+
   test("a stable job is not reported unstable", () => {
     const r = evaluate(
       new Map([["k", sum({ key: "k", execMedian: 12, execSpread: 1 })]]),

--- a/scripts/ci-latency/evaluate.test.ts
+++ b/scripts/ci-latency/evaluate.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluate } from "./evaluate.ts";
+import type { KeySummary, LatencyBaseline } from "./types.ts";
+
+const sum = (over: Partial<KeySummary> & { key: string }): KeySummary => ({
+  samples: 10,
+  execMedian: 10,
+  execSpread: 1,
+  queueMedian: 0,
+  dagWaitMedian: 0,
+  ...over,
+});
+const base = (e: Record<string, { execMedian: number; execSpread: number }>): LatencyBaseline => ({
+  version: 1,
+  generated_at: "x",
+  entries: new Map(Object.entries(e)),
+});
+const kinds = (r: { findings: { key: string; kind: string }[] }, key: string) =>
+  r.findings.filter((f) => f.key === key).map((f) => f.kind);
+
+describe("evaluate", () => {
+  test("a job within its noise band is not a finding", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 10.5 })]]),
+      base({ k: { execMedian: 10, execSpread: 2 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a regression beyond the band fails", () => {
+    // Ubuntu Unit+Coverage: median 12.2, spread 2.0 — a 4-minute regression must
+    // fail. Under a flat 50% tolerance it needed 6.1 and would have passed.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 16.2 })]]),
+      base({ k: { execMedian: 12.2, execSpread: 2 } }),
+    );
+    expect(r.regressions.map((f) => f.key)).toEqual(["k"]);
+    expect(r.regressions[0]?.detail).toContain("12.2");
+  });
+
+  test("a noisy job gets its own wide band, not a global constant", () => {
+    // Windows Unit+Coverage: median 13.2, spread 14.5. A 10-minute swing is this
+    // job's normal behaviour and must NOT fail; a global 3-minute cap would.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 23.2 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 14.5 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("MIN_ABSOLUTE_DELTA floors the band on a sub-minute job", () => {
+    // 0.3 -> 0.5 is +67% but irrelevant; the 1-minute floor absorbs it.
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 0.5 })]]),
+      base({ k: { execMedian: 0.3, execSpread: 0 } }),
+    );
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("too few samples is insufficient-data, never a regression", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 99, samples: 2 })]]),
+      base({ k: { execMedian: 1, execSpread: 0 } }),
+    );
+    expect(kinds(r, "k")).toContain("insufficient-data");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a key absent from the baseline is new-key, never a regression", () => {
+    const r = evaluate(new Map([["k", sum({ key: "k" })]]), base({}));
+    expect(kinds(r, "k")).toContain("new-key");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a baseline entry with no observations is stale, never a regression", () => {
+    const r = evaluate(new Map(), base({ gone: { execMedian: 5, execSpread: 1 } }));
+    expect(kinds(r, "gone")).toContain("stale-baseline-entry");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("an erratic job is reported unstable but never failed for it", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 13.2, execSpread: 14.5 })]]),
+      base({ k: { execMedian: 13.2, execSpread: 14.5 } }),
+    );
+    expect(kinds(r, "k")).toContain("unstable");
+    expect(r.regressions).toEqual([]);
+  });
+
+  test("a stable job is not reported unstable", () => {
+    const r = evaluate(
+      new Map([["k", sum({ key: "k", execMedian: 12, execSpread: 1 })]]),
+      base({ k: { execMedian: 12, execSpread: 1 } }),
+    );
+    expect(kinds(r, "k")).not.toContain("unstable");
+  });
+});

--- a/scripts/ci-latency/evaluate.test.ts
+++ b/scripts/ci-latency/evaluate.test.ts
@@ -29,11 +29,12 @@ describe("evaluate", () => {
   });
 
   test("a regression beyond the band fails", () => {
-    // Ubuntu Unit+Coverage: median 12.2, spread 2.0 — a 4-minute regression must
-    // fail. Under a flat 50% tolerance it needed 6.1 and would have passed.
+    // Ubuntu Unit+Coverage: median 12.2, spread 0.22 (below the 1-minute
+    // MIN_ABSOLUTE_DELTA floor) — a 4-minute regression must fail. Under a flat
+    // 50% tolerance it needed 6.1 and would have passed.
     const r = evaluate(
       new Map([["k", sum({ key: "k", execMedian: 16.2 })]]),
-      base({ k: { execMedian: 12.2, execSpread: 2 } }),
+      base({ k: { execMedian: 12.2, execSpread: 0.22 } }),
     );
     expect(r.regressions.map((f) => f.key)).toEqual(["k"]);
     expect(r.regressions[0]?.detail).toContain("12.2");

--- a/scripts/ci-latency/evaluate.ts
+++ b/scripts/ci-latency/evaluate.ts
@@ -1,11 +1,21 @@
 /**
- * The gate decision. ONLY `regression` can fail the run.
+ * The gate decision. ONLY a `regression` finding can fail the run.
  *
- * `queue`, `dagWait` and `unstable` are deliberately observation-only: none is
- * caused by the change under test. Queue wait moves with how many PRs happen to
- * be open, and a flaky job is flaky regardless of the diff — failing a
- * contributor for either would report a condition they cannot fix, which the
- * infrastructure roadmap names as the way a gate becomes one everybody ignores.
+ * `insufficient-data`, `new-key`, `stale-baseline-entry` and `unstable` are
+ * reported and never fail, and `queue`/`dagWait` are surfaced by the shell
+ * rather than classified here at all. None of them is caused by the change
+ * under test — queue wait moves with how many runs are in flight — and the
+ * infrastructure roadmap names reporting an unfixable condition as the way a
+ * gate becomes one everybody ignores.
+ *
+ * `unstable` is a LABEL on a key, NOT an exemption — a deliberate choice, since
+ * the alternative is worse. An unstable key can still produce a `regression`,
+ * because its allowed band is already its own (wide) historical spread: the
+ * noisiest job in this repo carries a ~10-minute band, so it can only fail by
+ * getting more than ten minutes slower, which is precisely when it should. The
+ * opposite rule — exempting unstable keys — would hand permanent immunity to
+ * the slowest, most-worth-watching jobs, which is how a latency gate ends up
+ * measuring only the jobs that never mattered. `evaluate.test.ts` pins this.
  */
 
 import { MIN_ABSOLUTE_DELTA_MIN, MIN_SAMPLES, UNSTABLE_SPREAD_RATIO } from "./constants.ts";

--- a/scripts/ci-latency/evaluate.ts
+++ b/scripts/ci-latency/evaluate.ts
@@ -1,0 +1,71 @@
+/**
+ * The gate decision. ONLY `regression` can fail the run.
+ *
+ * `queue`, `dagWait` and `unstable` are deliberately observation-only: none is
+ * caused by the change under test. Queue wait moves with how many PRs happen to
+ * be open, and a flaky job is flaky regardless of the diff — failing a
+ * contributor for either would report a condition they cannot fix, which the
+ * infrastructure roadmap names as the way a gate becomes one everybody ignores.
+ */
+
+import { MIN_ABSOLUTE_DELTA_MIN, MIN_SAMPLES, UNSTABLE_SPREAD_RATIO } from "./constants.ts";
+import type { CheckResult, Finding, KeySummary, LatencyBaseline } from "./types.ts";
+
+const r1 = (n: number): string => n.toFixed(1);
+
+export function evaluate(
+  summaries: ReadonlyMap<string, KeySummary>,
+  baseline: LatencyBaseline,
+): CheckResult {
+  const findings: Finding[] = [];
+
+  for (const [key, s] of summaries) {
+    if (s.execSpread > s.execMedian * UNSTABLE_SPREAD_RATIO && s.execMedian > 0) {
+      findings.push({
+        key,
+        kind: "unstable",
+        detail: `spread ${r1(s.execSpread)}m on a ${r1(s.execMedian)}m median — flaky, not a regression`,
+      });
+    }
+
+    if (s.samples < MIN_SAMPLES) {
+      findings.push({
+        key,
+        kind: "insufficient-data",
+        detail: `${s.samples} sample(s), need ${MIN_SAMPLES} — skipped, and no retry creates more history`,
+      });
+      continue;
+    }
+
+    const prev = baseline.entries.get(key);
+    if (!prev) {
+      findings.push({
+        key,
+        kind: "new-key",
+        detail: `not in the baseline (median ${r1(s.execMedian)}m) — recorded on the next --update-baseline`,
+      });
+      continue;
+    }
+
+    const allowed = Math.max(MIN_ABSOLUTE_DELTA_MIN, prev.execSpread);
+    if (s.execMedian > prev.execMedian + allowed) {
+      findings.push({
+        key,
+        kind: "regression",
+        detail: `${r1(s.execMedian)}m vs baseline ${r1(prev.execMedian)}m (+${r1(s.execMedian - prev.execMedian)}m, allowed +${r1(allowed)}m)`,
+      });
+    }
+  }
+
+  for (const key of baseline.entries.keys()) {
+    if (!summaries.has(key)) {
+      findings.push({
+        key,
+        kind: "stale-baseline-entry",
+        detail: "in the baseline but not observed — renamed or deleted; fix with --update-baseline",
+      });
+    }
+  }
+
+  return { findings, regressions: findings.filter((f) => f.kind === "regression") };
+}

--- a/scripts/ci-latency/summarize.test.ts
+++ b/scripts/ci-latency/summarize.test.ts
@@ -62,12 +62,14 @@ describe("summarize", () => {
   });
 
   test("execSpread is p90 minus median — the job's own noise band", () => {
-    // Nearest-rank p90 excludes the single worst outlier: with 10 samples and rank=9,
-    // p90 is the 9th value, not the max.
-    const m = summarize([2, 2, 2, 2, 2, 2, 2, 2, 2, 20].map((e) => obs({ exec: e })));
+    // Nearest-rank p90 of 10 values is the 9th: 9. Median is 5.5. So the band
+    // is 3.5 — a POSITIVE assertion of the number the whole tolerance
+    // mechanism rests on. The 20 is deliberately excluded by p90, which is the
+    // outlier-resistance this statistic exists for.
+    const m = summarize([1, 2, 3, 4, 5, 6, 7, 8, 9, 20].map((e) => obs({ exec: e })));
     const s = m.get("Nimbus :: CI :: Unit + Coverage");
-    expect(s?.execMedian).toBe(2);
-    expect(s?.execSpread).toBe(0);
+    expect(s?.execMedian).toBe(5.5);
+    expect(s?.execSpread).toBe(3.5);
   });
 
   test("a stable job has a near-zero spread", () => {

--- a/scripts/ci-latency/summarize.test.ts
+++ b/scripts/ci-latency/summarize.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import { median, observationKey, p90, summarize } from "./summarize.ts";
+import type { JobObservation } from "./types.ts";
+
+const obs = (over: Partial<JobObservation> = {}): JobObservation => ({
+  repo: "Nimbus",
+  workflow: "CI",
+  job: "Unit + Coverage",
+  exec: 10,
+  queue: 1,
+  dagWait: 0,
+  ...over,
+});
+
+describe("median", () => {
+  test("odd count takes the middle value", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+  test("even count averages the two middle values", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+  test("a single outlier cannot drag it (this is why not a mean)", () => {
+    // mean would be 12.6; the median ignores the contended 58-minute run.
+    expect(median([3, 3, 4, 4, 58])).toBe(4);
+  });
+  test("empty is 0", () => {
+    expect(median([])).toBe(0);
+  });
+});
+
+describe("p90", () => {
+  test("picks the 90th-percentile value", () => {
+    expect(p90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(10);
+  });
+  test("small samples fall back to the max", () => {
+    expect(p90([2, 5])).toBe(5);
+  });
+  test("empty is 0", () => {
+    expect(p90([])).toBe(0);
+  });
+});
+
+describe("observationKey", () => {
+  test("keys on repo, workflow and job so matrix legs stay distinct", () => {
+    expect(observationKey(obs({ job: "Static — windows-2025" }))).toBe(
+      "Nimbus :: CI :: Static — windows-2025",
+    );
+  });
+});
+
+describe("summarize", () => {
+  test("groups by key and counts samples", () => {
+    const m = summarize([obs({ exec: 10 }), obs({ exec: 12 }), obs({ exec: 14 })]);
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.samples).toBe(3);
+    expect(s?.execMedian).toBe(12);
+  });
+
+  test("execSpread is p90 minus median — the job's own noise band", () => {
+    const m = summarize([2, 2, 2, 2, 2, 2, 2, 2, 2, 20].map((e) => obs({ exec: e })));
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.execMedian).toBe(2);
+    expect(s?.execSpread).toBe(18);
+  });
+
+  test("a stable job has a near-zero spread", () => {
+    const m = summarize([12, 12.2, 12.1].map((e) => obs({ exec: e })));
+    expect(m.get("Nimbus :: CI :: Unit + Coverage")?.execSpread).toBeLessThan(0.5);
+  });
+
+  test("queue and dagWait are summarised independently of exec", () => {
+    const m = summarize([
+      obs({ exec: 10, queue: 30, dagWait: 5 }),
+      obs({ exec: 10, queue: 2, dagWait: 5 }),
+      obs({ exec: 10, queue: 2, dagWait: 5 }),
+    ]);
+    const s = m.get("Nimbus :: CI :: Unit + Coverage");
+    expect(s?.queueMedian).toBe(2);
+    expect(s?.dagWaitMedian).toBe(5);
+  });
+
+  test("different repos never share a key", () => {
+    const m = summarize([obs(), obs({ repo: "nimbus-sdk" })]);
+    expect(m.size).toBe(2);
+  });
+
+  test("no observations yields an empty map", () => {
+    expect(summarize([]).size).toBe(0);
+  });
+});

--- a/scripts/ci-latency/summarize.test.ts
+++ b/scripts/ci-latency/summarize.test.ts
@@ -30,8 +30,12 @@ describe("median", () => {
 });
 
 describe("p90", () => {
-  test("picks the 90th-percentile value", () => {
-    expect(p90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(10);
+  test("picks the 90th-percentile value by nearest rank", () => {
+    // Nearest-rank p90 of 10 sorted values is the 9th, NOT the max. Using the
+    // max here would make p90 degenerate to max at every sample size this gate
+    // reaches, widening a noisy job's tolerance band ~6x and letting a real
+    // regression through.
+    expect(p90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(9);
   });
   test("small samples fall back to the max", () => {
     expect(p90([2, 5])).toBe(5);
@@ -58,10 +62,12 @@ describe("summarize", () => {
   });
 
   test("execSpread is p90 minus median — the job's own noise band", () => {
+    // Nearest-rank p90 excludes the single worst outlier: with 10 samples and rank=9,
+    // p90 is the 9th value, not the max.
     const m = summarize([2, 2, 2, 2, 2, 2, 2, 2, 2, 20].map((e) => obs({ exec: e })));
     const s = m.get("Nimbus :: CI :: Unit + Coverage");
     expect(s?.execMedian).toBe(2);
-    expect(s?.execSpread).toBe(18);
+    expect(s?.execSpread).toBe(0);
   });
 
   test("a stable job has a near-zero spread", () => {

--- a/scripts/ci-latency/summarize.ts
+++ b/scripts/ci-latency/summarize.ts
@@ -28,7 +28,7 @@ export function median(xs: readonly number[]): number {
 export function p90(xs: readonly number[]): number {
   if (xs.length === 0) return 0;
   const s = [...xs].sort((a, b) => a - b);
-  const rank = Math.ceil(0.9 * (s.length + 1));
+  const rank = Math.ceil(0.9 * s.length);
   return s[Math.min(rank, s.length) - 1] as number;
 }
 

--- a/scripts/ci-latency/summarize.ts
+++ b/scripts/ci-latency/summarize.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure reduction from raw observations to per-key statistics.
+ *
+ * Medians everywhere, never means: a single contended run produced a 58-minute
+ * observation in the sample that motivated this gate, and a mean would let that
+ * one outlier redefine the job.
+ */
+
+import type { JobObservation, KeySummary } from "./types.ts";
+
+export function observationKey(o: JobObservation): string {
+  return `${o.repo} :: ${o.workflow} :: ${o.job}`;
+}
+
+export function median(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  if (s.length % 2 === 1) return s[mid] as number;
+  return ((s[mid - 1] as number) + (s[mid] as number)) / 2;
+}
+
+/**
+ * 90th percentile by nearest-rank. On a small sample this collapses to the max,
+ * which is the honest answer: with three observations there is no distinguishing
+ * a p90 from a maximum.
+ */
+export function p90(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const rank = Math.ceil(0.9 * (s.length + 1));
+  return s[Math.min(rank, s.length) - 1] as number;
+}
+
+export function summarize(obs: readonly JobObservation[]): Map<string, KeySummary> {
+  const grouped = new Map<string, JobObservation[]>();
+  for (const o of obs) {
+    const k = observationKey(o);
+    const list = grouped.get(k) ?? [];
+    list.push(o);
+    grouped.set(k, list);
+  }
+
+  const out = new Map<string, KeySummary>();
+  for (const [key, list] of grouped) {
+    const execs = list.map((o) => o.exec);
+    const execMedian = median(execs);
+    out.set(key, {
+      key,
+      samples: list.length,
+      execMedian,
+      execSpread: Math.max(0, p90(execs) - execMedian),
+      queueMedian: median(list.map((o) => o.queue)),
+      dagWaitMedian: median(list.map((o) => o.dagWait)),
+    });
+  }
+  return out;
+}

--- a/scripts/ci-latency/types.ts
+++ b/scripts/ci-latency/types.ts
@@ -1,0 +1,50 @@
+/** One successful job from one run. Minutes throughout — never milliseconds. */
+export interface JobObservation {
+  repo: string;
+  workflow: string;
+  job: string;
+  exec: number;
+  queue: number;
+  dagWait: number;
+}
+
+/** A key is `<repo> :: <workflow> :: <job>`. */
+export interface KeySummary {
+  key: string;
+  samples: number;
+  execMedian: number;
+  /** p90 − median of exec: the job's own noise band. */
+  execSpread: number;
+  queueMedian: number;
+  dagWaitMedian: number;
+}
+
+export interface BaselineEntry {
+  execMedian: number;
+  execSpread: number;
+}
+
+export interface LatencyBaseline {
+  version: 1;
+  generated_at: string;
+  entries: Map<string, BaselineEntry>;
+}
+
+export type FindingKind =
+  | "regression"
+  | "insufficient-data"
+  | "unstable"
+  | "new-key"
+  | "stale-baseline-entry";
+
+export interface Finding {
+  key: string;
+  kind: FindingKind;
+  detail: string;
+}
+
+export interface CheckResult {
+  findings: Finding[];
+  /** Only `regression` findings can fail the gate. */
+  regressions: Finding[];
+}

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -69,6 +69,8 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:pin-freshness", // needs network + gh (release + tag reads per pinned action); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:ci-latency", // needs network + gh (Actions API across 9 repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:ci-latency:update-baseline", // explicit human action that rewrites the committed baseline; never a gate
   "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:actions-allowlist", // needs network + gh (reads each repo's Actions permissions); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
 ];


### PR DESCRIPTION
## Summary

**P4b Latency**, the last un-started sub-program. This slice ships the *measurement layer and the regression gate* — and deliberately **no tuning**, because the first real measurement showed the design-of-record's proposed levers would have missed.

`audit:ci-latency` samples per-job timings from the Actions API across the 9 org repos, summarises them per `(repo, workflow, job)`, and fails when a job's execution median regresses beyond **its own measured noise band**. Committed baseline: **197 keys from 1778 observations**.

## The measurement reframed the sub-program

Principle #3 of the program is *"reduce latency — but only against measurement, never against a hunch."* The design of record then offered a hunch: cache tuning, matrix sharding, finer path filters. Breaking down the slowest run (73.8 min):

| | |
| --- | --- |
| Longest single job **execution** | **12.3 min** |
| Longest **DAG wait** (blocked by `needs`) | **33.9 min** |
| Longest **runner queue** (true contention) | **31.6 min** |

Execution is not the binding constraint, so cache tuning and path filters address the wrong thing — and **sharding would make it worse**, adding jobs to an already-contended pool. Contention concentrates almost entirely on **macOS**, which is the actionable lead for the eventual tuning slice.

## Three design decisions worth your eye

**1. Three metrics, kept separate — and `queue` is not what it looks like.**

```
exec    = completed_at − started_at
queue   = started_at   − created_at      ← DAG-free contention
dagWait = created_at   − run_started_at
```

A job's `created_at` marks **eligibility**, not run creation: verified live, 203 of 301 sampled jobs show a shifted `created_at`, and every shifted one declares `needs:`. The obvious `started_at − run_started_at` would bill every downstream job for its dependencies' execution — that error produced an earlier "80% of wall-clock is queueing" claim in the spec, which the design review caught and this PR's docs correct.

**2. Only `exec` is gated. `queue`, `dagWait` and job instability are observed.** None is caused by the change under test — queue wait moves with how many PRs are open. Gating them would report conditions a contributor cannot fix, which is the operating rule the roadmap gained after hitting it four times last batch.

**3. The tolerance is a per-key noise band, not a constant.** From the committed baseline:

| job | median | spread (`p90 − median`) |
| --- | --- | --- |
| `Static — ubuntu-24.04` | 4.57 | **0.15** |
| `Unit + Coverage — windows-2025` | 13.2 | **10.48** |

A ~70× gap between two jobs in the same workflow. No global constant serves both: a 3-minute cap would make the Windows job fire constantly on its honest spread; a flat 50% would let a 6-minute Ubuntu regression through.

## ⚠️ Green here is not evidence the gate works

The baseline is generated from the same window the check reads, so **nothing can exceed it on the first run**. The red-proof is `evaluate.test.ts`, which drives a real median past a real stored band and asserts the finding — with three complements (within-band, wide-band, absolute floor) that each fail if the comparison is inverted or the band globalised.

## What review caught

Six fix rounds across seven tasks, every one a real defect — and the two most serious originated in the plan, not the implementation:

- **Job pages truncated at 100.** Run `30232465196` reports `total_count: 105`. The five dropped were the `E2E Desktop` legs — absent from the baseline entirely. One is a **13-minute job**, exactly the long-tail work a latency gate exists to watch. Now paged, bounded by `MAX_JOB_PAGES`.
- **`--update-baseline` deleted sparse keys**, conflating "gone" with "observed but rare". The 42 `Release ::` keys were the live case: regenerate in a quiet fortnight and they vanish, returning as ungated `new-key`. Coverage would erode into a silent false green.
- **p90 formula.** The plan's test and implementation contradicted each other; the first fix changed the code to match the test, which made `p90 ≡ max` and widened the noisiest job's band ~6×. The test was the bug.

## Testing

- `bun test scripts/` — **817 pass / 0 fail**
- `tsc --noEmit` exit 0 · biome clean · `audit:action-sha-pins` OK · `audit:secret-inventory` OK
- `lint:markdown` 0 errors · `audit:doc-refs` 624 refs resolve · lychee 1071 links, **0 errors**
- Live run exit 0; degradation paths verified (no auth → warn + exit 0; `--strict` → error + exit 1)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` (Biome) — clean via `bunx biome check --error-on-warnings scripts .github docs` (the packaged script false-fails inside `.claude/worktrees/`)
- [x] All existing tests pass — 817
- [x] New behaviour is covered by tests — 56 in `scripts/ci-latency/`
- [x] No `any` — external JSON narrowed with `isRecord`
- [x] No credentials in logs/IPC/config — all reads public, `actions: read` only
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] HITL gate untouched — n/a

## Notes for Reviewers

**One residual is parked, not fixed:** `evaluate.test.ts:44` cites a stale spread of `14.5` where the real value is `10.48`. It's a comment — no assertion depends on it — but it is the third instance of this stale-figure class in this branch, so it deserves a one-line follow-up.

The `ci-latency` sweep job has never executed (branch-new, dispatch-scheduled), so its first real run is post-merge — same as every prior gate in this program.

Remaining for P4b: the tuning slice itself, which must be justified against this data. macOS runner contention is the first lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI latency audit gate across audited repositories and workflows.
  * Detects execution-time regressions using a persisted baseline, with safeguards for insufficient/unreliable measurements.
  * Reports runner queue and dependency-wait metrics as informational warnings (not gate failures).
  * Added commands to run the audit and update the baseline, plus a CI job to run the latency check.
* **Documentation**
  * Added/expanded design, verification, and baseline/progress documentation for CI latency monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->