### PR TITLE
fix(perf): stop a huggingface.co stall from blowing the 45m bench timeout

### DIFF
--- a/.github/workflows/_perf.yml
+++ b/.github/workflows/_perf.yml
@@ -136,6 +136,21 @@ jobs:
           security unlock-keychain -p "" nimbus-ci.keychain
           security set-keychain-settings -lut 7200 nimbus-ci.keychain
 
+      # The 12 S8 cells embed with `Xenova/all-MiniLM-L6-v2`, which
+      # `@xenova/transformers` pulls from huggingface.co on a cold cache. In run
+      # 30300911723 huggingface.co went unreachable from the ubuntu runner and
+      # the leg died on the 45-minute job timeout. Persisting the weights across
+      # runs takes huggingface.co off the critical path entirely, so S8 stays
+      # measurable (and the run ~30 s shorter) whatever the network is doing.
+      # The repo id is pinned in `embedding/load-feature-extraction-pipeline.ts`
+      # — bump the `-v1` suffix when that pin changes, since actions/cache never
+      # overwrites an existing key.
+      - name: Cache MiniLM embedding weights (S8)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/perf-models
+          key: ${{ runner.os }}-perf-minilm-xenova-all-minilm-l6-v2-v1
+
       # Derive runner_id once. bench-ci.ts and the artifact upload BOTH
       # consume this id verbatim — earlier versions had divergent forms
       # (matrix OS for upload, normalised id for lookup) and the artifact
@@ -159,6 +174,11 @@ jobs:
           github.event_name != 'schedule' ||
           github.event.schedule == '0 4 * * 0'
         shell: bash
+        env:
+          # Points every embedder in the bench at the cached weights above.
+          # `createLocalEmbedder` treats this as the transformers cache dir, so a
+          # cold cache downloads INTO it and the post-job cache save persists it.
+          NIMBUS_EMBEDDING_MODEL_DIR: ${{ runner.temp }}/perf-models
         # The whole bench is one long-lived `bun` process. On the shared GHA
         # runners it intermittently dies with a SIGSEGV (exit 139) inside the
         # `bun:sqlite` Worker / `dlopen(sqlite-vec.dylib)` path the S8/S10
@@ -173,7 +193,7 @@ jobs:
         # `ci.yml`'s `pr-quality-cross-platform`.
         run: |
           set +e
-          mkdir -p "${RUNNER_TEMP}/perf-fixtures"
+          mkdir -p "${RUNNER_TEMP}/perf-fixtures" "${RUNNER_TEMP}/perf-models"
           for attempt in 1 2; do
             # Each attempt writes the single aggregate history line only on a
             # clean finish (bench-cli.ts), and a SIGSEGV is uncatchable so it

--- a/packages/gateway/src/perf/surfaces/bench-embedding-throughput.test.ts
+++ b/packages/gateway/src/perf/surfaces/bench-embedding-throughput.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-import { runEmbeddingThroughputOnce } from "./bench-embedding-throughput.ts";
+import type { Embedder } from "../../embedding/types.ts";
+import {
+  resetEmbedderCacheForTest,
+  runEmbeddingThroughputOnce,
+} from "./bench-embedding-throughput.ts";
 
 interface CallLog {
   texts: string[];
@@ -114,5 +118,98 @@ describe("runEmbeddingThroughputOnce", () => {
       embedder,
     });
     expect(calls).toHaveLength(3);
+  });
+});
+
+// The 12 S8 cells (l{50|500|5000} × b{1|8|32|64}) each call this surface. Run
+// 30300911723 blew the 45-minute bench job because each cell independently
+// re-resolved the MiniLM weights against an unreachable huggingface.co and paid
+// the full ~6m45s failure ladder — 12 × that is ~81 min of dead wall-clock. The
+// load is now memoised per cache dir so the model is resolved exactly once per
+// process, success or failure.
+describe("runEmbeddingThroughputOnce — shared model load", () => {
+  beforeEach(() => {
+    resetEmbedderCacheForTest();
+  });
+
+  function countingFactory(): {
+    createEmbedder: (cacheDir: string) => Promise<Embedder>;
+    dirs: string[];
+  } {
+    const dirs: string[] = [];
+    return {
+      dirs,
+      createEmbedder: async (cacheDir: string): Promise<Embedder> => {
+        dirs.push(cacheDir);
+        return {
+          model: "fake-mini",
+          dims: 384,
+          embed: async (texts: string[]): Promise<Float32Array[]> =>
+            texts.map(() => new Float32Array(384)),
+        };
+      },
+    };
+  }
+
+  test("resolves the model once across cells sharing a cache dir", async () => {
+    const { createEmbedder, dirs } = countingFactory();
+    for (const batch of [1, 8, 32] as const) {
+      await runEmbeddingThroughputOnce({
+        length: 50,
+        batch,
+        totalItems: 8,
+        cacheDir: "/models",
+        createEmbedder,
+      });
+    }
+    expect(dirs).toEqual(["/models"]);
+  });
+
+  test("resolves separately per distinct cache dir", async () => {
+    const { createEmbedder, dirs } = countingFactory();
+    for (const cacheDir of ["/models-a", "/models-b"]) {
+      await runEmbeddingThroughputOnce({
+        length: 50,
+        batch: 8,
+        totalItems: 8,
+        cacheDir,
+        createEmbedder,
+      });
+    }
+    expect(dirs).toEqual(["/models-a", "/models-b"]);
+  });
+
+  test("a failed model load is not retried by every subsequent cell", async () => {
+    let attempts = 0;
+    const createEmbedder = async (): Promise<Embedder> => {
+      attempts += 1;
+      throw new Error("Unable to connect. Is the computer able to access the url?");
+    };
+    for (let cell = 0; cell < 12; cell += 1) {
+      await expect(
+        runEmbeddingThroughputOnce({
+          length: 50,
+          batch: 8,
+          totalItems: 8,
+          cacheDir: "/models",
+          createEmbedder,
+        }),
+      ).rejects.toThrow("Unable to connect");
+    }
+    expect(attempts).toBe(1);
+  });
+
+  test("an injected embedder bypasses the shared load entirely", async () => {
+    const { createEmbedder, dirs } = countingFactory();
+    const { embedder } = makeFakeEmbedder(0);
+    await runEmbeddingThroughputOnce({
+      length: 50,
+      batch: 8,
+      totalItems: 8,
+      cacheDir: "/models",
+      embedder,
+      createEmbedder,
+    });
+    expect(dirs).toEqual([]);
   });
 });

