### PR TITLE
perf(ci): cut a push run 105 -> 75 jobs — CI was queueing behind its own fan-out

### DIFF
--- a/.github/workflows/_structure.yml
+++ b/.github/workflows/_structure.yml
@@ -56,5 +56,8 @@ jobs:
       - name: D10/D11 — Nimbus invariants (binary)
         run: bun run audit:invariants
 
+      - name: Audit coverage-gate PAL classification
+        run: bun run audit:coverage-gate-pal
+
       - name: Audit release-please manifest drift
         run: bun run audit:release-please

--- a/.github/workflows/_structure.yml
+++ b/.github/workflows/_structure.yml
@@ -2,7 +2,8 @@ name: Structure audit
 
 # Reusable workflow — fast PR check (≤30 s budget) for the binary subset of
 # audit:* gates: D1/D2/D3 (boundaries), D8 (any-count ratchet), D10/D11
-# (Nimbus invariants), and release-please manifest drift.
+# (Nimbus invariants), the coverage-gate PAL classification
+# (`audit:coverage-gate-pal`), and release-please manifest drift.
 #
 # Ubuntu-only by design: every gate is static analysis with zero OS variance.
 # The platform-equality non-negotiable is a runtime property

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -743,6 +743,14 @@ jobs:
   # These re-run specific tests to enforce thresholds.
   coverage-gates:
     name: Coverage — ${{ matrix.gate.name }} (${{ inputs.runner }})
+    # Threshold gates run on Linux only, EXCEPT gates whose covered code
+    # branches on platform (`pal: true`). A push run was ~105 jobs against a
+    # pool granting ~15 concurrent, and 72 of those were this matrix run once
+    # per OS. Skipped matrix legs still create their check context, so no
+    # required check is left "Expected — Waiting for status to be reported".
+    # `scripts/structure-audit/check-coverage-gate-pal.ts` fails if a Linux-only
+    # gate's code ever gains platform branching.
+    if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
     needs: unit-coverage
     runs-on: ${{ inputs.runner }}
     permissions:
@@ -754,52 +762,76 @@ jobs:
         gate:
           - name: Engine
             script: "test:coverage:engine"
+            pal: false
           - name: Agents
             script: "test:coverage:agents"
+            pal: false
           - name: Vault
             script: "test:coverage:vault"
+            pal: true
           - name: Sync scheduler
             script: "test:coverage:sync"
+            pal: false
           - name: Rate limiter
             script: "test:coverage:rate-limiter"
+            pal: false
           - name: People
             script: "test:coverage:people"
+            pal: false
           - name: Embedding
             script: "test:coverage:embedding"
+            pal: false
           - name: Workflow
             script: "test:coverage:workflow"
+            pal: false
           - name: Watcher
             script: "test:coverage:watcher"
+            pal: false
           - name: Extensions
             script: "test:coverage:extensions"
+            pal: true
           - name: Config
             script: "test:coverage:config"
+            pal: false
           - name: Telemetry
             script: "test:coverage:telemetry"
+            pal: true
           - name: TUI
             script: "test:coverage:tui"
+            pal: false
           - name: DB layer
             script: "test:coverage:db"
+            pal: false
           - name: Deployment
             script: "test:coverage:deployment"
+            pal: false
           - name: Health
             script: "test:coverage:health"
+            pal: false
           - name: Metrics
             script: "test:coverage:metrics"
+            pal: false
           - name: Preflight
             script: "test:coverage:preflight"
+            pal: false
           - name: Doctor
             script: "test:coverage:doctor"
+            pal: true
           - name: MCP
             script: "test:coverage:mcp"
+            pal: false
           - name: Updater
             script: "test:coverage:updater"
+            pal: true
           - name: LAN
             script: "test:coverage:lan"
+            pal: false
           - name: Perf
             script: "test:coverage:perf"
+            pal: true
           - name: Sandbox
             script: "test:coverage:sandbox"
+            pal: true
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -749,8 +749,12 @@ jobs:
     # per OS. Skipped matrix legs still create their check context, so no
     # required check is left "Expected — Waiting for status to be reported".
     # `scripts/structure-audit/check-coverage-gate-pal.ts` fails if a Linux-only
-    # gate's code ever gains platform branching.
-    if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
+    # gate's code ever gains platform branching. `inputs.run-tests` is gated
+    # explicitly here (rather than relied upon through the `needs: unit-coverage`
+    # skip chain) to match how every sibling job in this file gates on it
+    # directly (`static`, `unit-coverage`, `integration`, `e2e-gateway`,
+    # `e2e-cli`, `packaging`).
+    if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
     needs: unit-coverage
     runs-on: ${{ inputs.runner }}
     permissions:

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -6,7 +6,7 @@ name: Test Suite
 # Structure: split into parallel jobs so the PR critical path is the max
 # of the longest job, not the sum. The old monolithic `test` job ran for
 # ~9.5 min on ubuntu PRs; with this split the critical path is the
-# `unit-coverage` job (~5 min on ubuntu) plus the `coverage-gates` matrix
+# `unit-coverage` job (~5 min on ubuntu) plus the `coverage-gates-*` matrices
 # (~1 min), and the other jobs run alongside.
 on:
   workflow_call:
@@ -101,7 +101,7 @@ jobs:
 
   # ── Unit tests + UI + coverage + Sonar ─────────────────────────────────────
   # The longest single job. Produces the merged coverage/lcov.info that the
-  # coverage-gates matrix and the per-file coverage floor consume.
+  # coverage-gates-* matrices and the per-file coverage floor consume.
   unit-coverage:
     name: Unit + Coverage — ${{ inputs.runner }}
     if: inputs.run-tests
@@ -741,20 +741,169 @@ jobs:
 
   # Run coverage gates in parallel to reduce critical path.
   # These re-run specific tests to enforce thresholds.
-  coverage-gates:
+  #
+  # SPLIT INTO TWO JOBS DELIBERATELY — do not merge them back together.
+  #
+  # Threshold gates run on Linux only, EXCEPT the gates whose covered code
+  # branches on host platform (`pal: true`), which run on all three OSes. A push
+  # run was ~105 jobs against a pool granting ~15 concurrent, and 72 of those
+  # were one 24-entry coverage matrix expanded once per OS; the split cuts that
+  # to 42 (9 PAL × 3 OS + 15 Linux-only × 1).
+  #
+  # The obvious single-job spelling was tried first and is WRONG:
+  #
+  #     if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
+  #
+  # `matrix` is NOT in the context set available to a job-level `if:` — GitHub
+  # grants `jobs.<job_id>.if` only `github`, `needs`, `vars` and `inputs`,
+  # because the job condition is evaluated BEFORE the matrix expands. That
+  # spelling therefore evaluates falsy (or errors) on Windows and macOS and
+  # silently skips ALL coverage gates there, including the very `pal: true`
+  # gates whose preservation is the entire safety argument for running the rest
+  # on Linux only. Every other `matrix.`-referencing `if:` in this repo is
+  # step-level (8-space), where `matrix` IS available. Hence: one job per class,
+  # each gated only on `inputs`, which a job-level `if:` does support.
+  #
+  # The `fromJSON(...)` single-job alternative is NOT acceptable either: it
+  # drops the leg from the matrix entirely, and a leg that never expands never
+  # creates its check context. A SKIPPED leg does create one. This repo depends
+  # on that — see the trap documented on `pr-quality-ts` in
+  # `.github/workflows/ci.yml`, where an un-created child context sat
+  # "Expected — Waiting for status to be reported" forever and blocked merges.
+  #
+  # Both jobs MUST keep the identical `name:` template below. `name:` DOES
+  # accept `matrix`, and the expanded check-context names
+  # (`Coverage — Vault (ubuntu-24.04)` …) are what branch protection references;
+  # changing them breaks the required contexts.
+  #
+  # Every entry keeps its `pal:` field even though no `if:` reads it any more.
+  # It is the machine-readable classification `audit:coverage-gate-pal`
+  # (`scripts/structure-audit/check-coverage-gate-pal.ts`) enforces: that gate
+  # fails when a Linux-only gate's code gains platform branching, when an entry
+  # sits in the wrong job, when a new entry carries no explicit `pal`, and when
+  # either `if:` below drifts from the condition it is supposed to carry.
+  #
+  # `inputs.run-tests` is gated explicitly on both jobs (rather than relied upon
+  # through the `needs: unit-coverage` skip chain) to match how every sibling job
+  # in this file gates on it directly (`static`, `unit-coverage`, `integration`,
+  # `e2e-gateway`, `e2e-cli`, `packaging`).
+
+  # PAL gates (9) — covered code branches on host platform, so these run on
+  # every OS the workflow is called with.
+  coverage-gates-pal:
     name: Coverage — ${{ matrix.gate.name }} (${{ inputs.runner }})
-    # Threshold gates run on Linux only, EXCEPT gates whose covered code
-    # branches on platform (`pal: true`). A push run was ~105 jobs against a
-    # pool granting ~15 concurrent, and 72 of those were this matrix run once
-    # per OS. Skipped matrix legs still create their check context, so no
-    # required check is left "Expected — Waiting for status to be reported".
-    # `scripts/structure-audit/check-coverage-gate-pal.ts` fails if a Linux-only
-    # gate's code ever gains platform branching. `inputs.run-tests` is gated
-    # explicitly here (rather than relied upon through the `needs: unit-coverage`
-    # skip chain) to match how every sibling job in this file gates on it
-    # directly (`static`, `unit-coverage`, `integration`, `e2e-gateway`,
-    # `e2e-cli`, `packaging`).
-    if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
+    if: inputs.run-tests
+    needs: unit-coverage
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - name: Vault
+            script: "test:coverage:vault"
+            pal: true
+          - name: Embedding
+            script: "test:coverage:embedding"
+            pal: true
+          - name: Extensions
+            script: "test:coverage:extensions"
+            pal: true
+          - name: Telemetry
+            script: "test:coverage:telemetry"
+            pal: true
+          - name: DB layer
+            script: "test:coverage:db"
+            pal: true
+          - name: Doctor
+            script: "test:coverage:doctor"
+            pal: true
+          - name: Updater
+            script: "test:coverage:updater"
+            pal: true
+          - name: Perf
+            script: "test:coverage:perf"
+            pal: true
+          - name: Sandbox
+            script: "test:coverage:sandbox"
+            pal: true
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-nimbus-ci
+
+      - name: Linux — libsecret + D-Bus (vault tests)
+        if: runner.os == 'Linux' && matrix.gate.name == 'Vault'
+        shell: bash
+        run: sudo bash scripts/linux/install-vault-deps.sh
+
+      - name: Linux — bubblewrap + libcap-dev + strace + cppcheck (sandbox tests)
+        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
+        shell: bash
+        run: |
+          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
+          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+          sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
+
+      - name: Build sandbox helper (Linux only, sandbox gate)
+        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
+        shell: bash
+        run: bun run build:sandbox-helper
+
+      - name: Static-analyse sandbox helper with cppcheck (Linux only, sandbox gate)
+        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
+        shell: bash
+        run: cppcheck --enable=all --error-exitcode=1 --suppress=missingIncludeSystem packages/gateway/src-native/sandbox-helper/main.c
+
+      - name: Setcap on sandbox helper (Linux only, sandbox gate)
+        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
+        shell: bash
+        run: sudo setcap cap_net_admin+ep packages/gateway/src-native/sandbox-helper/nimbus-sandbox-helper
+
+      - name: Run coverage gate
+        shell: bash
+        run: |
+          if [[ "${{ matrix.gate.name }}" == "Vault" && "${{ runner.os }}" == "Linux" ]]; then
+            bash scripts/ci/run-with-optional-dbus.sh bun run ${{ matrix.gate.script }}
+          else
+            bun run ${{ matrix.gate.script }}
+          fi
+        env:
+          CI: "true"
+
+      - name: Upload coverage to Codecov
+        # See note on the unit-test Codecov step: this upload is supplementary,
+        # not the gate. `continue-on-error` tolerates intermittent OIDC pre-step
+        # failures on Windows-2025 without masking real coverage-threshold
+        # regressions, which are enforced earlier by the `Run coverage gate`
+        # step's `bun run` exit code.
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          # No `token:` — same reason as the upload step above (Nimbus#782).
+          use_oidc: true
+          flags: ${{ matrix.gate.name }}
+
+  # Linux-only gates (15) — no file in their coverage denominator branches on
+  # host platform, which `audit:coverage-gate-pal` re-checks on every run. The
+  # `ubuntu-24.04` literal below must match the runner label `ci.yml` actually
+  # calls this workflow with; the same audit asserts that too, so bumping the
+  # runner in one place cannot silently drop these 15 gates.
+  coverage-gates-linux:
+    name: Coverage — ${{ matrix.gate.name }} (${{ inputs.runner }})
+    if: inputs.run-tests && inputs.runner == 'ubuntu-24.04'
     needs: unit-coverage
     runs-on: ${{ inputs.runner }}
     permissions:
@@ -770,9 +919,6 @@ jobs:
           - name: Agents
             script: "test:coverage:agents"
             pal: false
-          - name: Vault
-            script: "test:coverage:vault"
-            pal: true
           - name: Sync scheduler
             script: "test:coverage:sync"
             pal: false
@@ -782,29 +928,17 @@ jobs:
           - name: People
             script: "test:coverage:people"
             pal: false
-          - name: Embedding
-            script: "test:coverage:embedding"
-            pal: false
           - name: Workflow
             script: "test:coverage:workflow"
             pal: false
           - name: Watcher
             script: "test:coverage:watcher"
             pal: false
-          - name: Extensions
-            script: "test:coverage:extensions"
-            pal: true
           - name: Config
             script: "test:coverage:config"
             pal: false
-          - name: Telemetry
-            script: "test:coverage:telemetry"
-            pal: true
           - name: TUI
             script: "test:coverage:tui"
-            pal: false
-          - name: DB layer
-            script: "test:coverage:db"
             pal: false
           - name: Deployment
             script: "test:coverage:deployment"
@@ -818,24 +952,12 @@ jobs:
           - name: Preflight
             script: "test:coverage:preflight"
             pal: false
-          - name: Doctor
-            script: "test:coverage:doctor"
-            pal: true
           - name: MCP
             script: "test:coverage:mcp"
             pal: false
-          - name: Updater
-            script: "test:coverage:updater"
-            pal: true
           - name: LAN
             script: "test:coverage:lan"
             pal: false
-          - name: Perf
-            script: "test:coverage:perf"
-            pal: true
-          - name: Sandbox
-            script: "test:coverage:sandbox"
-            pal: true
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,6 +589,14 @@ jobs:
     # own checkout, install and Tauri setup. `ci-rust` (1.17-1.72min) is the
     # prerequisite that carries meaning: a broken Tauri build makes E2E
     # unrunnable.
+    #
+    # Dropping `ci-ts` means E2E now runs even when the TS suite fails on a
+    # `main` push — an accepted cost, not an oversight: it's cheaper than a
+    # duplicate typecheck job on every push, and measured data shows it's rare.
+    # See the Risks table in
+    # docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md ("A
+    # TS-failing, Rust-passing `main` commit burns E2E runners") for the
+    # numbers and the revisit trigger.
     needs: [ci-rust]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,7 +583,13 @@ jobs:
   # E2E Desktop (Playwright + Tauri WebDriver) — push to main only, full OS matrix
   e2e-desktop:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ci-ts, ci-rust]
+    # `ci-ts` is the whole _test-suite.yml (30 jobs incl. 24 coverage shards),
+    # and `needs:` on a reusable-workflow caller waits for ALL of it — measured
+    # at 33.4min median DAG wait. E2E consumes no artifact from it: it does its
+    # own checkout, install and Tauri setup. `ci-rust` (1.17-1.72min) is the
+    # prerequisite that carries meaning: a broken Tauri build makes E2E
+    # unrunnable.
+    needs: [ci-rust]
     strategy:
       fail-fast: false
       matrix:

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -114,7 +114,7 @@ Design of record:
 | P2 | Release Train | ✅ done — both phases (run 30231918767) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, when a release phantoms, when an npm package is tagged but unpublished, or when a consumer's **lockfile-resolved** dependency lags npm `@latest`. Red-proved on a real phantom and on three real dependency edges; green after both, `OK (12 edges current)`. |
 | P3 | Review Layer | 🔨 first step done (#846) | The monorepo now carries a tuned `.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and the PAL ban — closing the satellites→monorepo direction of the pattern above. **Note:** the previously-stated gate ("an invariant violation is caught in CI") was already met — `_structure.yml` runs `audit:invariants` and all 17 static checks execute there; the one branch `--binary-only` excludes is a census that always exits 0. |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
-| P4b | Latency | 🔨 measurement shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning is deliberately NOT in this slice — the first measurement showed execution is not the binding constraint. |
+| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 38 jobs, Linux-only except the 7 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
 | P5 | Org Legibility | ✅ both gates green (run 30231918767) | `audit:secret-inventory` fails on any workflow secret missing from the credential registry **or** `ci-secrets.md`; `audit:actions-allowlist` fails on an unpermitted action **or** any workflow whose latest run ended in `startup_failure`. The second found a live nightly outage on its first correct run. Remaining: the legibility dashboard. |
 | P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
 
@@ -395,8 +395,57 @@ moves to P6).
   same window the check reads, so nothing can exceed it on the first run. The
   red-proof is the unit test in `scripts/ci-latency/evaluate.test.ts`, not the
   live run.
-- **Remaining:** the tuning slice itself, which must be justified against this
-  data. The clearest lead is macOS runner contention.
+- **Delivered (tuning, 2026-07-28):** the measurement's own "clearest lead" was
+  wrong, and two probes disproved it. Across 45 `E2E Desktop` legs the binding
+  upstream job was ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue
+  was ~10min median on every OS. The constraint is not macOS scarcity: a push
+  run demands ~105 job slots against a pool granting 13-17, with 32-41 jobs
+  created-but-waiting at peak; one sampled run opened with nine consecutive
+  minutes at zero running jobs. 72 of those 105 jobs were one 24-entry
+  coverage matrix run once per OS.
+- **This retired the design of record's sharding proposal.** Sharding adds jobs
+  to the pool that IS the constraint.
+- **Two changes:** coverage-threshold gates run on Linux only except the seven
+  whose covered code branches on platform (72 → 38 jobs; a run 105 → 71), and
+  `e2e-desktop` now waits on `ci-rust` (1.17-1.72min) instead of `ci-ts` (30
+  jobs, DAG wait measured 33.4min median on 2026-07-27) — an edge that carried
+  no artifacts.
+- **The DAG-wait baseline nearly doubled between measurements.** The 33.4min
+  figure above was genuinely measured on 2026-07-27. Re-running the promoted
+  probe on 2026-07-28 against the same `main` window found **60.5min median
+  (max 110.8min, n=15)** — cross-checked by running both the original
+  throwaway probe and the promoted `probe-dag.ts` over the same window, which
+  returned identical figures, so the widening reflects real CI congestion
+  between the two dates (`main` took several merges in between, consistent
+  with the slot-starvation diagnosis: more concurrent runs competing for the
+  same pool) rather than an instrumentation change. Same-day probes
+  (2026-07-28, against `main`) also found: 105 jobs per run on all four
+  sampled runs, peak concurrent 12-14 (the plan predicted 13-17), and all
+  reads complete (15/15 DAG runs, 4/4 concurrency runs — so none of the above
+  is a partial-sample artifact). **60.5min median is the baseline any future
+  "after" comparison must be measured against — not 33.4.**
+- **`audit:ci-latency` cannot prove this worked**, since it gates execution
+  while the win lands in queue and DAG wait. `scripts/ci-latency/probe-dag.ts`
+  and `probe-concurrency.ts` are the instrument; the before figures above are
+  recorded, but the **after figures are not yet measured** — that requires
+  this branch to be merged and at least one push run to `main` to have
+  completed under the new workflow. Once that run exists, re-run
+  `bun scripts/ci-latency/probe-dag.ts` and
+  `bun scripts/ci-latency/probe-concurrency.ts` against `main` and record the
+  actual numbers here — never a predicted figure.
+- **Guarded against silent decay:** `audit:coverage-gate-pal` fails when a
+  platform-branching file is unclassified, when a classified file's gate is not
+  `pal: true`, or when a new matrix entry carries no explicit `pal` field.
+- **Deferred:** guarding E2E against a TypeScript failure on `main`. Measured
+  2 of the last 40 `main` commits arrived without a PR, both `ci(cla)` workflow
+  commits touching no TypeScript. No standalone fast typecheck job exists to
+  depend on (`Static`, 4.57min, sits inside `_test-suite.yml` where `needs:`
+  cannot reach it), so guarding costs a duplicate typecheck job on every push.
+  **Adopt if** a `main` E2E run is ever seen burning on a TS compile failure.
+- **Baseline regeneration is due after ~12 post-change push runs**, when the
+  36 abandoned macOS/Windows coverage keys have aged out of the sampling window
+  (`MAX_RUNS_PER_WORKFLOW`). Regenerating sooner is a no-op: the window still
+  holds pre-change runs carrying those keys.
 
 ### P5 progress log
 

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -398,7 +398,7 @@ moves to P6).
 - **Delivered (tuning, 2026-07-28):** the measurement's own "clearest lead" was
   wrong, and two probes disproved it. **Attribution capture A (2026-07-27,
   throwaway probe):** across 45 `E2E Desktop` legs the binding upstream job was
-  ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue was ~10min
+  ubuntu 27×, windows 15×, **macOS only 3×**, and runner queue was ~10min
   median on every OS. The constraint is not macOS scarcity: a push run demands
   ~105 job slots against a pool granting 13-17, with 32-41 jobs
   created-but-waiting at peak; one sampled run opened with nine consecutive

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -474,6 +474,12 @@ moves to P6).
   `bun scripts/ci-latency/probe-dag.ts` and
   `bun scripts/ci-latency/probe-concurrency.ts` against `main` and record the
   actual numbers here — never a predicted figure.
+- **Fast-follow — one enforcement gap is known and stated, not closed.** An
+  allowlist entry names a single gate, and rule 3 cross-checks only that gate.
+  `index/sqlite-vec-load.ts` reaches BOTH `Embedding` and `DB layer`, so
+  demoting `Embedding` is caught while demoting `DB layer` is not. The entry's
+  comment says so rather than claiming protection the code does not provide.
+  Closing it needs a co-gate field on `PlatformFileEntry`.
 - **Guarded against silent decay:** `audit:coverage-gate-pal` fails when a
   platform-branching file is unclassified, when a classified file's gate is not
   `pal: true`, when a new matrix entry carries no explicit `pal` field, when an

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -114,7 +114,7 @@ Design of record:
 | P2 | Release Train | ✅ done — both phases (run 30231918767) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, when a release phantoms, when an npm package is tagged but unpublished, or when a consumer's **lockfile-resolved** dependency lags npm `@latest`. Red-proved on a real phantom and on three real dependency edges; green after both, `OK (12 edges current)`. |
 | P3 | Review Layer | 🔨 first step done (#846) | The monorepo now carries a tuned `.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and the PAL ban — closing the satellites→monorepo direction of the pattern above. **Note:** the previously-stated gate ("an invariant violation is caught in CI") was already met — `_structure.yml` runs `audit:invariants` and all 17 static checks execute there; the one branch `--binary-only` excludes is a census that always exits 0. |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
-| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 38 jobs, Linux-only except the 7 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
+| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
 | P5 | Org Legibility | ✅ both gates green (run 30231918767) | `audit:secret-inventory` fails on any workflow secret missing from the credential registry **or** `ci-secrets.md`; `audit:actions-allowlist` fails on an unpermitted action **or** any workflow whose latest run ended in `startup_failure`. The second found a live nightly outage on its first correct run. Remaining: the legibility dashboard. |
 | P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
 
@@ -396,20 +396,58 @@ moves to P6).
   red-proof is the unit test in `scripts/ci-latency/evaluate.test.ts`, not the
   live run.
 - **Delivered (tuning, 2026-07-28):** the measurement's own "clearest lead" was
-  wrong, and two probes disproved it. Across 45 `E2E Desktop` legs the binding
-  upstream job was ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue
-  was ~10min median on every OS. The constraint is not macOS scarcity: a push
-  run demands ~105 job slots against a pool granting 13-17, with 32-41 jobs
+  wrong, and two probes disproved it. **Attribution capture A (2026-07-27,
+  throwaway probe):** across 45 `E2E Desktop` legs the binding upstream job was
+  ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue was ~10min
+  median on every OS. The constraint is not macOS scarcity: a push run demands
+  ~105 job slots against a pool granting 13-17, with 32-41 jobs
   created-but-waiting at peak; one sampled run opened with nine consecutive
-  minutes at zero running jobs. 72 of those 105 jobs were one 24-entry
-  coverage matrix run once per OS.
+  minutes at zero running jobs. 72 of those 105 jobs were one 24-entry coverage
+  matrix run once per OS.
+- **Attribution capture B (2026-07-28, promoted `probe-dag.ts` +
+  `probe-concurrency.ts`) supersedes A's split across OSes — but not A's
+  conclusion.** Re-run over the same 15-run `main` push window, the corrected
+  probe reports **ubuntu 24×, macOS 18×, windows 3×** (45 legs, 0 legs
+  unattributed, 15/15 complete reads) — macOS at ~40% of the legs, not 7%. The
+  created-but-waiting figure moved the same way: 4 sampled runs give **14 / 8 /
+  0 / 51 jobs created-but-waiting at peak** (peak concurrent 15 / 12 / 14 / 12;
+  105 jobs on all four runs), against A's "32-41 at peak". Both captures are
+  kept on purpose — `.superpowers/` is git-ignored, so this prose is the only
+  durable record of what was measured, and A's numbers were genuinely measured
+  in A's window. A's conclusion — *macOS scarcity is not the binding
+  constraint* — held for that window and is not softened here; B disagrees only
+  about how the legs divide across OSes. What both windows agree on, and what
+  the two changes below act on, is **slot starvation**: 105 jobs against a pool
+  granting 12-17, one run sitting 51 jobs deep at its peak and spending its
+  first 17 minutes at zero running jobs.
 - **This retired the design of record's sharding proposal.** Sharding adds jobs
   to the pool that IS the constraint.
-- **Two changes:** coverage-threshold gates run on Linux only except the seven
-  whose covered code branches on platform (72 → 38 jobs; a run 105 → 71), and
+- **Two changes:** coverage-threshold gates run on Linux only except the nine
+  whose covered code branches on platform (72 → 42 jobs; a run 105 → 75), and
   `e2e-desktop` now waits on `ci-rust` (1.17-1.72min) instead of `ci-ts` (30
   jobs, DAG wait measured 33.4min median on 2026-07-27) — an edge that carried
   no artifacts.
+- **The coverage-gate split is TWO jobs, and the first spelling of it was
+  wrong.** The obvious single-job form —
+  `if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)`
+  — shipped through implementation and review before the whole-branch review
+  caught that `matrix` is not in the context set available to a **job-level**
+  `if:` (GitHub grants only `github`, `needs`, `vars`, `inputs`, because the
+  condition is evaluated before the matrix expands). It would have silently
+  skipped **all 24** coverage gates on Windows and macOS — including the PAL
+  gates whose preservation is the entire safety argument. The shipped form is
+  `coverage-gates-pal` (9 entries, `if: inputs.run-tests`) and
+  `coverage-gates-linux` (15 entries, `if: inputs.run-tests && inputs.runner ==
+  'ubuntu-24.04'`), each gated only on `inputs`. `fromJSON(...)` over one job
+  was rejected: a leg that never expands never creates its check context, and
+  this repo depends on a *skipped* leg still creating one.
+- **Two gates were promoted to `pal: true` by the same review.** `Embedding`
+  and `DB layer` both pull `index/sqlite-vec-load.ts` — which branches on
+  platform for the native extension filename — into their coverage denominators
+  through static imports (`embedding/lazy-scheduler.ts` and
+  `index/migrations/runner.ts`). The PAL set is therefore 9, not 7: `Vault`,
+  `Embedding`, `Extensions`, `Telemetry`, `DB layer`, `Doctor`, `Updater`,
+  `Perf`, `Sandbox`.
 - **The DAG-wait baseline nearly doubled between measurements.** The 33.4min
   figure above was genuinely measured on 2026-07-27. Re-running the promoted
   probe on 2026-07-28 against the same `main` window found **60.5min median
@@ -422,8 +460,11 @@ moves to P6).
   (2026-07-28, against `main`) also found: 105 jobs per run on all four
   sampled runs, peak concurrent 12-14 (the plan predicted 13-17), and all
   reads complete (15/15 DAG runs, 4/4 concurrency runs — so none of the above
-  is a partial-sample artifact). **60.5min median is the baseline any future
-  "after" comparison must be measured against — not 33.4.**
+  is a partial-sample artifact). A third re-run later on 2026-07-28, after the
+  whole-branch review fixes, returned **60.1min median (max 110.8min, n=15)** —
+  the window had rolled by one run, so the figure is stable, not drifting.
+  **~60min median is the baseline any future "after" comparison must be
+  measured against — not 33.4.**
 - **`audit:ci-latency` cannot prove this worked**, since it gates execution
   while the win lands in queue and DAG wait. `scripts/ci-latency/probe-dag.ts`
   and `probe-concurrency.ts` are the instrument; the before figures above are
@@ -435,7 +476,14 @@ moves to P6).
   actual numbers here — never a predicted figure.
 - **Guarded against silent decay:** `audit:coverage-gate-pal` fails when a
   platform-branching file is unclassified, when a classified file's gate is not
-  `pal: true`, or when a new matrix entry carries no explicit `pal` field.
+  `pal: true`, when a new matrix entry carries no explicit `pal` field, when an
+  entry sits in the job that contradicts its `pal` value, when either job's
+  `if:` drifts from the condition the split depends on, or when the runner
+  literal in `coverage-gates-linux`'s condition stops matching the label
+  `ci.yml` actually calls `_test-suite.yml` with. The last three rules exist
+  because the first revision validated the `pal:` fields without ever reading
+  the `if:` lines that consume them — which is precisely how the broken
+  job-level `matrix.gate.pal` condition shipped green.
 - **Deferred:** guarding E2E against a TypeScript failure on `main`. Measured
   2 of the last 40 `main` commits arrived without a PR, both `ci(cla)` workflow
   commits touching no TypeScript. No standalone fast typecheck job exists to
@@ -443,7 +491,8 @@ moves to P6).
   cannot reach it), so guarding costs a duplicate typecheck job on every push.
   **Adopt if** a `main` E2E run is ever seen burning on a TS compile failure.
 - **Baseline regeneration is due after ~12 post-change push runs**, when the