--- a/packages/gateway/src/perf/surfaces/bench-embedding-throughput.ts
+++ b/packages/gateway/src/perf/surfaces/bench-embedding-throughput.ts
@@ -13,6 +13,8 @@ export interface EmbeddingThroughputOptions {
   corpus?: CorpusTier;
   embedder?: Embedder;
   cacheDir?: string;
+  /** DI seam for the memoised model load (tests only; production uses `createLocalEmbedder`). */
+  createEmbedder?: (cacheDir: string) => Promise<Embedder>;
 }
 
 const DEFAULT_BATCH_MULTIPLIER = 1_000;
@@ -27,11 +29,35 @@ function resolveBatchMultiplier(corpus: CorpusTier | undefined): number {
   return corpus === undefined ? DEFAULT_BATCH_MULTIPLIER : CORPUS_BATCH_MULTIPLIER[corpus];
 }
 
-async function getEmbedder(opts: EmbeddingThroughputOptions): Promise<Embedder> {
-  if (opts.embedder !== undefined) return opts.embedder;
-  return createLocalEmbedder({
-    cacheDir: opts.cacheDir ?? join(tmpdir(), "nimbus-bench-models"),
-  });
+/**
+ * Process-lifetime memo of the MiniLM load, keyed by cache dir.
+ *
+ * All 12 S8 cells (l{50|500|5000} × b{1|8|32|64}) resolve the same weights from
+ * the same directory, so the load belongs to the process, not to the cell. The
+ * REJECTED promise is cached deliberately: when the weights are absent AND
+ * huggingface.co is unreachable, `@xenova/transformers` burns ~6m45s before
+ * giving up, and re-paying that per cell is ~81 min — which is what cancelled
+ * the 45-minute `Bench (ubuntu-24.04)` leg of run 30300911723. Caching the
+ * failure turns 12 hangs into one, so the leg still finishes and reports the
+ * remaining surfaces. Warm weights (see the model cache in `_perf.yml`) make
+ * the failure path unreachable in steady state.
+ */
+const embedderByCacheDir = new Map<string, Promise<Embedder>>();
+
+/** Drops the memo so tests don't leak a loaded (or failed) embedder into each other. */
+export function resetEmbedderCacheForTest(): void {
+  embedderByCacheDir.clear();
+}
+
+function getEmbedder(opts: EmbeddingThroughputOptions): Promise<Embedder> {
+  if (opts.embedder !== undefined) return Promise.resolve(opts.embedder);
+  const cacheDir = opts.cacheDir ?? join(tmpdir(), "nimbus-bench-models");
+  const memoised = embedderByCacheDir.get(cacheDir);
+  if (memoised !== undefined) return memoised;
+  const create = opts.createEmbedder ?? ((dir: string) => createLocalEmbedder({ cacheDir: dir }));
+  const pending = create(cacheDir);
+  embedderByCacheDir.set(cacheDir, pending);
+  return pending;
 }
 
 export async function runEmbeddingThroughputOnce(


### PR DESCRIPTION
## What broke

[`Bench (ubuntu-24.04)`](https://github.com/nimbus-agent/Nimbus/actions/runs/30300911723/job/90093517497) was **cancelled on the job's `timeout-minutes: 45`**, not on any measurement.

Worth stating up front, because it inverts the usual read of a red perf leg: **individual surface failures are tolerated.** `bench-cli.ts` records them as `S<n>  failed: …` and still exits 0. On Linux, S1 / S4 / S6-\* / S7-a / S7-b fail on *every* run (the spawned gateway child can't init the Vault), and [the green leg 90 minutes earlier](https://github.com/nimbus-agent/Nimbus/actions/runs/30294063937) had exactly those failures and finished in 11m48s. Wall-clock is the only thing that reds this job.

## Root cause

The outage was the trigger; the amplifier was ours.

1. **Trigger (transient)** — huggingface.co became unreachable from the runner. The Harden Runner DNS trace shows `huggingface.co` returning AAAA-only records, re-queried every 25 s, never connecting. The 12 S8 cells need `Xenova/all-MiniLM-L6-v2`, fetched live on a cold cache.
2. **Amplifier (structural)** — `bench-embedding-throughput.ts::getEmbedder()` called `createLocalEmbedder()` **fresh for every cell**. With nothing on disk, each cell independently paid the full `@xenova/transformers` failure ladder — **~6m45s each**, measured off consecutive log timestamps. 12 × that ≈ **81 min** of dead wall-clock.

The job died at cell 6 of 12 (`S8-l500-b1`), which is *before* the step's own `for attempt in 1 2` retry could run — so no artifact and no history line either.

A resource load placed inside a fan-out surface is paid N times, so a transient failure is multiplied by the fan-out factor rather than bounded by it.

## The fix

**`bench-embedding-throughput.ts`** — memoise the MiniLM load per cache dir for the process lifetime. The **rejected** promise is cached deliberately: one stall now costs one attempt instead of twelve, so the leg finishes and still reports its other surfaces. Injection goes through a new `opts.createEmbedder` DI seam rather than `mock.module`, per the repo's CI-Linux guidance.

**`_perf.yml`** — belt-and-braces, `actions/cache` the weights at `${{ runner.temp }}/perf-models` and point the bench at them via `NIMBUS_EMBEDDING_MODEL_DIR`. This takes huggingface.co off the critical path entirely, so S8 stays *measurable* rather than merely failing fast. Bump the key's `-v1` when the model pin in `embedding/load-feature-extraction-pipeline.ts` changes — `actions/cache` never overwrites an existing key.

Model load sits outside the timed window (there's already an explicit warm-up embed before `t0`), so none of this shifts what S8 measures.

## Verification

- **4 new tests, all red-proven** — with the memo disabled, the failure test reports `Received: 12` instead of `1`.
- `bun test packages/gateway/src/perf/` — 259 pass, 0 fail.
- `bun run preflight:fast` — **PASSED**, all 20 gates (incl. `audit:action-sha-pins` for the new pinned action).
- CI unit suite (`packages/gateway packages/cli packages/mcp-connectors scripts`) — **14965 pass, 1 fail**, and that one failure (`test/integration/updater/wiring.test.ts`) **reproduces identically on `main`** — pre-existing, not this diff.
- `packages/gateway/src/perf/` is coverage-floor exempt, so no baseline update is needed.
- No markdown touched, so the lychee link total is unchanged from `main`.

**Not verified locally:** the `build` gate fails on this machine with `Export named 'forEach' not found in module 'neotraverse'` — it **fails identically on `main`**, and Docs Quality is green on `main` in CI, so it's a local Windows ESM artifact rather than a branch regression. It does mean `test:ci` aborts before its test phases here, which is why the unit suite was run directly.

## Left out

`bench-harness.ts` has no per-surface timeout, so a future hang in a non-S8 surface can still eat the 45-minute budget. That's a broader change with its own flake risk (picking a default that doesn't false-trip on `S8-l5000-b64`, which legitimately runs ~6m22s on Windows), so it's deliberately not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved embedding benchmark performance by reusing downloaded model weights across workflow runs.
  * Prevented repeated model loading during benchmark runs, reducing unnecessary setup overhead.
  * Added safeguards for model-loading failures and separate cache locations.

* **Tests**
  * Expanded benchmark coverage for shared model loading, isolated caches, failure handling, and explicit embedder configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->