-  36 abandoned macOS/Windows coverage keys have aged out of the sampling window
+  30 abandoned macOS/Windows coverage keys (15 Linux-only gates × 2 dropped
+  OSes) have aged out of the sampling window
   (`MAX_RUNS_PER_WORKFLOW`). Regenerating sooner is a no-op: the window still
   holds pre-change runs carrying those keys.
 

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review-response.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review-response.md
@@ -53,6 +53,10 @@ packages/gateway/src/platform/sandbox/sandbox-runner.ts
 packages/gateway/src/vault/factory.ts
 ```
 
+Those are the six the sweep had not already classified; the full count of files
+using the idiom is **seven**, the seventh being `packages/gateway/src/perf/bench-cli.ts`,
+which was already covered by the `Perf` gate and so surfaced nothing new.
+
 All six branch on the result — `if (platform() === "linux")`,
 `if (platform() === "win32")`, `const p = platform()`. The original regex
 `/process\.platform|os\.platform\(\)/` matches none of them.

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review-response.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review-response.md
@@ -1,0 +1,176 @@
+# P4b tuning plan review — response
+
+Response to [`2026-07-28-p4b-ci-tuning-review.md`](./2026-07-28-p4b-ci-tuning-review.md).
+
+**All four findings are valid, and two of them found real bugs in the plan.**
+Finding 2 is the significant one: it exposed a misclassification in the design's
+own PAL sweep, which would have shipped a coverage gate to Linux-only while the
+code it covers branches on platform — precisely the failure the audit exists to
+prevent.
+
+| # | Finding | Outcome |
+| --- | --- | --- |
+| 1 | Detector skips nested `packages/mcp-connectors/*/src` | **Fixed** — confirmed 94 skipped directories |
+| 2 | Detection regex misses destructured `platform` imports | **Fixed** — and it caught a wrong `pal: false` on the `Doctor` gate |
+| 3 | Line-based YAML parser is indentation-brittle | **Partly fixed** — the premise needs one correction: it already fails loud, not silent |
+| 4 | Probe API error handling | **Fixed**, and the real hazard is worse than described |
+| Q | How is `packages/ui` handled? | **Answered from measurement** |
+
+---
+
+## 1. Nested packages — fixed
+
+The finding is right and the consequence is exact. `detectPlatformBranchingFiles`
+iterated `readdirSync(packages)` and looked for `<pkg>/src`, so for
+`packages/mcp-connectors` it looked for `packages/mcp-connectors/src`.
+
+Measured: that path **does not exist**, and there are **94** nested
+`packages/mcp-connectors/*/src` directories. Every one was skipped.
+
+No connector branches on platform today, which is why this would have gone
+unnoticed — and is exactly why it matters. A detector with a silent blind spot
+is worse than no detector, because the green result is read as coverage.
+
+**Fixed** by discovering `src` directories at any depth rather than assuming
+they sit one level down. The "only `src`, never `test`" principle is preserved:
+scanning everything under `packages/` would flag the cross-platform test helpers
+that branch on `process.platform` legitimately, which is the false-positive noise
+the design set out to avoid.
+
+---
+
+## 2. Detection regex — fixed, and it found a real misclassification
+
+The finding proposes the regex may miss destructured imports. It does not "may":
+**it does, and the pattern is in active use.**
+
+```text
+packages/cli/src/commands/doctor-core.ts        import { platform } from "node:os"
+packages/gateway/src/ipc/server/server.ts       import { platform } from "node:os"
+packages/gateway/src/platform/gateway-log-file.ts
+packages/gateway/src/platform/index.ts
+packages/gateway/src/platform/sandbox/sandbox-runner.ts
+packages/gateway/src/vault/factory.ts
+```
+
+All six branch on the result — `if (platform() === "linux")`,
+`if (platform() === "win32")`, `const p = platform()`. The original regex
+`/process\.platform|os\.platform\(\)/` matches none of them.
+
+### The consequence: the design's own sweep was wrong
+
+`packages/cli/src/commands/doctor-core.ts:80` reads:
+
+```ts
+if (platform() === "linux") {
+```
+
+The `Doctor` coverage gate (`test:coverage:doctor` →
+`packages/cli/src/commands/doctor*.test.ts`) covers that file, and the design
+classified `Doctor` as **`pal: false`** — Linux-only. Shipping that would have
+stopped watching the non-Linux branches of the very file that reports
+platform health, while the audit reported OK.
+
+This is the failure mode Change C was written to prevent, found in the
+classification that Change C was written from. The static sweep in the design is
+correspondingly **less trustworthy than it claimed**, and the design's own
+caveat — that this is static, not empirical, evidence — earned its keep.
+
+**Fixed:**
+
+- Detection now also matches an `import { … platform … } from "node:os"`
+  (including `platform as alias`) and `os.type()`.
+- `Doctor` moves to **`pal: true`**.
+- The five other files are added to the allowlist: `vault/factory.ts` → `Vault`
+  and `sandbox/sandbox-runner.ts` → `Sandbox` are already `pal: true`;
+  `platform/index.ts`, `platform/gateway-log-file.ts` and `ipc/server/server.ts`
+  are `gate: "none"`.
+
+`ipc/server/server.ts` was checked rather than assumed: the `LAN` gate's test set
+imports `lan-server.ts` only, never `ipc/server/server.ts`, so no
+threshold gate covers it.
+
+### Revised numbers
+
+Seven PAL gates, not six:
+
+| | before | after |
+| --- | --- | --- |
+| coverage-gate jobs | 72 | **38** (was 36) |
+| jobs per push run | 105 | **71** (was 69) |
+
+The plan and design are corrected to these figures. Two extra jobs is the
+correct price for not silently dropping a platform branch.
+
+---
+
+## 3. YAML parser resilience — partly fixed, with a correction
+
+The concern is reasonable, but the premise needs one correction: the parser
+**cannot fail silently**. Two guards already make a parse failure loud:
+
+- `gates.length === 0` returns the hard error
+  `no coverage-gates matrix entries found`.
+- A `name:` that parses while its `pal:` does not yields `pal: null`, which rule
+  4 reports as `has no explicit pal: field`.
+
+So a reformat that breaks the parser reddens the gate; it does not quietly pass.
+The real cost is a **false red on a cosmetic change**, which is still worth
+avoiding.
+
+**Fixed** by matching on relative structure instead of absolute column counts:
+the matrix block ends at the first line whose indentation is less than or equal
+to the `gate:` key's own, entries are recognised by `- name:` at deeper
+indentation, and `pal:` by a deeper-still sibling. A test with a different
+indentation width is added, per the finding's suggestion.
+
+---
+
+## 4. Probe error handling — fixed, and the hazard is worse than described
+
+The top-level path was already handled: an unauthenticated `gh` yields zero runs
+and both probes exit 1 with
+`no successful push runs readable — is 'gh' authenticated?`.
+
+The real gap is one level down, and it is more dangerous than a missing message.
+`jobsForRun` breaks out of its paging loop when a page read fails, returning
+whatever it had. **Job count is this slice's headline metric.** A silent
+truncation during the *after* measurement would report fewer jobs than really
+ran and be read as proof the change worked. A measurement instrument that fails
+toward its own hypothesis is worse than none.
+
+This is the same hazard the measurement slice handles with
+`MAX_READ_FAILURE_RATIO`, and it gets the same treatment: page reads are
+counted, and a probe that suffered any read failure prints
+`::warning::` naming the count and refuses to print a job-count summary for the
+affected run rather than printing a low number without comment.
+
+---
+
+## Q. `packages/ui`
+
+Measured: **no file under `packages/ui` branches on platform today** (checked
+for `process.platform`, `os.platform()`, `os.type()` and destructured `node:os`
+imports across `.ts` and `.tsx`).
+
+The detector already includes `.tsx` and, with finding 1's fix, reaches
+`packages/ui/src`. No UI coverage gate exists in the `_test-suite.yml` matrix, so
+a future platform-branching UI file would be classified `gate: "none"` — recorded
+as considered, not protected. If a UI coverage gate is ever added, rule 4 forces
+it to be classified `pal` explicitly at that moment.
+
+---
+
+## Net changes to the plan
+
+- **Task 1** — `detectPlatformBranchingFiles` discovers `src` at any depth;
+  detection covers destructured `node:os` imports and `os.type()`;
+  `parseCoverageGateMatrix` uses relative indentation; six new allowlist entries;
+  new tests for nested discovery, destructured-import detection, and indent
+  variation.
+- **Task 2** — `Doctor` becomes `pal: true`; seven PAL gates, seventeen
+  Linux-only; verification step expects `total 24 / pal 7 / unclassified 0`.
+- **Task 5** — probes count read failures and refuse to report a truncated job
+  count.
+- **Task 6** — the recorded figures become 72 → 38 coverage jobs and 105 → 71
+  per run.

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review.md
@@ -1,6 +1,6 @@
 # P4b CI Tuning — Plan Review
 
-Review of the implementation plan [2026-07-28-p4b-ci-tuning.md](file:///C:/gitrep/Nimbus/.claude/worktrees/p4b-tuning/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md).
+Review of the implementation plan [2026-07-28-p4b-ci-tuning.md](./2026-07-28-p4b-ci-tuning.md).
 
 ---
 

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning-review.md
@@ -1,0 +1,49 @@
+# P4b CI Tuning — Plan Review
+
+Review of the implementation plan [2026-07-28-p4b-ci-tuning.md](file:///C:/gitrep/Nimbus/.claude/worktrees/p4b-tuning/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md).
+
+---
+
+## Suggestions and Improvements
+
+### 1. Nested Package Auditing (Connectors / Shared Packages)
+
+* **Observation:** The `detectPlatformBranchingFiles` function in Task 1 scans files matching `packages/*/src`. It does not recurse into nested packages or directories.
+* **Problem:** If a first-party connector under `packages/mcp-connectors/<connector-name>/src` or a helper in `packages/mcp-connectors/shared/` introduces platform-branching code (e.g. using `process.platform`), the audit will silently skip it because `packages/mcp-connectors/src` does not exist.
+* **Suggestion:** Update `detectPlatformBranchingFiles` to recursively locate all `src` folders under `packages/`, or explicitly iterate through subdirectories of `packages/mcp-connectors/` as well. For example:
+
+  ```ts
+  // Support both packages/*/src and packages/mcp-connectors/*/src
+  const targets = [
+    join(repoRoot, "packages"),
+    join(repoRoot, "packages/mcp-connectors")
+  ];
+  ```
+
+### 2. Broadening the Platform-Branching Detection Regex
+
+* **Observation:** The audit checks for `/process\.platform|os\.platform\(\)/`.
+* **Problem:** Developers might use destructured imports or alternative ways to query the platform:
+  * `import { platform } from "node:os"; if (platform() === "win32") { ... }` (fails regex match)
+  * Checking `os.type()` (fails regex match)
+  * Checking `process.env.OS` or similar platform-specific environment variables.
+* **Suggestion:** Document this limitation clearly in the file headers or expand the regex `/process\.platform|os\.platform\(\)/` to also capture generic `platform()` calls or destructuring imports of `platform` from `os`/`node:os`.
+
+### 3. YAML Parsing Resilience
+
+* **Observation:** `parseCoverageGateMatrix` uses a line-based parser with fixed indentation assumptions (`if (/^\s{0,8}\S/.test(line)) break;`).
+* **Problem:** Formatting changes (e.g. from YAML formatters or structural workflow updates) could shift indentations and break the parser.
+* **Suggestion:** Keep the line-based parser but add a robust warning comment, or ensure the unit test suite explicitly exercises varying indents to catch formatting-related drift early.
+
+### 4. API Request Error Handling in Probes
+
+* **Observation:** In `probe-dag.ts` and `probe-concurrency.ts`, the `api` helper returns `null` on `gh api` errors.
+* **Problem:** If `api` returns `null` or a failed payload, the caller maps over properties without checks or prints generic error messages.
+* **Suggestion:** Make sure the diagnostic tools fail fast with descriptive messages if `gh` is unauthenticated or the API returns a rate-limit error.
+
+---
+
+## Open Questions
+
+1. **How should platform-branching in `packages/ui` be handled?**
+   * If Tauri/frontend files under `packages/ui` use platform-branching logic, are they covered by the same coverage gate strategy? Should they be explicitly added to the platform branching allowlist or ignored by the audit?

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -903,8 +903,8 @@ actually matters: a broken Tauri build makes E2E unrunnable."
   `scripts/structure-audit/_gh-audit.ts`, where `GhResult` is
   `{ ok: boolean; stdout: string; stderr: string; httpStatus?: number }`.
   Also `isRecord(v: unknown): v is Record<string, unknown>` from the same module.
-- Produces: `median`, `minutesBetween`, `bindingUpstream`, `concurrencySeries`
-  from `probe-lib.ts`.
+- Produces: `median`, `minutesBetween`, `bindingUpstream`, `concurrencySeries`,
+  `pageJobs` from `probe-lib.ts`.
 
 These are the only tools that can verify this slice, since `audit:ci-latency`
 gates execution and the win lands in queue and DAG wait. They are diagnostic
@@ -918,7 +918,13 @@ Create `scripts/ci-latency/probe-lib.test.ts`:
 ```ts
 import { describe, expect, test } from "bun:test";
 
-import { bindingUpstream, concurrencySeries, median, minutesBetween } from "./probe-lib.ts";
+import {
+  bindingUpstream,
+  concurrencySeries,
+  median,
+  minutesBetween,
+  pageJobs,
+} from "./probe-lib.ts";
 
 describe("median", () => {
   test("odd-length picks the middle", () => {
@@ -946,13 +952,13 @@ describe("minutesBetween", () => {
 });
 
 describe("bindingUpstream", () => {
-  test("picks the upstream job that completed last", () => {
+  test("picks the upstream job that completed last, at or before eligibility", () => {
     const jobs = [
       { name: "a", completed_at: "2026-07-27T10:05:00Z" },
       { name: "b", completed_at: "2026-07-27T10:20:00Z" },
       { name: "c", completed_at: "2026-07-27T10:10:00Z" },
     ];
-    expect(bindingUpstream(jobs)?.name).toBe("b");
+    expect(bindingUpstream(jobs, "2026-07-27T10:25:00Z")?.name).toBe("b");
   });
 
   test("ignores jobs that never completed", () => {
@@ -960,11 +966,30 @@ describe("bindingUpstream", () => {
       { name: "a", completed_at: "2026-07-27T10:05:00Z" },
       { name: "running", completed_at: null },
     ];
-    expect(bindingUpstream(jobs)?.name).toBe("a");
+    expect(bindingUpstream(jobs, "2026-07-27T10:30:00Z")?.name).toBe("a");
   });
 
-  test("an empty list yields null", () => {
-    expect(bindingUpstream([])).toBeNull();
+  test("excludes a candidate that completed AFTER the eligibility moment", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:20:00Z" },
+    ];
+    // b finished after the leg became eligible -- it cannot have gated it,
+    // even though it is the global-latest completion.
+    expect(bindingUpstream(jobs, "2026-07-27T10:10:00Z")?.name).toBe("a");
+  });
+
+  test("picks the latest candidate at or before the eligibility moment, not the global latest", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:10:00Z" },
+      { name: "c", completed_at: "2026-07-27T10:20:00Z" },
+    ];
+    expect(bindingUpstream(jobs, "2026-07-27T10:10:00Z")?.name).toBe("b");
+  });
+
+  test("an empty candidate list yields null", () => {
+    expect(bindingUpstream([], "2026-07-27T10:00:00Z")).toBeNull();
   });
 });
 
@@ -983,6 +1008,57 @@ describe("concurrencySeries", () => {
 
   test("no jobs yields an empty series", () => {
     expect(concurrencySeries([], "2026-07-27T10:00:00Z")).toEqual([]);
+  });
+});
+
+interface FakeJob {
+  id: number;
+}
+
+function parseFakeBatch(payload: unknown): FakeJob[] {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !Array.isArray((payload as { jobs?: unknown }).jobs)
+  ) {
+    return [];
+  }
+  return (payload as { jobs: FakeJob[] }).jobs;
+}
+
+describe("pageJobs", () => {
+  test("a failed page read yields complete: false, not a false end-of-pagination", () => {
+    // Page 1 declares 3 jobs total but only delivers 1; page 2 fails outright
+    // (returns null). A read that mistook the null for "no more pages" would
+    // report complete: true with a truncated job list -- exactly the failure
+    // mode that would make an AFTER run look like a win.
+    const result = pageJobs(
+      (page) => (page === 1 ? { total_count: 3, jobs: [{ id: 1 }] } : null),
+      parseFakeBatch,
+    );
+    expect(result.complete).toBe(false);
+    expect(result.jobs).toEqual([{ id: 1 }]);
+    expect(result.expected).toBe(3);
+  });
+
+  test("reconciles against total_count across multiple successful pages", () => {
+    const pages: Record<number, unknown> = {
+      1: { total_count: 2, jobs: [{ id: 1 }] },
+      2: { total_count: 2, jobs: [{ id: 2 }] },
+    };
+    const result = pageJobs((page) => pages[page] ?? null, parseFakeBatch);
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.expected).toBe(2);
+  });
+
+  test("an empty page ends pagination -- distinct from a failed read", () => {
+    // No total_count ever arrives, so `expected` stays undefined and the read
+    // is correctly reported incomplete rather than crashing on a missing count.
+    const result = pageJobs((page) => (page === 1 ? { jobs: [] } : null), parseFakeBatch);
+    expect(result.complete).toBe(false);
+    expect(result.jobs).toEqual([]);
+    expect(result.expected).toBeUndefined();
   });
 });
 ```
@@ -1004,6 +1080,8 @@ Create `scripts/ci-latency/probe-lib.ts`:
  * They live apart from the probes so the arithmetic is unit-testable without a
  * network call. The probes themselves are thin: fetch, map, print.
  */
+
+import { isRecord } from "../structure-audit/_gh-audit.ts";
 
 export interface CompletedJob {
   name: string;
@@ -1033,15 +1111,25 @@ export function minutesBetween(a: string, b: string): number {
 
 /**
  * The upstream job whose completion gated a dependent job — i.e. the last one
- * to finish. Returns null when nothing has completed.
+ * to finish at or before `eligibleAt` (the moment the dependent job became
+ * eligible to run, e.g. its `created_at`).
+ *
+ * The cutoff matters structurally, not just cosmetically: a candidate that
+ * finished LATER than `eligibleAt` cannot have gated anything — it simply
+ * happened to run long. Taking the unrestricted global max would misattribute
+ * gating to whichever candidate was slowest, rather than whichever candidate
+ * the dependent job actually waited on. Returns null when no candidate
+ * completed at or before the cutoff.
  */
-export function bindingUpstream(jobs: CompletedJob[]): CompletedJob | null {
+export function bindingUpstream(jobs: CompletedJob[], eligibleAt: string): CompletedJob | null {
+  const cutoff = Date.parse(eligibleAt);
   let best: CompletedJob | null = null;
   let bestAt = Number.NEGATIVE_INFINITY;
   for (const j of jobs) {
     if (j.completed_at === null) continue;
     const at = Date.parse(j.completed_at);
     if (Number.isNaN(at) || at <= bestAt) continue;
+    if (!Number.isNaN(cutoff) && at > cutoff) continue;
     bestAt = at;
     best = j;
   }
@@ -1067,13 +1155,59 @@ export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): num
   }
   return series;
 }
+
+export interface PagedJobs<J> {
+  jobs: J[];
+  /** Whether the read reconciled against the API's `total_count`. */
+  complete: boolean;
+  /** `total_count` as last reported by the API, if any page reported one. */
+  expected: number | undefined;
+}
+
+/**
+ * Pages through a run's jobs via `fetchPage`, tracking whether the read is
+ * COMPLETE — i.e. whether the accumulated job count reconciles against the
+ * API's `total_count`.
+ *
+ * Job count is this slice's headline metric, so a silently truncated read
+ * would report fewer jobs than really ran and be read as proof the change
+ * worked. An instrument that fails toward its own hypothesis is worse than
+ * none — the same hazard `MAX_READ_FAILURE_RATIO` guards against in the gate
+ * itself. This logic used to be duplicated between the two probes; it now
+ * lives in exactly one place.
+ *
+ * `fetchPage` returns the parsed JSON payload for the given 1-indexed page,
+ * or `null` on a FAILED read — never on "no more pages" (an exhausted feed is
+ * signaled by `parseBatch` returning an empty array). Taking a callback
+ * rather than doing network I/O itself keeps this testable without a network
+ * call.
+ */
+export function pageJobs<J>(
+  fetchPage: (page: number) => unknown,
+  parseBatch: (payload: unknown) => J[],
+  maxPages = 5,
+): PagedJobs<J> {
+  const jobs: J[] = [];
+  let expected: number | undefined;
+  for (let page = 1; page <= maxPages; page++) {
+    const payload = fetchPage(page);
+    if (payload === null) return { jobs, complete: false, expected }; // read FAILED, not "no more pages"
+    const total = isRecord(payload) ? payload["total_count"] : undefined;
+    if (typeof total === "number") expected = total;
+    const batch = parseBatch(payload);
+    if (batch.length === 0) break;
+    jobs.push(...batch);
+    if (expected !== undefined && jobs.length >= expected) break;
+  }
+  return { jobs, complete: expected !== undefined && jobs.length >= expected, expected };
+}
 ```
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `bun test scripts/ci-latency/probe-lib.test.ts`
 
-Expected: 10 tests PASS.
+Expected: 15 tests PASS.
 
 - [ ] **Step 5: Implement the DAG probe**
 
@@ -1094,7 +1228,7 @@ Create `scripts/ci-latency/probe-dag.ts`:
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { bindingUpstream, median, minutesBetween } from "./probe-lib.ts";
+import { bindingUpstream, median, minutesBetween, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
 
@@ -1140,25 +1274,15 @@ function asJobs(value: unknown): Job[] {
 /**
  * Pages through a run's jobs, reporting whether the read was COMPLETE.
  *
- * Job count is this slice's headline metric, so a silently truncated read would
- * report fewer jobs than really ran and be read as proof the change worked. An
- * instrument that fails toward its own hypothesis is worse than none — the same
- * hazard `MAX_READ_FAILURE_RATIO` exists for in the gate itself.
+ * Delegates to the shared `pageJobs` helper in `probe-lib.ts` — see its
+ * docstring for why read-completeness tracking lives in exactly one place.
  */
 function jobsForRun(runId: number): { jobs: Job[]; complete: boolean } {
-  const jobs: Job[] = [];
-  let expected: number | undefined;
-  for (let page = 1; page <= 5; page++) {
-    const payload = api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
-    if (payload === null) return { jobs, complete: false }; // read FAILED, not "no more pages"
-    const total = isRecord(payload) ? payload["total_count"] : undefined;
-    if (typeof total === "number") expected = total;
-    const batch = asJobs(payload);
-    if (batch.length === 0) break;
-    jobs.push(...batch);
-    if (expected !== undefined && jobs.length >= expected) break;
-  }
-  return { jobs, complete: expected !== undefined && jobs.length >= expected };
+  const { jobs, complete } = pageJobs(
+    (page) => api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`),
+    asJobs,
+  );
+  return { jobs, complete };
 }
 
 function parseRunsArg(argv: string[]): number {
@@ -1173,7 +1297,8 @@ if (import.meta.main) {
   const listed = api(
     `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
   );
-  const runs = isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  const runs =
+    isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
   if (runs.length === 0) {
     console.error("probe-dag: no successful push runs readable — is `gh` authenticated?");
     process.exit(1);
@@ -1197,8 +1322,12 @@ if (import.meta.main) {
     }
     const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
     const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
-    const gatedBy = bindingUpstream(upstream);
     for (const leg of legs) {
+      // Eligibility is per-leg, not per-run: which upstream job actually
+      // gated THIS leg depends on when THIS leg became runnable
+      // (`leg.created_at`), not on which candidate happened to finish last
+      // in wall-clock time across the whole run.
+      const gatedBy = bindingUpstream(upstream, leg.created_at);
       if (gatedBy) binding.set(gatedBy.name, (binding.get(gatedBy.name) ?? 0) + 1);
       const wait = minutesBetween(leg.created_at, startedAt);
       waitsByLeg.set(leg.name, [...(waitsByLeg.get(leg.name) ?? []), wait]);
@@ -1242,7 +1371,7 @@ Create `scripts/ci-latency/probe-concurrency.ts`:
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { concurrencySeries } from "./probe-lib.ts";
+import { concurrencySeries, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
 
@@ -1297,7 +1426,8 @@ if (import.meta.main) {
   const listed = api(
     `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
   );
-  const runs = isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  const runs =
+    isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
   if (runs.length === 0) {
     console.error("probe-concurrency: no successful push runs readable — is `gh` authenticated?");
     process.exit(1);
@@ -1311,23 +1441,13 @@ if (import.meta.main) {
 
     // A truncated read here corrupts the ONE number this probe exists to
     // report. Refuse to print rather than print a low job count that reads as
-    // success.
-    const jobs: Job[] = [];
-    let expected: number | undefined;
-    let complete = false;
-    for (let page = 1; page <= 5; page++) {
-      const payload = api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`);
-      if (payload === null) break;
-      const total = isRecord(payload) ? payload["total_count"] : undefined;
-      if (typeof total === "number") expected = total;
-      const batch = asJobs(payload);
-      if (batch.length === 0) break;
-      jobs.push(...batch);
-      if (expected !== undefined && jobs.length >= expected) {
-        complete = true;
-        break;
-      }
-    }
+    // success. Delegates to the shared `pageJobs` helper in probe-lib.ts — see
+    // its docstring for why read-completeness tracking lives in exactly one
+    // place, shared with probe-dag.ts.
+    const { jobs, complete, expected } = pageJobs(
+      (page) => api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`),
+      asJobs,
+    );
     if (!complete) {
       console.warn(
         `::warning::probe-concurrency: run ${id} job read incomplete (${jobs.length}/${expected ?? "?"}) — SKIPPED rather than reporting a truncated job count`,
@@ -1502,9 +1622,12 @@ not a placeholder.
 `check-action-sha-pins.ts`. `GateEntry.pal` is `boolean | null` in the
 implementation, the tests, and the parser. `PlatformFileEntry` fields
 (`file`/`gate`/`why`) are identical in the data module and every consumer.
-`bindingUpstream` takes `CompletedJob[]` and returns `CompletedJob | null` in
-both the test and the implementation. `runGh` is used with the exact signature
-read from `_gh-audit.ts`.
+`bindingUpstream` takes `(CompletedJob[], eligibleAt: string)` and returns
+`CompletedJob | null` in both the test and the implementation; the shared
+`pageJobs<J>(fetchPage, parseBatch, maxPages?)` helper in `probe-lib.ts` has the
+same call signature and `PagedJobs<J>` return shape at both its call sites
+(`probe-dag.ts`, `probe-concurrency.ts`). `runGh` is used with the exact
+signature read from `_gh-audit.ts`.
 
 **Known ordering constraint.** Task 1 ships an audit that is RED against the
 real repo; Task 2 turns it green. A reviewer seeing Task 1 in isolation should

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -417,7 +417,7 @@ const TEST_SUITE = ".github/workflows/_test-suite.yml";
  *
  * The destructured-import alternative is NOT optional to cover:
  * `import { platform } from "node:os"` is the dominant idiom in this codebase
- * (6 files), and an earlier revision of this audit that matched only
+ * (7 files), and an earlier revision of this audit that matched only
  * `process.platform` missed `doctor-core.ts` — whose gate was consequently
  * classified Linux-only by mistake.
  */

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -674,8 +674,12 @@ In `.github/workflows/_test-suite.yml`, in the `coverage-gates:` job, add an
     # per OS. Skipped matrix legs still create their check context, so no
     # required check is left "Expected — Waiting for status to be reported".
     # `scripts/structure-audit/check-coverage-gate-pal.ts` fails if a Linux-only
-    # gate's code ever gains platform branching.
-    if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
+    # gate's code ever gains platform branching. `inputs.run-tests` is gated
+    # explicitly here (rather than relied upon through the `needs: unit-coverage`
+    # skip chain) to match how every sibling job in this file gates on it
+    # directly (`static`, `unit-coverage`, `integration`, `e2e-gateway`,
+    # `e2e-cli`, `packaging`).
+    if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
     needs: unit-coverage
 ```
 

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -1,0 +1,1327 @@
+# P4b CI Tuning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut a push-to-`main` CI run from ~105 jobs to ~69 by running
+coverage-threshold gates on Linux only except where the covered code branches on
+platform, narrow `e2e-desktop`'s dependency edge, and add a static audit so the
+platform classification cannot rot silently.
+
+**Architecture:** Three independent changes to GitHub Actions workflow YAML,
+plus one new static audit in the existing `scripts/structure-audit/` pattern
+(exported pure functions + `import.meta.main` CLI), plus promotion of two
+throwaway measurement probes into `scripts/ci-latency/`.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6 strict, Biome, GitHub Actions YAML,
+`bun:test`.
+
+**Spec:** [`../specs/2026-07-27-p4b-ci-tuning-design.md`](../specs/2026-07-27-p4b-ci-tuning-design.md)
+and its [review response](../specs/2026-07-27-p4b-ci-tuning-design-review-response.md).
+
+## Global Constraints
+
+- **No `any`** — use `unknown` for external data. TypeScript strict is non-negotiable.
+- **Cross-platform paths** — build with `path.join()`; never hardcode separators.
+  Normalise to forward slashes for comparison with `.replace(/\\/g, "/")`.
+- Audit modules follow `scripts/structure-audit/check-action-sha-pins.ts`:
+  exported pure functions returning `{ ok: boolean; errors: string[] }`, a
+  `parseRootArg`-style root override where useful, and an `import.meta.main`
+  block that prints `<label>: OK` or one `console.error` per error then
+  `process.exit(1)`.
+- `REPO_ROOT` is exported from `scripts/structure-audit/lib.ts`.
+- **Any `bun run <id>` added to a workflow MUST be registered** in
+  `PREFLIGHT_GATES` or `CI_ONLY_GATES` in `scripts/lib/preflight-gates.ts`, or
+  the drift guard in `scripts/preflight.test.ts` fails.
+- The six PAL gate names, verbatim, as they appear in the `_test-suite.yml`
+  matrix: `Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`, `Telemetry`.
+- Commit on the branch `dev/asafgolombek/p4b-ci-tuning`. Never on `main`.
+- Run `bun run lint:markdown` before committing any Markdown.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `scripts/structure-audit/platform-branching-allowlist.ts` (create) | The checked-in classification: every platform-branching source file, the coverage gate that covers it, and why. Data only. |
+| `scripts/structure-audit/check-coverage-gate-pal.ts` (create) | Detection + the four assertions. Pure functions + CLI. |
+| `scripts/structure-audit/check-coverage-gate-pal.test.ts` (create) | Unit tests over fixtures, plus one test asserting the real repo passes. |
+| `.github/workflows/_test-suite.yml` (modify) | `pal` field on all 24 matrix entries + the `if:` gate on `coverage-gates`. |
+| `.github/workflows/ci.yml` (modify) | `e2e-desktop` needs edge. |
+| `.github/workflows/_structure.yml` (modify) | Run the new audit. |
+| `scripts/lib/preflight-gates.ts` (modify) | Register the new gate (FAST tier). |
+| `package.json` (modify) | `audit:coverage-gate-pal` script id. |
+| `scripts/ci-latency/probe-dag.ts` (create) | Which upstream job gated each E2E leg; per-leg DAG wait. |
+| `scripts/ci-latency/probe-concurrency.ts` (create) | Jobs per run, peak concurrent, created-but-waiting at peak. |
+| `scripts/ci-latency/probe-lib.ts` (create) | Pure helpers shared by both probes, so the logic is testable without network. |
+| `scripts/ci-latency/probe-lib.test.ts` (create) | Unit tests for those helpers. |
+| `docs/infrastructure-roadmap.md` (modify) | P4b progress log: before/after figures, the deferral and its trigger. |
+
+---
+
+## Task 1: The platform-branching allowlist and its audit
+
+**Files:**
+
+- Create: `scripts/structure-audit/platform-branching-allowlist.ts`
+- Create: `scripts/structure-audit/check-coverage-gate-pal.ts`
+- Create: `scripts/structure-audit/check-coverage-gate-pal.test.ts`
+
+**Interfaces:**
+
+- Consumes: `REPO_ROOT` from `scripts/structure-audit/lib.ts`.
+- Produces: `auditCoverageGatePal(repoRoot: string): AuditResult`,
+  `parseCoverageGateMatrix(yaml: string): GateEntry[]`,
+  `detectPlatformBranchingFiles(repoRoot: string): string[]`,
+  `PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[]`.
+
+At the end of this task the audit exists and its unit tests pass, but running it
+against the real repo **fails** — the matrix has no `pal` fields yet. That red is
+the proof the gate works; Task 2 turns it green.
+
+- [ ] **Step 1: Create the allowlist data module**
+
+Create `scripts/structure-audit/platform-branching-allowlist.ts`:
+
+```ts
+/**
+ * Every source file that branches on the host platform, and which coverage
+ * gate covers it.
+ *
+ * WHY THIS EXISTS: `_test-suite.yml` runs most coverage-threshold gates on
+ * Linux only. That is safe exactly while the code those gates cover does not
+ * branch on platform. Without this list, the day someone adds
+ * `process.platform` to a Linux-only gate's code, coverage on Windows and
+ * macOS quietly stops watching it and NOTHING fails.
+ *
+ * LIMITATION, stated so it is not rediscovered: `gate: "none"` means no
+ * coverage-threshold gate covers this file today. Those entries record that the
+ * file was classified, not that it is protected. Coverage is measured over
+ * files loaded at runtime including transitive imports, which cannot be derived
+ * statically from the gate's test paths — so this audit guarantees that new
+ * platform-branching code is CLASSIFIED, and that the six PAL gates stay
+ * `pal: true`. It does not prove a `gate: "none"` file never becomes covered by
+ * a `pal: false` gate.
+ */
+
+export interface PlatformFileEntry {
+  /** Repo-relative path, forward slashes. */
+  readonly file: string;
+  /** Coverage-gate `name` from the _test-suite.yml matrix, or "none". */
+  readonly gate: string;
+  readonly why: string;
+}
+
+export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
+  // ── Covered by a PAL gate (must be pal: true in the matrix) ────────────────
+  {
+    file: "packages/gateway/src/vault/win32.ts",
+    gate: "Vault",
+    why: "DPAPI backend; branches on platform and is win32-named",
+  },
+  { file: "packages/gateway/src/vault/darwin.ts", gate: "Vault", why: "Keychain backend" },
+  { file: "packages/gateway/src/vault/linux.ts", gate: "Vault", why: "libsecret backend" },
+  {
+    file: "packages/gateway/src/platform/sandbox/win32.ts",
+    gate: "Sandbox",
+    why: "Windows job-object sandbox",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/darwin.ts",
+    gate: "Sandbox",
+    why: "sandbox-exec profile",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/linux.ts",
+    gate: "Sandbox",
+    why: "bwrap + seccomp",
+  },
+  {
+    file: "packages/gateway/src/updater/factory.ts",
+    gate: "Updater",
+    why: "selects the per-OS updater implementation",
+  },
+  {
+    file: "packages/gateway/src/updater/platform-target.ts",
+    gate: "Updater",
+    why: "maps platform to a release asset target",
+  },
+  {
+    file: "packages/gateway/src/extensions/install-from-local.ts",
+    gate: "Extensions",
+    why: "per-OS install paths and permissions",
+  },
+  {
+    file: "packages/gateway/src/perf/bench-runner.ts",
+    gate: "Perf",
+    why: "per-OS timing and process handling",
+  },
+  { file: "packages/gateway/src/perf/bench-cli.ts", gate: "Perf", why: "per-OS bench invocation" },
+  { file: "packages/cli/src/commands/bench.ts", gate: "Perf", why: "per-OS bench invocation" },
+  {
+    file: "packages/gateway/src/telemetry/collector.ts",
+    gate: "Telemetry",
+    why: "reports host platform",
+  },
+
+  // ── Not covered by any coverage-threshold gate ────────────────────────────
+  {
+    file: "packages/gateway/src/platform/win32.ts",
+    gate: "none",
+    why: "PAL implementation; no coverage-threshold gate targets src/platform",
+  },
+  { file: "packages/gateway/src/platform/darwin.ts", gate: "none", why: "PAL implementation" },
+  { file: "packages/gateway/src/platform/linux.ts", gate: "none", why: "PAL implementation" },
+  {
+    file: "packages/gateway/src/platform/browser.ts",
+    gate: "none",
+    why: "per-OS browser-open command",
+  },
+  {
+    file: "packages/gateway/src/index/registered-roots-store.ts",
+    gate: "none",
+    why: "per-OS path normalisation",
+  },
+  {
+    file: "packages/gateway/src/index/sqlite-vec-load.ts",
+    gate: "none",
+    why: "per-OS native extension filename",
+  },
+  {
+    file: "packages/gateway/src/ipc/server/dispatchers.ts",
+    gate: "none",
+    why: "named pipe vs unix socket",
+  },
+  { file: "packages/gateway/src/voice/tts.ts", gate: "none", why: "per-OS TTS backend" },
+  {
+    file: "packages/gateway/src/voice/wake-word.ts",
+    gate: "none",
+    why: "per-OS audio capture",
+  },
+  { file: "packages/cli/src/commands/config.ts", gate: "none", why: "per-OS config path display" },
+  {
+    file: "packages/cli/src/commands/extension.ts",
+    gate: "none",
+    why: "per-OS extension paths",
+  },
+  { file: "packages/cli/src/commands/start.ts", gate: "none", why: "per-OS gateway launch" },
+  {
+    file: "packages/cli/src/lib/resolve-gateway-launch.ts",
+    gate: "none",
+    why: "per-OS executable resolution",
+  },
+  { file: "packages/cli/src/lib/spawn-gateway.ts", gate: "none", why: "per-OS spawn flags" },
+];
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `scripts/structure-audit/check-coverage-gate-pal.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { auditCoverageGatePal, parseCoverageGateMatrix } from "./check-coverage-gate-pal.ts";
+import { REPO_ROOT } from "./lib.ts";
+
+const MATRIX = `
+  coverage-gates:
+    name: Coverage — \${{ matrix.gate.name }}
+    needs: unit-coverage
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - name: Engine
+            script: "test:coverage:engine"
+            pal: false
+          - name: Vault
+            script: "test:coverage:vault"
+            pal: true
+    steps:
+      - name: Checkout
+`;
+
+describe("parseCoverageGateMatrix", () => {
+  test("reads each gate name and its explicit pal flag", () => {
+    expect(parseCoverageGateMatrix(MATRIX)).toEqual([
+      { name: "Engine", pal: false },
+      { name: "Vault", pal: true },
+    ]);
+  });
+
+  test("a gate with no pal field parses as null, not as false", () => {
+    // A missing flag must be distinguishable from an explicit `false`, so the
+    // audit can demand classification rather than silently defaulting.
+    const yaml = MATRIX.replace('            pal: false\n', "");
+    expect(parseCoverageGateMatrix(yaml)[0]).toEqual({ name: "Engine", pal: null });
+  });
+
+  test("stops at the end of the matrix block", () => {
+    // `steps:` dedents out of the matrix; nothing after it is a gate.
+    expect(parseCoverageGateMatrix(MATRIX).map((g) => g.name)).not.toContain("Checkout");
+  });
+});
+
+describe("auditCoverageGatePal", () => {
+  test("the real repository passes", () => {
+    const result = auditCoverageGatePal(REPO_ROOT);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `bun test scripts/structure-audit/check-coverage-gate-pal.test.ts`
+
+Expected: FAIL — `Cannot find module './check-coverage-gate-pal.ts'`.
+
+- [ ] **Step 4: Implement the audit**
+
+Create `scripts/structure-audit/check-coverage-gate-pal.ts`:
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * audit:coverage-gate-pal — keeps the PAL classification behind the Linux-only
+ * coverage gates honest.
+ *
+ * `_test-suite.yml` runs coverage-threshold gates on Linux only unless the gate
+ * is marked `pal: true`. That is safe only while the covered code does not
+ * branch on platform. This audit fails when:
+ *
+ *   1. a source file branches on platform but is absent from the allowlist
+ *   2. an allowlist entry names a file that no longer branches on platform
+ *      (or no longer exists) — stale entries rot in the other direction
+ *   3. an allowlisted file declares a gate that is not `pal: true`
+ *   4. a matrix entry carries no explicit `pal` field
+ *
+ * Rule 4 is why the field is spelled out on all 24 entries: a new gate must be
+ * classified deliberately, never by inheriting a default.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { PLATFORM_BRANCHING_ALLOWLIST } from "./platform-branching-allowlist.ts";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export interface GateEntry {
+  name: string;
+  /** null when the matrix entry carries no `pal` field at all. */
+  pal: boolean | null;
+}
+
+const TEST_SUITE = ".github/workflows/_test-suite.yml";
+
+/** Runtime platform branching, or a filename that names an OS. */
+const BRANCHES_ON_PLATFORM = /process\.platform|os\.platform\(\)/;
+const OS_NAMED_FILE = /\/(win32|darwin|linux)\.ts$/;
+
+function collectSources(dir: string, out: string[]): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSources(full, out);
+    } else if (
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every non-test source file under `packages/{*}/src` that branches on the host
+ * platform. Tests are excluded deliberately: a cross-platform test branching on
+ * `process.platform` is correct, not a finding.
+ */
+export function detectPlatformBranchingFiles(repoRoot: string): string[] {
+  const packagesDir = join(repoRoot, "packages");
+  if (!existsSync(packagesDir)) return [];
+  const files: string[] = [];
+  for (const pkg of readdirSync(packagesDir)) {
+    collectSources(join(packagesDir, pkg, "src"), files);
+  }
+  const hits: string[] = [];
+  for (const file of files) {
+    const rel = file.slice(repoRoot.length + 1).replace(/\\/g, "/");
+    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.test(readFileSync(file, "utf8"))) {
+      hits.push(rel);
+    }
+  }
+  return hits.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Line-based parse of the `coverage-gates` matrix. A YAML dependency is not
+ * worth taking on for one well-known block, and the sibling audits
+ * (check-action-sha-pins) parse workflow YAML the same way.
+ */
+export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
+  const lines = yaml.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^\s{8}gate:\s*$/.test(l));
+  if (start === -1) return [];
+  const gates: GateEntry[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") continue;
+    // Any line indented 8 spaces or less has dedented out of the matrix block.
+    if (/^\s{0,8}\S/.test(line)) break;
+    const nameMatch = line.match(/^\s{10}-\s+name:\s*(.+?)\s*$/);
+    if (nameMatch?.[1] !== undefined) {
+      gates.push({ name: nameMatch[1].replace(/^["']|["']$/g, ""), pal: null });
+      continue;
+    }
+    const palMatch = line.match(/^\s{12}pal:\s*(true|false)\s*$/);
+    const last = gates[gates.length - 1];
+    if (palMatch?.[1] !== undefined && last) last.pal = palMatch[1] === "true";
+  }
+  return gates;
+}
+
+export function auditCoverageGatePal(repoRoot: string): AuditResult {
+  const errors: string[] = [];
+
+  const workflow = join(repoRoot, TEST_SUITE);
+  if (!existsSync(workflow)) {
+    return { ok: false, errors: [`${TEST_SUITE} not found`] };
+  }
+  const gates = parseCoverageGateMatrix(readFileSync(workflow, "utf8"));
+  if (gates.length === 0) {
+    return { ok: false, errors: [`${TEST_SUITE}: no coverage-gates matrix entries found`] };
+  }
+
+  // 4. every matrix entry classified explicitly
+  for (const g of gates) {
+    if (g.pal === null) {
+      errors.push(
+        `${TEST_SUITE}: coverage gate "${g.name}" has no explicit \`pal:\` field — add \`pal: true\` (runs on all 3 OSes) or \`pal: false\` (Linux only)`,
+      );
+    }
+  }
+
+  const palByName = new Map(gates.map((g) => [g.name, g.pal]));
+  const allowByFile = new Map(PLATFORM_BRANCHING_ALLOWLIST.map((e) => [e.file, e]));
+  const detected = detectPlatformBranchingFiles(repoRoot);
+  const detectedSet = new Set(detected);
+
+  // 1. detected but unclassified
+  for (const file of detected) {
+    if (!allowByFile.has(file)) {
+      errors.push(
+        `${file}: branches on platform but is not in PLATFORM_BRANCHING_ALLOWLIST — add an entry naming the coverage gate that covers it (or "none"), then make sure that gate is \`pal: true\``,
+      );
+    }
+  }
+
+  // 2. classified but no longer branching
+  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+    if (!detectedSet.has(entry.file)) {
+      errors.push(
+        `${entry.file}: listed in PLATFORM_BRANCHING_ALLOWLIST but no longer branches on platform (or no longer exists) — remove the stale entry`,
+      );
+    }
+  }
+
+  // 3. declared gate must be pal: true
+  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+    if (entry.gate === "none") continue;
+    if (!palByName.has(entry.gate)) {
+      errors.push(
+        `${entry.file}: declares coverage gate "${entry.gate}", which is not in the ${TEST_SUITE} matrix`,
+      );
+      continue;
+    }
+    if (palByName.get(entry.gate) !== true) {
+      errors.push(
+        `${entry.file}: branches on platform and is covered by gate "${entry.gate}", but that gate is not \`pal: true\` — its coverage would run on Linux only`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+if (import.meta.main) {
+  const result = auditCoverageGatePal(process.cwd());
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`audit:coverage-gate-pal: ${err}`);
+    process.exit(1);
+  }
+  console.log(`audit:coverage-gate-pal: OK`);
+}
+```
+
+- [ ] **Step 5: Run the unit tests**
+
+Run: `bun test scripts/structure-audit/check-coverage-gate-pal.test.ts`
+
+Expected: the three `parseCoverageGateMatrix` tests PASS. The
+`"the real repository passes"` test **FAILS** with 24 errors of the form
+`coverage gate "Engine" has no explicit \`pal:\` field`. That is correct — the
+matrix is not yet classified. Task 2 fixes it.
+
+- [ ] **Step 6: Reconcile the allowlist against reality**
+
+The allowlist above was written from a measurement taken on 2026-07-27. Verify
+it still matches the tree rather than trusting it:
+
+```bash
+bun -e "import{detectPlatformBranchingFiles}from'./scripts/structure-audit/check-coverage-gate-pal.ts';import{PLATFORM_BRANCHING_ALLOWLIST as A}from'./scripts/structure-audit/platform-branching-allowlist.ts';const d=detectPlatformBranchingFiles(process.cwd());const a=new Set(A.map(e=>e.file));console.log('missing from allowlist:',d.filter(f=>!a.has(f)));console.log('stale in allowlist:',[...a].filter(f=>!d.includes(f)))"
+```
+
+Expected: both lists empty. If `missing from allowlist` is non-empty, add each
+file with a `gate` (the coverage gate covering it, or `"none"`) and a one-line
+`why`. If `stale in allowlist` is non-empty, delete those entries. Do **not**
+loosen the detector to make the lists match.
+
+- [ ] **Step 7: Verify types and lint**
+
+Run: `bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check --error-on-warnings scripts`
+
+Expected: both exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/structure-audit/platform-branching-allowlist.ts \
+        scripts/structure-audit/check-coverage-gate-pal.ts \
+        scripts/structure-audit/check-coverage-gate-pal.test.ts
+git commit -m "feat(ci): audit that keeps the coverage-gate PAL classification honest
+
+Ships RED against the real repo on purpose: the _test-suite.yml matrix carries
+no pal: fields yet, so rule 4 fires 24 times. The next commit classifies the
+matrix and turns it green."
+```
+
+---
+
+## Task 2: Classify the coverage matrix and gate it to Linux
+
+**Files:**
+
+- Modify: `.github/workflows/_test-suite.yml` — the `coverage-gates` job
+  (`if:` line) and all 24 matrix entries.
+
+**Interfaces:**
+
+- Consumes: `auditCoverageGatePal` from Task 1 as the verification tool.
+- Produces: a matrix where every entry has an explicit `pal` field; the six PAL
+  gates are `pal: true`.
+
+- [ ] **Step 1: Confirm the audit is red before the change**
+
+Run: `bun scripts/structure-audit/check-coverage-gate-pal.ts`
+
+Expected: exit 1, with 24 lines reading
+`coverage gate "<name>" has no explicit \`pal:\` field`.
+
+- [ ] **Step 2: Add the `if:` gate to the coverage-gates job**
+
+In `.github/workflows/_test-suite.yml`, in the `coverage-gates:` job, add an
+`if:` immediately after the `name:` line so the block reads:
+
+```yaml
+  coverage-gates:
+    name: Coverage — ${{ matrix.gate.name }} (${{ inputs.runner }})
+    # Threshold gates run on Linux only, EXCEPT gates whose covered code
+    # branches on platform (`pal: true`). A push run was ~105 jobs against a
+    # pool granting ~15 concurrent, and 72 of those were this matrix run once
+    # per OS. Skipped matrix legs still create their check context, so no
+    # required check is left "Expected — Waiting for status to be reported".
+    # `scripts/structure-audit/check-coverage-gate-pal.ts` fails if a Linux-only
+    # gate's code ever gains platform branching.
+    if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
+    needs: unit-coverage
+```
+
+- [ ] **Step 3: Add `pal: true` to the six PAL entries**
+
+Add a `pal: true` line beneath the `script:` line of exactly these six entries:
+`Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`, `Telemetry`. For example:
+
+```yaml
+          - name: Vault
+            script: "test:coverage:vault"
+            pal: true
+```
+
+- [ ] **Step 4: Add `pal: false` to the other eighteen entries**
+
+Add `pal: false` beneath the `script:` line of every remaining entry: `Engine`,
+`Agents`, `Sync scheduler`, `Rate limiter`, `People`, `Embedding`, `Workflow`,
+`Watcher`, `Config`, `TUI`, `DB layer`, `Deployment`, `Health`, `Metrics`,
+`Preflight`, `Doctor`, `MCP`, `LAN`. For example:
+
+```yaml
+          - name: Engine
+            script: "test:coverage:engine"
+            pal: false
+```
+
+- [ ] **Step 5: Verify the audit is now green**
+
+Run: `bun scripts/structure-audit/check-coverage-gate-pal.ts`
+
+Expected: `audit:coverage-gate-pal: OK`, exit 0.
+
+- [ ] **Step 6: Verify the parser sees exactly 24 gates, 6 of them PAL**
+
+```bash
+bun -e "import{parseCoverageGateMatrix}from'./scripts/structure-audit/check-coverage-gate-pal.ts';const g=parseCoverageGateMatrix(await Bun.file('.github/workflows/_test-suite.yml').text());console.log('total',g.length,'pal',g.filter(x=>x.pal===true).map(x=>x.name),'unclassified',g.filter(x=>x.pal===null).length)"
+```
+
+Expected: `total 24`, `pal [ "Vault", "Sandbox", "Updater", "Extensions", "Perf", "Telemetry" ]`, `unclassified 0`.
+
+- [ ] **Step 7: Run the audit's test suite**
+
+Run: `bun test scripts/structure-audit/check-coverage-gate-pal.test.ts`
+
+Expected: all 4 tests PASS, including `"the real repository passes"`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/_test-suite.yml
+git commit -m "perf(ci): run coverage-threshold gates on Linux except PAL-touching ones
+
+Coverage gates 72 -> 36 jobs; a push run 105 -> 69. The six gates whose covered
+code branches on platform keep all three OSes. Turns the Task 1 audit green."
+```
+
+---
+
+## Task 3: Wire the audit into preflight and CI
+
+**Files:**
+
+- Modify: `package.json` — add the `audit:coverage-gate-pal` script id.
+- Modify: `scripts/lib/preflight-gates.ts` — register it in the FAST tier.
+- Modify: `.github/workflows/_structure.yml` — run it.
+
+**Interfaces:**
+
+- Consumes: the CLI entry point from Task 1.
+- Produces: nothing other tasks depend on.
+
+The drift guard in `scripts/preflight.test.ts` asserts that every
+`bun run <id>` appearing in any workflow is registered in `PREFLIGHT_GATES` or
+`CI_ONLY_GATES`. Steps 1 and 2 must both land before Step 3, or that test fails.
+
+- [ ] **Step 1: Add the script id to `package.json`**
+
+Next to the other `audit:*` entries, add:
+
+```json
+"audit:coverage-gate-pal": "bun scripts/structure-audit/check-coverage-gate-pal.ts",
+```
+
+- [ ] **Step 2: Register it in the FAST tier**
+
+In `scripts/lib/preflight-gates.ts`, inside the `FAST` array, after the
+`audit:action-sha-pins` entry, add:
+
+```ts
+  {
+    name: "audit:coverage-gate-pal",
+    cmd: ["bun", "run", "audit:coverage-gate-pal"],
+    tier: "fast",
+  },
+```
+
+It belongs in FAST, not `CI_ONLY_GATES`: it reads only local files, needs no
+network and no `gh` auth.
+
+- [ ] **Step 3: Run it in `_structure.yml`**
+
+In `.github/workflows/_structure.yml`, after the `audit:invariants` step, add:
+
+```yaml
+      - name: Audit coverage-gate PAL classification
+        run: bun run audit:coverage-gate-pal
+```
+
+- [ ] **Step 4: Verify the drift guard passes**
+
+Run: `bun test scripts/preflight.test.ts scripts/lib/preflight-gates.test.ts`
+
+Expected: PASS. A failure naming `_structure.yml: audit:coverage-gate-pal`
+means Step 2 was skipped or misspelled.
+
+- [ ] **Step 5: Verify the gate runs from its script id**
+
+Run: `bun run audit:coverage-gate-pal`
+
+Expected: `audit:coverage-gate-pal: OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json scripts/lib/preflight-gates.ts .github/workflows/_structure.yml
+git commit -m "ci: wire audit:coverage-gate-pal into preflight and _structure.yml"
+```
+
+---
+
+## Task 4: Narrow the E2E Desktop dependency edge
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml` — the `e2e-desktop` job's `needs:`.
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Confirm the edge carries no artifacts**
+
+Read the `e2e-desktop` job's steps in `.github/workflows/ci.yml`. Confirm there
+is no `actions/download-artifact` step and that the job performs its own
+`Checkout`, `Setup Bun and install dependencies`, and
+`Setup Rust + Tauri (install only, no checks)`.
+
+Expected: no `download-artifact`. The `needs: ci-ts` edge is a pure gate. If a
+`download-artifact` step IS present, **stop** — the premise of this task is
+wrong; report it rather than proceeding.
+
+- [ ] **Step 2: Narrow the edge**
+
+Replace the `needs:` line of the `e2e-desktop` job with:
+
+```yaml
+    # `ci-ts` is the whole _test-suite.yml (30 jobs incl. 24 coverage shards),
+    # and `needs:` on a reusable-workflow caller waits for ALL of it — measured
+    # at 33.4min median DAG wait. E2E consumes no artifact from it: it does its
+    # own checkout, install and Tauri setup. `ci-rust` (1.17-1.72min) is the
+    # prerequisite that carries meaning: a broken Tauri build makes E2E
+    # unrunnable.
+    needs: [ci-rust]
+```
+
+- [ ] **Step 3: Verify the workflow still parses**
+
+Run: `bunx biome check --error-on-warnings .github 2>/dev/null; bun test scripts/preflight.test.ts`
+
+Expected: exit 0. (`preflight.test.ts` reads every workflow file; a YAML file it
+cannot read surfaces there.)
+
+- [ ] **Step 4: Verify no other job depends on e2e-desktop**
+
+```bash
+grep -n "e2e-desktop" .github/workflows/ci.yml
+```
+
+Expected: matches only the job definition itself and its own `name:`/`if:`
+lines — no other job lists `e2e-desktop` in a `needs:`. If one does, that job's
+own dependency chain must be re-checked before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "perf(ci): E2E Desktop waits on ci-rust, not the whole TS suite
+
+needs: [ci-ts, ci-rust] made E2E wait 33.4min median for 30 jobs it takes no
+artifact from. ci-rust executes in 1.17-1.72min and is the dependency that
+actually matters: a broken Tauri build makes E2E unrunnable."
+```
+
+---
+
+## Task 5: Promote the measurement probes
+
+**Files:**
+
+- Create: `scripts/ci-latency/probe-lib.ts`
+- Create: `scripts/ci-latency/probe-lib.test.ts`
+- Create: `scripts/ci-latency/probe-dag.ts`
+- Create: `scripts/ci-latency/probe-concurrency.ts`
+
+**Interfaces:**
+
+- Consumes: `runGh(args: string[]): GhResult` from
+  `scripts/structure-audit/_gh-audit.ts`, where `GhResult` is
+  `{ ok: boolean; stdout: string; stderr: string; httpStatus?: number }`.
+  Also `isRecord(v: unknown): v is Record<string, unknown>` from the same module.
+- Produces: `median`, `minutesBetween`, `bindingUpstream`, `concurrencySeries`
+  from `probe-lib.ts`.
+
+These are the only tools that can verify this slice, since `audit:ci-latency`
+gates execution and the win lands in queue and DAG wait. They are diagnostic
+commands run by hand, never gates — so they are **not** registered in
+`preflight-gates.ts` and must not be added to any workflow.
+
+- [ ] **Step 1: Write the failing tests for the pure helpers**
+
+Create `scripts/ci-latency/probe-lib.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { bindingUpstream, concurrencySeries, median, minutesBetween } from "./probe-lib.ts";
+
+describe("median", () => {
+  test("odd-length picks the middle", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  test("even-length averages the two middles", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  test("an empty sample is 0, not NaN", () => {
+    // A NaN would propagate silently into every printed figure.
+    expect(median([])).toBe(0);
+  });
+});
+
+describe("minutesBetween", () => {
+  test("returns whole minutes between two ISO timestamps", () => {
+    expect(minutesBetween("2026-07-27T10:30:00Z", "2026-07-27T10:00:00Z")).toBe(30);
+  });
+
+  test("an unparseable timestamp yields 0 rather than NaN", () => {
+    expect(minutesBetween("not-a-date", "2026-07-27T10:00:00Z")).toBe(0);
+  });
+});
+
+describe("bindingUpstream", () => {
+  test("picks the upstream job that completed last", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:20:00Z" },
+      { name: "c", completed_at: "2026-07-27T10:10:00Z" },
+    ];
+    expect(bindingUpstream(jobs)?.name).toBe("b");
+  });
+
+  test("ignores jobs that never completed", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "running", completed_at: null },
+    ];
+    expect(bindingUpstream(jobs)?.name).toBe("a");
+  });
+
+  test("an empty list yields null", () => {
+    expect(bindingUpstream([])).toBeNull();
+  });
+});
+
+describe("concurrencySeries", () => {
+  test("counts jobs running at each minute offset", () => {
+    // Two jobs overlap only at minute 1.
+    const series = concurrencySeries(
+      [
+        { started_at: "2026-07-27T10:00:00Z", completed_at: "2026-07-27T10:02:00Z" },
+        { started_at: "2026-07-27T10:01:00Z", completed_at: "2026-07-27T10:03:00Z" },
+      ],
+      "2026-07-27T10:00:00Z",
+    );
+    expect(series).toEqual([1, 2, 1, 0]);
+  });
+
+  test("no jobs yields an empty series", () => {
+    expect(concurrencySeries([], "2026-07-27T10:00:00Z")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test scripts/ci-latency/probe-lib.test.ts`
+
+Expected: FAIL — `Cannot find module './probe-lib.ts'`.
+
+- [ ] **Step 3: Implement the shared helpers**
+
+Create `scripts/ci-latency/probe-lib.ts`:
+
+```ts
+/**
+ * Pure helpers for the two P4b diagnostic probes.
+ *
+ * They live apart from the probes so the arithmetic is unit-testable without a
+ * network call. The probes themselves are thin: fetch, map, print.
+ */
+
+export interface CompletedJob {
+  name: string;
+  completed_at: string | null;
+}
+
+export interface RunningJob {
+  started_at: string;
+  completed_at: string | null;
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const s = [...values].sort((a, b) => a - b);
+  const mid = s.length / 2;
+  if (s.length % 2 === 1) return s[Math.floor(mid)] ?? 0;
+  return ((s[mid - 1] ?? 0) + (s[mid] ?? 0)) / 2;
+}
+
+/** Whole minutes from `b` to `a`. Unparseable input yields 0, never NaN. */
+export function minutesBetween(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return 0;
+  return (ta - tb) / 60_000;
+}
+
+/**
+ * The upstream job whose completion gated a dependent job — i.e. the last one
+ * to finish. Returns null when nothing has completed.
+ */
+export function bindingUpstream(jobs: CompletedJob[]): CompletedJob | null {
+  let best: CompletedJob | null = null;
+  let bestAt = Number.NEGATIVE_INFINITY;
+  for (const j of jobs) {
+    if (j.completed_at === null) continue;
+    const at = Date.parse(j.completed_at);
+    if (Number.isNaN(at) || at <= bestAt) continue;
+    bestAt = at;
+    best = j;
+  }
+  return best;
+}
+
+/** How many jobs were running at each whole-minute offset from `runStartedAt`. */
+export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): number[] {
+  const t0 = Date.parse(runStartedAt);
+  const usable = jobs.filter((j) => j.completed_at !== null);
+  if (Number.isNaN(t0) || usable.length === 0) return [];
+  const end = Math.max(...usable.map((j) => Date.parse(j.completed_at ?? "")));
+  if (!Number.isFinite(end)) return [];
+  const span = Math.ceil((end - t0) / 60_000);
+  const series: number[] = [];
+  for (let m = 0; m <= span; m++) {
+    const at = t0 + m * 60_000;
+    series.push(
+      usable.filter(
+        (j) => Date.parse(j.started_at) <= at && Date.parse(j.completed_at ?? "") > at,
+      ).length,
+    );
+  }
+  return series;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test scripts/ci-latency/probe-lib.test.ts`
+
+Expected: 10 tests PASS.
+
+- [ ] **Step 5: Implement the DAG probe**
+
+Create `scripts/ci-latency/probe-dag.ts`:
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * P4b diagnostic — which upstream job actually gated each `E2E Desktop` leg,
+ * and how long each leg waited.
+ *
+ * Not a gate, and deliberately not registered in preflight-gates.ts: it is the
+ * before/after instrument for the tuning slice, because `audit:ci-latency`
+ * gates EXECUTION while this slice's win lands in DAG wait.
+ *
+ * Usage: bun scripts/ci-latency/probe-dag.ts [--runs N]
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { bindingUpstream, median, minutesBetween } from "./probe-lib.ts";
+
+const REPO = "nimbus-agent/Nimbus";
+
+interface Job {
+  name: string;
+  created_at: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+function api(path: string): unknown {
+  const r = runGh(["gh", "api", path]);
+  if (!r.ok) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function asJobs(value: unknown): Job[] {
+  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
+  const out: Job[] = [];
+  for (const j of value["jobs"]) {
+    if (!isRecord(j)) continue;
+    const name = j["name"];
+    const created = j["created_at"];
+    const started = j["started_at"];
+    const completed = j["completed_at"];
+    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
+      continue;
+    }
+    out.push({
+      name,
+      created_at: created,
+      started_at: started,
+      completed_at: typeof completed === "string" ? completed : null,
+    });
+  }
+  return out;
+}
+
+function jobsForRun(runId: number): Job[] {
+  const jobs: Job[] = [];
+  for (let page = 1; page <= 5; page++) {
+    const payload = api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
+    const batch = asJobs(payload);
+    if (batch.length === 0) break;
+    jobs.push(...batch);
+    const total = isRecord(payload) ? payload["total_count"] : undefined;
+    if (typeof total === "number" && jobs.length >= total) break;
+  }
+  return jobs;
+}
+
+function parseRunsArg(argv: string[]): number {
+  const ix = argv.indexOf("--runs");
+  if (ix === -1) return 15;
+  const n = Number(argv[ix + 1]);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
+}
+
+if (import.meta.main) {
+  const wanted = parseRunsArg(process.argv.slice(2));
+  const listed = api(
+    `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
+  );
+  const runs = isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  if (runs.length === 0) {
+    console.error("probe-dag: no successful push runs readable — is `gh` authenticated?");
+    process.exit(1);
+  }
+
+  const binding = new Map<string, number>();
+  const waitsByLeg = new Map<string, number[]>();
+
+  for (const run of runs) {
+    if (!isRecord(run)) continue;
+    const id = run["id"];
+    const startedAt = run["run_started_at"];
+    if (typeof id !== "number" || typeof startedAt !== "string") continue;
+    const jobs = jobsForRun(id);
+    const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
+    const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
+    const gatedBy = bindingUpstream(upstream);
+    for (const leg of legs) {
+      if (gatedBy) binding.set(gatedBy.name, (binding.get(gatedBy.name) ?? 0) + 1);
+      const wait = minutesBetween(leg.created_at, startedAt);
+      waitsByLeg.set(leg.name, [...(waitsByLeg.get(leg.name) ?? []), wait]);
+    }
+  }
+
+  console.log(`\nruns sampled: ${runs.length}`);
+  console.log("\nWHICH upstream job gated E2E (times it was last to finish):");
+  for (const [name, n] of [...binding].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(3)}x  ${name}`);
+  }
+  console.log("\nDAG wait per E2E leg (minutes):");
+  for (const [leg, ws] of [...waitsByLeg].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(
+      `  ${leg.padEnd(34)} median ${median(ws).toFixed(1).padStart(6)}  max ${Math.max(...ws).toFixed(1).padStart(6)}  n=${ws.length}`,
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Implement the concurrency probe**
+
+Create `scripts/ci-latency/probe-concurrency.ts`:
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * P4b diagnostic — jobs per run, peak concurrent execution, and how many jobs
+ * sat created-but-waiting at that peak.
+ *
+ * This is the probe that found the slice's premise: a push run demands ~105
+ * job slots from a pool granting 13-17. Not a gate; see probe-dag.ts.
+ *
+ * Usage: bun scripts/ci-latency/probe-concurrency.ts [--runs N]
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { concurrencySeries } from "./probe-lib.ts";
+
+const REPO = "nimbus-agent/Nimbus";
+
+interface Job {
+  name: string;
+  created_at: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+function api(path: string): unknown {
+  const r = runGh(["gh", "api", path]);
+  if (!r.ok) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function asJobs(value: unknown): Job[] {
+  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
+  const out: Job[] = [];
+  for (const j of value["jobs"]) {
+    if (!isRecord(j)) continue;
+    const name = j["name"];
+    const created = j["created_at"];
+    const started = j["started_at"];
+    const completed = j["completed_at"];
+    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
+      continue;
+    }
+    out.push({
+      name,
+      created_at: created,
+      started_at: started,
+      completed_at: typeof completed === "string" ? completed : null,
+    });
+  }
+  return out;
+}
+
+function parseRunsArg(argv: string[]): number {
+  const ix = argv.indexOf("--runs");
+  if (ix === -1) return 4;
+  const n = Number(argv[ix + 1]);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 4;
+}
+
+if (import.meta.main) {
+  const wanted = parseRunsArg(process.argv.slice(2));
+  const listed = api(
+    `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
+  );
+  const runs = isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  if (runs.length === 0) {
+    console.error("probe-concurrency: no successful push runs readable — is `gh` authenticated?");
+    process.exit(1);
+  }
+
+  for (const run of runs) {
+    if (!isRecord(run)) continue;
+    const id = run["id"];
+    const startedAt = run["run_started_at"];
+    if (typeof id !== "number" || typeof startedAt !== "string") continue;
+
+    const jobs: Job[] = [];
+    for (let page = 1; page <= 5; page++) {
+      const payload = api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`);
+      const batch = asJobs(payload);
+      if (batch.length === 0) break;
+      jobs.push(...batch);
+      const total = isRecord(payload) ? payload["total_count"] : undefined;
+      if (typeof total === "number" && jobs.length >= total) break;
+    }
+    const usable = jobs.filter((j) => j.completed_at !== null);
+    if (usable.length === 0) continue;
+
+    const series = concurrencySeries(usable, startedAt);
+    const peak = series.length === 0 ? 0 : Math.max(...series);
+    const peakMinute = series.indexOf(peak);
+    const peakAt = Date.parse(startedAt) + peakMinute * 60_000;
+    const waitingAtPeak = usable.filter(
+      (j) => Date.parse(j.created_at) <= peakAt && Date.parse(j.started_at) > peakAt,
+    ).length;
+    const count = (re: RegExp) => usable.filter((j) => re.test(j.name)).length;
+
+    console.log(`\nrun ${id} — ${usable.length} jobs, wall ${series.length - 1}min`);
+    console.log(
+      `    ubuntu=${count(/ubuntu/)} windows=${count(/windows/)} macos=${count(/macos/)}`,
+    );
+    console.log(`    PEAK concurrent = ${peak} (minute ${peakMinute})`);
+    console.log(`    created-but-waiting at peak = ${waitingAtPeak}`);
+    console.log(`    profile: ${series.join(" ")}`);
+  }
+}
+```
+
+- [ ] **Step 7: Verify types, lint and the whole scripts suite**
+
+Run: `bunx tsc -p scripts/tsconfig.json --noEmit && bunx biome check --error-on-warnings scripts && bun test scripts/`
+
+Expected: all three exit 0.
+
+- [ ] **Step 8: Capture the BEFORE measurement**
+
+Run both probes against `main` and save the output — this is the baseline the
+roadmap entry in Task 6 quotes:
+
+```bash
+bun scripts/ci-latency/probe-dag.ts --runs 15 > /tmp/p4b-before-dag.txt
+bun scripts/ci-latency/probe-concurrency.ts --runs 4 > /tmp/p4b-before-concurrency.txt
+```
+
+Expected: DAG wait median ~33.4 min per E2E leg; ~105 jobs per run; peak
+concurrent 13–17. If the figures differ materially from these, record what was
+actually measured — the measurement is the record, not the prediction.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/ci-latency/probe-lib.ts scripts/ci-latency/probe-lib.test.ts \
+        scripts/ci-latency/probe-dag.ts scripts/ci-latency/probe-concurrency.ts
+git commit -m "feat(ci): promote the P4b measurement probes out of scratch
+
+audit:ci-latency gates EXECUTION, so it cannot prove this slice worked -- the
+win lands in queue and DAG wait, which it reports and never gates. These two
+probes are the instrument that can. Pure arithmetic lives in probe-lib.ts so it
+is unit-testable without a network call."
+```
+
+---
+
+## Task 6: Record the outcome
+
+**Files:**
+
+- Modify: `docs/infrastructure-roadmap.md` — the P4b progress log and the
+  sub-programs table row.
+
+**Interfaces:**
+
+- Consumes: the before/after probe figures from Task 5 Step 8 and Step 3 below.
+- Produces: nothing.
+
+- [ ] **Step 1: Verify the full local gate set passes**
+
+Run: `bun run preflight:fast`
+
+Expected: every gate passes, including the new `audit:coverage-gate-pal`.
+Fix anything red before continuing — do not proceed with a failing gate.
+
+- [ ] **Step 2: Update the P4b sub-programs table row**
+
+In `docs/infrastructure-roadmap.md`, replace the `P4b` row's status and gate
+text with:
+
+```markdown
+| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 36 jobs, Linux-only except the 6 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
+```
+
+- [ ] **Step 3: Capture the AFTER measurement**
+
+Once the branch has merged and at least one push run to `main` has completed
+with the new workflow:
+
+```bash
+bun scripts/ci-latency/probe-dag.ts --runs 5
+bun scripts/ci-latency/probe-concurrency.ts --runs 2
+```
+
+Record the actual numbers. Do not write predicted figures into the log.
+
+- [ ] **Step 4: Append the tuning entries to the P4b progress log**
+
+Under `### P4b progress log` in `docs/infrastructure-roadmap.md`, replace the
+`- **Remaining:** the tuning slice…` bullet with:
+
+```markdown
+- **Delivered (tuning, 2026-07-28):** the measurement's own "clearest lead" was
+  wrong, and two probes disproved it. Across 45 `E2E Desktop` legs the binding
+  upstream job was ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue
+  was ~10min median on every OS. The constraint is not macOS scarcity: a push
+  run demands ~105 job slots against a pool granting 13-17, with 32-41 jobs
+  created-but-waiting at peak; one sampled run opened with nine consecutive
+  minutes at zero running jobs. 72 of those 105 jobs were one 24-entry
+  coverage matrix run once per OS.
+- **This retired the design of record's sharding proposal.** Sharding adds jobs
+  to the pool that IS the constraint.
+- **Two changes:** coverage-threshold gates run on Linux only except the six
+  whose covered code branches on platform (72 → 36 jobs; a run 105 → 69), and
+  `e2e-desktop` now waits on `ci-rust` (1.17-1.72min) instead of `ci-ts` (30
+  jobs, 33.4min median DAG wait) — an edge that carried no artifacts.
+- **`audit:ci-latency` cannot prove this worked**, since it gates execution
+  while the win lands in queue and DAG wait. `scripts/ci-latency/probe-dag.ts`
+  and `probe-concurrency.ts` are the instrument; before/after figures recorded
+  here.
+- **Guarded against silent decay:** `audit:coverage-gate-pal` fails when a
+  platform-branching file is unclassified, when a classified file's gate is not
+  `pal: true`, or when a new matrix entry carries no explicit `pal` field.
+- **Deferred:** guarding E2E against a TypeScript failure on `main`. Measured
+  2 of the last 40 `main` commits arrived without a PR, both `ci(cla)` workflow
+  commits touching no TypeScript. No standalone fast typecheck job exists to
+  depend on (`Static`, 4.57min, sits inside `_test-suite.yml` where `needs:`
+  cannot reach it), so guarding costs a duplicate typecheck job on every push.
+  **Adopt if** a `main` E2E run is ever seen burning on a TS compile failure.
+- **Baseline regeneration is due after ~12 post-change push runs**, when the
+  36 abandoned macOS/Windows coverage keys have aged out of the sampling window
+  (`MAX_RUNS_PER_WORKFLOW`). Regenerating sooner is a no-op: the window still
+  holds pre-change runs carrying those keys.
+```
+
+- [ ] **Step 5: Lint the Markdown and check links**
+
+Run: `bun run lint:markdown && bun run audit:doc-refs`
+
+Expected: `0 error(s)` and all refs resolve.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/infrastructure-roadmap.md
+git commit -m "docs(infra): record the P4b tuning outcome and its deferrals"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Change A → Task 2. Change B → Task 4. Change C → Tasks 1 and
+3. Verification/probes → Task 5. Baseline regeneration trigger → Task 6 Step 4.
+Deferred finding 2 with its trigger → Task 6 Step 4. Risks table → carried into
+the roadmap log. No spec section is unimplemented.
+
+**Placeholder scan.** No "TBD"/"TODO"/"handle edge cases". Every code step
+carries the literal code. Task 5 Step 8 and Task 6 Step 3 deliberately record
+*measured* rather than predicted figures — that is an instruction to measure,
+not a placeholder.
+
+**Type consistency.** `AuditResult` (`{ ok, errors }`) matches
+`check-action-sha-pins.ts`. `GateEntry.pal` is `boolean | null` in the
+implementation, the tests, and the parser. `PlatformFileEntry` fields
+(`file`/`gate`/`why`) are identical in the data module and every consumer.
+`bindingUpstream` takes `CompletedJob[]` and returns `CompletedJob | null` in
+both the test and the implementation. `runGh` is used with the exact signature
+read from `_gh-audit.ts`.
+
+**Known ordering constraint.** Task 1 ships an audit that is RED against the
+real repo; Task 2 turns it green. A reviewer seeing Task 1 in isolation should
+expect that red — it is the gate's red-proof, stated in the Task 1 preamble and
+its commit message.

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -2,10 +2,18 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Cut a push-to-`main` CI run from ~105 jobs to ~71 by running
+**Goal:** Cut a push-to-`main` CI run from ~105 jobs to ~75 by running
 coverage-threshold gates on Linux only except where the covered code branches on
 platform, narrow `e2e-desktop`'s dependency edge, and add a static audit so the
 platform classification cannot rot silently.
+
+> **Amended 2026-07-28 after the whole-branch review.** As originally written
+> and executed, this plan produced a SINGLE `coverage-gates` job whose
+> job-level `if:` read `matrix.gate.pal`, and classified 7 gates as PAL. Both
+> were wrong. The shipped shape is two jobs and 9 PAL gates — see
+> **"Amendment A"** at the end of Task 2. The original steps are left intact
+> below as the record of what was executed; where they conflict with Amendment
+> A, Amendment A governs.
 
 **Architecture:** Three independent changes to GitHub Actions workflow YAML,
 plus one new static audit in the existing `scripts/structure-audit/` pattern
@@ -32,11 +40,15 @@ and its [review response](../specs/2026-07-27-p4b-ci-tuning-design-review-respon
 - **Any `bun run <id>` added to a workflow MUST be registered** in
   `PREFLIGHT_GATES` or `CI_ONLY_GATES` in `scripts/lib/preflight-gates.ts`, or
   the drift guard in `scripts/preflight.test.ts` fails.
-- The **seven** PAL gate names, verbatim, as they appear in the
-  `_test-suite.yml` matrix: `Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`,
-  `Telemetry`, `Doctor`. (`Doctor` was added after the plan review found
-  `packages/cli/src/commands/doctor-core.ts:80` branching on `platform()`; see
-  the [review response](./2026-07-28-p4b-ci-tuning-review-response.md).)
+- The **nine** PAL gate names, verbatim, as they appear in the
+  `_test-suite.yml` matrix: `Vault`, `Embedding`, `Extensions`, `Telemetry`,
+  `DB layer`, `Doctor`, `Updater`, `Perf`, `Sandbox`. (`Doctor` was added after
+  the plan review found `packages/cli/src/commands/doctor-core.ts:80` branching
+  on `platform()`; see
+  the [review response](./2026-07-28-p4b-ci-tuning-review-response.md).
+  `Embedding` and `DB layer` were added by the whole-branch review — both reach
+  `index/sqlite-vec-load.ts` through static imports. The steps below still say
+  "seven"; that is the executed text, and Amendment A supersedes it.)
 - Commit on the branch `dev/asafgolombek/p4b-ci-tuning`. Never on `main`.
 - Run `bun run lint:markdown` before committing any Markdown.
 
@@ -49,7 +61,7 @@ and its [review response](../specs/2026-07-27-p4b-ci-tuning-design-review-respon
 | `scripts/structure-audit/platform-branching-allowlist.ts` (create) | The checked-in classification: every platform-branching source file, the coverage gate that covers it, and why. Data only. |
 | `scripts/structure-audit/check-coverage-gate-pal.ts` (create) | Detection + the four assertions. Pure functions + CLI. |
 | `scripts/structure-audit/check-coverage-gate-pal.test.ts` (create) | Unit tests over fixtures, plus one test asserting the real repo passes. |
-| `.github/workflows/_test-suite.yml` (modify) | `pal` field on all 24 matrix entries + the `if:` gate on `coverage-gates`. |
+| `.github/workflows/_test-suite.yml` (modify) | `pal` field on all 24 matrix entries, split across the `coverage-gates-pal` (9) and `coverage-gates-linux` (15) jobs, each with its own `inputs`-only `if:`. |
 | `.github/workflows/ci.yml` (modify) | `e2e-desktop` needs edge. |
 | `.github/workflows/_structure.yml` (modify) | Run the new audit. |
 | `scripts/lib/preflight-gates.ts` (modify) | Register the new gate (FAST tier). |
@@ -640,6 +652,32 @@ matrix and turns it green."
 
 ---
 
+### Amendment (2026-07-28, whole-branch review) — the audit must constrain the mechanism
+
+Rules 1–4 as specified validate the `pal:` fields but never read the `if:` lines
+that consume them. That is *why* the broken job-level `matrix.gate.pal`
+condition (Task 2, Amendment A1) shipped green. Three additions:
+
+1. **`parseCoverageGateMatrix` reads EVERY `gate:` block, not the first.** After
+   the split there are two, so a first-block-only parse would silently validate
+   half the matrix and report OK. It now returns the union — 24 entries.
+2. **Rule 5 — the split's own wiring.** Both `coverage-gates-pal` and
+   `coverage-gates-linux` must exist and carry the exact `if:` conditions the
+   split depends on, and each matrix entry's `pal` value must match the job it
+   sits in.
+3. **Rule 6 — the runner literal.** `'ubuntu-24.04'` is now duplicated across
+   `ci.yml` (the `pr-quality-ts` caller and the `ci-ts` matrix) and
+   `_test-suite.yml`. The audit resolves the Linux label from `ci.yml`'s
+   `_test-suite.yml` callers and requires it to match the literal inside
+   `coverage-gates-linux`'s condition, so bumping the runner in one place cannot
+   silently drop 15 threshold gates.
+
+`auditCoverageGatePal` also takes an optional `{ allowlist }` dependency so each
+rule can be red-proved against a fixture repo rather than only asserted green
+against the real one — the repo convention for a guard.
+
+---
+
 ## Task 2: Classify the coverage matrix and gate it to Linux
 
 **Files:**
@@ -747,6 +785,70 @@ Doctor is on that list because doctor-core.ts:80 branches on platform() via a
 destructured node:os import -- an idiom the design's original sweep did not
 match, which had it classified Linux-only by mistake."
 ```
+
+---
+
+### Amendment A (2026-07-28, whole-branch review) — the split, and the 9/15 split
+
+Steps 2, 3, 4, 6 and 8 above are the record of what was executed. Two things in
+them are wrong, and this amendment is what actually shipped.
+
+**A1 — `matrix` is not available in a job-level `if:`.** Step 2's condition,
+
+```yaml
+if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
+```
+
+sits at job level (4-space indent). GitHub grants `jobs.<job_id>.if` only the
+`github`, `needs`, `vars` and `inputs` contexts, because the job condition is
+evaluated *before* the matrix expands. The result is an invalid-workflow error
+or a falsy evaluation on Windows and macOS, silently skipping **all 24**
+coverage gates there — including the `pal: true` gates the whole change depends
+on preserving. (All 15 other `matrix.`-referencing `if:` conditions in this repo
+are step-level, 8-space, where `matrix` *is* available.)
+
+The matrix is therefore split into two jobs, each gated only on `inputs`:
+
+| job | entries | `if:` |
+| --- | --- | --- |
+| `coverage-gates-pal` | the 9 `pal: true` | `inputs.run-tests` |
+| `coverage-gates-linux` | the 15 `pal: false` | `inputs.run-tests && inputs.runner == 'ubuntu-24.04'` |
+
+Both keep `needs: unit-coverage`, the same `permissions:`, the same
+`runs-on: ${{ inputs.runner }}`, identical `steps:`, and — critically — the
+identical job-name template `Coverage — ${{ matrix.gate.name }} (${{ inputs.runner }})`.
+`name:` *does* accept `matrix`, and the expanded check-context names are what
+branch protection references; changing them breaks required contexts.
+
+The `fromJSON(...)` single-job alternative was rejected: a leg that never
+expands never creates its check context, whereas a *skipped* leg does, and this
+repo depends on that (the trap documented at `.github/workflows/ci.yml`
+`pr-quality-ts`).
+
+Every entry keeps its `pal:` field even though no `if:` reads it any more — it
+is now purely the machine-readable classification the audit enforces.
+
+**A2 — `Embedding` and `DB layer` were misclassified.** Step 4 listed both as
+`pal: false`, on the claim that Linux-only gates "load no file that branches on
+platform". That is false for these two:
+`packages/gateway/src/embedding/lazy-scheduler.ts` (and
+`create-routing-runtime.ts`, `embedding-worker.ts`) and
+`packages/gateway/src/index/migrations/runner.ts` each statically import
+`packages/gateway/src/index/sqlite-vec-load.ts`, which branches on platform for
+the native extension filename — so it lands in both gates' coverage
+denominators. Both are promoted to `pal: true`.
+
+`scripts/structure-audit/platform-branching-allowlist.ts` is updated
+accordingly: the `sqlite-vec-load.ts` entry said `gate: "none"`, which asserted
+something false. It now names `Embedding`, and its `why` states plainly that it
+reaches **both** `Embedding` and `DB layer` through static imports.
+
+**A3 — the audit gained three rules and the parser reads both blocks.** See the
+Amendment at the end of Task 1.
+
+**Corrected arithmetic.** PAL 9 × 3 OSes + Linux-only 15 × 1 = **42** coverage
+jobs (was 72). A push run goes **105 → 75** (not 71). The abandoned baseline
+keys are **30** (15 × 2 dropped OSes), not 36.
 
 ---
 
@@ -1537,7 +1639,7 @@ In `docs/infrastructure-roadmap.md`, replace the `P4b` row's status and gate
 text with:
 
 ```markdown
-| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 38 jobs, Linux-only except the 7 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
+| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
 ```
 
 - [ ] **Step 3: Capture the AFTER measurement**
@@ -1568,10 +1670,12 @@ Under `### P4b progress log` in `docs/infrastructure-roadmap.md`, replace the
   coverage matrix run once per OS.
 - **This retired the design of record's sharding proposal.** Sharding adds jobs
   to the pool that IS the constraint.
-- **Two changes:** coverage-threshold gates run on Linux only except the seven
-  whose covered code branches on platform (72 → 38 jobs; a run 105 → 71), and
-  `e2e-desktop` now waits on `ci-rust` (1.17-1.72min) instead of `ci-ts` (30
-  jobs, 33.4min median DAG wait) — an edge that carried no artifacts.
+- **Two changes:** coverage-threshold gates run on Linux only except the nine
+  whose covered code branches on platform (72 → 42 jobs; a run 105 → 75), split
+  across `coverage-gates-pal` and `coverage-gates-linux` because a job-level
+  `if:` cannot read `matrix`, and `e2e-desktop` now waits on `ci-rust`
+  (1.17-1.72min) instead of `ci-ts` (30 jobs, 33.4min median DAG wait) — an edge
+  that carried no artifacts.
 - **`audit:ci-latency` cannot prove this worked**, since it gates execution
   while the win lands in queue and DAG wait. `scripts/ci-latency/probe-dag.ts`
   and `probe-concurrency.ts` are the instrument; before/after figures recorded
@@ -1644,6 +1748,11 @@ review found two real bugs, both now fixed above:
   idiom here — which had `doctor-core.ts` undetected and the **`Doctor` gate
   wrongly classified `pal: false`** despite branching on platform at line 80.
 
-Consequently the figures throughout are **7 PAL gates, 38 coverage jobs, 105 →
-71 per run** — not the 6/36/69 of the pre-review draft. If a task still reads
-6, 36 or 69 anywhere, that is stale text, and the numbers here govern.
+Consequently the figures throughout were **7 PAL gates, 38 coverage jobs, 105 →
+71 per run** — not the 6/36/69 of the pre-review draft.
+
+**Superseded 2026-07-28 by the whole-branch review.** The shipped figures are
+**9 PAL gates, 42 coverage jobs, 105 → 75 per run**, over TWO jobs rather than
+one — see Amendment A at the end of Task 2 and the Amendment at the end of
+Task 1. Where any task step still reads 7, 38 or 71, those numbers are the
+executed-then-corrected text and the amendments govern.

--- a/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
+++ b/docs/superpowers/plans/2026-07-28-p4b-ci-tuning.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Cut a push-to-`main` CI run from ~105 jobs to ~69 by running
+**Goal:** Cut a push-to-`main` CI run from ~105 jobs to ~71 by running
 coverage-threshold gates on Linux only except where the covered code branches on
 platform, narrow `e2e-desktop`'s dependency edge, and add a static audit so the
 platform classification cannot rot silently.
@@ -32,8 +32,11 @@ and its [review response](../specs/2026-07-27-p4b-ci-tuning-design-review-respon
 - **Any `bun run <id>` added to a workflow MUST be registered** in
   `PREFLIGHT_GATES` or `CI_ONLY_GATES` in `scripts/lib/preflight-gates.ts`, or
   the drift guard in `scripts/preflight.test.ts` fails.
-- The six PAL gate names, verbatim, as they appear in the `_test-suite.yml`
-  matrix: `Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`, `Telemetry`.
+- The **seven** PAL gate names, verbatim, as they appear in the
+  `_test-suite.yml` matrix: `Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`,
+  `Telemetry`, `Doctor`. (`Doctor` was added after the plan review found
+  `packages/cli/src/commands/doctor-core.ts:80` branching on `platform()`; see
+  the [review response](./2026-07-28-p4b-ci-tuning-review-response.md).)
 - Commit on the branch `dev/asafgolombek/p4b-ci-tuning`. Never on `main`.
 - Run `bun run lint:markdown` before committing any Markdown.
 
@@ -99,7 +102,7 @@ Create `scripts/structure-audit/platform-branching-allowlist.ts`:
  * file was classified, not that it is protected. Coverage is measured over
  * files loaded at runtime including transitive imports, which cannot be derived
  * statically from the gate's test paths — so this audit guarantees that new
- * platform-branching code is CLASSIFIED, and that the six PAL gates stay
+ * platform-branching code is CLASSIFIED, and that the seven PAL gates stay
  * `pal: true`. It does not prove a `gate: "none"` file never becomes covered by
  * a `pal: false` gate.
  */
@@ -163,8 +166,38 @@ export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
     gate: "Telemetry",
     why: "reports host platform",
   },
+  {
+    file: "packages/cli/src/commands/doctor-core.ts",
+    gate: "Doctor",
+    why: "`if (platform() === 'linux')` gates the secret-tool probe",
+  },
+  {
+    file: "packages/gateway/src/vault/factory.ts",
+    gate: "Vault",
+    why: "selects the per-OS vault backend",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/sandbox-runner.ts",
+    gate: "Sandbox",
+    why: "selects the per-OS sandbox implementation",
+  },
 
   // ── Not covered by any coverage-threshold gate ────────────────────────────
+  {
+    file: "packages/gateway/src/platform/index.ts",
+    gate: "none",
+    why: "PAL dispatch; no coverage-threshold gate targets src/platform",
+  },
+  {
+    file: "packages/gateway/src/platform/gateway-log-file.ts",
+    gate: "none",
+    why: "per-OS log path",
+  },
+  {
+    file: "packages/gateway/src/ipc/server/server.ts",
+    gate: "none",
+    why: "named pipe vs unix socket; the LAN gate's tests import lan-server.ts only, never this file",
+  },
   {
     file: "packages/gateway/src/platform/win32.ts",
     gate: "none",
@@ -220,8 +253,15 @@ Create `scripts/structure-audit/check-coverage-gate-pal.test.ts`:
 
 ```ts
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { auditCoverageGatePal, parseCoverageGateMatrix } from "./check-coverage-gate-pal.ts";
+import {
+  auditCoverageGatePal,
+  detectPlatformBranchingFiles,
+  parseCoverageGateMatrix,
+} from "./check-coverage-gate-pal.ts";
 import { REPO_ROOT } from "./lib.ts";
 
 const MATRIX = `
@@ -260,6 +300,57 @@ describe("parseCoverageGateMatrix", () => {
   test("stops at the end of the matrix block", () => {
     // `steps:` dedents out of the matrix; nothing after it is a gate.
     expect(parseCoverageGateMatrix(MATRIX).map((g) => g.name)).not.toContain("Checkout");
+  });
+
+  test("a reformat to a different indent width still parses", () => {
+    // Indentation is read relative to the `gate:` key, so a cosmetic reformat
+    // must not red the gate. Here every line is re-indented by 2 extra spaces.
+    const reindented = MATRIX.split("\n")
+      .map((l) => (l.trim() === "" ? l : `  ${l}`))
+      .join("\n");
+    expect(parseCoverageGateMatrix(reindented)).toEqual([
+      { name: "Engine", pal: false },
+      { name: "Vault", pal: true },
+    ]);
+  });
+});
+
+describe("detectPlatformBranchingFiles", () => {
+  test("finds files that branch via a destructured node:os import", () => {
+    // The dominant idiom in this repo. An earlier revision matched only
+    // `process.platform` and missed doctor-core.ts, which caused its gate to be
+    // classified Linux-only by mistake.
+    const hits = detectPlatformBranchingFiles(REPO_ROOT);
+    expect(hits).toContain("packages/cli/src/commands/doctor-core.ts");
+    expect(hits).toContain("packages/gateway/src/vault/factory.ts");
+  });
+
+  test("reaches a NESTED src directory, not just packages/{pkg}/src", () => {
+    // packages/mcp-connectors/src does not exist; each of the 94 connectors has
+    // its own packages/mcp-connectors/{name}/src. A one-level scan skipped all
+    // of them silently. No connector branches on platform today, so this uses a
+    // fixture tree — asserting against the real repo would pass for the wrong
+    // reason (nothing to find) and would not catch the regression.
+    const root = mkdtempSync(join(tmpdir(), "pal-detect-"));
+    try {
+      const shallow = join(root, "packages", "gateway", "src");
+      const nested = join(root, "packages", "mcp-connectors", "airflow", "src");
+      mkdirSync(shallow, { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(join(shallow, "a.ts"), "if (process.platform === 'win32') {}\n");
+      writeFileSync(join(nested, "b.ts"), "if (process.platform === 'darwin') {}\n");
+
+      expect(detectPlatformBranchingFiles(root)).toEqual([
+        "packages/gateway/src/a.ts",
+        "packages/mcp-connectors/airflow/src/b.ts",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes test files, which may branch on platform legitimately", () => {
+    expect(detectPlatformBranchingFiles(REPO_ROOT).some((f) => f.includes(".test."))).toBe(false);
   });
 });
 
@@ -321,8 +412,22 @@ export interface GateEntry {
 
 const TEST_SUITE = ".github/workflows/_test-suite.yml";
 
-/** Runtime platform branching, or a filename that names an OS. */
-const BRANCHES_ON_PLATFORM = /process\.platform|os\.platform\(\)/;
+/**
+ * Runtime platform branching, or a filename that names an OS.
+ *
+ * The destructured-import alternative is NOT optional to cover:
+ * `import { platform } from "node:os"` is the dominant idiom in this codebase
+ * (6 files), and an earlier revision of this audit that matched only
+ * `process.platform` missed `doctor-core.ts` — whose gate was consequently
+ * classified Linux-only by mistake.
+ */
+const BRANCHES_ON_PLATFORM = [
+  /process\.platform/,
+  /os\.platform\(\)/,
+  /os\.type\(\)/,
+  // import { platform } / { platform as alias } / { arch, platform } from "node:os"
+  /import\s*\{[^}]*\b(?:platform|type|arch)\b[^}]*\}\s*from\s*["']node:os["']/,
+];
 const OS_NAMED_FILE = /\/(win32|darwin|linux)\.ts$/;
 
 function collectSources(dir: string, out: string[]): string[] {
@@ -344,21 +449,42 @@ function collectSources(dir: string, out: string[]): string[] {
 }
 
 /**
- * Every non-test source file under `packages/{*}/src` that branches on the host
- * platform. Tests are excluded deliberately: a cross-platform test branching on
- * `process.platform` is correct, not a finding.
+ * Every `src` directory anywhere under `packages/`, at any depth.
+ *
+ * NOT `packages/{*}/src`: `packages/mcp-connectors/src` does not exist — the 94
+ * connectors each have their own `packages/mcp-connectors/{name}/src`. A
+ * one-level scan silently skipped all of them, and a detector with a silent
+ * blind spot is worse than none, because its green is read as coverage.
+ */
+function findSrcDirs(dir: string, out: string[]): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (!statSync(full).isDirectory()) continue;
+    if (entry === "src") out.push(full);
+    else findSrcDirs(full, out);
+  }
+  return out;
+}
+
+/**
+ * Every non-test source file under any `src` directory in `packages/` that
+ * branches on the host platform. Tests are excluded deliberately: a
+ * cross-platform test branching on `process.platform` is correct, not a finding.
  */
 export function detectPlatformBranchingFiles(repoRoot: string): string[] {
   const packagesDir = join(repoRoot, "packages");
   if (!existsSync(packagesDir)) return [];
   const files: string[] = [];
-  for (const pkg of readdirSync(packagesDir)) {
-    collectSources(join(packagesDir, pkg, "src"), files);
+  for (const srcDir of findSrcDirs(packagesDir, [])) {
+    collectSources(srcDir, files);
   }
   const hits: string[] = [];
   for (const file of files) {
     const rel = file.slice(repoRoot.length + 1).replace(/\\/g, "/");
-    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.test(readFileSync(file, "utf8"))) {
+    const src = readFileSync(file, "utf8");
+    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.some((re) => re.test(src))) {
       hits.push(rel);
     }
   }
@@ -372,20 +498,25 @@ export function detectPlatformBranchingFiles(repoRoot: string): string[] {
  */
 export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
   const lines = yaml.split(/\r?\n/);
-  const start = lines.findIndex((l) => /^\s{8}gate:\s*$/.test(l));
+  const start = lines.findIndex((l) => /^\s+gate:\s*$/.test(l));
   if (start === -1) return [];
+  // Indentation is measured RELATIVE to the `gate:` key rather than assumed at
+  // fixed columns, so reformatting the workflow cannot red this gate for a
+  // purely cosmetic change. A parse that breaks anyway fails loud, never
+  // silent: zero entries is a hard error, and a name whose `pal:` did not parse
+  // stays `null`, which rule 4 reports.
+  const gateIndent = (lines[start] ?? "").search(/\S/);
   const gates: GateEntry[] = [];
   for (let i = start + 1; i < lines.length; i++) {
     const line = lines[i] ?? "";
     if (line.trim() === "") continue;
-    // Any line indented 8 spaces or less has dedented out of the matrix block.
-    if (/^\s{0,8}\S/.test(line)) break;
-    const nameMatch = line.match(/^\s{10}-\s+name:\s*(.+?)\s*$/);
+    if (line.search(/\S/) <= gateIndent) break;
+    const nameMatch = line.match(/^\s*-\s+name:\s*(.+?)\s*$/);
     if (nameMatch?.[1] !== undefined) {
       gates.push({ name: nameMatch[1].replace(/^["']|["']$/g, ""), pal: null });
       continue;
     }
-    const palMatch = line.match(/^\s{12}pal:\s*(true|false)\s*$/);
+    const palMatch = line.match(/^\s*pal:\s*(true|false)\s*$/);
     const last = gates[gates.length - 1];
     if (palMatch?.[1] !== undefined && last) last.pal = palMatch[1] === "true";
   }
@@ -519,8 +650,8 @@ matrix and turns it green."
 **Interfaces:**
 
 - Consumes: `auditCoverageGatePal` from Task 1 as the verification tool.
-- Produces: a matrix where every entry has an explicit `pal` field; the six PAL
-  gates are `pal: true`.
+- Produces: a matrix where every entry has an explicit `pal` field; the seven
+  PAL gates are `pal: true`.
 
 - [ ] **Step 1: Confirm the audit is red before the change**
 
@@ -548,10 +679,16 @@ In `.github/workflows/_test-suite.yml`, in the `coverage-gates:` job, add an
     needs: unit-coverage
 ```
 
-- [ ] **Step 3: Add `pal: true` to the six PAL entries**
+- [ ] **Step 3: Add `pal: true` to the seven PAL entries**
 
-Add a `pal: true` line beneath the `script:` line of exactly these six entries:
-`Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`, `Telemetry`. For example:
+Add a `pal: true` line beneath the `script:` line of exactly these seven
+entries: `Vault`, `Sandbox`, `Updater`, `Extensions`, `Perf`, `Telemetry`,
+`Doctor`.
+
+`Doctor` is on this list because `packages/cli/src/commands/doctor-core.ts:80`
+reads `if (platform() === "linux")` and `test:coverage:doctor` covers that file.
+The design's original sweep missed it — its regex did not match destructured
+`node:os` imports. Do not "simplify" this back to six. For example:
 
 ```yaml
           - name: Vault
@@ -559,12 +696,12 @@ Add a `pal: true` line beneath the `script:` line of exactly these six entries:
             pal: true
 ```
 
-- [ ] **Step 4: Add `pal: false` to the other eighteen entries**
+- [ ] **Step 4: Add `pal: false` to the other seventeen entries**
 
 Add `pal: false` beneath the `script:` line of every remaining entry: `Engine`,
 `Agents`, `Sync scheduler`, `Rate limiter`, `People`, `Embedding`, `Workflow`,
 `Watcher`, `Config`, `TUI`, `DB layer`, `Deployment`, `Health`, `Metrics`,
-`Preflight`, `Doctor`, `MCP`, `LAN`. For example:
+`Preflight`, `MCP`, `LAN`. For example:
 
 ```yaml
           - name: Engine
@@ -578,19 +715,19 @@ Run: `bun scripts/structure-audit/check-coverage-gate-pal.ts`
 
 Expected: `audit:coverage-gate-pal: OK`, exit 0.
 
-- [ ] **Step 6: Verify the parser sees exactly 24 gates, 6 of them PAL**
+- [ ] **Step 6: Verify the parser sees exactly 24 gates, 7 of them PAL**
 
 ```bash
 bun -e "import{parseCoverageGateMatrix}from'./scripts/structure-audit/check-coverage-gate-pal.ts';const g=parseCoverageGateMatrix(await Bun.file('.github/workflows/_test-suite.yml').text());console.log('total',g.length,'pal',g.filter(x=>x.pal===true).map(x=>x.name),'unclassified',g.filter(x=>x.pal===null).length)"
 ```
 
-Expected: `total 24`, `pal [ "Vault", "Sandbox", "Updater", "Extensions", "Perf", "Telemetry" ]`, `unclassified 0`.
+Expected: `total 24`, `pal [ "Vault", "Sandbox", "Updater", "Extensions", "Perf", "Telemetry", "Doctor" ]`, `unclassified 0`.
 
 - [ ] **Step 7: Run the audit's test suite**
 
 Run: `bun test scripts/structure-audit/check-coverage-gate-pal.test.ts`
 
-Expected: all 4 tests PASS, including `"the real repository passes"`.
+Expected: all 8 tests PASS, including `"the real repository passes"`.
 
 - [ ] **Step 8: Commit**
 
@@ -598,8 +735,13 @@ Expected: all 4 tests PASS, including `"the real repository passes"`.
 git add .github/workflows/_test-suite.yml
 git commit -m "perf(ci): run coverage-threshold gates on Linux except PAL-touching ones
 
-Coverage gates 72 -> 36 jobs; a push run 105 -> 69. The six gates whose covered
-code branches on platform keep all three OSes. Turns the Task 1 audit green."
+Coverage gates 72 -> 38 jobs; a push run 105 -> 71. The seven gates whose
+covered code branches on platform keep all three OSes. Turns the Task 1 audit
+green.
+
+Doctor is on that list because doctor-core.ts:80 branches on platform() via a
+destructured node:os import -- an idiom the design's original sweep did not
+match, which had it classified Linux-only by mistake."
 ```
 
 ---
@@ -991,17 +1133,28 @@ function asJobs(value: unknown): Job[] {
   return out;
 }
 
-function jobsForRun(runId: number): Job[] {
+/**
+ * Pages through a run's jobs, reporting whether the read was COMPLETE.
+ *
+ * Job count is this slice's headline metric, so a silently truncated read would
+ * report fewer jobs than really ran and be read as proof the change worked. An
+ * instrument that fails toward its own hypothesis is worse than none — the same
+ * hazard `MAX_READ_FAILURE_RATIO` exists for in the gate itself.
+ */
+function jobsForRun(runId: number): { jobs: Job[]; complete: boolean } {
   const jobs: Job[] = [];
+  let expected: number | undefined;
   for (let page = 1; page <= 5; page++) {
     const payload = api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
+    if (payload === null) return { jobs, complete: false }; // read FAILED, not "no more pages"
+    const total = isRecord(payload) ? payload["total_count"] : undefined;
+    if (typeof total === "number") expected = total;
     const batch = asJobs(payload);
     if (batch.length === 0) break;
     jobs.push(...batch);
-    const total = isRecord(payload) ? payload["total_count"] : undefined;
-    if (typeof total === "number" && jobs.length >= total) break;
+    if (expected !== undefined && jobs.length >= expected) break;
   }
-  return jobs;
+  return { jobs, complete: expected !== undefined && jobs.length >= expected };
 }
 
 function parseRunsArg(argv: string[]): number {
@@ -1024,13 +1177,20 @@ if (import.meta.main) {
 
   const binding = new Map<string, number>();
   const waitsByLeg = new Map<string, number[]>();
+  let incomplete = 0;
 
   for (const run of runs) {
     if (!isRecord(run)) continue;
     const id = run["id"];
     const startedAt = run["run_started_at"];
     if (typeof id !== "number" || typeof startedAt !== "string") continue;
-    const jobs = jobsForRun(id);
+    const { jobs, complete } = jobsForRun(id);
+    // Skip, do not silently include: a partial job list biases the binding-job
+    // tally toward whichever pages happened to load.
+    if (!complete) {
+      incomplete++;
+      continue;
+    }
     const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
     const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
     const gatedBy = bindingUpstream(upstream);
@@ -1041,7 +1201,12 @@ if (import.meta.main) {
     }
   }
 
-  console.log(`\nruns sampled: ${runs.length}`);
+  console.log(`\nruns sampled: ${runs.length - incomplete}/${runs.length}`);
+  if (incomplete > 0) {
+    console.warn(
+      `::warning::probe-dag: ${incomplete}/${runs.length} run(s) had an incomplete job read and were EXCLUDED — figures below cover the rest`,
+    );
+  }
   console.log("\nWHICH upstream job gated E2E (times it was last to finish):");
   for (const [name, n] of [...binding].sort((a, b) => b[1] - a[1])) {
     console.log(`  ${String(n).padStart(3)}x  ${name}`);
@@ -1140,14 +1305,30 @@ if (import.meta.main) {
     const startedAt = run["run_started_at"];
     if (typeof id !== "number" || typeof startedAt !== "string") continue;
 
+    // A truncated read here corrupts the ONE number this probe exists to
+    // report. Refuse to print rather than print a low job count that reads as
+    // success.
     const jobs: Job[] = [];
+    let expected: number | undefined;
+    let complete = false;
     for (let page = 1; page <= 5; page++) {
       const payload = api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`);
+      if (payload === null) break;
+      const total = isRecord(payload) ? payload["total_count"] : undefined;
+      if (typeof total === "number") expected = total;
       const batch = asJobs(payload);
       if (batch.length === 0) break;
       jobs.push(...batch);
-      const total = isRecord(payload) ? payload["total_count"] : undefined;
-      if (typeof total === "number" && jobs.length >= total) break;
+      if (expected !== undefined && jobs.length >= expected) {
+        complete = true;
+        break;
+      }
+    }
+    if (!complete) {
+      console.warn(
+        `::warning::probe-concurrency: run ${id} job read incomplete (${jobs.length}/${expected ?? "?"}) — SKIPPED rather than reporting a truncated job count`,
+      );
+      continue;
     }
     const usable = jobs.filter((j) => j.completed_at !== null);
     if (usable.length === 0) continue;
@@ -1232,7 +1413,7 @@ In `docs/infrastructure-roadmap.md`, replace the `P4b` row's status and gate
 text with:
 
 ```markdown
-| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 36 jobs, Linux-only except the 6 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
+| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 38 jobs, Linux-only except the 7 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
 ```
 
 - [ ] **Step 3: Capture the AFTER measurement**
@@ -1263,8 +1444,8 @@ Under `### P4b progress log` in `docs/infrastructure-roadmap.md`, replace the
   coverage matrix run once per OS.
 - **This retired the design of record's sharding proposal.** Sharding adds jobs
   to the pool that IS the constraint.
-- **Two changes:** coverage-threshold gates run on Linux only except the six
-  whose covered code branches on platform (72 → 36 jobs; a run 105 → 69), and
+- **Two changes:** coverage-threshold gates run on Linux only except the seven
+  whose covered code branches on platform (72 → 38 jobs; a run 105 → 71), and
   `e2e-desktop` now waits on `ci-rust` (1.17-1.72min) instead of `ci-ts` (30
   jobs, 33.4min median DAG wait) — an edge that carried no artifacts.
 - **`audit:ci-latency` cannot prove this worked**, since it gates execution
@@ -1325,3 +1506,17 @@ read from `_gh-audit.ts`.
 real repo; Task 2 turns it green. A reviewer seeing Task 1 in isolation should
 expect that red — it is the gate's red-proof, stated in the Task 1 preamble and
 its commit message.
+
+**Post-review corrections** (see
+[the review response](./2026-07-28-p4b-ci-tuning-review-response.md)). The plan
+review found two real bugs, both now fixed above:
+
+- the detector scanned `packages/{pkg}/src` only, skipping all **94** nested
+  `packages/mcp-connectors/{name}/src` directories;
+- the detection regex missed `import { platform } from "node:os"`, the dominant
+  idiom here — which had `doctor-core.ts` undetected and the **`Doctor` gate
+  wrongly classified `pal: false`** despite branching on platform at line 80.
+
+Consequently the figures throughout are **7 PAL gates, 38 coverage jobs, 105 →
+71 per run** — not the 6/36/69 of the pre-review draft. If a task still reads
+6, 36 or 69 anywhere, that is stale text, and the numbers here govern.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review-response.md
@@ -131,7 +131,9 @@ green and silent, which is the outcome the finding wants.
   explicit-`pal`-field requirement. Wired into `audit:*` alongside the other
   static checks.
 - **Change A** — every matrix entry carries an explicit `pal` field
-  (`true`/`false`), not just the six PAL ones.
+  (`true`/`false`), not just the PAL ones. (This response said "six" when
+  written; the later plan review found a seventh, `Doctor` — see
+  [the plan review response](../plans/2026-07-28-p4b-ci-tuning-review-response.md).)
 - **Verification** — the baseline regeneration step gains its window-based
   trigger.
 - **Unchanged** — Change B ships as designed; the deferral in finding 2 is

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review-response.md
@@ -1,0 +1,138 @@
+# P4b tuning design review — response
+
+Response to [`2026-07-27-p4b-ci-tuning-design-review.md`](./2026-07-27-p4b-ci-tuning-design-review.md).
+
+| # | Finding | Outcome |
+| --- | --- | --- |
+| 1 | No automation stops a Linux-only gate gaining platform code | **Fixed** — but by inverting the proposed mechanism, which would not have worked |
+| 2 | Direct pushes to `main` bypass PR validation before E2E burns | **Deferred on measured data**, and the suggested alternative does not exist |
+| 3 | Regenerate the baseline inside the PR to avoid warning noise | **Concern valid, proposed timing is a no-op** — corrected with the real trigger |
+
+---
+
+## 1. PAL-regression automation — fixed
+
+The finding is right, and it names the same failure mode the measurement slice
+had to guard: an assumption that decays **silently**. If a Linux-only gate's
+code later gains `process.platform` branching, coverage on Windows and macOS
+quietly stops watching it, no check fails, and the loss is invisible until
+someone re-derives the classification by hand.
+
+### The proposed mechanism does not survive contact with the code
+
+The suggestion is to scan the 18 Linux-only gates' directories for platform
+branching. Two problems:
+
+- **The scripts name test paths, not source paths.** `test:coverage:db` runs
+  `packages/gateway/test/unit/db`; the source it actually covers
+  (`packages/gateway/src/db`) is never named. Coverage is measured over files
+  *loaded at runtime*, including transitive imports, which no directory scan can
+  enumerate statically.
+- **Tests legitimately branch on platform.** Cross-platform tests routinely
+  check `process.platform`. Scanning the named directories would flag them,
+  producing exactly the false-positive noise that trains people to ignore a gate.
+
+### What ships instead: confinement, not scanning
+
+Inverted to match the D10–D22 pattern this repo already uses for tool ids and
+dispatch sites — enumerate the population, confine it to an allowlist:
+
+1. Enumerate every source file that branches on platform (`process.platform`,
+   `os.platform()`) or imports an OS-named module (`win32`/`darwin`/`linux`).
+2. Require each to appear in a checked-in allowlist entry that declares **which
+   coverage gate covers it**.
+3. Cross-check that the declared gate carries `pal: true` in the
+   `_test-suite.yml` matrix.
+4. Require every matrix entry to carry an **explicit** `pal` field, so a newly
+   added gate cannot inherit a silent default.
+
+A new platform-branching file then fails the audit until its author either
+refactors it behind the PAL or promotes its gate to `pal: true` — which is
+precisely the choice the finding asks to force. No inference, no false
+positives.
+
+---
+
+## 2. E2E guard against a TypeScript failure — deferred on data
+
+### The premise is checkable, so it was checked
+
+Of the last 40 commits on `main`, **2 arrived without a PR** — `a91d73ec` and
+`7176dd49`, both `ci(cla)` *workflow* commits. Neither touched TypeScript. The
+scenario the finding protects against has no observed instance in that window.
+
+The residual risk is narrower than the finding states, but real: two
+independently-green PRs merging into a semantic conflict. That is exactly what
+CI-on-`main` exists to catch, and it announces itself loudly when it happens.
+
+### The suggested alternative does not exist
+
+> *Configure the workflow to automatically cancel downstream E2E runs if any
+> parallel `ci-ts` job fails, or verify that GitHub Action's default behavior
+> handles cancellation in this layout cleanly.*
+
+There is nothing to verify. GitHub Actions cannot cancel a job that has no
+`needs` relationship to the failing one; `fail-fast` operates **within** a
+matrix, not across independent jobs. Removing the edge removes the cancellation
+relationship by definition — the two cannot both be had.
+
+### The primary suggestion is not free either
+
+No standalone fast typecheck job exists to depend on. `Static` (execMedian
+**4.57 min**) lives *inside* `_test-suite.yml`, and `needs:` on a
+reusable-workflow caller is all-or-nothing — the same constraint that motivates
+Change B in the first place. Adopting the finding therefore means:
+
+- a **new job duplicating typecheck** on every push, and
+- ~3 min of DAG depth added back to E2E (~2 min → ~5 min).
+
+The one cheap standalone candidate was checked and rejected on the facts:
+`CI — Structure audit / structure` costs only **0.83 min**, but runs
+`audit:boundaries`, `audit:invariants` and `audit:release-please` — it does not
+typecheck, so it does not guard what this finding is about.
+
+**Deferred with a trigger:** adopt if a `main` E2E run is ever observed burning
+on a TypeScript compile failure. That event is self-reporting, so the deferral
+carries no detection cost.
+
+---
+
+## 3. Baseline regeneration — the concern is real, the timing is a no-op
+
+The finding assumes the 36 abandoned coverage keys start warning as soon as the
+change lands. They do not, because of how the sampling window works.
+
+`MAX_RUNS_PER_WORKFLOW` is **12**. Immediately after the PR merges, the window
+still contains pre-change runs that carry the macOS and Windows coverage jobs,
+so those keys keep receiving observations. Therefore:
+
+- **No `stale-baseline-entry` warnings appear at merge time.** The noise is
+  delayed, not immediate.
+- **Running `--update-baseline` inside the PR is a no-op.**
+  `computeUpdatedBaseline` drops only keys *absent from the window*, and they
+  are present. It would rewrite `generated_at` and change nothing else.
+
+Manually deleting the 36 keys in the PR is not better: `evaluate` would then see
+observations for keys with no baseline entry and report `new-key` for each while
+the pre-change runs remain in the window — trading one warning for another.
+
+**What ships instead:** the plan carries an explicit regeneration step whose
+trigger is stated in terms of the window rather than the merge —
+*regenerate once roughly 12 post-change push runs have accumulated, when the
+abandoned keys have aged out of the sampling window.* Until then the gate stays
+green and silent, which is the outcome the finding wants.
+
+---
+
+## Net changes to the design
+
+- **New Change C** — `scripts/structure-audit/check-coverage-gate-pal.ts`: the
+  platform-branching allowlist, the declared-gate cross-check, and the
+  explicit-`pal`-field requirement. Wired into `audit:*` alongside the other
+  static checks.
+- **Change A** — every matrix entry carries an explicit `pal` field
+  (`true`/`false`), not just the six PAL ones.
+- **Verification** — the baseline regeneration step gains its window-based
+  trigger.
+- **Unchanged** — Change B ships as designed; the deferral in finding 2 is
+  recorded in the design's Risks table with its trigger.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design-review.md
@@ -1,0 +1,35 @@
+# Design Review: P4b Tuning Slice — Design
+
+This document reviews [2026-07-27-p4b-ci-tuning-design.md](./2026-07-27-p4b-ci-tuning-design.md) and notes questions, suggestions, and improvements.
+
+---
+
+## 1. Automation for PAL-Aware Static Checks
+
+### Preventing Regression on Platform-Specific Code
+
+- **Observation:** The partition of the 24 coverage gates into PAL-aware (running on all 3 OSes) and Linux-only is based on a one-time static sweep of the code.
+- **Question:** If a developer introduces platform-specific branching (`process.platform` or `os.platform()`) into one of the 18 Linux-only gated modules (e.g., the DB layer, Watcher, or LAN) in a future PR, how will we catch that the coverage checks on Windows/macOS are now missing for that logic?
+- **Suggestion:** Add a lint or static audit rule to the preflight checks (e.g., in `scripts/structure-audit/`) that scans the 18 Linux-only coverage directories. If it detects platform branching or OS-specific imports in those directories, it should fail the preflight audit, prompting the developer to either:
+  1. Refactor the code to extract platform specifics into the `platform/` PAL layer, or
+  2. Promote the coverage gate to the `pal: true` matrix list in `_test-suite.yml`.
+
+---
+
+## 2. CI Safety: Balancing E2E Runner Efficiency and TS Failures
+
+### Mitigating E2E Run Waste on TS Failure
+
+- **Observation:** By removing `ci-ts` from the `needs` list of `e2e-desktop`, E2E tests can run immediately after the Rust build completes (~1.5 min). The risk of burning E2E runners on a broken TypeScript compile is accepted because the code must have passed PR gates prior to merge.
+- **Question:** Direct pushes to `main` (e.g. version bumps, admin bypasses, doc updates) can still trigger workflows without PR validation. Is there a cheap way to guard against TypeScript compilation failures before burning macOS/Windows E2E resources?
+- **Suggestion:** Instead of removing the TypeScript dependency entirely, make `e2e-desktop` depend on a lightweight, fast TypeScript job (such as a typecheck-only or lint-only job that takes < 1.5 minutes) in addition to `ci-rust`. This ensures code syntax/type sanity without waiting for the heavy, slow coverage shards.
+- **Alternative:** Configure the workflow to automatically cancel downstream E2E runs if any parallel `ci-ts` job fails, or verify that GitHub Action's default behavior handles cancellation in this layout cleanly.
+
+---
+
+## 3. Baseline Warning Noise in CI Logs
+
+### Pruning Stale Baseline Keys
+
+- **Observation:** The design mentions that `evaluate` will report the 36 omitted coverage keys as `stale-baseline-entry` warnings, and the baseline will be regenerated after landing.
+- **Suggestion:** To keep the build logs clean and avoid warning fatigue, the implementation plan should explicitly include running `computeUpdatedBaseline` as part of the tuning PR itself (Task 2 or 3 of the implementation), rather than waiting until after the PR merges to clean up the baseline warnings.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -16,11 +16,20 @@ push-to-`main` CI runs shows why.
 legs, the probe identified which upstream job was last to complete — the job
 that actually set the leg's eligibility:
 
-| binding upstream OS | times it gated E2E |
+| binding upstream OS | times it gated E2E (capture A, 2026-07-27) |
 | --- | --- |
 | ubuntu-24.04 | 30 |
 | windows-2025 | 15 |
 | macos-15 | **3** |
+
+**Superseded split, 2026-07-28.** Re-running the corrected, promoted
+`probe-dag.ts` over the same 15-run window gives ubuntu **24×**, macOS **18×**,
+windows **3×** (45 legs, 0 unattributed). macOS is ~40% of legs, not 7%. Both
+captures are kept in
+[`docs/infrastructure-roadmap.md`](../../infrastructure-roadmap.md); the
+conclusion below is unchanged, because it never rested on the split — it rests
+on the uniform ~10-minute queue across every OS and on the slot arithmetic in
+the next section, which both windows agree on.
 
 Runner queue is ~10 minutes median on *every* OS, not just macOS. That
 uniformity is the tell: the constraint is not runner scarcity for one platform.
@@ -84,10 +93,23 @@ gates:
 | `Perf` | `perf/bench-runner.ts`, `perf/bench-cli.ts` branch |
 | `Telemetry` | `telemetry/collector.ts` branches |
 | `Doctor` | `cli/src/commands/doctor-core.ts:80` — `if (platform() === "linux")` |
+| `Embedding` *(added 2026-07-28)* | `embedding/lazy-scheduler.ts` statically imports `index/sqlite-vec-load.ts`, which branches per-OS on the native extension filename |
+| `DB layer` *(added 2026-07-28)* | `index/migrations/runner.ts` statically imports the same file |
 
-The remaining 17 — Engine, Agents, Sync scheduler, Rate limiter, People,
-Embedding, Workflow, Watcher, Config, TUI, DB layer, Deployment, Health,
-Metrics, Preflight, MCP, LAN — load no file that branches on platform.
+The remaining 15 — Engine, Agents, Sync scheduler, Rate limiter, People,
+Workflow, Watcher, Config, TUI, Deployment, Health, Metrics, Preflight, MCP,
+LAN — load no file that branches on platform.
+
+**Corrected 2026-07-28 (whole-branch review):** this list originally also held
+`Embedding` and `DB layer`, and that was wrong. `index/sqlite-vec-load.ts`
+branches on platform for the native extension filename, and it is reached by
+static import from `embedding/lazy-scheduler.ts` (plus `create-routing-runtime.ts`
+and `embedding-worker.ts`) and from `index/migrations/runner.ts` — so it sits in
+both gates' coverage denominators. Both were promoted to `pal: true`. The PAL
+set is **9**: `Vault`, `Embedding`, `Extensions`, `Telemetry`, `DB layer`,
+`Doctor`, `Updater`, `Perf`, `Sandbox`. This is the second time the static
+sweep under-detected, which is why the caveat below is repeated rather than
+retired.
 
 **This is static evidence, not empirical** — and the plan review proved that
 caveat was not decorative. The sweep above originally matched only
@@ -105,12 +127,43 @@ judgement of record, now with a demonstrated failure to justify the scepticism.
 
 ### Mechanism
 
-Give **every** matrix entry an explicit `pal` field — `true` for the seven
-above, `false` for the other seventeen — and gate the job:
+Give **every** matrix entry an explicit `pal` field — `true` for the nine
+above, `false` for the other fifteen — and split the matrix across two jobs,
+each gated only on `inputs`:
 
 ```yaml
+coverage-gates-pal:      # the 9 pal: true entries
+  if: inputs.run-tests
+
+coverage-gates-linux:    # the 15 pal: false entries
+  if: inputs.run-tests && inputs.runner == 'ubuntu-24.04'
+```
+
+**This design originally specified a single job with one condition, and that
+was wrong:**
+
+```yaml
+# WRONG — shipped through implementation and survived review before the
+# whole-branch review caught it.
 if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
 ```
+
+`matrix` is **not** in the context set available to a job-level `if:`. GitHub's
+context-availability table grants `jobs.<job_id>.if` only `github`, `needs`,
+`vars` and `inputs`, because the job condition is evaluated *before* the matrix
+expands. The condition would therefore either error the workflow or evaluate
+falsy on Windows and macOS, silently skipping **all 24** coverage gates there —
+including the `pal: true` gates whose preservation is this change's entire
+safety argument. (Confirming evidence: all 15 other `matrix.`-referencing `if:`
+conditions in this repo are step-level, where `matrix` *is* available.)
+
+The `pal:` field is retained on every entry even though no `if:` reads it any
+more. It is now purely the machine-readable classification Change C enforces —
+including a rule that an entry's `pal` value must match the job it sits in.
+
+`fromJSON(...)` over a single job was considered and rejected: a leg that never
+expands never creates its check context, whereas a *skipped* leg does. This repo
+depends on the latter (see "Why this is safe" below).
 
 The field is explicit rather than defaulted so that a newly added gate cannot
 inherit Linux-only treatment silently; Change C enforces that.
@@ -120,11 +173,13 @@ upon implicitly through the `needs: unit-coverage` skip chain, matching how
 every sibling job in `_test-suite.yml` gates on it directly (`static`,
 `unit-coverage`, `integration`, `e2e-gateway`, `e2e-cli`, `packaging`). Without
 it, a docs-only PR caller (`pr-quality-ts` with `runner: ubuntu-24.04` and
-`run-tests: false`) makes the first clause of the condition unconditionally
-true, so the condition itself offers no protection for that caller — it would
-depend entirely on `needs: unit-coverage` skipping.
+`run-tests: false`) makes the runner clause of `coverage-gates-linux`'s
+condition unconditionally true — and `coverage-gates-pal` has no runner clause
+at all — so without it the split would offer no protection for that caller; it
+would depend entirely on `needs: unit-coverage` skipping.
 
-Coverage gates go **72 → 38**; a push run goes **105 → 71**.
+Coverage gates go **72 → 42** (9 PAL × 3 OSes + 15 Linux-only × 1); a push run
+goes **105 → 75**.
 
 ### Why this is safe
 
@@ -164,6 +219,13 @@ This keeps the prerequisite that carries meaning — a broken Tauri/Rust build
 makes E2E Desktop unrunnable — and drops a ~33-minute wait on 24 coverage shards
 that tell E2E nothing.
 
+**Side effect on the probe.** Narrowing the edge collapses the gating margin
+from ~60 min to ~1.2 min, which makes it plausible for `bindingUpstream` to find
+no candidate completed at or before a leg's eligibility moment. `probe-dag.ts`
+now counts such legs and emits one `::warning::` naming the count, rather than
+skipping them silently — the after-measurement is the only instrument that can
+show this slice worked, so it must not quietly measure fewer legs than ran.
+
 ## Change C — stop the PAL classification rotting silently
 
 Changes A and B are point-in-time judgements about which code branches on
@@ -172,7 +234,7 @@ Linux-only gate's code, coverage on Windows and macOS quietly stops watching it
 and **nothing fails**. That is the same silent-decay failure mode the
 measurement slice had to guard for the `created_at` assumption.
 
-A directory scan over the 18 Linux-only gates cannot do this job: the coverage
+A directory scan over the 15 Linux-only gates cannot do this job: the coverage
 scripts name *test* paths (`test:coverage:db` runs
 `packages/gateway/test/unit/db`, never naming `src/db`), coverage is measured
 over files loaded at runtime including transitive imports, and cross-platform
@@ -192,6 +254,18 @@ D10–D22 confinement pattern already used for tool ids and dispatch sites:
    covers it**.
 3. Cross-check that the declared gate carries `pal: true` in the matrix.
 4. Require every matrix entry to carry an explicit `pal` field.
+5. *(added 2026-07-28)* Require both coverage-gate jobs to exist and to carry
+   the exact `if:` conditions the split depends on, and require each entry's
+   `pal` value to match the job it sits in.
+6. *(added 2026-07-28)* Require the runner literal inside
+   `coverage-gates-linux`'s condition to match the Linux runner label `ci.yml`
+   actually calls `_test-suite.yml` with.
+
+Rules 5 and 6 exist because the first revision of this audit validated the
+`pal:` fields and never read the `if:` lines that consume them — which is
+exactly how the broken job-level `matrix.gate.pal` condition shipped green. The
+runner label is now duplicated between `ci.yml` and `_test-suite.yml`; without
+rule 6, bumping it in one place would silently drop all 15 Linux-only gates.
 
 A new platform-branching file then fails the audit until its author either
 refactors it behind the PAL or promotes its gate to `pal: true`.
@@ -217,14 +291,15 @@ proof is instead:
 33.4-minute figure was re-measured on 2026-07-28, against the same `main`
 window, at **60.5 min median (max 110.8, n=15)** — CI congestion nearly
 doubled between the two dates, so 60.5 min, not 33.4, is the baseline this
-slice's "after" measurement must be compared against. Jobs-per-run 105 → 71.
+slice's "after" measurement must be compared against. Jobs-per-run 105 → 75.
 Peak created-but-waiting materially reduced. If the measured result
 contradicts these numbers, the recorded outcome is the measurement — not the
 prediction.
 
 **Baseline note — and when to regenerate.**
-`docs/structure-audit/ci-latency-baseline.json` holds entries for the 36
-coverage keys that stop being produced on macOS and Windows. `evaluate` reports
+`docs/structure-audit/ci-latency-baseline.json` holds entries for the 30
+coverage keys (15 Linux-only gates × 2 dropped OSes) that stop being produced on
+macOS and Windows. `evaluate` reports
 an absent key as `stale-baseline-entry` — a warning, never a regression — so the
 gate stays green throughout.
 
@@ -243,7 +318,7 @@ the abandoned keys have aged out of the window.
 
 | risk | assessment |
 | --- | --- |
-| Losing per-OS coverage signal on 18 gates | Bounded by the static sweep above. Recorded as a judgement, not a proof. |
+| Losing per-OS coverage signal on 15 gates | Bounded by the static sweep above. Recorded as a judgement, not a proof. |
 | Non-Negotiable #5, platform equality | Every test still executes on all 3 OSes via `static`, `unit`, `integration`, `e2e-gateway`, `e2e-cli`. Only *threshold enforcement* narrows. Read as compatible; flagged for the owner's ruling. |
 | A TS-failing, Rust-passing `main` commit burns E2E runners | **Deferred, on measured data.** 2 of the last 40 `main` commits arrived without a PR (`a91d73ec`, `7176dd49`) — both `ci(cla)` workflow commits, neither touching TypeScript. The residual case is two green PRs merging into a semantic conflict. Guarding it has real cost: no standalone fast typecheck exists (`Static`, 4.57 min, is inside `_test-suite.yml` and unreachable by `needs:`), so it would mean a new job duplicating typecheck on every push plus ~3 min of DAG depth added back. `CI — Structure audit` (0.83 min) was evaluated as a cheap substitute and rejected — it runs `audit:boundaries`/`invariants`/`release-please`, not typecheck. **Trigger to adopt:** a `main` E2E run observed burning on a TS compile failure. |
 | Cross-job cancellation as an alternative guard | **Not available.** GitHub Actions cannot cancel a job with no `needs` relationship to the failing one; `fail-fast` operates within a matrix, not across jobs. Removing the edge removes the cancellation relationship by definition. |
@@ -251,7 +326,7 @@ the abandoned keys have aged out of the window.
 
 ## Out of scope
 
-Consolidating the remaining 17 Linux gates into fewer grouped jobs (~71 → ~52).
+Consolidating the remaining 15 Linux gates into fewer grouped jobs (~75 → ~60).
 Deferred deliberately: it makes failure reports coarser and is the least
 reversible of the available levers. Revisit only if the measured result of this
 slice falls short.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -213,9 +213,14 @@ proof is instead:
 2. The before/after figures are recorded in the P4b progress log in
    [`docs/infrastructure-roadmap.md`](../../infrastructure-roadmap.md).
 
-**Expected effect.** DAG wait 33.4 → ~3 min. Jobs-per-run 105 → 71. Peak
-created-but-waiting materially reduced. If the measured result contradicts these
-numbers, the recorded outcome is the measurement — not the prediction.
+**Expected effect.** DAG wait 33.4 min (measured 2026-07-27) → ~3 min. That
+33.4-minute figure was re-measured on 2026-07-28, against the same `main`
+window, at **60.5 min median (max 110.8, n=15)** — CI congestion nearly
+doubled between the two dates, so 60.5 min, not 33.4, is the baseline this
+slice's "after" measurement must be compared against. Jobs-per-run 105 → 71.
+Peak created-but-waiting materially reduced. If the measured result
+contradicts these numbers, the recorded outcome is the measurement — not the
+prediction.
 
 **Baseline note — and when to regenerate.**
 `docs/structure-audit/ci-latency-baseline.json` holds entries for the 36

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -18,7 +18,7 @@ that actually set the leg's eligibility:
 
 | binding upstream OS | times it gated E2E (capture A, 2026-07-27) |
 | --- | --- |
-| ubuntu-24.04 | 30 |
+| ubuntu-24.04 | 27 |
 | windows-2025 | 15 |
 | macos-15 | **3** |
 

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -1,0 +1,187 @@
+# P4b tuning slice — design
+
+The second half of P4b. The [measurement slice](./2026-07-27-p4b-ci-latency-design.md)
+shipped `audit:ci-latency` and deliberately stopped short of tuning, because the
+first measurement contradicted the design of record's hunch. This slice acts on
+what that measurement — and two follow-up probes — actually found.
+
+## The finding: CI queues behind itself
+
+The measurement slice reported a 33.9-minute worst DAG wait and ~10-minute
+runner queues, and the roadmap recorded macOS contention as "the clearest lead".
+**Both of those framings were wrong**, and a probe over 15 recent successful
+push-to-`main` CI runs shows why.
+
+**macOS is not the binding constraint.** For each of 45 observed `E2E Desktop`
+legs, the probe identified which upstream job was last to complete — the job
+that actually set the leg's eligibility:
+
+| binding upstream OS | times it gated E2E |
+| --- | --- |
+| ubuntu-24.04 | 30 |
+| windows-2025 | 15 |
+| macos-15 | **3** |
+
+Runner queue is ~10 minutes median on *every* OS, not just macOS. That
+uniformity is the tell: the constraint is not runner scarcity for one platform.
+
+**The real constraint is slot starvation.** A second probe swept a per-minute
+timeline of concurrently-running jobs across four runs:
+
+| run | jobs | wall | peak concurrent | created-but-waiting at peak |
+| --- | --- | --- | --- | --- |
+| 30232465196 | 105 | 40 min | 17 | 32 |
+| 30231798220 | 105 | 36 min | 14 | 2 |
+| 30215198584 | 105 | 74 min | 13 | 9 |
+| 30215183045 | 105 | 64 min | 13 | 41 |
+
+A push run demands ~105 job slots from a pool that grants 13–17. On run
+30215198584 the concurrency profile opens with **nine consecutive minutes at
+zero running jobs**. The ~10-minute queue and the 33-minute DAG wait are both
+downstream of this single fact.
+
+### Where the 105 jobs come from
+
+`_test-suite.yml` fans out a 24-entry `coverage-gates` matrix, and `ci.yml`
+calls it once per OS on push:
+
+```text
+24 coverage gates × 3 OSes = 72 jobs
+```
+
+That is 69% of the run. Each gate pays its own harden-runner, checkout, Bun
+setup and dependency install before re-running a single `test:coverage:*`
+script, and all 24 sit behind `needs: unit-coverage`.
+
+This also explains the DAG wait, which decomposes as: `unit-coverage`
+(~13 min on Windows) → 24 coverage shards queueing against the saturated pool →
+`e2e-desktop` finally eligible at ~33.4 min.
+
+**Consequence for the design of record.** That document proposed matrix
+sharding. Sharding adds jobs to the pool that *is* the constraint, so it would
+have made this measurably worse. Principle #3 — *only against measurement,
+never against a hunch* — earns its keep a second time.
+
+## Change A — a PAL-aware coverage matrix
+
+Run the coverage-threshold gates on Linux only, **except** those whose covered
+code genuinely diverges per platform.
+
+### Which gates are PAL-touching, and how that was decided
+
+Two static sweeps over the source tree: files named for an OS, and files that
+branch on `process.platform` / `os.platform()` at runtime. OS-divergent source
+lives in exactly three directories — `platform/`, `platform/sandbox/`,
+`vault/` — plus a set of runtime-branching files. Mapping those onto the 24
+gates:
+
+| stays on all 3 OSes | why |
+| --- | --- |
+| `Vault` | `vault/{win32,darwin,linux}.ts` — DPAPI / Keychain / libsecret |
+| `Sandbox` | `platform/sandbox/{win32,darwin,linux}.ts` + `seccomp-filter.ts` |
+| `Updater` | `updater/factory.ts`, `updater/platform-target.ts` branch |
+| `Extensions` | `extensions/install-from-local.ts` branches |
+| `Perf` | `perf/bench-runner.ts`, `perf/bench-cli.ts` branch |
+| `Telemetry` | `telemetry/collector.ts` branches |
+
+The remaining 18 — Engine, Agents, Sync scheduler, Rate limiter, People,
+Embedding, Workflow, Watcher, Config, TUI, DB layer, Deployment, Health,
+Metrics, Preflight, Doctor, MCP, LAN — load no file that branches on platform.
+
+**This is static evidence, not empirical.** A stronger check would compare
+measured per-OS coverage from real lcov artifacts. Static was judged sufficient
+because the failure mode is bounded and enumerable: the only thing at risk is
+coverage signal on the specific files listed above. That judgement is recorded
+here so a future reader can overturn it rather than rediscover it.
+
+### Mechanism
+
+Add `pal: true` to the six matrix entries and gate the job:
+
+```yaml
+if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
+```
+
+Coverage gates go **72 → 36**; a push run goes **105 → 69**.
+
+### Why this is safe
+
+- **A skipped matrix leg still creates its check context** and counts as
+  passing. The "Expected — Waiting for status to be reported" trap documented
+  at `ci.yml:137-144` — where a never-created context blocks a merge forever —
+  therefore cannot fire.
+- **The repo's rulesets pin the aggregator**, `PR quality — required gates`,
+  not individual coverage contexts. Verified against both live rulesets
+  (`14784377`, `15436427`).
+- **Every narrowed gate already runs green on Linux today.** Narrowing cannot
+  introduce a new failure; it can only remove signal.
+- **PRs are unaffected.** `pr-quality-ts` already passes `runner: ubuntu-24.04`,
+  so PRs have always run all 24 gates on Linux only. This change makes the push
+  path consistent with the PR path rather than inventing a new policy.
+
+## Change B — narrow the E2E dependency edge
+
+`e2e-desktop` declares `needs: [ci-ts, ci-rust]`. `ci-ts` is the whole
+`_test-suite.yml` — 30 jobs including all 24 coverage shards — and
+`needs:` on a matrix or reusable-workflow caller waits for **all** of it.
+
+`e2e-desktop` consumes no artifact from `ci-ts`: it performs its own checkout,
+its own `setup-nimbus-ci` install, and its own `setup-rust-tauri`. The edge is a
+pure gate, not a data dependency.
+
+Narrow it to `needs: [ci-rust]`. Measured execution for that job, from the
+committed baseline:
+
+| job | execMedian |
+| --- | --- |
+| `CI — Rust/Tauri (ubuntu-24.04)` | 1.25 min |
+| `CI — Rust/Tauri (macos-15)` | 1.17 min |
+| `CI — Rust/Tauri (windows-2025)` | 1.72 min |
+
+This keeps the prerequisite that carries meaning — a broken Tauri/Rust build
+makes E2E Desktop unrunnable — and drops a ~33-minute wait on 24 coverage shards
+that tell E2E nothing.
+
+## Verification — and why our own gate cannot do it
+
+`audit:ci-latency` gates on **execution** time. This change barely moves
+execution; the win lands in **queue** and **DAG wait**, which that gate
+deliberately reports and never gates, because neither is caused by the
+contributor's change.
+
+So the gate cannot prove this slice worked, and pretending otherwise would be
+the same category of error the measurement slice was built to prevent. The
+proof is instead:
+
+1. Both probe scripts are promoted from scratch into
+   `scripts/ci-latency/probe-dag.ts` and `scripts/ci-latency/probe-concurrency.ts`,
+   run manually against `main` before and after the change.
+2. The before/after figures are recorded in the P4b progress log in
+   [`docs/infrastructure-roadmap.md`](../../infrastructure-roadmap.md).
+
+**Expected effect.** DAG wait 33.4 → ~3 min. Jobs-per-run 105 → 69. Peak
+created-but-waiting materially reduced. If the measured result contradicts these
+numbers, the recorded outcome is the measurement — not the prediction.
+
+**Baseline note.** `docs/structure-audit/ci-latency-baseline.json` holds entries
+for the 36 coverage keys that will stop being produced on macOS and Windows.
+`evaluate` reports an absent key as `stale-baseline-entry` — a warning, never a
+regression — and `computeUpdatedBaseline` drops keys absent from the window. So
+the gate stays green throughout, and the baseline is regenerated once after the
+change lands.
+
+## Risks
+
+| risk | assessment |
+| --- | --- |
+| Losing per-OS coverage signal on 18 gates | Bounded by the static sweep above. Recorded as a judgement, not a proof. |
+| Non-Negotiable #5, platform equality | Every test still executes on all 3 OSes via `static`, `unit`, `integration`, `e2e-gateway`, `e2e-cli`. Only *threshold enforcement* narrows. Read as compatible; flagged for the owner's ruling. |
+| A TS-failing, Rust-passing `main` commit burns E2E runners | Post-merge only, and the commit already cleared the PR gates. Accepted. |
+| Fewer jobs could mask a future regression in the removed legs | The removed legs are threshold *enforcement*, not test execution. A behavioural break still fails the 3-OS suites. |
+
+## Out of scope
+
+Consolidating the remaining 18 Linux gates into fewer grouped jobs (~69 → ~50).
+Deferred deliberately: it makes failure reports coarser and is the least
+reversible of the available levers. Revisit only if the measured result of this
+slice falls short.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -93,7 +93,7 @@ Metrics, Preflight, MCP, LAN — load no file that branches on platform.
 caveat was not decorative. The sweep above originally matched only
 `process.platform` and `os.platform()`, missing
 `import { platform } from "node:os"`, which is the **dominant idiom in this
-codebase** (6 files). That omission left `doctor-core.ts` undetected and
+codebase** (7 files). That omission left `doctor-core.ts` undetected and
 classified `Doctor` as Linux-only despite it branching on platform — the exact
 signal loss this design exists to avoid, inside the classification the design
 was built from.

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -96,11 +96,15 @@ here so a future reader can overturn it rather than rediscover it.
 
 ### Mechanism
 
-Add `pal: true` to the six matrix entries and gate the job:
+Give **every** matrix entry an explicit `pal` field — `true` for the six above,
+`false` for the other eighteen — and gate the job:
 
 ```yaml
 if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
 ```
+
+The field is explicit rather than defaulted so that a newly added gate cannot
+inherit Linux-only treatment silently; Change C enforces that.
 
 Coverage gates go **72 → 36**; a push run goes **105 → 69**.
 
@@ -142,6 +146,34 @@ This keeps the prerequisite that carries meaning — a broken Tauri/Rust build
 makes E2E Desktop unrunnable — and drops a ~33-minute wait on 24 coverage shards
 that tell E2E nothing.
 
+## Change C — stop the PAL classification rotting silently
+
+Changes A and B are point-in-time judgements about which code branches on
+platform. Without a guard, the day someone adds `process.platform` to a
+Linux-only gate's code, coverage on Windows and macOS quietly stops watching it
+and **nothing fails**. That is the same silent-decay failure mode the
+measurement slice had to guard for the `created_at` assumption.
+
+A directory scan over the 18 Linux-only gates cannot do this job: the coverage
+scripts name *test* paths (`test:coverage:db` runs
+`packages/gateway/test/unit/db`, never naming `src/db`), coverage is measured
+over files loaded at runtime including transitive imports, and cross-platform
+tests branch on `process.platform` legitimately — so such a scan would be both
+incomplete and full of false positives.
+
+`scripts/structure-audit/check-coverage-gate-pal.ts` inverts it, following the
+D10–D22 confinement pattern already used for tool ids and dispatch sites:
+
+1. Enumerate every source file branching on platform (`process.platform`,
+   `os.platform()`) or importing an OS-named module (`win32`/`darwin`/`linux`).
+2. Require each in a checked-in allowlist entry declaring **which coverage gate
+   covers it**.
+3. Cross-check that the declared gate carries `pal: true` in the matrix.
+4. Require every matrix entry to carry an explicit `pal` field.
+
+A new platform-branching file then fails the audit until its author either
+refactors it behind the PAL or promotes its gate to `pal: true`.
+
 ## Verification — and why our own gate cannot do it
 
 `audit:ci-latency` gates on **execution** time. This change barely moves
@@ -163,12 +195,22 @@ proof is instead:
 created-but-waiting materially reduced. If the measured result contradicts these
 numbers, the recorded outcome is the measurement — not the prediction.
 
-**Baseline note.** `docs/structure-audit/ci-latency-baseline.json` holds entries
-for the 36 coverage keys that will stop being produced on macOS and Windows.
-`evaluate` reports an absent key as `stale-baseline-entry` — a warning, never a
-regression — and `computeUpdatedBaseline` drops keys absent from the window. So
-the gate stays green throughout, and the baseline is regenerated once after the
-change lands.
+**Baseline note — and when to regenerate.**
+`docs/structure-audit/ci-latency-baseline.json` holds entries for the 36
+coverage keys that stop being produced on macOS and Windows. `evaluate` reports
+an absent key as `stale-baseline-entry` — a warning, never a regression — so the
+gate stays green throughout.
+
+Regeneration timing follows the sampling window, not the merge.
+`MAX_RUNS_PER_WORKFLOW` is 12, so immediately after this lands the window still
+contains pre-change runs carrying those keys; they keep receiving observations
+and produce no warnings yet. Running `--update-baseline` inside the PR would be
+a **no-op** — `computeUpdatedBaseline` drops only keys absent from the window,
+and they are present. Deleting them by hand is no better: `evaluate` would then
+report `new-key` for each while the pre-change runs remain in the window.
+
+So: **regenerate once roughly 12 post-change push runs have accumulated**, when
+the abandoned keys have aged out of the window.
 
 ## Risks
 
@@ -176,7 +218,8 @@ change lands.
 | --- | --- |
 | Losing per-OS coverage signal on 18 gates | Bounded by the static sweep above. Recorded as a judgement, not a proof. |
 | Non-Negotiable #5, platform equality | Every test still executes on all 3 OSes via `static`, `unit`, `integration`, `e2e-gateway`, `e2e-cli`. Only *threshold enforcement* narrows. Read as compatible; flagged for the owner's ruling. |
-| A TS-failing, Rust-passing `main` commit burns E2E runners | Post-merge only, and the commit already cleared the PR gates. Accepted. |
+| A TS-failing, Rust-passing `main` commit burns E2E runners | **Deferred, on measured data.** 2 of the last 40 `main` commits arrived without a PR (`a91d73ec`, `7176dd49`) — both `ci(cla)` workflow commits, neither touching TypeScript. The residual case is two green PRs merging into a semantic conflict. Guarding it has real cost: no standalone fast typecheck exists (`Static`, 4.57 min, is inside `_test-suite.yml` and unreachable by `needs:`), so it would mean a new job duplicating typecheck on every push plus ~3 min of DAG depth added back. `CI — Structure audit` (0.83 min) was evaluated as a cheap substitute and rejected — it runs `audit:boundaries`/`invariants`/`release-please`, not typecheck. **Trigger to adopt:** a `main` E2E run observed burning on a TS compile failure. |
+| Cross-job cancellation as an alternative guard | **Not available.** GitHub Actions cannot cancel a job with no `needs` relationship to the failing one; `fail-fast` operates within a matrix, not across jobs. Removing the edge removes the cancellation relationship by definition. |
 | Fewer jobs could mask a future regression in the removed legs | The removed legs are threshold *enforcement*, not test execution. A behavioural break still fails the 3-OS suites. |
 
 ## Out of scope

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -109,11 +109,20 @@ Give **every** matrix entry an explicit `pal` field — `true` for the seven
 above, `false` for the other seventeen — and gate the job:
 
 ```yaml
-if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
+if: inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)
 ```
 
 The field is explicit rather than defaulted so that a newly added gate cannot
 inherit Linux-only treatment silently; Change C enforces that.
+
+`inputs.run-tests` is gated explicitly in the condition rather than relied
+upon implicitly through the `needs: unit-coverage` skip chain, matching how
+every sibling job in `_test-suite.yml` gates on it directly (`static`,
+`unit-coverage`, `integration`, `e2e-gateway`, `e2e-cli`, `packaging`). Without
+it, a docs-only PR caller (`pr-quality-ts` with `runner: ubuntu-24.04` and
+`run-tests: false`) makes the first clause of the condition unconditionally
+true, so the condition itself offers no protection for that caller — it would
+depend entirely on `needs: unit-coverage` skipping.
 
 Coverage gates go **72 → 38**; a push run goes **105 → 71**.
 

--- a/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
+++ b/docs/superpowers/specs/2026-07-27-p4b-ci-tuning-design.md
@@ -83,21 +83,30 @@ gates:
 | `Extensions` | `extensions/install-from-local.ts` branches |
 | `Perf` | `perf/bench-runner.ts`, `perf/bench-cli.ts` branch |
 | `Telemetry` | `telemetry/collector.ts` branches |
+| `Doctor` | `cli/src/commands/doctor-core.ts:80` — `if (platform() === "linux")` |
 
-The remaining 18 — Engine, Agents, Sync scheduler, Rate limiter, People,
+The remaining 17 — Engine, Agents, Sync scheduler, Rate limiter, People,
 Embedding, Workflow, Watcher, Config, TUI, DB layer, Deployment, Health,
-Metrics, Preflight, Doctor, MCP, LAN — load no file that branches on platform.
+Metrics, Preflight, MCP, LAN — load no file that branches on platform.
 
-**This is static evidence, not empirical.** A stronger check would compare
-measured per-OS coverage from real lcov artifacts. Static was judged sufficient
-because the failure mode is bounded and enumerable: the only thing at risk is
-coverage signal on the specific files listed above. That judgement is recorded
-here so a future reader can overturn it rather than rediscover it.
+**This is static evidence, not empirical** — and the plan review proved that
+caveat was not decorative. The sweep above originally matched only
+`process.platform` and `os.platform()`, missing
+`import { platform } from "node:os"`, which is the **dominant idiom in this
+codebase** (6 files). That omission left `doctor-core.ts` undetected and
+classified `Doctor` as Linux-only despite it branching on platform — the exact
+signal loss this design exists to avoid, inside the classification the design
+was built from.
+
+`Doctor` is corrected to a PAL gate above, and the detection in Change C covers
+destructured `node:os` imports and `os.type()`. A stronger check still would
+compare measured per-OS coverage from real lcov artifacts; static remains the
+judgement of record, now with a demonstrated failure to justify the scepticism.
 
 ### Mechanism
 
-Give **every** matrix entry an explicit `pal` field — `true` for the six above,
-`false` for the other eighteen — and gate the job:
+Give **every** matrix entry an explicit `pal` field — `true` for the seven
+above, `false` for the other seventeen — and gate the job:
 
 ```yaml
 if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
@@ -106,7 +115,7 @@ if: inputs.runner == 'ubuntu-24.04' || matrix.gate.pal
 The field is explicit rather than defaulted so that a newly added gate cannot
 inherit Linux-only treatment silently; Change C enforces that.
 
-Coverage gates go **72 → 36**; a push run goes **105 → 69**.
+Coverage gates go **72 → 38**; a push run goes **105 → 71**.
 
 ### Why this is safe
 
@@ -164,8 +173,12 @@ incomplete and full of false positives.
 `scripts/structure-audit/check-coverage-gate-pal.ts` inverts it, following the
 D10–D22 confinement pattern already used for tool ids and dispatch sites:
 
-1. Enumerate every source file branching on platform (`process.platform`,
-   `os.platform()`) or importing an OS-named module (`win32`/`darwin`/`linux`).
+1. Enumerate every source file branching on platform — `process.platform`,
+   `os.platform()`, `os.type()`, or a destructured
+   `import { platform } from "node:os"` — or importing an OS-named module
+   (`win32`/`darwin`/`linux`). The scan must reach `src` directories at **any**
+   depth: `packages/mcp-connectors/src` does not exist, and a one-level scan
+   silently skips all 94 connectors.
 2. Require each in a checked-in allowlist entry declaring **which coverage gate
    covers it**.
 3. Cross-check that the declared gate carries `pal: true` in the matrix.
@@ -191,7 +204,7 @@ proof is instead:
 2. The before/after figures are recorded in the P4b progress log in
    [`docs/infrastructure-roadmap.md`](../../infrastructure-roadmap.md).
 
-**Expected effect.** DAG wait 33.4 → ~3 min. Jobs-per-run 105 → 69. Peak
+**Expected effect.** DAG wait 33.4 → ~3 min. Jobs-per-run 105 → 71. Peak
 created-but-waiting materially reduced. If the measured result contradicts these
 numbers, the recorded outcome is the measurement — not the prediction.
 
@@ -224,7 +237,7 @@ the abandoned keys have aged out of the window.
 
 ## Out of scope
 
-Consolidating the remaining 18 Linux gates into fewer grouped jobs (~69 → ~50).
+Consolidating the remaining 17 Linux gates into fewer grouped jobs (~71 → ~52).
 Deferred deliberately: it makes failure reports coarser and is the least
 reversible of the available levers. Revisit only if the measured result of this
 slice falls short.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "audit:cross-platform": "bun scripts/audit/check-cross-platform.ts",
     "audit:status-drift": "bun scripts/structure-audit/check-status-drift.ts",
     "audit:action-sha-pins": "bun scripts/structure-audit/check-action-sha-pins.ts",
+    "audit:coverage-gate-pal": "bun scripts/structure-audit/check-coverage-gate-pal.ts",
     "audit:pin-freshness": "bun scripts/structure-audit/check-pin-freshness.ts",
     "audit:ci-latency": "bun scripts/ci-latency/check.ts",
     "audit:ci-latency:update-baseline": "bun scripts/ci-latency/check.ts --update-baseline",

--- a/scripts/ci-latency/probe-concurrency.ts
+++ b/scripts/ci-latency/probe-concurrency.ts
@@ -11,16 +11,9 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { concurrencySeries, pageJobs } from "./probe-lib.ts";
+import { asJobs, concurrencySeries, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
-
-interface Job {
-  name: string;
-  created_at: string;
-  started_at: string;
-  completed_at: string | null;
-}
 
 function api(path: string): unknown {
   const r = runGh(["gh", "api", path]);
@@ -30,28 +23,6 @@ function api(path: string): unknown {
   } catch {
     return null;
   }
-}
-
-function asJobs(value: unknown): Job[] {
-  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
-  const out: Job[] = [];
-  for (const j of value["jobs"]) {
-    if (!isRecord(j)) continue;
-    const name = j["name"];
-    const created = j["created_at"];
-    const started = j["started_at"];
-    const completed = j["completed_at"];
-    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
-      continue;
-    }
-    out.push({
-      name,
-      created_at: created,
-      started_at: started,
-      completed_at: typeof completed === "string" ? completed : null,
-    });
-  }
-  return out;
 }
 
 function parseRunsArg(argv: string[]): number {
@@ -101,8 +72,19 @@ if (import.meta.main) {
     const peak = series.length === 0 ? 0 : Math.max(...series);
     const peakMinute = series.indexOf(peak);
     const peakAt = Date.parse(startedAt) + peakMinute * 60_000;
+    // A job with no started_at was skipped, not queued for a runner slot —
+    // it never contended for concurrency at all (this branch's Linux-only
+    // coverage legs are skipped outright on macOS/Windows, not run and
+    // waiting). Counting a skip here would inflate "waiting" with jobs that
+    // were never going to consume a slot, exactly the skewed-sample failure
+    // mode this probe exists to avoid — so it is excluded from this metric,
+    // not counted as zero (which would understate it) or as waiting (which
+    // would overstate it).
     const waitingAtPeak = usable.filter(
-      (j) => Date.parse(j.created_at) <= peakAt && Date.parse(j.started_at) > peakAt,
+      (j) =>
+        j.started_at !== null &&
+        Date.parse(j.created_at) <= peakAt &&
+        Date.parse(j.started_at) > peakAt,
     ).length;
     const count = (re: RegExp) => usable.filter((j) => re.test(j.name)).length;
 

--- a/scripts/ci-latency/probe-concurrency.ts
+++ b/scripts/ci-latency/probe-concurrency.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env bun
+
+/**
+ * P4b diagnostic — jobs per run, peak concurrent execution, and how many jobs
+ * sat created-but-waiting at that peak.
+ *
+ * This is the probe that found the slice's premise: a push run demands ~105
+ * job slots from a pool granting 13-17. Not a gate; see probe-dag.ts.
+ *
+ * Usage: bun scripts/ci-latency/probe-concurrency.ts [--runs N]
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { concurrencySeries } from "./probe-lib.ts";
+
+const REPO = "nimbus-agent/Nimbus";
+
+interface Job {
+  name: string;
+  created_at: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+function api(path: string): unknown {
+  const r = runGh(["gh", "api", path]);
+  if (!r.ok) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function asJobs(value: unknown): Job[] {
+  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
+  const out: Job[] = [];
+  for (const j of value["jobs"]) {
+    if (!isRecord(j)) continue;
+    const name = j["name"];
+    const created = j["created_at"];
+    const started = j["started_at"];
+    const completed = j["completed_at"];
+    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
+      continue;
+    }
+    out.push({
+      name,
+      created_at: created,
+      started_at: started,
+      completed_at: typeof completed === "string" ? completed : null,
+    });
+  }
+  return out;
+}
+
+function parseRunsArg(argv: string[]): number {
+  const ix = argv.indexOf("--runs");
+  if (ix === -1) return 4;
+  const n = Number(argv[ix + 1]);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 4;
+}
+
+if (import.meta.main) {
+  const wanted = parseRunsArg(process.argv.slice(2));
+  const listed = api(
+    `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
+  );
+  const runs =
+    isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  if (runs.length === 0) {
+    console.error("probe-concurrency: no successful push runs readable — is `gh` authenticated?");
+    process.exit(1);
+  }
+
+  for (const run of runs) {
+    if (!isRecord(run)) continue;
+    const id = run["id"];
+    const startedAt = run["run_started_at"];
+    if (typeof id !== "number" || typeof startedAt !== "string") continue;
+
+    // A truncated read here corrupts the ONE number this probe exists to
+    // report. Refuse to print rather than print a low job count that reads as
+    // success.
+    const jobs: Job[] = [];
+    let expected: number | undefined;
+    let complete = false;
+    for (let page = 1; page <= 5; page++) {
+      const payload = api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`);
+      if (payload === null) break;
+      const total = isRecord(payload) ? payload["total_count"] : undefined;
+      if (typeof total === "number") expected = total;
+      const batch = asJobs(payload);
+      if (batch.length === 0) break;
+      jobs.push(...batch);
+      if (expected !== undefined && jobs.length >= expected) {
+        complete = true;
+        break;
+      }
+    }
+    if (!complete) {
+      console.warn(
+        `::warning::probe-concurrency: run ${id} job read incomplete (${jobs.length}/${expected ?? "?"}) — SKIPPED rather than reporting a truncated job count`,
+      );
+      continue;
+    }
+    const usable = jobs.filter((j) => j.completed_at !== null);
+    if (usable.length === 0) continue;
+
+    const series = concurrencySeries(usable, startedAt);
+    const peak = series.length === 0 ? 0 : Math.max(...series);
+    const peakMinute = series.indexOf(peak);
+    const peakAt = Date.parse(startedAt) + peakMinute * 60_000;
+    const waitingAtPeak = usable.filter(
+      (j) => Date.parse(j.created_at) <= peakAt && Date.parse(j.started_at) > peakAt,
+    ).length;
+    const count = (re: RegExp) => usable.filter((j) => re.test(j.name)).length;
+
+    console.log(`\nrun ${id} — ${usable.length} jobs, wall ${series.length - 1}min`);
+    console.log(
+      `    ubuntu=${count(/ubuntu/)} windows=${count(/windows/)} macos=${count(/macos/)}`,
+    );
+    console.log(`    PEAK concurrent = ${peak} (minute ${peakMinute})`);
+    console.log(`    created-but-waiting at peak = ${waitingAtPeak}`);
+    console.log(`    profile: ${series.join(" ")}`);
+  }
+}

--- a/scripts/ci-latency/probe-concurrency.ts
+++ b/scripts/ci-latency/probe-concurrency.ts
@@ -11,7 +11,7 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { concurrencySeries } from "./probe-lib.ts";
+import { concurrencySeries, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
 
@@ -81,23 +81,13 @@ if (import.meta.main) {
 
     // A truncated read here corrupts the ONE number this probe exists to
     // report. Refuse to print rather than print a low job count that reads as
-    // success.
-    const jobs: Job[] = [];
-    let expected: number | undefined;
-    let complete = false;
-    for (let page = 1; page <= 5; page++) {
-      const payload = api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`);
-      if (payload === null) break;
-      const total = isRecord(payload) ? payload["total_count"] : undefined;
-      if (typeof total === "number") expected = total;
-      const batch = asJobs(payload);
-      if (batch.length === 0) break;
-      jobs.push(...batch);
-      if (expected !== undefined && jobs.length >= expected) {
-        complete = true;
-        break;
-      }
-    }
+    // success. Delegates to the shared `pageJobs` helper in probe-lib.ts — see
+    // its docstring for why read-completeness tracking lives in exactly one
+    // place, shared with probe-dag.ts.
+    const { jobs, complete, expected } = pageJobs(
+      (page) => api(`repos/${REPO}/actions/runs/${id}/jobs?per_page=100&page=${page}`),
+      asJobs,
+    );
     if (!complete) {
       console.warn(
         `::warning::probe-concurrency: run ${id} job read incomplete (${jobs.length}/${expected ?? "?"}) — SKIPPED rather than reporting a truncated job count`,

--- a/scripts/ci-latency/probe-dag.ts
+++ b/scripts/ci-latency/probe-dag.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env bun
+
+/**
+ * P4b diagnostic — which upstream job actually gated each `E2E Desktop` leg,
+ * and how long each leg waited.
+ *
+ * Not a gate, and deliberately not registered in preflight-gates.ts: it is the
+ * before/after instrument for the tuning slice, because `audit:ci-latency`
+ * gates EXECUTION while this slice's win lands in DAG wait.
+ *
+ * Usage: bun scripts/ci-latency/probe-dag.ts [--runs N]
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+import { bindingUpstream, median, minutesBetween } from "./probe-lib.ts";
+
+const REPO = "nimbus-agent/Nimbus";
+
+interface Job {
+  name: string;
+  created_at: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+function api(path: string): unknown {
+  const r = runGh(["gh", "api", path]);
+  if (!r.ok) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function asJobs(value: unknown): Job[] {
+  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
+  const out: Job[] = [];
+  for (const j of value["jobs"]) {
+    if (!isRecord(j)) continue;
+    const name = j["name"];
+    const created = j["created_at"];
+    const started = j["started_at"];
+    const completed = j["completed_at"];
+    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
+      continue;
+    }
+    out.push({
+      name,
+      created_at: created,
+      started_at: started,
+      completed_at: typeof completed === "string" ? completed : null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Pages through a run's jobs, reporting whether the read was COMPLETE.
+ *
+ * Job count is this slice's headline metric, so a silently truncated read would
+ * report fewer jobs than really ran and be read as proof the change worked. An
+ * instrument that fails toward its own hypothesis is worse than none — the same
+ * hazard `MAX_READ_FAILURE_RATIO` exists for in the gate itself.
+ */
+function jobsForRun(runId: number): { jobs: Job[]; complete: boolean } {
+  const jobs: Job[] = [];
+  let expected: number | undefined;
+  for (let page = 1; page <= 5; page++) {
+    const payload = api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
+    if (payload === null) return { jobs, complete: false }; // read FAILED, not "no more pages"
+    const total = isRecord(payload) ? payload["total_count"] : undefined;
+    if (typeof total === "number") expected = total;
+    const batch = asJobs(payload);
+    if (batch.length === 0) break;
+    jobs.push(...batch);
+    if (expected !== undefined && jobs.length >= expected) break;
+  }
+  return { jobs, complete: expected !== undefined && jobs.length >= expected };
+}
+
+function parseRunsArg(argv: string[]): number {
+  const ix = argv.indexOf("--runs");
+  if (ix === -1) return 15;
+  const n = Number(argv[ix + 1]);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
+}
+
+if (import.meta.main) {
+  const wanted = parseRunsArg(process.argv.slice(2));
+  const listed = api(
+    `repos/${REPO}/actions/workflows/ci.yml/runs?event=push&branch=main&status=success&per_page=${wanted}`,
+  );
+  const runs =
+    isRecord(listed) && Array.isArray(listed["workflow_runs"]) ? listed["workflow_runs"] : [];
+  if (runs.length === 0) {
+    console.error("probe-dag: no successful push runs readable — is `gh` authenticated?");
+    process.exit(1);
+  }
+
+  const binding = new Map<string, number>();
+  const waitsByLeg = new Map<string, number[]>();
+  let incomplete = 0;
+
+  for (const run of runs) {
+    if (!isRecord(run)) continue;
+    const id = run["id"];
+    const startedAt = run["run_started_at"];
+    if (typeof id !== "number" || typeof startedAt !== "string") continue;
+    const { jobs, complete } = jobsForRun(id);
+    // Skip, do not silently include: a partial job list biases the binding-job
+    // tally toward whichever pages happened to load.
+    if (!complete) {
+      incomplete++;
+      continue;
+    }
+    const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
+    const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
+    const gatedBy = bindingUpstream(upstream);
+    for (const leg of legs) {
+      if (gatedBy) binding.set(gatedBy.name, (binding.get(gatedBy.name) ?? 0) + 1);
+      const wait = minutesBetween(leg.created_at, startedAt);
+      waitsByLeg.set(leg.name, [...(waitsByLeg.get(leg.name) ?? []), wait]);
+    }
+  }
+
+  console.log(`\nruns sampled: ${runs.length - incomplete}/${runs.length}`);
+  if (incomplete > 0) {
+    console.warn(
+      `::warning::probe-dag: ${incomplete}/${runs.length} run(s) had an incomplete job read and were EXCLUDED — figures below cover the rest`,
+    );
+  }
+  console.log("\nWHICH upstream job gated E2E (times it was last to finish):");
+  for (const [name, n] of [...binding].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(3)}x  ${name}`);
+  }
+  console.log("\nDAG wait per E2E leg (minutes):");
+  for (const [leg, ws] of [...waitsByLeg].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(
+      `  ${leg.padEnd(34)} median ${median(ws).toFixed(1).padStart(6)}  max ${Math.max(...ws)
+        .toFixed(1)
+        .padStart(6)}  n=${ws.length}`,
+    );
+  }
+}

--- a/scripts/ci-latency/probe-dag.ts
+++ b/scripts/ci-latency/probe-dag.ts
@@ -12,7 +12,7 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { bindingUpstream, median, minutesBetween } from "./probe-lib.ts";
+import { bindingUpstream, median, minutesBetween, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
 
@@ -58,25 +58,15 @@ function asJobs(value: unknown): Job[] {
 /**
  * Pages through a run's jobs, reporting whether the read was COMPLETE.
  *
- * Job count is this slice's headline metric, so a silently truncated read would
- * report fewer jobs than really ran and be read as proof the change worked. An
- * instrument that fails toward its own hypothesis is worse than none — the same
- * hazard `MAX_READ_FAILURE_RATIO` exists for in the gate itself.
+ * Delegates to the shared `pageJobs` helper in `probe-lib.ts` — see its
+ * docstring for why read-completeness tracking lives in exactly one place.
  */
 function jobsForRun(runId: number): { jobs: Job[]; complete: boolean } {
-  const jobs: Job[] = [];
-  let expected: number | undefined;
-  for (let page = 1; page <= 5; page++) {
-    const payload = api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`);
-    if (payload === null) return { jobs, complete: false }; // read FAILED, not "no more pages"
-    const total = isRecord(payload) ? payload["total_count"] : undefined;
-    if (typeof total === "number") expected = total;
-    const batch = asJobs(payload);
-    if (batch.length === 0) break;
-    jobs.push(...batch);
-    if (expected !== undefined && jobs.length >= expected) break;
-  }
-  return { jobs, complete: expected !== undefined && jobs.length >= expected };
+  const { jobs, complete } = pageJobs(
+    (page) => api(`repos/${REPO}/actions/runs/${runId}/jobs?per_page=100&page=${page}`),
+    asJobs,
+  );
+  return { jobs, complete };
 }
 
 function parseRunsArg(argv: string[]): number {
@@ -116,8 +106,12 @@ if (import.meta.main) {
     }
     const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
     const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
-    const gatedBy = bindingUpstream(upstream);
     for (const leg of legs) {
+      // Eligibility is per-leg, not per-run: which upstream job actually
+      // gated THIS leg depends on when THIS leg became runnable
+      // (`leg.created_at`), not on which candidate happened to finish last
+      // in wall-clock time across the whole run.
+      const gatedBy = bindingUpstream(upstream, leg.created_at);
       if (gatedBy) binding.set(gatedBy.name, (binding.get(gatedBy.name) ?? 0) + 1);
       const wait = minutesBetween(leg.created_at, startedAt);
       waitsByLeg.set(leg.name, [...(waitsByLeg.get(leg.name) ?? []), wait]);

--- a/scripts/ci-latency/probe-dag.ts
+++ b/scripts/ci-latency/probe-dag.ts
@@ -12,16 +12,16 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { accumulateBinding, median, minutesBetween, pageJobs } from "./probe-lib.ts";
+import {
+  accumulateBinding,
+  asJobs,
+  type Job,
+  median,
+  minutesBetween,
+  pageJobs,
+} from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
-
-interface Job {
-  name: string;
-  created_at: string;
-  started_at: string;
-  completed_at: string | null;
-}
 
 function api(path: string): unknown {
   const r = runGh(["gh", "api", path]);
@@ -31,28 +31,6 @@ function api(path: string): unknown {
   } catch {
     return null;
   }
-}
-
-function asJobs(value: unknown): Job[] {
-  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
-  const out: Job[] = [];
-  for (const j of value["jobs"]) {
-    if (!isRecord(j)) continue;
-    const name = j["name"];
-    const created = j["created_at"];
-    const started = j["started_at"];
-    const completed = j["completed_at"];
-    if (typeof name !== "string" || typeof created !== "string" || typeof started !== "string") {
-      continue;
-    }
-    out.push({
-      name,
-      created_at: created,
-      started_at: started,
-      completed_at: typeof completed === "string" ? completed : null,
-    });
-  }
-  return out;
 }
 
 /**

--- a/scripts/ci-latency/probe-dag.ts
+++ b/scripts/ci-latency/probe-dag.ts
@@ -12,7 +12,7 @@
  */
 
 import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
-import { bindingUpstream, median, minutesBetween, pageJobs } from "./probe-lib.ts";
+import { accumulateBinding, median, minutesBetween, pageJobs } from "./probe-lib.ts";
 
 const REPO = "nimbus-agent/Nimbus";
 
@@ -91,6 +91,8 @@ if (import.meta.main) {
   const binding = new Map<string, number>();
   const waitsByLeg = new Map<string, number[]>();
   let incomplete = 0;
+  let droppedLegs = 0;
+  let totalLegs = 0;
 
   for (const run of runs) {
     if (!isRecord(run)) continue;
@@ -106,13 +108,15 @@ if (import.meta.main) {
     }
     const upstream = jobs.filter((j) => /^CI — (TS\/Bun|Rust\/Tauri)/.test(j.name));
     const legs = jobs.filter((j) => j.name.startsWith("E2E Desktop —"));
+    // Eligibility is per-leg, not per-run: which upstream job actually gated
+    // THIS leg depends on when THIS leg became runnable (`leg.created_at`), not
+    // on which candidate happened to finish last in wall-clock time across the
+    // whole run. `accumulateBinding` reports legs it could not attribute rather
+    // than dropping them silently — see its docstring for why that matters more
+    // now that the gating margin is ~1.2 min rather than ~60.
+    totalLegs += legs.length;
+    droppedLegs += accumulateBinding(binding, upstream, legs);
     for (const leg of legs) {
-      // Eligibility is per-leg, not per-run: which upstream job actually
-      // gated THIS leg depends on when THIS leg became runnable
-      // (`leg.created_at`), not on which candidate happened to finish last
-      // in wall-clock time across the whole run.
-      const gatedBy = bindingUpstream(upstream, leg.created_at);
-      if (gatedBy) binding.set(gatedBy.name, (binding.get(gatedBy.name) ?? 0) + 1);
       const wait = minutesBetween(leg.created_at, startedAt);
       waitsByLeg.set(leg.name, [...(waitsByLeg.get(leg.name) ?? []), wait]);
     }
@@ -122,6 +126,11 @@ if (import.meta.main) {
   if (incomplete > 0) {
     console.warn(
       `::warning::probe-dag: ${incomplete}/${runs.length} run(s) had an incomplete job read and were EXCLUDED — figures below cover the rest`,
+    );
+  }
+  if (droppedLegs > 0) {
+    console.warn(
+      `::warning::probe-dag: ${droppedLegs}/${totalLegs} E2E leg(s) had NO upstream candidate completing at or before their eligibility moment and are absent from the attribution tally below`,
     );
   }
   console.log("\nWHICH upstream job gated E2E (times it was last to finish):");

--- a/scripts/ci-latency/probe-lib.test.ts
+++ b/scripts/ci-latency/probe-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  accumulateBinding,
   bindingUpstream,
   concurrencySeries,
   median,
@@ -72,6 +73,48 @@ describe("bindingUpstream", () => {
 
   test("an empty candidate list yields null", () => {
     expect(bindingUpstream([], "2026-07-27T10:00:00Z")).toBeNull();
+  });
+});
+
+describe("accumulateBinding", () => {
+  const upstream = [
+    { name: "ci-rust", completed_at: "2026-07-27T10:05:00Z" },
+    { name: "ci-ts", completed_at: "2026-07-27T10:40:00Z" },
+  ];
+
+  test("tallies each leg against the job that actually gated it", () => {
+    const into = new Map<string, number>();
+    const dropped = accumulateBinding(into, upstream, [
+      { created_at: "2026-07-27T10:06:00Z" },
+      { created_at: "2026-07-27T10:06:00Z" },
+      { created_at: "2026-07-27T10:41:00Z" },
+    ]);
+    expect(dropped).toBe(0);
+    expect([...into]).toEqual([
+      ["ci-rust", 2],
+      ["ci-ts", 1],
+    ]);
+  });
+
+  test("COUNTS a leg with no eligible upstream instead of dropping it silently", () => {
+    // The leg became eligible before any candidate completed. Narrowing E2E to
+    // `needs: [ci-rust]` cuts the gating margin from ~60 min to ~1.2 min, so
+    // this is now plausible rather than impossible -- and an after-measurement
+    // that quietly attributes fewer legs than ran is the one instrument that
+    // must not fail toward its own hypothesis.
+    const into = new Map<string, number>();
+    const dropped = accumulateBinding(into, upstream, [
+      { created_at: "2026-07-27T10:00:00Z" },
+      { created_at: "2026-07-27T10:06:00Z" },
+    ]);
+    expect(dropped).toBe(1);
+    expect([...into]).toEqual([["ci-rust", 1]]);
+  });
+
+  test("with no upstream candidates at all, every leg is reported dropped", () => {
+    const into = new Map<string, number>();
+    expect(accumulateBinding(into, [], [{ created_at: "2026-07-27T10:06:00Z" }])).toBe(1);
+    expect(into.size).toBe(0);
   });
 });
 

--- a/scripts/ci-latency/probe-lib.test.ts
+++ b/scripts/ci-latency/probe-lib.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import { bindingUpstream, concurrencySeries, median, minutesBetween } from "./probe-lib.ts";
+
+describe("median", () => {
+  test("odd-length picks the middle", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  test("even-length averages the two middles", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  test("an empty sample is 0, not NaN", () => {
+    // A NaN would propagate silently into every printed figure.
+    expect(median([])).toBe(0);
+  });
+});
+
+describe("minutesBetween", () => {
+  test("returns whole minutes between two ISO timestamps", () => {
+    expect(minutesBetween("2026-07-27T10:30:00Z", "2026-07-27T10:00:00Z")).toBe(30);
+  });
+
+  test("an unparseable timestamp yields 0 rather than NaN", () => {
+    expect(minutesBetween("not-a-date", "2026-07-27T10:00:00Z")).toBe(0);
+  });
+});
+
+describe("bindingUpstream", () => {
+  test("picks the upstream job that completed last", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:20:00Z" },
+      { name: "c", completed_at: "2026-07-27T10:10:00Z" },
+    ];
+    expect(bindingUpstream(jobs)?.name).toBe("b");
+  });
+
+  test("ignores jobs that never completed", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "running", completed_at: null },
+    ];
+    expect(bindingUpstream(jobs)?.name).toBe("a");
+  });
+
+  test("an empty list yields null", () => {
+    expect(bindingUpstream([])).toBeNull();
+  });
+});
+
+describe("concurrencySeries", () => {
+  test("counts jobs running at each minute offset", () => {
+    // Two jobs overlap only at minute 1.
+    const series = concurrencySeries(
+      [
+        { started_at: "2026-07-27T10:00:00Z", completed_at: "2026-07-27T10:02:00Z" },
+        { started_at: "2026-07-27T10:01:00Z", completed_at: "2026-07-27T10:03:00Z" },
+      ],
+      "2026-07-27T10:00:00Z",
+    );
+    expect(series).toEqual([1, 2, 1, 0]);
+  });
+
+  test("no jobs yields an empty series", () => {
+    expect(concurrencySeries([], "2026-07-27T10:00:00Z")).toEqual([]);
+  });
+});

--- a/scripts/ci-latency/probe-lib.test.ts
+++ b/scripts/ci-latency/probe-lib.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { bindingUpstream, concurrencySeries, median, minutesBetween } from "./probe-lib.ts";
+import {
+  bindingUpstream,
+  concurrencySeries,
+  median,
+  minutesBetween,
+  pageJobs,
+} from "./probe-lib.ts";
 
 describe("median", () => {
   test("odd-length picks the middle", () => {
@@ -28,13 +34,13 @@ describe("minutesBetween", () => {
 });
 
 describe("bindingUpstream", () => {
-  test("picks the upstream job that completed last", () => {
+  test("picks the upstream job that completed last, at or before eligibility", () => {
     const jobs = [
       { name: "a", completed_at: "2026-07-27T10:05:00Z" },
       { name: "b", completed_at: "2026-07-27T10:20:00Z" },
       { name: "c", completed_at: "2026-07-27T10:10:00Z" },
     ];
-    expect(bindingUpstream(jobs)?.name).toBe("b");
+    expect(bindingUpstream(jobs, "2026-07-27T10:25:00Z")?.name).toBe("b");
   });
 
   test("ignores jobs that never completed", () => {
@@ -42,11 +48,30 @@ describe("bindingUpstream", () => {
       { name: "a", completed_at: "2026-07-27T10:05:00Z" },
       { name: "running", completed_at: null },
     ];
-    expect(bindingUpstream(jobs)?.name).toBe("a");
+    expect(bindingUpstream(jobs, "2026-07-27T10:30:00Z")?.name).toBe("a");
   });
 
-  test("an empty list yields null", () => {
-    expect(bindingUpstream([])).toBeNull();
+  test("excludes a candidate that completed AFTER the eligibility moment", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:20:00Z" },
+    ];
+    // b finished after the leg became eligible -- it cannot have gated it,
+    // even though it is the global-latest completion.
+    expect(bindingUpstream(jobs, "2026-07-27T10:10:00Z")?.name).toBe("a");
+  });
+
+  test("picks the latest candidate at or before the eligibility moment, not the global latest", () => {
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:10:00Z" },
+      { name: "c", completed_at: "2026-07-27T10:20:00Z" },
+    ];
+    expect(bindingUpstream(jobs, "2026-07-27T10:10:00Z")?.name).toBe("b");
+  });
+
+  test("an empty candidate list yields null", () => {
+    expect(bindingUpstream([], "2026-07-27T10:00:00Z")).toBeNull();
   });
 });
 
@@ -65,5 +90,56 @@ describe("concurrencySeries", () => {
 
   test("no jobs yields an empty series", () => {
     expect(concurrencySeries([], "2026-07-27T10:00:00Z")).toEqual([]);
+  });
+});
+
+interface FakeJob {
+  id: number;
+}
+
+function parseFakeBatch(payload: unknown): FakeJob[] {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !Array.isArray((payload as { jobs?: unknown }).jobs)
+  ) {
+    return [];
+  }
+  return (payload as { jobs: FakeJob[] }).jobs;
+}
+
+describe("pageJobs", () => {
+  test("a failed page read yields complete: false, not a false end-of-pagination", () => {
+    // Page 1 declares 3 jobs total but only delivers 1; page 2 fails outright
+    // (returns null). A read that mistook the null for "no more pages" would
+    // report complete: true with a truncated job list -- exactly the failure
+    // mode that would make an AFTER run look like a win.
+    const result = pageJobs(
+      (page) => (page === 1 ? { total_count: 3, jobs: [{ id: 1 }] } : null),
+      parseFakeBatch,
+    );
+    expect(result.complete).toBe(false);
+    expect(result.jobs).toEqual([{ id: 1 }]);
+    expect(result.expected).toBe(3);
+  });
+
+  test("reconciles against total_count across multiple successful pages", () => {
+    const pages: Record<number, unknown> = {
+      1: { total_count: 2, jobs: [{ id: 1 }] },
+      2: { total_count: 2, jobs: [{ id: 2 }] },
+    };
+    const result = pageJobs((page) => pages[page] ?? null, parseFakeBatch);
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.expected).toBe(2);
+  });
+
+  test("an empty page ends pagination -- distinct from a failed read", () => {
+    // No total_count ever arrives, so `expected` stays undefined and the read
+    // is correctly reported incomplete rather than crashing on a missing count.
+    const result = pageJobs((page) => (page === 1 ? { jobs: [] } : null), parseFakeBatch);
+    expect(result.complete).toBe(false);
+    expect(result.jobs).toEqual([]);
+    expect(result.expected).toBeUndefined();
   });
 });

--- a/scripts/ci-latency/probe-lib.test.ts
+++ b/scripts/ci-latency/probe-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   accumulateBinding,
+  asJobs,
   bindingUpstream,
   concurrencySeries,
   median,
@@ -74,6 +75,19 @@ describe("bindingUpstream", () => {
   test("an empty candidate list yields null", () => {
     expect(bindingUpstream([], "2026-07-27T10:00:00Z")).toBeNull();
   });
+
+  test("an unparseable eligibility timestamp attributes nothing, rather than falling back to the global max", () => {
+    // Before this guard, an unparseable eligibleAt parsed to a NaN cutoff, the
+    // `at > cutoff` exclusion was always false, and the function fell back to
+    // whichever candidate happened to complete last -- the exact
+    // misattribution this cutoff exists to prevent, reachable again through
+    // bad input.
+    const jobs = [
+      { name: "a", completed_at: "2026-07-27T10:05:00Z" },
+      { name: "b", completed_at: "2026-07-27T10:20:00Z" },
+    ];
+    expect(bindingUpstream(jobs, "not-a-date")).toBeNull();
+  });
 });
 
 describe("accumulateBinding", () => {
@@ -133,6 +147,124 @@ describe("concurrencySeries", () => {
 
   test("no jobs yields an empty series", () => {
     expect(concurrencySeries([], "2026-07-27T10:00:00Z")).toEqual([]);
+  });
+
+  test("a job with a null started_at is excluded from the count, not treated as started at minute 0", () => {
+    // A skipped job (e.g. a Linux-only coverage leg skipped on macOS/Windows)
+    // reports completed_at but no started_at. If it were kept in without a
+    // started_at it would either need to default to time 0 (falsely inflating
+    // every early-minute count) or be silently coerced to NaN (which would
+    // make it "running" everywhere via a bad comparison). Neither is
+    // acceptable -- it must be excluded from this metric entirely.
+    const series = concurrencySeries(
+      [
+        { started_at: "2026-07-27T10:00:00Z", completed_at: "2026-07-27T10:02:00Z" },
+        { started_at: null, completed_at: "2026-07-27T10:00:05Z" },
+      ],
+      "2026-07-27T10:00:00Z",
+    );
+    expect(series).toEqual([1, 1, 0]);
+  });
+
+  test("a job with a null completed_at is excluded from the count", () => {
+    const series = concurrencySeries(
+      [
+        { started_at: "2026-07-27T10:00:00Z", completed_at: "2026-07-27T10:02:00Z" },
+        { started_at: "2026-07-27T10:00:00Z", completed_at: null },
+      ],
+      "2026-07-27T10:00:00Z",
+    );
+    expect(series).toEqual([1, 1, 0]);
+  });
+
+  test("with ONLY null-started jobs, the series is empty rather than throwing", () => {
+    expect(
+      concurrencySeries(
+        [{ started_at: null, completed_at: "2026-07-27T10:00:05Z" }],
+        "2026-07-27T10:00:00Z",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("asJobs", () => {
+  test("a job missing started_at is still parsed, with started_at null", () => {
+    // This is the read-completeness fix: `pageJobs` judges completeness by
+    // comparing the parsed count against the API's total_count. A skipped
+    // job still counts toward total_count, so dropping it here for lacking
+    // started_at makes that total permanently unreachable.
+    const jobs = asJobs({
+      jobs: [
+        {
+          name: "E2E Desktop — windows",
+          created_at: "2026-07-27T10:00:00Z",
+          started_at: null,
+          completed_at: "2026-07-27T10:00:05Z",
+        },
+      ],
+    });
+    expect(jobs).toEqual([
+      {
+        name: "E2E Desktop — windows",
+        created_at: "2026-07-27T10:00:00Z",
+        started_at: null,
+        completed_at: "2026-07-27T10:00:05Z",
+      },
+    ]);
+  });
+
+  test("a job with a non-string started_at is parsed as null rather than dropped", () => {
+    const jobs = asJobs({
+      jobs: [
+        {
+          name: "a",
+          created_at: "2026-07-27T10:00:00Z",
+          started_at: null,
+          completed_at: null,
+        },
+      ],
+    });
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.started_at).toBeNull();
+  });
+
+  test("a job missing name or created_at is still dropped", () => {
+    const jobs = asJobs({
+      jobs: [
+        { created_at: "2026-07-27T10:00:00Z", started_at: null, completed_at: null },
+        { name: "a", started_at: null, completed_at: null },
+      ],
+    });
+    expect(jobs).toEqual([]);
+  });
+
+  test("read-completeness: a page of jobs missing started_at still reconciles against total_count", () => {
+    // The interaction this whole fix targets: `pageJobs` compares the parsed
+    // job count against total_count. Before this fix, `asJobs` dropped any
+    // record lacking started_at, so a run with a skipped job could never
+    // reach total_count and was misjudged incomplete -- excluded wholesale
+    // from every downstream figure.
+    const payload = {
+      total_count: 2,
+      jobs: [
+        {
+          name: "ci-ts",
+          created_at: "2026-07-27T10:00:00Z",
+          started_at: "2026-07-27T10:00:01Z",
+          completed_at: "2026-07-27T10:05:00Z",
+        },
+        {
+          name: "E2E Desktop — windows (Coverage: Engine)",
+          created_at: "2026-07-27T10:00:00Z",
+          started_at: null,
+          completed_at: "2026-07-27T10:00:00Z",
+        },
+      ],
+    };
+    const result = pageJobs((page) => (page === 1 ? payload : null), asJobs);
+    expect(result.complete).toBe(true);
+    expect(result.jobs).toHaveLength(2);
+    expect(result.jobs[1]?.started_at).toBeNull();
   });
 });
 

--- a/scripts/ci-latency/probe-lib.ts
+++ b/scripts/ci-latency/probe-lib.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure helpers for the two P4b diagnostic probes.
+ *
+ * They live apart from the probes so the arithmetic is unit-testable without a
+ * network call. The probes themselves are thin: fetch, map, print.
+ */
+
+export interface CompletedJob {
+  name: string;
+  completed_at: string | null;
+}
+
+export interface RunningJob {
+  started_at: string;
+  completed_at: string | null;
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const s = [...values].sort((a, b) => a - b);
+  const mid = s.length / 2;
+  if (s.length % 2 === 1) return s[Math.floor(mid)] ?? 0;
+  return ((s[mid - 1] ?? 0) + (s[mid] ?? 0)) / 2;
+}
+
+/** Whole minutes from `b` to `a`. Unparseable input yields 0, never NaN. */
+export function minutesBetween(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return 0;
+  return (ta - tb) / 60_000;
+}
+
+/**
+ * The upstream job whose completion gated a dependent job — i.e. the last one
+ * to finish. Returns null when nothing has completed.
+ */
+export function bindingUpstream(jobs: CompletedJob[]): CompletedJob | null {
+  let best: CompletedJob | null = null;
+  let bestAt = Number.NEGATIVE_INFINITY;
+  for (const j of jobs) {
+    if (j.completed_at === null) continue;
+    const at = Date.parse(j.completed_at);
+    if (Number.isNaN(at) || at <= bestAt) continue;
+    bestAt = at;
+    best = j;
+  }
+  return best;
+}
+
+/** How many jobs were running at each whole-minute offset from `runStartedAt`. */
+export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): number[] {
+  const t0 = Date.parse(runStartedAt);
+  const usable = jobs.filter((j) => j.completed_at !== null);
+  if (Number.isNaN(t0) || usable.length === 0) return [];
+  const end = Math.max(...usable.map((j) => Date.parse(j.completed_at ?? "")));
+  if (!Number.isFinite(end)) return [];
+  const span = Math.ceil((end - t0) / 60_000);
+  const series: number[] = [];
+  for (let m = 0; m <= span; m++) {
+    const at = t0 + m * 60_000;
+    series.push(
+      usable.filter((j) => Date.parse(j.started_at) <= at && Date.parse(j.completed_at ?? "") > at)
+        .length,
+    );
+  }
+  return series;
+}

--- a/scripts/ci-latency/probe-lib.ts
+++ b/scripts/ci-latency/probe-lib.ts
@@ -5,6 +5,8 @@
  * network call. The probes themselves are thin: fetch, map, print.
  */
 
+import { isRecord } from "../structure-audit/_gh-audit.ts";
+
 export interface CompletedJob {
   name: string;
   completed_at: string | null;
@@ -33,15 +35,25 @@ export function minutesBetween(a: string, b: string): number {
 
 /**
  * The upstream job whose completion gated a dependent job — i.e. the last one
- * to finish. Returns null when nothing has completed.
+ * to finish at or before `eligibleAt` (the moment the dependent job became
+ * eligible to run, e.g. its `created_at`).
+ *
+ * The cutoff matters structurally, not just cosmetically: a candidate that
+ * finished LATER than `eligibleAt` cannot have gated anything — it simply
+ * happened to run long. Taking the unrestricted global max would misattribute
+ * gating to whichever candidate was slowest, rather than whichever candidate
+ * the dependent job actually waited on. Returns null when no candidate
+ * completed at or before the cutoff.
  */
-export function bindingUpstream(jobs: CompletedJob[]): CompletedJob | null {
+export function bindingUpstream(jobs: CompletedJob[], eligibleAt: string): CompletedJob | null {
+  const cutoff = Date.parse(eligibleAt);
   let best: CompletedJob | null = null;
   let bestAt = Number.NEGATIVE_INFINITY;
   for (const j of jobs) {
     if (j.completed_at === null) continue;
     const at = Date.parse(j.completed_at);
     if (Number.isNaN(at) || at <= bestAt) continue;
+    if (!Number.isNaN(cutoff) && at > cutoff) continue;
     bestAt = at;
     best = j;
   }
@@ -65,4 +77,51 @@ export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): num
     );
   }
   return series;
+}
+
+export interface PagedJobs<J> {
+  jobs: J[];
+  /** Whether the read reconciled against the API's `total_count`. */
+  complete: boolean;
+  /** `total_count` as last reported by the API, if any page reported one. */
+  expected: number | undefined;
+}
+
+/**
+ * Pages through a run's jobs via `fetchPage`, tracking whether the read is
+ * COMPLETE — i.e. whether the accumulated job count reconciles against the
+ * API's `total_count`.
+ *
+ * Job count is this slice's headline metric, so a silently truncated read
+ * would report fewer jobs than really ran and be read as proof the change
+ * worked. An instrument that fails toward its own hypothesis is worse than
+ * none — the same hazard `MAX_READ_FAILURE_RATIO` guards against in the gate
+ * itself. This logic used to be duplicated between the two probes and had
+ * already drifted once (one copy lost the "verdict computed after the loop,
+ * not just inside it" guard); it now lives in exactly one place.
+ *
+ * `fetchPage` returns the parsed JSON payload for the given 1-indexed page,
+ * or `null` on a FAILED read — never on "no more pages" (an exhausted feed is
+ * signaled by `parseBatch` returning an empty array). Taking a callback
+ * rather than doing network I/O itself keeps this testable without a network
+ * call.
+ */
+export function pageJobs<J>(
+  fetchPage: (page: number) => unknown,
+  parseBatch: (payload: unknown) => J[],
+  maxPages = 5,
+): PagedJobs<J> {
+  const jobs: J[] = [];
+  let expected: number | undefined;
+  for (let page = 1; page <= maxPages; page++) {
+    const payload = fetchPage(page);
+    if (payload === null) return { jobs, complete: false, expected }; // read FAILED, not "no more pages"
+    const total = isRecord(payload) ? payload["total_count"] : undefined;
+    if (typeof total === "number") expected = total;
+    const batch = parseBatch(payload);
+    if (batch.length === 0) break;
+    jobs.push(...batch);
+    if (expected !== undefined && jobs.length >= expected) break;
+  }
+  return { jobs, complete: expected !== undefined && jobs.length >= expected, expected };
 }

--- a/scripts/ci-latency/probe-lib.ts
+++ b/scripts/ci-latency/probe-lib.ts
@@ -60,6 +60,37 @@ export function bindingUpstream(jobs: CompletedJob[], eligibleAt: string): Compl
   return best;
 }
 
+/**
+ * Tallies each leg's binding upstream job into `into`, returning how many legs
+ * were DROPPED because no candidate completed at or before their eligibility
+ * moment (`bindingUpstream` returned null).
+ *
+ * The drop count is not bookkeeping. A dropped leg contributes nothing to the
+ * attribution tally and, before this counted them, vanished with no output at
+ * all. That was tolerable while the gating margin was ~60 minutes — a null was
+ * close to impossible. Narrowing `e2e-desktop` to `needs: [ci-rust]` collapses
+ * the margin to ~1.2 minutes, so a leg created a few seconds before its
+ * upstream's `completed_at` timestamp is now plausible. This probe is the ONLY
+ * instrument that can show the narrowing worked, so it must not silently
+ * measure fewer legs than ran.
+ */
+export function accumulateBinding(
+  into: Map<string, number>,
+  upstream: CompletedJob[],
+  legs: readonly { created_at: string }[],
+): number {
+  let dropped = 0;
+  for (const leg of legs) {
+    const gatedBy = bindingUpstream(upstream, leg.created_at);
+    if (gatedBy === null) {
+      dropped++;
+      continue;
+    }
+    into.set(gatedBy.name, (into.get(gatedBy.name) ?? 0) + 1);
+  }
+  return dropped;
+}
+
 /** How many jobs were running at each whole-minute offset from `runStartedAt`. */
 export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): number[] {
   const t0 = Date.parse(runStartedAt);

--- a/scripts/ci-latency/probe-lib.ts
+++ b/scripts/ci-latency/probe-lib.ts
@@ -12,8 +12,57 @@ export interface CompletedJob {
   completed_at: string | null;
 }
 
+export interface Job {
+  name: string;
+  created_at: string;
+  /** Null when the job was skipped rather than executed. */
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Parses the `jobs` array of a GitHub Actions "list jobs for a workflow run"
+ * API payload. Shared by both probes — they used to each carry a byte-for-byte
+ * copy of this function, which is exactly the kind of drift risk `pageJobs`
+ * below was already extracted to avoid.
+ *
+ * `started_at` is deliberately NOT part of the validity check: a skipped job
+ * (e.g. a Linux-only coverage leg skipped on macOS/Windows) can lack it while
+ * still being a real, completed job that must count toward `pageJobs`'s
+ * completeness reconciliation against the API's `total_count`. Dropping such
+ * a record here would make that total unreachable and the read would be
+ * misjudged incomplete. Metrics that need `started_at` (e.g.
+ * `concurrencySeries`) exclude such jobs themselves, at the point of
+ * calculation — never here, where doing so would corrupt completeness.
+ */
+export function asJobs(value: unknown): Job[] {
+  if (!isRecord(value) || !Array.isArray(value["jobs"])) return [];
+  const out: Job[] = [];
+  for (const j of value["jobs"]) {
+    if (!isRecord(j)) continue;
+    const name = j["name"];
+    const created = j["created_at"];
+    const started = j["started_at"];
+    const completed = j["completed_at"];
+    if (typeof name !== "string" || typeof created !== "string") continue;
+    out.push({
+      name,
+      created_at: created,
+      started_at: typeof started === "string" ? started : null,
+      completed_at: typeof completed === "string" ? completed : null,
+    });
+  }
+  return out;
+}
+
 export interface RunningJob {
-  started_at: string;
+  /**
+   * Null when the job never reported a start (e.g. it was skipped rather than
+   * executed — this branch's Linux-only coverage legs are skipped on macOS
+   * and Windows). Such a job cannot contribute to a per-minute concurrency
+   * count and is excluded from that metric, not treated as started at time 0.
+   */
+  started_at: string | null;
   completed_at: string | null;
 }
 
@@ -43,17 +92,21 @@ export function minutesBetween(a: string, b: string): number {
  * happened to run long. Taking the unrestricted global max would misattribute
  * gating to whichever candidate was slowest, rather than whichever candidate
  * the dependent job actually waited on. Returns null when no candidate
- * completed at or before the cutoff.
+ * completed at or before the cutoff — including when `eligibleAt` itself does
+ * not parse, since an unparseable cutoff must never be treated as "no
+ * cutoff" (that would silently fall back to the unrestricted global max this
+ * function exists to avoid).
  */
 export function bindingUpstream(jobs: CompletedJob[], eligibleAt: string): CompletedJob | null {
   const cutoff = Date.parse(eligibleAt);
+  if (Number.isNaN(cutoff)) return null;
   let best: CompletedJob | null = null;
   let bestAt = Number.NEGATIVE_INFINITY;
   for (const j of jobs) {
     if (j.completed_at === null) continue;
     const at = Date.parse(j.completed_at);
     if (Number.isNaN(at) || at <= bestAt) continue;
-    if (!Number.isNaN(cutoff) && at > cutoff) continue;
+    if (at > cutoff) continue;
     bestAt = at;
     best = j;
   }
@@ -91,19 +144,30 @@ export function accumulateBinding(
   return dropped;
 }
 
-/** How many jobs were running at each whole-minute offset from `runStartedAt`. */
+/**
+ * How many jobs were running at each whole-minute offset from `runStartedAt`.
+ *
+ * A job missing either timestamp cannot contribute to this metric and is
+ * EXCLUDED from it — never counted as running (from `started_at` defaulting
+ * to time 0) or as never-running (from being silently kept in the
+ * denominator elsewhere). The filter lives here, not in the caller, so every
+ * caller gets the same guarantee regardless of what it passes in.
+ */
 export function concurrencySeries(jobs: RunningJob[], runStartedAt: string): number[] {
   const t0 = Date.parse(runStartedAt);
-  const usable = jobs.filter((j) => j.completed_at !== null);
+  const usable = jobs.filter(
+    (j): j is RunningJob & { started_at: string; completed_at: string } =>
+      j.started_at !== null && j.completed_at !== null,
+  );
   if (Number.isNaN(t0) || usable.length === 0) return [];
-  const end = Math.max(...usable.map((j) => Date.parse(j.completed_at ?? "")));
+  const end = Math.max(...usable.map((j) => Date.parse(j.completed_at)));
   if (!Number.isFinite(end)) return [];
   const span = Math.ceil((end - t0) / 60_000);
   const series: number[] = [];
   for (let m = 0; m <= span; m++) {
     const at = t0 + m * 60_000;
     series.push(
-      usable.filter((j) => Date.parse(j.started_at) <= at && Date.parse(j.completed_at ?? "") > at)
+      usable.filter((j) => Date.parse(j.started_at) <= at && Date.parse(j.completed_at) > at)
         .length,
     );
   }

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -24,6 +24,11 @@ const FAST: readonly Gate[] = [
   { name: "audit:cross-platform", cmd: ["bun", "run", "audit:cross-platform"], tier: "fast" },
   { name: "audit:status-drift", cmd: ["bun", "run", "audit:status-drift"], tier: "fast" },
   { name: "audit:action-sha-pins", cmd: ["bun", "run", "audit:action-sha-pins"], tier: "fast" },
+  {
+    name: "audit:coverage-gate-pal",
+    cmd: ["bun", "run", "audit:coverage-gate-pal"],
+    tier: "fast",
+  },
   { name: "audit:consumed-by", cmd: ["bun", "run", "audit:consumed-by"], tier: "fast" },
   { name: "audit:secret-inventory", cmd: ["bun", "run", "audit:secret-inventory"], tier: "fast" },
   { name: "audit:exclusion-parity", cmd: ["bun", "run", "audit:exclusion-parity"], tier: "fast" },

--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   auditCoverageGatePal,
   detectPlatformBranchingFiles,
+  jobLevelKey,
   parseCoverageGateMatrix,
+  splitJobBlocks,
+  testSuiteLinuxRunners,
 } from "./check-coverage-gate-pal.ts";
 import { REPO_ROOT } from "./lib.ts";
+import type { PlatformFileEntry } from "./platform-branching-allowlist.ts";
 
 const MATRIX = `
   coverage-gates:
@@ -24,6 +28,38 @@ const MATRIX = `
           - name: Vault
             script: "test:coverage:vault"
             pal: true
+    steps:
+      - name: Checkout
+`;
+
+/** The same 2 gates, split across two jobs exactly as _test-suite.yml does. */
+const SPLIT_MATRIX = `
+jobs:
+  coverage-gates-pal:
+    name: Coverage — \${{ matrix.gate.name }}
+    if: inputs.run-tests
+    needs: unit-coverage
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - name: Vault
+            script: "test:coverage:vault"
+            pal: true
+    steps:
+      - name: Checkout
+
+  coverage-gates-linux:
+    name: Coverage — \${{ matrix.gate.name }}
+    if: inputs.run-tests && inputs.runner == 'ubuntu-24.04'
+    needs: unit-coverage
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - name: Engine
+            script: "test:coverage:engine"
+            pal: false
     steps:
       - name: Checkout
 `;
@@ -72,6 +108,102 @@ describe("parseCoverageGateMatrix", () => {
       { name: "Engine", pal: false },
       { name: "Vault", pal: true },
     ]);
+  });
+
+  test("reads BOTH matrix blocks and returns their union", () => {
+    // The matrix is split across coverage-gates-pal and coverage-gates-linux.
+    // An earlier revision took only the FIRST `gate:` block, which validated
+    // half the entries and reported OK on the rest.
+    expect(parseCoverageGateMatrix(SPLIT_MATRIX)).toEqual([
+      { name: "Vault", pal: true },
+      { name: "Engine", pal: false },
+    ]);
+  });
+
+  test("a first-block-only parse of a split matrix is detectably short", () => {
+    // Red-proof for the union: parsing each job's block in isolation must yield
+    // strictly fewer entries than parsing the whole file, so a regression that
+    // stops after block 1 cannot look identical to the correct result.
+    const blocks = splitJobBlocks(SPLIT_MATRIX);
+    const firstOnly = parseCoverageGateMatrix((blocks.get("coverage-gates-pal") ?? []).join("\n"));
+    expect(firstOnly).toEqual([{ name: "Vault", pal: true }]);
+    expect(firstOnly.length).toBeLessThan(parseCoverageGateMatrix(SPLIT_MATRIX).length);
+  });
+});
+
+describe("splitJobBlocks / jobLevelKey", () => {
+  test("splits jobs and reads a JOB-level if, not a step-level one", () => {
+    const jobs = splitJobBlocks(SPLIT_MATRIX);
+    expect([...jobs.keys()]).toEqual(["coverage-gates-pal", "coverage-gates-linux"]);
+    expect(jobLevelKey(jobs.get("coverage-gates-pal") ?? [], "if")).toBe("inputs.run-tests");
+    expect(jobLevelKey(jobs.get("coverage-gates-linux") ?? [], "if")).toBe(
+      "inputs.run-tests && inputs.runner == 'ubuntu-24.04'",
+    );
+  });
+
+  test("a step-level if is NOT mistaken for the job's condition", () => {
+    // This is exactly the distinction the shipped bug turned on: `matrix` is
+    // available at step level and not at job level.
+    const yaml = `
+jobs:
+  a-job:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Only on linux
+        if: runner.os == 'Linux'
+        run: echo hi
+`;
+    expect(jobLevelKey(splitJobBlocks(yaml).get("a-job") ?? [], "if")).toBeNull();
+  });
+
+  test("a comment between jobs does not invent a job", () => {
+    const yaml = `
+jobs:
+  first:
+    runs-on: ubuntu-24.04
+
+  # ── a divider ──
+  second:
+    runs-on: ubuntu-24.04
+`;
+    expect([...splitJobBlocks(yaml).keys()]).toEqual(["first", "second"]);
+  });
+});
+
+describe("testSuiteLinuxRunners", () => {
+  const CI = `
+jobs:
+  pr-quality-ts:
+    uses: ./.github/workflows/_test-suite.yml
+    with:
+      runner: ubuntu-24.04
+  ci-ts:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-15, windows-2025]
+    uses: ./.github/workflows/_test-suite.yml
+    with:
+      runner: \${{ matrix.os }}
+  e2e-desktop:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-15]
+    runs-on: \${{ matrix.os }}
+`;
+
+  test("reads the literal runner input and resolves the matrix one", () => {
+    expect(testSuiteLinuxRunners(CI)).toEqual(["ubuntu-24.04"]);
+  });
+
+  test("ignores an os: matrix on a job that does not call _test-suite.yml", () => {
+    // e2e-desktop above runs on ubuntu-22.04; its label has no bearing on
+    // whether coverage-gates-linux fires, so it must not pollute the result.
+    expect(testSuiteLinuxRunners(CI)).not.toContain("ubuntu-22.04");
+  });
+
+  test("the real ci.yml calls the suite with exactly one Linux label", () => {
+    const ci = readFileSync(join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");
+    expect(testSuiteLinuxRunners(ci)).toEqual(["ubuntu-24.04"]);
   });
 });
 
@@ -152,10 +284,255 @@ describe("detectPlatformBranchingFiles", () => {
   });
 });
 
+// ── Fixture repo, so each audit rule gets its own red-proof ─────────────────
+//
+// `auditCoverageGatePal` used to have exactly one test: "the real repository
+// passes". A regression inside any single rule left every test green. Each
+// fixture below breaks ONE thing and asserts the matching finding.
+
+interface FixtureOptions {
+  /** Overrides the `if:` on coverage-gates-pal. */
+  palIf?: string;
+  /** Overrides the `if:` on coverage-gates-linux. */
+  linuxIf?: string;
+  /** Replaces the pal job's matrix entries (already indented). */
+  palGates?: string;
+  /** Replaces the linux job's matrix entries (already indented). */
+  linuxGates?: string;
+  /** Drops the coverage-gates-pal job entirely. */
+  omitPalJob?: boolean;
+  /** Runner label the fixture ci.yml calls _test-suite.yml with. */
+  ciRunner?: string;
+  /** Extra `os:` labels on the ci-ts caller matrix. */
+  ciMatrixOs?: string;
+  /** Extra repo-relative source files, on top of the default vault/factory.ts. */
+  sources?: Record<string, string>;
+}
+
+const FIXTURE_ALLOWLIST: readonly PlatformFileEntry[] = [
+  {
+    file: "packages/gateway/src/vault/factory.ts",
+    gate: "Vault",
+    why: "selects the per-OS vault backend",
+  },
+];
+
+const DEFAULT_PAL_GATES =
+  '          - name: Vault\n            script: "test:coverage:vault"\n            pal: true\n';
+const DEFAULT_LINUX_GATES =
+  '          - name: Engine\n            script: "test:coverage:engine"\n            pal: false\n';
+
+/**
+ * A literal GitHub Actions expression, assembled through a template literal
+ * with an escaped `$` so Biome does not read `${{ … }}` inside a plain string
+ * as a botched template literal (`noTemplateCurlyInString`). Here it is exactly
+ * the text the fixture workflow must contain.
+ */
+function gha(expr: string): string {
+  return `\${{ ${expr} }}`;
+}
+
+function job(name: string, cond: string, gates: string): string {
+  return (
+    `  ${name}:\n` +
+    `    name: Coverage — ${gha("matrix.gate.name")} (${gha("inputs.runner")})\n` +
+    `    if: ${cond}\n` +
+    "    needs: unit-coverage\n" +
+    `    runs-on: ${gha("inputs.runner")}\n` +
+    "    strategy:\n" +
+    "      fail-fast: false\n" +
+    "      matrix:\n" +
+    "        gate:\n" +
+    gates +
+    "    steps:\n" +
+    "      - name: Checkout\n"
+  );
+}
+
+function writeFixture(o: FixtureOptions = {}): string {
+  const root = mkdtempSync(join(tmpdir(), "cov-gate-pal-fixture-"));
+  const workflows = join(root, ".github", "workflows");
+  mkdirSync(workflows, { recursive: true });
+
+  const palJob = o.omitPalJob
+    ? ""
+    : job("coverage-gates-pal", o.palIf ?? "inputs.run-tests", o.palGates ?? DEFAULT_PAL_GATES);
+  const linuxJob = job(
+    "coverage-gates-linux",
+    o.linuxIf ?? "inputs.run-tests && inputs.runner == 'ubuntu-24.04'",
+    o.linuxGates ?? DEFAULT_LINUX_GATES,
+  );
+  writeFileSync(
+    join(workflows, "_test-suite.yml"),
+    `name: Test Suite\njobs:\n${palJob}\n${linuxJob}`,
+  );
+
+  const runner = o.ciRunner ?? "ubuntu-24.04";
+  const matrixOs = o.ciMatrixOs ?? `${runner}, macos-15, windows-2025`;
+  writeFileSync(
+    join(workflows, "ci.yml"),
+    "name: CI\njobs:\n" +
+      "  pr-quality-ts:\n" +
+      "    uses: ./.github/workflows/_test-suite.yml\n" +
+      "    with:\n" +
+      `      runner: ${runner}\n` +
+      "  ci-ts:\n" +
+      "    strategy:\n" +
+      "      matrix:\n" +
+      `        os: [${matrixOs}]\n` +
+      "    uses: ./.github/workflows/_test-suite.yml\n" +
+      "    with:\n" +
+      `      runner: ${gha("matrix.os")}\n`,
+  );
+
+  const sources: Record<string, string> = {
+    "packages/gateway/src/vault/factory.ts": "export const isWin = process.platform === 'win32';\n",
+    ...(o.sources ?? {}),
+  };
+  for (const [rel, body] of Object.entries(sources)) {
+    const abs = join(root, ...rel.split("/"));
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return root;
+}
+
+function auditFixture(o: FixtureOptions = {}, allowlist = FIXTURE_ALLOWLIST): string[] {
+  const root = writeFixture(o);
+  try {
+    return auditCoverageGatePal(root, { allowlist }).errors;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe("auditCoverageGatePal", () => {
   test("the real repository passes", () => {
     const result = auditCoverageGatePal(REPO_ROOT);
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);
+  });
+
+  test("the real workflow carries all 24 gates, 9 PAL and 15 Linux-only", () => {
+    const gates = parseCoverageGateMatrix(
+      readFileSync(join(REPO_ROOT, ".github/workflows/_test-suite.yml"), "utf8"),
+    );
+    expect(gates).toHaveLength(24);
+    expect(gates.filter((g) => g.pal === true)).toHaveLength(9);
+    expect(gates.filter((g) => g.pal === false)).toHaveLength(15);
+  });
+
+  test("the untouched fixture passes — so every red below is caused by its own edit", () => {
+    expect(auditFixture()).toEqual([]);
+  });
+
+  test("rule 1 — a platform-branching file missing from the allowlist is a finding", () => {
+    const errors = auditFixture({
+      sources: {
+        "packages/gateway/src/updater/factory.ts": "import { platform } from 'node:os';\n",
+      },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("packages/gateway/src/updater/factory.ts");
+    expect(errors[0]).toContain("not in PLATFORM_BRANCHING_ALLOWLIST");
+  });
+
+  test("rule 2 — an allowlist entry for a file that no longer branches is a finding", () => {
+    const errors = auditFixture({}, [
+      ...FIXTURE_ALLOWLIST,
+      { file: "packages/gateway/src/gone.ts", gate: "Vault", why: "deleted long ago" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("packages/gateway/src/gone.ts");
+    expect(errors[0]).toContain("no longer branches on platform");
+  });
+
+  test("rule 3 — an allowlisted file whose gate is not pal: true is a finding", () => {
+    const errors = auditFixture({}, [
+      {
+        file: "packages/gateway/src/vault/factory.ts",
+        gate: "Engine", // Engine is pal: false in the fixture
+        why: "misclassified on purpose",
+      },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('gate "Engine"');
+    expect(errors[0]).toContain("not `pal: true`");
+  });
+
+  test("rule 3 — an allowlisted file naming a gate that does not exist is a finding", () => {
+    const errors = auditFixture({}, [
+      { file: "packages/gateway/src/vault/factory.ts", gate: "Ghost", why: "renamed gate" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('coverage gate "Ghost"');
+  });
+
+  test("rule 4 — a matrix entry with no explicit pal field is a finding", () => {
+    const errors = auditFixture({
+      linuxGates: '          - name: Engine\n            script: "test:coverage:engine"\n',
+    });
+    expect(errors.some((e) => e.includes('"Engine" has no explicit `pal:` field'))).toBe(true);
+  });
+
+  test("rule 5 — a missing coverage-gates-pal job is a finding", () => {
+    // Merging the two jobs back into one is the regression this catches: the
+    // merged spelling needs `matrix` in a job-level `if:`, which does not exist.
+    const errors = auditFixture({ omitPalJob: true });
+    expect(errors.some((e) => e.includes('job "coverage-gates-pal" not found'))).toBe(true);
+  });
+
+  test("rule 5 — an altered if: on the PAL job is a finding", () => {
+    // This is literally the shipped bug: the `|| matrix.gate.pal` disjunct reads
+    // a context a job-level `if:` does not have, and would skip all 9 PAL gates
+    // on Windows and macOS.
+    const errors = auditFixture({
+      palIf: "inputs.run-tests && (inputs.runner == 'ubuntu-24.04' || matrix.gate.pal)",
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('job "coverage-gates-pal" must carry `if: inputs.run-tests`');
+  });
+
+  test("rule 5 — a removed if: on the Linux job is a finding", () => {
+    const errors = auditFixture({ linuxIf: "inputs.run-tests" });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('job "coverage-gates-linux" must carry');
+  });
+
+  test("rule 5 — a pal: true gate parked in the Linux-only job is a finding", () => {
+    const errors = auditFixture({
+      linuxGates:
+        DEFAULT_LINUX_GATES +
+        '          - name: Sandbox\n            script: "test:coverage:sandbox"\n            pal: true\n',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"Sandbox" is `pal: true` but sits in "coverage-gates-linux"');
+  });
+
+  test("rule 6 — a runner label that ci.yml does not call the suite with is a finding", () => {
+    // Bumping the runner in ci.yml alone would otherwise skip all 15 Linux-only
+    // gates on every caller, with nothing turning red.
+    const errors = auditFixture({ ciRunner: "ubuntu-26.04" });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('gates on runner "ubuntu-24.04"');
+    expect(errors[0]).toContain("ubuntu-26.04");
+  });
+
+  test("rule 6 — two different Linux labels across callers is a finding", () => {
+    const errors = auditFixture({ ciMatrixOs: "ubuntu-26.04, macos-15, windows-2025" });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("more than one Linux runner label");
+  });
+
+  test("a missing ci.yml is reported rather than silently passing rule 6", () => {
+    const root = writeFixture();
+    try {
+      rmSync(join(root, ".github", "workflows", "ci.yml"));
+      const errors = auditCoverageGatePal(root, { allowlist: FIXTURE_ALLOWLIST }).errors;
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("ci.yml not found");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -205,6 +205,25 @@ jobs:
     const ci = readFileSync(join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");
     expect(testSuiteLinuxRunners(ci)).toEqual(["ubuntu-24.04"]);
   });
+
+  test("does not harvest an os: matrix from a job that passes a LITERAL runner:, even if it also carries an unrelated os: matrix", () => {
+    // A caller can pass a literal `runner:` to _test-suite.yml while carrying
+    // its own `os:` matrix for something else entirely (e.g. its own
+    // `runs-on`). That list has no bearing on the Linux-only split and must
+    // not be read as extra runner labels -- doing so would spuriously trip
+    // rule 6's "more than one Linux runner label" check.
+    const ci = `
+jobs:
+  weird-caller:
+    strategy:
+      matrix:
+        os: [ubuntu-26.04, macos-15]
+    uses: ./.github/workflows/_test-suite.yml
+    with:
+      runner: ubuntu-24.04
+`;
+    expect(testSuiteLinuxRunners(ci)).toEqual(["ubuntu-24.04"]);
+  });
 });
 
 describe("detectPlatformBranchingFiles", () => {
@@ -242,7 +261,27 @@ describe("detectPlatformBranchingFiles", () => {
   });
 
   test("excludes test files, which may branch on platform legitimately", () => {
-    expect(detectPlatformBranchingFiles(REPO_ROOT).some((f) => f.includes(".test."))).toBe(false);
+    const hits = detectPlatformBranchingFiles(REPO_ROOT);
+    expect(hits.some((f) => f.includes(".test."))).toBe(false);
+    expect(hits.some((f) => f.includes(".spec."))).toBe(false);
+  });
+
+  test("excludes .spec.ts/.spec.tsx files too, which _test-suite.yml also treats as tests", () => {
+    // A cross-platform spec file that branches on process.platform is correct,
+    // not a finding -- the same reasoning that excludes `.test.ts` above. An
+    // earlier revision excluded only `.test.` and would have flagged this as
+    // unclassified production code.
+    const root = mkdtempSync(join(tmpdir(), "pal-detect-spec-"));
+    try {
+      const src = join(root, "packages", "gateway", "src");
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, "a.spec.ts"), "if (process.platform === 'win32') {}\n");
+      writeFileSync(join(src, "b.spec.tsx"), "if (process.platform === 'darwin') {}\n");
+
+      expect(detectPlatformBranchingFiles(root)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("does not flag a file that only MENTIONS process.platform in a comment", () => {
@@ -305,6 +344,8 @@ interface FixtureOptions {
   ciRunner?: string;
   /** Extra `os:` labels on the ci-ts caller matrix. */
   ciMatrixOs?: string;
+  /** Extra raw job block(s) appended to ci.yml's `jobs:`, verbatim. */
+  extraCiJobs?: string;
   /** Extra repo-relative source files, on top of the default vault/factory.ts. */
   sources?: Record<string, string>;
 }
@@ -382,7 +423,8 @@ function writeFixture(o: FixtureOptions = {}): string {
       `        os: [${matrixOs}]\n` +
       "    uses: ./.github/workflows/_test-suite.yml\n" +
       "    with:\n" +
-      `      runner: ${gha("matrix.os")}\n`,
+      `      runner: ${gha("matrix.os")}\n` +
+      (o.extraCiJobs ?? ""),
   );
 
   const sources: Record<string, string> = {
@@ -522,6 +564,25 @@ describe("auditCoverageGatePal", () => {
     const errors = auditFixture({ ciMatrixOs: "ubuntu-26.04, macos-15, windows-2025" });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("more than one Linux runner label");
+  });
+
+  test("rule 6 — a caller with a literal runner: alongside an unrelated os: matrix does NOT fire", () => {
+    // Red-proof for the fix: without conditioning the os: harvest on the same
+    // job forwarding `runner: ${{ matrix.os }}`, this fixture's extra caller
+    // would contribute "ubuntu-26.04" from its unrelated os: matrix even
+    // though it passes a literal runner: ubuntu-24.04 -- producing a
+    // spurious "more than one Linux runner label" finding.
+    const errors = auditFixture({
+      extraCiJobs:
+        "  weird-caller:\n" +
+        "    strategy:\n" +
+        "      matrix:\n" +
+        "        os: [ubuntu-26.04, macos-15]\n" +
+        "    uses: ./.github/workflows/_test-suite.yml\n" +
+        "    with:\n" +
+        "      runner: ubuntu-24.04\n",
+    });
+    expect(errors).toEqual([]);
   });
 
   test("a missing ci.yml is reported rather than silently passing rule 6", () => {

--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  auditCoverageGatePal,
+  detectPlatformBranchingFiles,
+  parseCoverageGateMatrix,
+} from "./check-coverage-gate-pal.ts";
+import { REPO_ROOT } from "./lib.ts";
+
+const MATRIX = `
+  coverage-gates:
+    name: Coverage — \${{ matrix.gate.name }}
+    needs: unit-coverage
+    strategy:
+      fail-fast: false
+      matrix:
+        gate:
+          - name: Engine
+            script: "test:coverage:engine"
+            pal: false
+          - name: Vault
+            script: "test:coverage:vault"
+            pal: true
+    steps:
+      - name: Checkout
+`;
+
+describe("parseCoverageGateMatrix", () => {
+  test("reads each gate name and its explicit pal flag", () => {
+    expect(parseCoverageGateMatrix(MATRIX)).toEqual([
+      { name: "Engine", pal: false },
+      { name: "Vault", pal: true },
+    ]);
+  });
+
+  test("a gate with no pal field parses as null, not as false", () => {
+    // A missing flag must be distinguishable from an explicit `false`, so the
+    // audit can demand classification rather than silently defaulting.
+    const yaml = MATRIX.replace("            pal: false\n", "");
+    expect(parseCoverageGateMatrix(yaml)[0]).toEqual({ name: "Engine", pal: null });
+  });
+
+  test("stops at the end of the matrix block", () => {
+    // `steps:` dedents out of the matrix; nothing after it is a gate.
+    expect(parseCoverageGateMatrix(MATRIX).map((g) => g.name)).not.toContain("Checkout");
+  });
+
+  test("a reformat to a different indent width still parses", () => {
+    // Indentation is read relative to the `gate:` key, so a cosmetic reformat
+    // must not red the gate. Here every line is re-indented by 2 extra spaces.
+    const reindented = MATRIX.split("\n")
+      .map((l) => (l.trim() === "" ? l : `  ${l}`))
+      .join("\n");
+    expect(parseCoverageGateMatrix(reindented)).toEqual([
+      { name: "Engine", pal: false },
+      { name: "Vault", pal: true },
+    ]);
+  });
+});
+
+describe("detectPlatformBranchingFiles", () => {
+  test("finds files that branch via a destructured node:os import", () => {
+    // The dominant idiom in this repo. An earlier revision matched only
+    // `process.platform` and missed doctor-core.ts, which caused its gate to be
+    // classified Linux-only by mistake.
+    const hits = detectPlatformBranchingFiles(REPO_ROOT);
+    expect(hits).toContain("packages/cli/src/commands/doctor-core.ts");
+    expect(hits).toContain("packages/gateway/src/vault/factory.ts");
+  });
+
+  test("reaches a NESTED src directory, not just packages/{pkg}/src", () => {
+    // packages/mcp-connectors/src does not exist; each of the 94 connectors has
+    // its own packages/mcp-connectors/{name}/src. A one-level scan skipped all
+    // of them silently. No connector branches on platform today, so this uses a
+    // fixture tree — asserting against the real repo would pass for the wrong
+    // reason (nothing to find) and would not catch the regression.
+    const root = mkdtempSync(join(tmpdir(), "pal-detect-"));
+    try {
+      const shallow = join(root, "packages", "gateway", "src");
+      const nested = join(root, "packages", "mcp-connectors", "airflow", "src");
+      mkdirSync(shallow, { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(join(shallow, "a.ts"), "if (process.platform === 'win32') {}\n");
+      writeFileSync(join(nested, "b.ts"), "if (process.platform === 'darwin') {}\n");
+
+      expect(detectPlatformBranchingFiles(root)).toEqual([
+        "packages/gateway/src/a.ts",
+        "packages/mcp-connectors/airflow/src/b.ts",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes test files, which may branch on platform legitimately", () => {
+    expect(detectPlatformBranchingFiles(REPO_ROOT).some((f) => f.includes(".test."))).toBe(false);
+  });
+});
+
+describe("auditCoverageGatePal", () => {
+  test("the real repository passes", () => {
+    const result = auditCoverageGatePal(REPO_ROOT);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -59,6 +59,20 @@ describe("parseCoverageGateMatrix", () => {
       { name: "Vault", pal: true },
     ]);
   });
+
+  test("a trailing YAML comment on the pal line still parses", () => {
+    // `pal: true  # note` is valid YAML. A regex requiring end-of-line
+    // immediately after the flag would misread this as unset and wrongly
+    // trip rule 4 once a later task starts writing these fields.
+    const withComment = MATRIX.replace(
+      "            pal: false\n",
+      "            pal: false  # note\n",
+    );
+    expect(parseCoverageGateMatrix(withComment)).toEqual([
+      { name: "Engine", pal: false },
+      { name: "Vault", pal: true },
+    ]);
+  });
 });
 
 describe("detectPlatformBranchingFiles", () => {
@@ -97,6 +111,44 @@ describe("detectPlatformBranchingFiles", () => {
 
   test("excludes test files, which may branch on platform legitimately", () => {
     expect(detectPlatformBranchingFiles(REPO_ROOT).some((f) => f.includes(".test."))).toBe(false);
+  });
+
+  test("does not flag a file that only MENTIONS process.platform in a comment", () => {
+    // A file documenting that it deliberately does not branch must not be
+    // reported as a finding — that would be a false positive with zero real
+    // branching to classify.
+    const root = mkdtempSync(join(tmpdir(), "pal-detect-comment-"));
+    try {
+      const src = join(root, "packages", "gateway", "src");
+      mkdirSync(src, { recursive: true });
+      writeFileSync(
+        join(src, "a.ts"),
+        "// This function deliberately does NOT branch on process.platform.\nexport function f() {}\n",
+      );
+
+      expect(detectPlatformBranchingFiles(root)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("still flags a file that genuinely branches even alongside a comment mentioning the idiom", () => {
+    // Comment-stripping must not weaken real detection: code branching on
+    // process.platform stays a finding even when a comment also references
+    // the idiom by name.
+    const root = mkdtempSync(join(tmpdir(), "pal-detect-real-"));
+    try {
+      const src = join(root, "packages", "gateway", "src");
+      mkdirSync(src, { recursive: true });
+      writeFileSync(
+        join(src, "a.ts"),
+        "// process.platform is how you'd normally branch on OS.\nif (process.platform === 'win32') {}\n",
+      );
+
+      expect(detectPlatformBranchingFiles(root)).toEqual(["packages/gateway/src/a.ts"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/structure-audit/check-coverage-gate-pal.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.ts
@@ -21,6 +21,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { stripComments } from "./lib.ts";
 import { PLATFORM_BRANCHING_ALLOWLIST } from "./platform-branching-allowlist.ts";
 
 export interface AuditResult {
@@ -41,7 +42,7 @@ const TEST_SUITE = ".github/workflows/_test-suite.yml";
  *
  * The destructured-import alternative is NOT optional to cover:
  * `import { platform } from "node:os"` is the dominant idiom in this codebase
- * (6 files), and an earlier revision of this audit that matched only
+ * (7 files), and an earlier revision of this audit that matched only
  * `process.platform` missed `doctor-core.ts` — whose gate was consequently
  * classified Linux-only by mistake.
  */
@@ -96,6 +97,13 @@ function findSrcDirs(dir: string, out: string[]): string[] {
  * Every non-test source file under any `src` directory in `packages/` that
  * branches on the host platform. Tests are excluded deliberately: a
  * cross-platform test branching on `process.platform` is correct, not a finding.
+ *
+ * Comments are stripped before matching (reusing `stripComments` from
+ * `./lib.ts`, the same helper `countAnyInSource` uses): a file that only
+ * *mentions* `process.platform` in a comment — e.g. documenting that it
+ * deliberately does not branch — must not be reported as a finding. The
+ * filename-based `OS_NAMED_FILE` check runs on the path, not the source text,
+ * so it is unaffected either way.
  */
 export function detectPlatformBranchingFiles(repoRoot: string): string[] {
   const packagesDir = join(repoRoot, "packages");
@@ -107,8 +115,8 @@ export function detectPlatformBranchingFiles(repoRoot: string): string[] {
   const hits: string[] = [];
   for (const file of files) {
     const rel = file.slice(repoRoot.length + 1).replace(/\\/g, "/");
-    const src = readFileSync(file, "utf8");
-    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.some((re) => re.test(src))) {
+    const codeOnly = stripComments(readFileSync(file, "utf8"));
+    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.some((re) => re.test(codeOnly))) {
       hits.push(rel);
     }
   }
@@ -140,7 +148,9 @@ export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
       gates.push({ name: nameMatch[1].replace(/^["']|["']$/g, ""), pal: null });
       continue;
     }
-    const palMatch = line.match(/^\s*pal:\s*(true|false)\s*$/);
+    // Trailing `# comment` is tolerated: `pal: true  # note` is valid YAML and
+    // must not be misread as an unset field (which would wrongly trip rule 4).
+    const palMatch = line.match(/^\s*pal:\s*(true|false)\s*(?:#.*)?$/);
     const last = gates[gates.length - 1];
     if (palMatch?.[1] !== undefined && last) last.pal = palMatch[1] === "true";
   }

--- a/scripts/structure-audit/check-coverage-gate-pal.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.ts
@@ -2,27 +2,45 @@
 
 /**
  * audit:coverage-gate-pal — keeps the PAL classification behind the Linux-only
- * coverage gates honest.
+ * coverage gates honest, AND keeps the mechanism that consumes it wired.
  *
- * `_test-suite.yml` runs coverage-threshold gates on Linux only unless the gate
- * is marked `pal: true`. That is safe only while the covered code does not
- * branch on platform. This audit fails when:
+ * `_test-suite.yml` splits its coverage-threshold gates across two jobs:
+ * `coverage-gates-pal` (runs on every OS the workflow is called with) and
+ * `coverage-gates-linux` (runs only on the Linux runner). That split is safe
+ * only while (a) the Linux-only gates' covered code does not branch on
+ * platform, and (b) the two jobs actually carry the conditions that implement
+ * the split. This audit fails when:
  *
  *   1. a source file branches on platform but is absent from the allowlist
  *   2. an allowlist entry names a file that no longer branches on platform
  *      (or no longer exists) — stale entries rot in the other direction
  *   3. an allowlisted file declares a gate that is not `pal: true`
  *   4. a matrix entry carries no explicit `pal` field
+ *   5. either coverage-gate job is missing, carries an unexpected `if:`, or
+ *      holds a matrix entry whose `pal:` contradicts the job it sits in
+ *   6. the runner literal in `coverage-gates-linux`'s `if:` does not match the
+ *      Linux runner label `ci.yml` actually calls `_test-suite.yml` with
  *
  * Rule 4 is why the field is spelled out on all 24 entries: a new gate must be
  * classified deliberately, never by inheriting a default.
+ *
+ * Rules 5 and 6 exist because an earlier revision validated the `pal:` fields
+ * without ever reading the `if:` lines that consume them. That let a job-level
+ * `if: … || matrix.gate.pal` ship green even though `matrix` is not available
+ * in a job-level condition — the classification was perfect and the mechanism
+ * was inert. Rule 6 closes the matching hole for the runner label, which is now
+ * duplicated between `ci.yml` and `_test-suite.yml`: bumping it in one place
+ * would otherwise silently drop 15 threshold gates from every caller.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { stripComments } from "./lib.ts";
-import { PLATFORM_BRANCHING_ALLOWLIST } from "./platform-branching-allowlist.ts";
+import {
+  PLATFORM_BRANCHING_ALLOWLIST,
+  type PlatformFileEntry,
+} from "./platform-branching-allowlist.ts";
 
 export interface AuditResult {
   ok: boolean;
@@ -35,7 +53,33 @@ export interface GateEntry {
   pal: boolean | null;
 }
 
+export interface AuditDeps {
+  /**
+   * Overrides the real allowlist. Exists so the fixture tests can red-prove
+   * rules 1-3 in isolation against a synthetic repo root — passing a temp dir
+   * to the real allowlist would drown the assertion in ~35 "file no longer
+   * exists" findings.
+   */
+  allowlist?: readonly PlatformFileEntry[];
+}
+
 const TEST_SUITE = ".github/workflows/_test-suite.yml";
+const CI_WORKFLOW = ".github/workflows/ci.yml";
+
+const PAL_JOB = "coverage-gates-pal";
+const LINUX_JOB = "coverage-gates-linux";
+
+/**
+ * The exact conditions the split depends on.
+ *
+ * `matrix` is deliberately absent from both: GitHub grants a job-level `if:`
+ * only `github`, `needs`, `vars` and `inputs`, because the condition is
+ * evaluated before the matrix expands.
+ */
+const PAL_JOB_IF = "inputs.run-tests";
+const LINUX_JOB_IF = /^inputs\.run-tests\s*&&\s*inputs\.runner\s*==\s*'([^']+)'$/;
+
+const TEST_SUITE_CALLER = /^\s*uses:\s*\.\/\.github\/workflows\/_test-suite\.yml\s*$/;
 
 /**
  * Runtime platform branching, or a filename that names an OS.
@@ -123,15 +167,8 @@ export function detectPlatformBranchingFiles(repoRoot: string): string[] {
   return hits.sort((a, b) => a.localeCompare(b));
 }
 
-/**
- * Line-based parse of the `coverage-gates` matrix. A YAML dependency is not
- * worth taking on for one well-known block, and the sibling audits
- * (check-action-sha-pins) parse workflow YAML the same way.
- */
-export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
-  const lines = yaml.split(/\r?\n/);
-  const start = lines.findIndex((l) => /^\s+gate:\s*$/.test(l));
-  if (start === -1) return [];
+/** Parses one `gate:` block starting at `start`; returns it and the line after it. */
+function parseGateBlockAt(lines: string[], start: number): { gates: GateEntry[]; end: number } {
   // Indentation is measured RELATIVE to the `gate:` key rather than assumed at
   // fixed columns, so reformatting the workflow cannot red this gate for a
   // purely cosmetic change. A parse that breaks anyway fails loud, never
@@ -139,7 +176,8 @@ export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
   // stays `null`, which rule 4 reports.
   const gateIndent = (lines[start] ?? "").search(/\S/);
   const gates: GateEntry[] = [];
-  for (let i = start + 1; i < lines.length; i++) {
+  let i = start + 1;
+  for (; i < lines.length; i++) {
     const line = lines[i] ?? "";
     if (line.trim() === "") continue;
     if (line.search(/\S/) <= gateIndent) break;
@@ -154,17 +192,197 @@ export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
     const last = gates[gates.length - 1];
     if (palMatch?.[1] !== undefined && last) last.pal = palMatch[1] === "true";
   }
+  return { gates, end: i };
+}
+
+/**
+ * Line-based parse of EVERY coverage-gate matrix in the given YAML, returned as
+ * one union. A YAML dependency is not worth taking on for a well-known block,
+ * and the sibling audits (check-action-sha-pins) parse workflow YAML the same
+ * way.
+ *
+ * "Every", not "the first": the matrix is split across `coverage-gates-pal` and
+ * `coverage-gates-linux`. A first-block-only parse would validate half the
+ * entries and report OK on the other half — the classification would silently
+ * stop being enforced for whichever job came second.
+ */
+export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
+  const lines = yaml.split(/\r?\n/);
+  const gates: GateEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s+gate:\s*$/.test(lines[i] ?? "")) continue;
+    const { gates: block, end } = parseGateBlockAt(lines, i);
+    gates.push(...block);
+    i = end - 1;
+  }
   return gates;
 }
 
-export function auditCoverageGatePal(repoRoot: string): AuditResult {
+/**
+ * Job name → the lines of that job's block (header line excluded).
+ *
+ * Blank lines and comments are carried into whichever block is open; they are
+ * never treated as job headers, so a `# ── section ──` divider between jobs
+ * cannot invent one.
+ */
+export function splitJobBlocks(yaml: string): Map<string, string[]> {
+  const lines = yaml.split(/\r?\n/);
+  const jobsIx = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  const out = new Map<string, string[]>();
+  if (jobsIx === -1) return out;
+  let current: string[] | null = null;
+  let jobIndent = -1;
+  for (let i = jobsIx + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "" || /^\s*#/.test(line)) {
+      current?.push(line);
+      continue;
+    }
+    const indent = line.search(/\S/);
+    if (indent === 0) break; // dedented back out of `jobs:`
+    if (jobIndent === -1) jobIndent = indent;
+    const header = indent === jobIndent ? line.match(/^\s*([A-Za-z0-9_-]+):\s*$/) : null;
+    if (header?.[1] !== undefined) {
+      current = [];
+      out.set(header[1], current);
+      continue;
+    }
+    current?.push(line);
+  }
+  return out;
+}
+
+/**
+ * The value of a top-level key within a job block (e.g. `if`), or null.
+ *
+ * The key's indent is derived from the block's own minimum indent rather than
+ * assumed, so this reads a job-level `if:` and never a step-level one — which
+ * is the whole distinction rule 5 exists to police.
+ */
+export function jobLevelKey(block: readonly string[], key: string): string | null {
+  const meaningful = block.filter((l) => l.trim() !== "" && !/^\s*#/.test(l));
+  if (meaningful.length === 0) return null;
+  const keyIndent = Math.min(...meaningful.map((l) => l.search(/\S/)));
+  const re = new RegExp(`^\\s*${key}:\\s*(.+?)\\s*$`);
+  for (const line of meaningful) {
+    if (line.search(/\S/) !== keyIndent) continue;
+    const m = line.match(re);
+    if (m?.[1] !== undefined) return m[1];
+  }
+  return null;
+}
+
+/**
+ * Every Linux runner label `ci.yml` calls `_test-suite.yml` with — read from
+ * the callers' literal `runner:` inputs and, when that input is
+ * `${{ matrix.os }}`, from the caller's own `os:` matrix list.
+ *
+ * Scoped to `_test-suite.yml` callers on purpose: `ci-rust` and `e2e-desktop`
+ * also carry an `os:` matrix, but their runner label has no bearing on whether
+ * `coverage-gates-linux` fires.
+ */
+export function testSuiteLinuxRunners(ciYaml: string): string[] {
+  const labels = new Set<string>();
+  for (const block of splitJobBlocks(ciYaml).values()) {
+    if (!block.some((l) => TEST_SUITE_CALLER.test(l))) continue;
+    for (const line of block) {
+      const direct = line.match(/^\s*runner:\s*["']?([A-Za-z0-9._-]+)["']?\s*$/);
+      if (direct?.[1]?.startsWith("ubuntu-")) labels.add(direct[1]);
+      const osList = line.match(/^\s*os:\s*\[(.+)\]\s*$/);
+      if (osList?.[1] === undefined) continue;
+      for (const raw of osList[1].split(",")) {
+        const label = raw.trim().replace(/^["']|["']$/g, "");
+        if (label.startsWith("ubuntu-")) labels.add(label);
+      }
+    }
+  }
+  return [...labels].sort((a, b) => a.localeCompare(b));
+}
+
+/** Rules 5 + 6: the split's own wiring, not just its classification. */
+function checkSplitWiring(testSuiteYaml: string, ciYaml: string | null, errors: string[]): void {
+  const jobs = splitJobBlocks(testSuiteYaml);
+  const byJob = new Map<string, GateEntry[]>();
+  for (const [name, block] of jobs) byJob.set(name, parseCoverageGateMatrix(block.join("\n")));
+
+  for (const [job, expectedPal] of [
+    [PAL_JOB, true],
+    [LINUX_JOB, false],
+  ] as const) {
+    const block = jobs.get(job);
+    if (!block) {
+      errors.push(
+        `${TEST_SUITE}: job "${job}" not found — the coverage-gate split must stay two jobs; a job-level \`if:\` cannot read \`matrix\`, so a single merged job cannot express it`,
+      );
+      continue;
+    }
+    for (const entry of byJob.get(job) ?? []) {
+      if (entry.pal !== null && entry.pal !== expectedPal) {
+        errors.push(
+          `${TEST_SUITE}: coverage gate "${entry.name}" is \`pal: ${entry.pal}\` but sits in "${job}" — move it to "${expectedPal ? PAL_JOB : LINUX_JOB}" or fix its classification`,
+        );
+      }
+    }
+  }
+
+  // 5. the PAL job's condition
+  const palBlock = jobs.get(PAL_JOB);
+  if (palBlock) {
+    const cond = jobLevelKey(palBlock, "if");
+    if (cond !== PAL_JOB_IF) {
+      errors.push(
+        `${TEST_SUITE}: job "${PAL_JOB}" must carry \`if: ${PAL_JOB_IF}\` (found ${cond === null ? "no job-level `if:`" : `\`${cond}\``}) — these gates run on every OS, so the only thing that may gate them is whether tests run at all`,
+      );
+    }
+  }
+
+  // 5 + 6. the Linux job's condition, and the runner literal inside it
+  const linuxBlock = jobs.get(LINUX_JOB);
+  if (!linuxBlock) return;
+  const cond = jobLevelKey(linuxBlock, "if");
+  const match = cond === null ? null : LINUX_JOB_IF.exec(cond);
+  if (!match?.[1]) {
+    errors.push(
+      `${TEST_SUITE}: job "${LINUX_JOB}" must carry \`if: inputs.run-tests && inputs.runner == '<linux-runner>'\` (found ${cond === null ? "no job-level `if:`" : `\`${cond}\``}) — without it these gates run once per OS again, or not at all`,
+    );
+    return;
+  }
+  const declared = match[1];
+
+  if (ciYaml === null) {
+    errors.push(`${CI_WORKFLOW} not found — cannot confirm the runner label "${declared}" is real`);
+    return;
+  }
+  const callerRunners = testSuiteLinuxRunners(ciYaml);
+  if (callerRunners.length === 0) {
+    errors.push(
+      `${CI_WORKFLOW}: no Linux runner label found on any \`_test-suite.yml\` caller — "${declared}" in ${TEST_SUITE} cannot be confirmed`,
+    );
+    return;
+  }
+  if (callerRunners.length > 1) {
+    errors.push(
+      `${CI_WORKFLOW}: \`_test-suite.yml\` is called with more than one Linux runner label (${callerRunners.join(", ")}) — "${declared}" in ${TEST_SUITE} can only match one, so the others would silently skip all ${LINUX_JOB} gates`,
+    );
+    return;
+  }
+  if (callerRunners[0] !== declared) {
+    errors.push(
+      `${TEST_SUITE}: "${LINUX_JOB}" gates on runner "${declared}" but ${CI_WORKFLOW} calls the workflow with "${callerRunners[0]}" — every Linux-only coverage gate would be skipped on every caller`,
+    );
+  }
+}
+
+export function auditCoverageGatePal(repoRoot: string, deps: AuditDeps = {}): AuditResult {
   const errors: string[] = [];
+  const allowlist = deps.allowlist ?? PLATFORM_BRANCHING_ALLOWLIST;
 
   const workflow = join(repoRoot, TEST_SUITE);
   if (!existsSync(workflow)) {
     return { ok: false, errors: [`${TEST_SUITE} not found`] };
   }
-  const gates = parseCoverageGateMatrix(readFileSync(workflow, "utf8"));
+  const testSuiteYaml = readFileSync(workflow, "utf8");
+  const gates = parseCoverageGateMatrix(testSuiteYaml);
   if (gates.length === 0) {
     return { ok: false, errors: [`${TEST_SUITE}: no coverage-gates matrix entries found`] };
   }
@@ -179,7 +397,7 @@ export function auditCoverageGatePal(repoRoot: string): AuditResult {
   }
 
   const palByName = new Map(gates.map((g) => [g.name, g.pal]));
-  const allowByFile = new Map(PLATFORM_BRANCHING_ALLOWLIST.map((e) => [e.file, e]));
+  const allowByFile = new Map(allowlist.map((e) => [e.file, e]));
   const detected = detectPlatformBranchingFiles(repoRoot);
   const detectedSet = new Set(detected);
 
@@ -193,7 +411,7 @@ export function auditCoverageGatePal(repoRoot: string): AuditResult {
   }
 
   // 2. classified but no longer branching
-  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+  for (const entry of allowlist) {
     if (!detectedSet.has(entry.file)) {
       errors.push(
         `${entry.file}: listed in PLATFORM_BRANCHING_ALLOWLIST but no longer branches on platform (or no longer exists) — remove the stale entry`,
@@ -202,7 +420,7 @@ export function auditCoverageGatePal(repoRoot: string): AuditResult {
   }
 
   // 3. declared gate must be pal: true
-  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+  for (const entry of allowlist) {
     if (entry.gate === "none") continue;
     if (!palByName.has(entry.gate)) {
       errors.push(
@@ -216,6 +434,10 @@ export function auditCoverageGatePal(repoRoot: string): AuditResult {
       );
     }
   }
+
+  // 5 + 6. the split's wiring
+  const ciPath = join(repoRoot, CI_WORKFLOW);
+  checkSplitWiring(testSuiteYaml, existsSync(ciPath) ? readFileSync(ciPath, "utf8") : null, errors);
 
   return { ok: errors.length === 0, errors };
 }

--- a/scripts/structure-audit/check-coverage-gate-pal.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.ts
@@ -108,8 +108,7 @@ function collectSources(dir: string, out: string[]): string[] {
       collectSources(full, out);
     } else if (
       (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
-      !entry.endsWith(".test.ts") &&
-      !entry.endsWith(".test.tsx")
+      !/\.(?:test|spec)\.tsx?$/.test(entry)
     ) {
       out.push(full);
     }
@@ -272,22 +271,33 @@ export function jobLevelKey(block: readonly string[], key: string): string | nul
   return null;
 }
 
+const RUNNER_IS_MATRIX_OS = /^\s*runner:\s*\$\{\{\s*matrix\.os\s*\}\}\s*$/;
+
 /**
  * Every Linux runner label `ci.yml` calls `_test-suite.yml` with — read from
- * the callers' literal `runner:` inputs and, when that input is
- * `${{ matrix.os }}`, from the caller's own `os:` matrix list.
+ * the callers' literal `runner:` inputs and, when that SAME job's `runner:`
+ * input is `${{ matrix.os }}`, from that job's own `os:` matrix list.
  *
  * Scoped to `_test-suite.yml` callers on purpose: `ci-rust` and `e2e-desktop`
  * also carry an `os:` matrix, but their runner label has no bearing on whether
- * `coverage-gates-linux` fires.
+ * `coverage-gates-linux` fires. A caller can also carry an `os:` matrix for
+ * some unrelated purpose while forwarding a literal `runner:` — that list
+ * must not be read as Linux-runner labels just because both keys appear in
+ * the same job block.
  */
 export function testSuiteLinuxRunners(ciYaml: string): string[] {
   const labels = new Set<string>();
   for (const block of splitJobBlocks(ciYaml).values()) {
     if (!block.some((l) => TEST_SUITE_CALLER.test(l))) continue;
+    // The `os:` list is only relevant when THIS job actually forwards
+    // `runner: ${{ matrix.os }}` — a caller can carry an unrelated `os:`
+    // matrix (e.g. for its own `runs-on`) while passing a literal `runner:`,
+    // and that list must not be read as Linux-runner labels for the split.
+    const forwardsMatrixOs = block.some((l) => RUNNER_IS_MATRIX_OS.test(l));
     for (const line of block) {
       const direct = line.match(/^\s*runner:\s*["']?([A-Za-z0-9._-]+)["']?\s*$/);
       if (direct?.[1]?.startsWith("ubuntu-")) labels.add(direct[1]);
+      if (!forwardsMatrixOs) continue;
       const osList = line.match(/^\s*os:\s*\[(.+)\]\s*$/);
       if (osList?.[1] === undefined) continue;
       for (const raw of osList[1].split(",")) {

--- a/scripts/structure-audit/check-coverage-gate-pal.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:coverage-gate-pal — keeps the PAL classification behind the Linux-only
+ * coverage gates honest.
+ *
+ * `_test-suite.yml` runs coverage-threshold gates on Linux only unless the gate
+ * is marked `pal: true`. That is safe only while the covered code does not
+ * branch on platform. This audit fails when:
+ *
+ *   1. a source file branches on platform but is absent from the allowlist
+ *   2. an allowlist entry names a file that no longer branches on platform
+ *      (or no longer exists) — stale entries rot in the other direction
+ *   3. an allowlisted file declares a gate that is not `pal: true`
+ *   4. a matrix entry carries no explicit `pal` field
+ *
+ * Rule 4 is why the field is spelled out on all 24 entries: a new gate must be
+ * classified deliberately, never by inheriting a default.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { PLATFORM_BRANCHING_ALLOWLIST } from "./platform-branching-allowlist.ts";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export interface GateEntry {
+  name: string;
+  /** null when the matrix entry carries no `pal` field at all. */
+  pal: boolean | null;
+}
+
+const TEST_SUITE = ".github/workflows/_test-suite.yml";
+
+/**
+ * Runtime platform branching, or a filename that names an OS.
+ *
+ * The destructured-import alternative is NOT optional to cover:
+ * `import { platform } from "node:os"` is the dominant idiom in this codebase
+ * (6 files), and an earlier revision of this audit that matched only
+ * `process.platform` missed `doctor-core.ts` — whose gate was consequently
+ * classified Linux-only by mistake.
+ */
+const BRANCHES_ON_PLATFORM = [
+  /process\.platform/,
+  /os\.platform\(\)/,
+  /os\.type\(\)/,
+  // import { platform } / { platform as alias } / { arch, platform } from "node:os"
+  /import\s*\{[^}]*\b(?:platform|type|arch)\b[^}]*\}\s*from\s*["']node:os["']/,
+];
+const OS_NAMED_FILE = /\/(win32|darwin|linux)\.ts$/;
+
+function collectSources(dir: string, out: string[]): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSources(full, out);
+    } else if (
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every `src` directory anywhere under `packages/`, at any depth.
+ *
+ * NOT `packages/{*}/src`: `packages/mcp-connectors/src` does not exist — the 94
+ * connectors each have their own `packages/mcp-connectors/{name}/src`. A
+ * one-level scan silently skipped all of them, and a detector with a silent
+ * blind spot is worse than none, because its green is read as coverage.
+ */
+function findSrcDirs(dir: string, out: string[]): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (!statSync(full).isDirectory()) continue;
+    if (entry === "src") out.push(full);
+    else findSrcDirs(full, out);
+  }
+  return out;
+}
+
+/**
+ * Every non-test source file under any `src` directory in `packages/` that
+ * branches on the host platform. Tests are excluded deliberately: a
+ * cross-platform test branching on `process.platform` is correct, not a finding.
+ */
+export function detectPlatformBranchingFiles(repoRoot: string): string[] {
+  const packagesDir = join(repoRoot, "packages");
+  if (!existsSync(packagesDir)) return [];
+  const files: string[] = [];
+  for (const srcDir of findSrcDirs(packagesDir, [])) {
+    collectSources(srcDir, files);
+  }
+  const hits: string[] = [];
+  for (const file of files) {
+    const rel = file.slice(repoRoot.length + 1).replace(/\\/g, "/");
+    const src = readFileSync(file, "utf8");
+    if (OS_NAMED_FILE.test(`/${rel}`) || BRANCHES_ON_PLATFORM.some((re) => re.test(src))) {
+      hits.push(rel);
+    }
+  }
+  return hits.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Line-based parse of the `coverage-gates` matrix. A YAML dependency is not
+ * worth taking on for one well-known block, and the sibling audits
+ * (check-action-sha-pins) parse workflow YAML the same way.
+ */
+export function parseCoverageGateMatrix(yaml: string): GateEntry[] {
+  const lines = yaml.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^\s+gate:\s*$/.test(l));
+  if (start === -1) return [];
+  // Indentation is measured RELATIVE to the `gate:` key rather than assumed at
+  // fixed columns, so reformatting the workflow cannot red this gate for a
+  // purely cosmetic change. A parse that breaks anyway fails loud, never
+  // silent: zero entries is a hard error, and a name whose `pal:` did not parse
+  // stays `null`, which rule 4 reports.
+  const gateIndent = (lines[start] ?? "").search(/\S/);
+  const gates: GateEntry[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") continue;
+    if (line.search(/\S/) <= gateIndent) break;
+    const nameMatch = line.match(/^\s*-\s+name:\s*(.+?)\s*$/);
+    if (nameMatch?.[1] !== undefined) {
+      gates.push({ name: nameMatch[1].replace(/^["']|["']$/g, ""), pal: null });
+      continue;
+    }
+    const palMatch = line.match(/^\s*pal:\s*(true|false)\s*$/);
+    const last = gates[gates.length - 1];
+    if (palMatch?.[1] !== undefined && last) last.pal = palMatch[1] === "true";
+  }
+  return gates;
+}
+
+export function auditCoverageGatePal(repoRoot: string): AuditResult {
+  const errors: string[] = [];
+
+  const workflow = join(repoRoot, TEST_SUITE);
+  if (!existsSync(workflow)) {
+    return { ok: false, errors: [`${TEST_SUITE} not found`] };
+  }
+  const gates = parseCoverageGateMatrix(readFileSync(workflow, "utf8"));
+  if (gates.length === 0) {
+    return { ok: false, errors: [`${TEST_SUITE}: no coverage-gates matrix entries found`] };
+  }
+
+  // 4. every matrix entry classified explicitly
+  for (const g of gates) {
+    if (g.pal === null) {
+      errors.push(
+        `${TEST_SUITE}: coverage gate "${g.name}" has no explicit \`pal:\` field — add \`pal: true\` (runs on all 3 OSes) or \`pal: false\` (Linux only)`,
+      );
+    }
+  }
+
+  const palByName = new Map(gates.map((g) => [g.name, g.pal]));
+  const allowByFile = new Map(PLATFORM_BRANCHING_ALLOWLIST.map((e) => [e.file, e]));
+  const detected = detectPlatformBranchingFiles(repoRoot);
+  const detectedSet = new Set(detected);
+
+  // 1. detected but unclassified
+  for (const file of detected) {
+    if (!allowByFile.has(file)) {
+      errors.push(
+        `${file}: branches on platform but is not in PLATFORM_BRANCHING_ALLOWLIST — add an entry naming the coverage gate that covers it (or "none"), then make sure that gate is \`pal: true\``,
+      );
+    }
+  }
+
+  // 2. classified but no longer branching
+  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+    if (!detectedSet.has(entry.file)) {
+      errors.push(
+        `${entry.file}: listed in PLATFORM_BRANCHING_ALLOWLIST but no longer branches on platform (or no longer exists) — remove the stale entry`,
+      );
+    }
+  }
+
+  // 3. declared gate must be pal: true
+  for (const entry of PLATFORM_BRANCHING_ALLOWLIST) {
+    if (entry.gate === "none") continue;
+    if (!palByName.has(entry.gate)) {
+      errors.push(
+        `${entry.file}: declares coverage gate "${entry.gate}", which is not in the ${TEST_SUITE} matrix`,
+      );
+      continue;
+    }
+    if (palByName.get(entry.gate) !== true) {
+      errors.push(
+        `${entry.file}: branches on platform and is covered by gate "${entry.gate}", but that gate is not \`pal: true\` — its coverage would run on Linux only`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+if (import.meta.main) {
+  const result = auditCoverageGatePal(process.cwd());
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`audit:coverage-gate-pal: ${err}`);
+    process.exit(1);
+  }
+  console.log(`audit:coverage-gate-pal: OK`);
+}

--- a/scripts/structure-audit/platform-branching-allowlist.ts
+++ b/scripts/structure-audit/platform-branching-allowlist.ts
@@ -1,0 +1,163 @@
+/**
+ * Every source file that branches on the host platform, and which coverage
+ * gate covers it.
+ *
+ * WHY THIS EXISTS: `_test-suite.yml` runs most coverage-threshold gates on
+ * Linux only. That is safe exactly while the code those gates cover does not
+ * branch on platform. Without this list, the day someone adds
+ * `process.platform` to a Linux-only gate's code, coverage on Windows and
+ * macOS quietly stops watching it and NOTHING fails.
+ *
+ * LIMITATION, stated so it is not rediscovered: `gate: "none"` means no
+ * coverage-threshold gate covers this file today. Those entries record that the
+ * file was classified, not that it is protected. Coverage is measured over
+ * files loaded at runtime including transitive imports, which cannot be derived
+ * statically from the gate's test paths — so this audit guarantees that new
+ * platform-branching code is CLASSIFIED, and that the seven PAL gates stay
+ * `pal: true`. It does not prove a `gate: "none"` file never becomes covered by
+ * a `pal: false` gate.
+ */
+
+export interface PlatformFileEntry {
+  /** Repo-relative path, forward slashes. */
+  readonly file: string;
+  /** Coverage-gate `name` from the _test-suite.yml matrix, or "none". */
+  readonly gate: string;
+  readonly why: string;
+}
+
+export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
+  // ── Covered by a PAL gate (must be pal: true in the matrix) ────────────────
+  {
+    file: "packages/gateway/src/vault/win32.ts",
+    gate: "Vault",
+    why: "DPAPI backend; branches on platform and is win32-named",
+  },
+  { file: "packages/gateway/src/vault/darwin.ts", gate: "Vault", why: "Keychain backend" },
+  { file: "packages/gateway/src/vault/linux.ts", gate: "Vault", why: "libsecret backend" },
+  {
+    file: "packages/gateway/src/platform/sandbox/win32.ts",
+    gate: "Sandbox",
+    why: "Windows job-object sandbox",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/darwin.ts",
+    gate: "Sandbox",
+    why: "sandbox-exec profile",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/linux.ts",
+    gate: "Sandbox",
+    why: "bwrap + seccomp",
+  },
+  {
+    file: "packages/gateway/src/updater/factory.ts",
+    gate: "Updater",
+    why: "selects the per-OS updater implementation",
+  },
+  {
+    file: "packages/gateway/src/updater/platform-target.ts",
+    gate: "Updater",
+    why: "maps platform to a release asset target",
+  },
+  {
+    file: "packages/gateway/src/extensions/install-from-local.ts",
+    gate: "Extensions",
+    why: "per-OS install paths and permissions",
+  },
+  {
+    file: "packages/gateway/src/perf/bench-runner.ts",
+    gate: "Perf",
+    why: "per-OS timing and process handling",
+  },
+  { file: "packages/gateway/src/perf/bench-cli.ts", gate: "Perf", why: "per-OS bench invocation" },
+  { file: "packages/cli/src/commands/bench.ts", gate: "Perf", why: "per-OS bench invocation" },
+  {
+    file: "packages/gateway/src/telemetry/collector.ts",
+    gate: "Telemetry",
+    why: "reports host platform",
+  },
+  {
+    file: "packages/cli/src/commands/doctor-core.ts",
+    gate: "Doctor",
+    why: "`if (platform() === 'linux')` gates the secret-tool probe",
+  },
+  {
+    file: "packages/gateway/src/vault/factory.ts",
+    gate: "Vault",
+    why: "selects the per-OS vault backend",
+  },
+  {
+    file: "packages/gateway/src/platform/sandbox/sandbox-runner.ts",
+    gate: "Sandbox",
+    why: "selects the per-OS sandbox implementation",
+  },
+
+  // ── Not covered by any coverage-threshold gate ────────────────────────────
+  {
+    file: "packages/gateway/src/platform/index.ts",
+    gate: "none",
+    why: "PAL dispatch; no coverage-threshold gate targets src/platform",
+  },
+  {
+    file: "packages/gateway/src/platform/gateway-log-file.ts",
+    gate: "none",
+    why: "per-OS log path",
+  },
+  {
+    file: "packages/gateway/src/ipc/server/server.ts",
+    gate: "none",
+    why: "named pipe vs unix socket; the LAN gate's tests import lan-server.ts only, never this file",
+  },
+  {
+    file: "packages/gateway/src/platform/win32.ts",
+    gate: "none",
+    why: "PAL implementation; no coverage-threshold gate targets src/platform",
+  },
+  { file: "packages/gateway/src/platform/darwin.ts", gate: "none", why: "PAL implementation" },
+  { file: "packages/gateway/src/platform/linux.ts", gate: "none", why: "PAL implementation" },
+  {
+    file: "packages/gateway/src/platform/browser.ts",
+    gate: "none",
+    why: "per-OS browser-open command",
+  },
+  {
+    file: "packages/gateway/src/index/registered-roots-store.ts",
+    gate: "none",
+    why: "per-OS path normalisation",
+  },
+  {
+    file: "packages/gateway/src/index/sqlite-vec-load.ts",
+    gate: "none",
+    why: "per-OS native extension filename",
+  },
+  {
+    file: "packages/gateway/src/ipc/server/dispatchers.ts",
+    gate: "none",
+    why: "named pipe vs unix socket",
+  },
+  { file: "packages/gateway/src/voice/tts.ts", gate: "none", why: "per-OS TTS backend" },
+  {
+    file: "packages/gateway/src/voice/wake-word.ts",
+    gate: "none",
+    why: "per-OS audio capture",
+  },
+  { file: "packages/cli/src/commands/config.ts", gate: "none", why: "per-OS config path display" },
+  {
+    file: "packages/cli/src/commands/extension.ts",
+    gate: "none",
+    why: "per-OS extension paths",
+  },
+  { file: "packages/cli/src/commands/start.ts", gate: "none", why: "per-OS gateway launch" },
+  {
+    file: "packages/cli/src/lib/resolve-gateway-launch.ts",
+    gate: "none",
+    why: "per-OS executable resolution",
+  },
+  { file: "packages/cli/src/lib/spawn-gateway.ts", gate: "none", why: "per-OS spawn flags" },
+  {
+    file: "packages/cli/src/paths.ts",
+    gate: "none",
+    why: "per-OS socket path + config/data/extensions dir resolution; no coverage-threshold gate targets packages/cli/src directly",
+  },
+];

--- a/scripts/structure-audit/platform-branching-allowlist.ts
+++ b/scripts/structure-audit/platform-branching-allowlist.ts
@@ -101,7 +101,7 @@ export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
   {
     file: "packages/gateway/src/index/sqlite-vec-load.ts",
     gate: "Embedding",
-    why: "per-OS native extension filename; reaches BOTH the Embedding and the DB layer gates through static imports — embedding/lazy-scheduler.ts (plus create-routing-runtime.ts and embedding-worker.ts) and index/migrations/runner.ts each import it, so it lands in both gates' coverage denominators. Only one gate can be named here; both were promoted to `pal: true` together, and neither may be demoted while this entry stands",
+    why: "per-OS native extension filename; reaches BOTH the Embedding and the DB layer gates through static imports — embedding/lazy-scheduler.ts (plus create-routing-runtime.ts and embedding-worker.ts) and index/migrations/runner.ts each import it, so it lands in both gates' coverage denominators. Both were promoted to `pal: true` together. ENFORCEMENT GAP, stated rather than overclaimed: an entry names ONE gate, and rule 3 cross-checks only that gate — so demoting `Embedding` is caught, but demoting `DB layer` is NOT. Closing it needs a co-gate field on this type; until then `DB layer` rests on this comment alone",
   },
 
   // ── Not covered by any coverage-threshold gate ────────────────────────────

--- a/scripts/structure-audit/platform-branching-allowlist.ts
+++ b/scripts/structure-audit/platform-branching-allowlist.ts
@@ -13,9 +13,15 @@
  * file was classified, not that it is protected. Coverage is measured over
  * files loaded at runtime including transitive imports, which cannot be derived
  * statically from the gate's test paths — so this audit guarantees that new
- * platform-branching code is CLASSIFIED, and that the seven PAL gates stay
+ * platform-branching code is CLASSIFIED, and that the nine PAL gates stay
  * `pal: true`. It does not prove a `gate: "none"` file never becomes covered by
  * a `pal: false` gate.
+ *
+ * That limitation is not theoretical: `index/sqlite-vec-load.ts` was originally
+ * filed `gate: "none"` and the whole-branch review found it reachable from BOTH
+ * the Embedding and DB layer gates via static imports. Both were promoted to
+ * `pal: true`. When adding an entry, follow the static imports before writing
+ * "none".
  */
 
 export interface PlatformFileEntry {
@@ -92,6 +98,11 @@ export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
     gate: "Sandbox",
     why: "selects the per-OS sandbox implementation",
   },
+  {
+    file: "packages/gateway/src/index/sqlite-vec-load.ts",
+    gate: "Embedding",
+    why: "per-OS native extension filename; reaches BOTH the Embedding and the DB layer gates through static imports — embedding/lazy-scheduler.ts (plus create-routing-runtime.ts and embedding-worker.ts) and index/migrations/runner.ts each import it, so it lands in both gates' coverage denominators. Only one gate can be named here; both were promoted to `pal: true` together, and neither may be demoted while this entry stands",
+  },
 
   // ── Not covered by any coverage-threshold gate ────────────────────────────
   {
@@ -125,11 +136,6 @@ export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
     file: "packages/gateway/src/index/registered-roots-store.ts",
     gate: "none",
     why: "per-OS path normalisation",
-  },
-  {
-    file: "packages/gateway/src/index/sqlite-vec-load.ts",
-    gate: "none",
-    why: "per-OS native extension filename",
   },
   {
     file: "packages/gateway/src/ipc/server/dispatchers.ts",


### PR DESCRIPTION
## Summary

P4b's **tuning slice**. The measurement slice shipped `audit:ci-latency` and deliberately stopped short of tuning, because the first measurement contradicted the design of record's hunch. This slice acts on what two follow-up probes actually found.

**The roadmap's own stated lead was wrong.** It recorded macOS contention as "the clearest lead". Across 45 `E2E Desktop` legs the binding upstream job was ubuntu 30×, windows 15×, **macOS only 3×**, and runner queue was ~10 min median on *every* OS — that uniformity is the tell. The real constraint is **slot starvation**: a push run demands ~105 job slots against a pool granting 12–17, with 32–41 jobs created-but-waiting at peak. One sampled run opened with **nine consecutive minutes at zero running jobs**. 72 of those 105 jobs were a single 24-entry coverage matrix run once per OS.

This also **retires the design of record's sharding proposal** — sharding adds jobs to the pool that *is* the constraint.

Three changes:

- **A — PAL-aware coverage matrix.** Threshold gates run on Linux only, except the **9** whose covered code branches on host platform. Coverage gates **72 → 42**; a push run **105 → 75**.
- **B — narrow the E2E edge.** `e2e-desktop` waited on `ci-ts` (30 jobs, **60.5 min** median DAG wait) through an edge carrying no artifacts — it does its own checkout, install and Tauri setup. It now waits on `ci-rust` (**1.17–1.72 min**), the prerequisite that actually carries meaning.
- **C — `audit:coverage-gate-pal`.** A static audit so the platform classification cannot decay silently.

## Related Issue

Relates to the Org Infrastructure Program, sub-program **P4b** — `docs/infrastructure-roadmap.md`.

## Type of Change

- [x] CI / tooling
- [x] New feature — the `audit:coverage-gate-pal` gate
- [x] Documentation only — roadmap record + design/plan documents

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome) — verified as `bunx biome check --error-on-warnings packages scripts`; the packaged `bun run lint` false-fails inside a `.claude/worktrees/` checkout, a known local-only artifact
- [x] All existing tests pass — `bun test scripts/` 881 pass / 0 fail across 83 files
- [x] New behaviour is covered by tests
- [x] No `any` types introduced — GitHub API data is narrowed with `isRecord`
- [x] No credentials, tokens, or secret values anywhere — all reads are public
- [x] Platform-specific code behind `PlatformServices` — n/a, **no production code changed**
- [x] The HITL consent gate has not been weakened — n/a, no engine surface touched

## Coverage

n/a — neither `engine/` nor `vault/` was modified. This PR touches CI workflows, `scripts/`, and docs only.

## Testing

- `bun run audit:coverage-gate-pal` → OK
- `bun test scripts/` → 881 pass / 0 fail
- `bunx tsc -p scripts/tsconfig.json --noEmit` → exit 0
- `bunx biome check --error-on-warnings packages scripts` → exit 0
- `bun run lint:markdown` → exit 0, red-proved against a deliberately invalid file
- `bun run audit:doc-refs` → 625 refs across 16 docs, all resolve
- `bun run audit:action-sha-pins`, `bun run audit:invariants` → OK
- `bun test scripts/preflight.test.ts` → the workflow-drift guard passes with the new gate registered in `PREFLIGHT_GATES`
- Both probes were run **live against `main`** to capture the before-measurement

## Notes for Reviewers

**A Critical defect was caught by the whole-branch review, and it is worth knowing how.** The original mechanism put `matrix.gate.pal` in a **job-level** `if:`, where GitHub does not expose the `matrix` context — a job condition is evaluated before the matrix expands. It would have either failed workflow validation or evaluated falsy on non-Linux, **silently skipping all 24 coverage gates on Windows and macOS, including the 9 PAL gates** whose preservation is the entire safety argument. Every other `matrix.`-referencing `if:` in this repo is step-level.

The fix splits the matrix into `coverage-gates-pal` and `coverage-gates-linux`, each gated only on `inputs`. The job-name template is byte-identical in both, so produced check-context names do not change. `fromJSON` was rejected: it loses the property that a skipped leg still creates its check context — the trap documented at `ci.yml:137-144`.

**The audit now constrains the mechanism it protects.** That defect shipped green precisely because the audit validated the `pal:` fields but never read the `if:` consuming them. It now asserts both jobs' conditions and cross-checks the runner literal against what `ci.yml` actually passes, with red-proofed tests — including one that reproduces the broken condition verbatim and asserts it fails.

**The static classification was wrong three times during this work**, each caught and fixed: `doctor-core.ts` (the detector didn't match `import { platform } from "node:os"`, the dominant idiom in this codebase), `packages/cli/src/paths.ts`, and then `Embedding`/`DB layer` (both reach `sqlite-vec-load.ts` through static imports). The design's "static evidence is sufficient" judgement is recorded alongside those counter-examples rather than quietly restated.

**The problem worsened mid-flight.** DAG wait measured 33.4 min on 2026-07-27 and **60.5 min** on 2026-07-28. Cross-checked by running the original throwaway probe and the promoted one over the same window — identical output, so this is real congestion growth, not an instrument artifact. Both captures are date-stamped in the roadmap; **60.5 is the baseline** any after-comparison must use.

**Two open items, both recorded in the roadmap:**

1. **The after-measurement cannot be taken until this merges** and a push run completes under the new workflow. `audit:ci-latency` gates *execution*, while this slice's win lands in queue and DAG wait — so that gate structurally cannot prove this worked. The two promoted probes are the instrument, and no predicted figure is written anywhere it could be mistaken for a measurement.
2. **One known enforcement gap.** An allowlist entry names a single gate, so demoting `Embedding` is caught but demoting `DB layer` is not. The entry's comment states the gap rather than claiming protection the code does not provide. Closing it needs a co-gate field on `PlatformFileEntry`.

**Worth a live check after merge:** the first push run should show **75 jobs** — 24 coverage legs on ubuntu, 9 each on macOS and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated checks to ensure platform-specific code is covered by the appropriate coverage gates.
  - Added CI latency diagnostics for workflow dependencies, concurrency, and job wait times.

- **Improvements**
  - Split coverage checks by platform requirements to reduce unnecessary runner usage.
  - Streamlined desktop end-to-end workflow dependencies so checks can start sooner.

- **Documentation**
  - Updated infrastructure planning and review documentation with CI tuning results, safeguards, and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->