### PR TITLE
fix(gateway): nimbus init could never index — connector.sync rejected every local syncable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,31 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-28 — `nimbus init` could never actually index; found by running the funnel.**
+  The zero-config path shipped (#887) with its sync step covered only by unit tests using an
+  injected fake. Run against a real gateway for the first time, it failed:
+  `connector.sync { serviceId: "filesystem" }` returned **`Invalid serviceId`**, so `init`
+  degraded to the generic next step and never printed the real `file:line` that was the whole
+  reason for building the index-driven picker. The same error hit
+  **`nimbus connector sync filesystem`** — the command `init` and the README hand a first-time
+  user — which exited 1. Cause: `requireRegisteredSchedulerServiceId` admitted only catalog
+  connector ids and `mcp_*` user-MCP ids, but the four LOCAL syncables (`filesystem`, `blame`,
+  `openapi`, `obsidian`) are registered straight into the scheduler by `assemble.ts` with no
+  catalog entry, so **none of them could be synced on demand**. Indexing still happened —
+  the scheduler registers with `nextRunAt = now` — so the data landed seconds later; the
+  promise was mistimed, not absent. Fixed with an explicit `GATEWAY_SYNCABLE_SERVICE_IDS`
+  SSoT admitted alongside the existing branches; membership only widens which NAMES are
+  addressable, the `persistedConnectorStatuses` registration check still authorises the sync.
+  A drift test reads `assemble.ts` and fails if the two sites disagree in either direction.
+  Also fixes an asymmetry surfaced by the same session: **`NIMBUS_GATEWAY_SOCKET` was read
+  only by the CLI** (`cli/src/paths.ts`), never by the gateway, so setting it left the CLI
+  dialling a socket that would never be bound — `nimbus start` sat in "Waiting for Gateway
+  IPC" for its full 60s timeout and failed with a healthy but unreachable gateway. The
+  gateway now honours it too, as a separate override from `NIMBUS_CONFIG_DIR` so a
+  test-isolation mistake cannot silently reroute live IPC. Verified end-to-end against a real
+  gateway in an isolated config+data dir: `init` now prints
+  `nimbus why src/auth.ts:1   # verifyToken` and that command returns real authorship.
+
 - **2026-07-28 — Zero-config onboarding: `nimbus init`, and the LLM demoted to optional.**
   The zero-config path already existed and was simply unexposed — `synthesize.ts` returns a
   deterministic render when no LLM is configured, and filesystem indexing needs no

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,7 +49,9 @@ Two behaviours worth knowing:
 - **If a Gateway is already running**, it cannot see a root that was just added: filesystem roots are read once at startup. `nimbus init` says so and asks you to `nimbus stop && nimbus start` rather than syncing nothing or restarting your daemon for you.
 - **If anything after the config write fails** — the Gateway will not start, the sync errors, or the index has no symbols yet — `init` still exits 0 and falls back to printing the generic `nimbus why <file>:<line>` next step. The config edit is the durable half of the work.
 
-`NIMBUS_CONFIG_DIR` overrides the config directory this command writes to (the Gateway honours the same variable). It moves the config directory only — never the data directory or the socket.
+`NIMBUS_CONFIG_DIR` overrides the config directory this command writes to (the Gateway honours the same variable). It moves the config directory only — never the data directory.
+
+`NIMBUS_GATEWAY_SOCKET` overrides the IPC socket/pipe path and is honoured by **both** the CLI and the Gateway. It is deliberately a separate variable from `NIMBUS_CONFIG_DIR`: one variable moving both would let a test-isolation mistake silently reroute live IPC. Note it does **not** move the data directory either, so a Gateway started with it still reads and writes the real index.
 
 ---
 

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -51,6 +51,8 @@ Usage:
 
 Environment (optional):
   NIMBUS_GATEWAY_EXECUTABLE   Path to nimbus-gateway binary (overrides auto-detection)
+  NIMBUS_GATEWAY_SOCKET       IPC socket/pipe path; honoured by BOTH the CLI and the gateway
+  NIMBUS_CONFIG_DIR           Config directory (nimbus.toml); does NOT move the data directory
   OPENAI_API_KEY              OpenAI embeddings when nimbus.toml [embedding] provider = "openai"
 `);
 }

--- a/packages/gateway/src/connectors/gateway-syncable-ids.test.ts
+++ b/packages/gateway/src/connectors/gateway-syncable-ids.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { normalizeConnectorServiceId } from "./connector-catalog.ts";
+import {
+  GATEWAY_SYNCABLE_SERVICE_IDS,
+  isGatewaySyncableServiceId,
+} from "./gateway-syncable-ids.ts";
+
+describe("gateway syncable service ids", () => {
+  test("recognises each listed id", () => {
+    for (const id of GATEWAY_SYNCABLE_SERVICE_IDS) {
+      expect(isGatewaySyncableServiceId(id)).toBe(true);
+    }
+  });
+
+  test("rejects a catalog connector, a user-MCP id, and junk", () => {
+    expect(isGatewaySyncableServiceId("github")).toBe(false);
+    expect(isGatewaySyncableServiceId("mcp_custom")).toBe(false);
+    expect(isGatewaySyncableServiceId("")).toBe(false);
+    expect(isGatewaySyncableServiceId("../filesystem")).toBe(false);
+  });
+
+  test("is disjoint from the connector catalog", () => {
+    // If an id ever became a real catalog connector, it would resolve through
+    // normalizeConnectorServiceId and this list would be a second, conflicting
+    // source of truth for the same name.
+    for (const id of GATEWAY_SYNCABLE_SERVICE_IDS) {
+      expect(normalizeConnectorServiceId(id)).toBeNull();
+    }
+  });
+
+  test("every listed id is actually registered with the scheduler by assemble.ts", () => {
+    // The whole point of the list is that these two sites agree. A drift here
+    // means either an unreachable id in the validator, or a registered
+    // syncable that `connector.sync` still rejects — which is the bug this
+    // module was added to fix.
+    const assemble = readFileSync(join(import.meta.dir, "..", "platform", "assemble.ts"), "utf8");
+    for (const id of GATEWAY_SYNCABLE_SERVICE_IDS) {
+      expect(assemble).toContain(`ensureConnectorSchedulerRegistration("${id}"`);
+    }
+  });
+
+  test("assemble.ts registers no non-catalog id that is missing from this list", () => {
+    const assemble = readFileSync(join(import.meta.dir, "..", "platform", "assemble.ts"), "utf8");
+    const registered = [
+      ...assemble.matchAll(/ensureConnectorSchedulerRegistration\("([a-z_]+)"/g),
+    ].map((m) => m[1] ?? "");
+    const missing = registered.filter(
+      (id) => normalizeConnectorServiceId(id) === null && !isGatewaySyncableServiceId(id),
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/gateway/src/connectors/gateway-syncable-ids.ts
+++ b/packages/gateway/src/connectors/gateway-syncable-ids.ts
@@ -1,0 +1,27 @@
+/**
+ * Service ids for the LOCAL, gateway-side syncables.
+ *
+ * These index `[[filesystem.roots]]` content rather than a cloud service, so
+ * they have no entry in the connector catalog, no vault secret, and no OAuth
+ * profile — but `assemble.ts` does register each one with the sync scheduler,
+ * which is what makes them addressable at all.
+ *
+ * Enumerated here because the id is needed in two places that must not drift:
+ * the registration site (`platform/assemble.ts`) and the RPC validator
+ * (`ipc/connector-rpc-shared.ts`). Before this list existed the validator
+ * accepted only catalog ids and `mcp_*` user-MCP ids, so `connector.sync`
+ * rejected every one of these with "Invalid serviceId" — including the
+ * `nimbus connector sync filesystem` that `nimbus init` and the README both
+ * tell a first-time user to run.
+ *
+ * Membership here does NOT by itself authorise a sync: the caller still has to
+ * clear the `persistedConnectorStatuses` check, so an id that was never
+ * registered on this machine is still rejected.
+ */
+export const GATEWAY_SYNCABLE_SERVICE_IDS = ["blame", "filesystem", "obsidian", "openapi"] as const;
+
+export type GatewaySyncableServiceId = (typeof GATEWAY_SYNCABLE_SERVICE_IDS)[number];
+
+export function isGatewaySyncableServiceId(id: string): id is GatewaySyncableServiceId {
+  return (GATEWAY_SYNCABLE_SERVICE_IDS as readonly string[]).includes(id);
+}

--- a/packages/gateway/src/ipc/connector-rpc-handlers/lifecycle.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/lifecycle.test.ts
@@ -97,3 +97,45 @@ describe("handleConnectorSync", () => {
     expect(cleared).toBe(false);
   });
 });
+
+describe("handleConnectorSync — gateway-side syncables", () => {
+  // Regression: these four are registered with the scheduler by assemble.ts but
+  // have no catalog entry, so the validator rejected every one of them with
+  // "Invalid serviceId". That broke `nimbus connector sync filesystem` — the
+  // command `nimbus init` and the README both hand a first-time user — and left
+  // `init` unable to print a real file:line. Caught only by running the funnel
+  // against a real gateway; the unit tests injected a fake sync.
+  for (const id of ["filesystem", "blame", "openapi", "obsidian"]) {
+    test(`${id} is accepted once registered, and reaches forceSync`, async () => {
+      fixture.localIndex.ensureConnectorSchedulerRegistration(id, 600_000, 1_700_000_000_000);
+      const { stub: scheduler, calls } = makeStubScheduler();
+      await handleConnectorSync(buildCtx({ serviceId: id }, scheduler));
+      expect(calls.forced).toEqual([id]);
+    });
+  }
+
+  test("a gateway-syncable id that is NOT registered is still rejected", async () => {
+    // Being on the allowlist widens which NAMES are addressable; it must not
+    // authorise a sync of something this machine never registered.
+    const { stub: scheduler, calls } = makeStubScheduler();
+    try {
+      await handleConnectorSync(buildCtx({ serviceId: "obsidian" }, scheduler));
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as ConnectorRpcError).rpcCode).toBe(-32602);
+      expect((e as ConnectorRpcError).message).toContain("Unknown connector");
+    }
+    expect(calls.forced).toEqual([]);
+  });
+
+  test("junk that merely looks local is still Invalid serviceId", async () => {
+    const { stub: scheduler } = makeStubScheduler();
+    try {
+      await handleConnectorSync(buildCtx({ serviceId: "filesystem-v2" }, scheduler));
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as ConnectorRpcError).rpcCode).toBe(-32602);
+      expect((e as ConnectorRpcError).message).toContain("Invalid serviceId");
+    }
+  });
+});

--- a/packages/gateway/src/ipc/connector-rpc-shared.ts
+++ b/packages/gateway/src/ipc/connector-rpc-shared.ts
@@ -4,6 +4,7 @@ import {
   normalizeConnectorServiceId,
 } from "../connectors/connector-catalog.ts";
 import { writeConnectorSecret } from "../connectors/connector-vault.ts";
+import { isGatewaySyncableServiceId } from "../connectors/gateway-syncable-ids.ts";
 import { USER_MCP_SERVICE_ID_PATTERN } from "../connectors/user-mcp-store.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import { stripTrailingSlashes } from "../string/strip-trailing-slashes.ts";
@@ -47,7 +48,18 @@ export function requireRegisteredSchedulerServiceId(
   const trimmed = raw.trim();
   const builtIn = normalizeConnectorServiceId(trimmed);
   const id = builtIn ?? trimmed.toLowerCase();
-  if (builtIn === null && !USER_MCP_SERVICE_ID_PATTERN.test(id)) {
+  // The gateway-side syncables (filesystem / blame / openapi / obsidian) are
+  // registered with the scheduler by assemble.ts but have no catalog entry, so
+  // before they were admitted here `connector.sync` rejected all four with
+  // "Invalid serviceId" — including the `nimbus connector sync filesystem`
+  // that `nimbus init` and the README tell a first-time user to run.
+  // This only widens which NAMES are addressable; the registration check below
+  // is still what authorises the sync.
+  if (
+    builtIn === null &&
+    !isGatewaySyncableServiceId(id) &&
+    !USER_MCP_SERVICE_ID_PATTERN.test(id)
+  ) {
     throw new ConnectorRpcError(-32602, "Invalid serviceId");
   }
   if (localIndex.persistedConnectorStatuses(id).length === 0) {

--- a/packages/gateway/src/platform/paths.test.ts
+++ b/packages/gateway/src/platform/paths.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -192,5 +192,48 @@ describe("NIMBUS_CONFIG_DIR override", () => {
   it("absent override leaves the platform default intact", () => {
     delete process.env["NIMBUS_CONFIG_DIR"];
     expect(createLinuxPaths().configDir).toBe(join(homedir(), ".config", "nimbus"));
+  });
+});
+
+describe("NIMBUS_GATEWAY_SOCKET override", () => {
+  const saved = process.env["NIMBUS_GATEWAY_SOCKET"];
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env["NIMBUS_GATEWAY_SOCKET"];
+    } else {
+      process.env["NIMBUS_GATEWAY_SOCKET"] = saved;
+    }
+  });
+
+  test("overrides socketPath on every platform creator", () => {
+    // The CLI has honoured this since before the gateway did
+    // (cli/src/paths.ts resolveSocketPath). While only one side read it, a user
+    // who set it got a CLI waiting on a pipe the gateway would never bind —
+    // `nimbus start` hung for 60s and then failed. Both sides must agree.
+    const target = join(tmpdir(), "nimbus-socket-override.sock");
+    process.env["NIMBUS_GATEWAY_SOCKET"] = target;
+    process.env["APPDATA"] ??= join(tmpdir(), "appdata");
+    process.env["LOCALAPPDATA"] ??= join(tmpdir(), "localappdata");
+
+    expect(createWindowsPaths().socketPath).toBe(target);
+    expect(createDarwinPaths().socketPath).toBe(target);
+    expect(createLinuxPaths().socketPath).toBe(target);
+  });
+
+  test("leaves configDir and dataDir alone — only the socket moves", () => {
+    delete process.env["NIMBUS_GATEWAY_SOCKET"];
+    const before = createLinuxPaths();
+    process.env["NIMBUS_GATEWAY_SOCKET"] = join(tmpdir(), "nimbus-socket-override.sock");
+    const after = createLinuxPaths();
+    expect(after.configDir).toBe(before.configDir);
+    expect(after.dataDir).toBe(before.dataDir);
+    expect(after.logDir).toBe(before.logDir);
+  });
+
+  test("an empty value is ignored, not treated as a socket path", () => {
+    delete process.env["NIMBUS_GATEWAY_SOCKET"];
+    const before = createLinuxPaths().socketPath;
+    process.env["NIMBUS_GATEWAY_SOCKET"] = "";
+    expect(createLinuxPaths().socketPath).toBe(before);
   });
 });

--- a/packages/gateway/src/platform/paths.ts
+++ b/packages/gateway/src/platform/paths.ts
@@ -17,9 +17,10 @@ export interface PlatformPaths {
  *
  * Exists because `createDarwinPaths()` reads `homedir()` with no env input at
  * all, so without this an isolated test on macOS would read and write the
- * developer's real config. Only `configDir` moves — `dataDir` and `socketPath`
- * deliberately do not, so this cannot silently repoint a live gateway's database
- * or make it listen somewhere unexpected.
+ * developer's real config. Only `configDir` moves — `dataDir` deliberately does
+ * not, so this cannot silently repoint a live gateway's database. (The socket
+ * has its own separate override, `socketPathOverride` below; a single variable
+ * moving both would make a test-isolation mistake silently reroute live IPC.)
  *
  * An empty value is ignored rather than treated as a valid path: an unset-but-
  * exported variable is a very common shell accident, and honouring it would send
@@ -27,6 +28,25 @@ export interface PlatformPaths {
  */
 function configDirOverride(): string | undefined {
   const v = processEnvGet("NIMBUS_CONFIG_DIR");
+  return v !== undefined && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Relocate the IPC endpoint the gateway listens on.
+ *
+ * The CLI has honoured `NIMBUS_GATEWAY_SOCKET` for far longer than the gateway
+ * did (`cli/src/paths.ts` `resolveSocketPath`). While only one side read it the
+ * variable was a trap: a user who set it got a CLI dialling a socket the
+ * gateway would never bind, so `nimbus start` sat in "Waiting for Gateway IPC"
+ * for its full 60s timeout and then failed with the gateway process healthy but
+ * unreachable. Both sides now resolve it the same way.
+ *
+ * Empty is ignored for the same reason as `configDirOverride` — an
+ * exported-but-unset variable is a common shell accident, and honouring it here
+ * would bind the socket to the process's working directory.
+ */
+function socketPathOverride(): string | undefined {
+  const v = processEnvGet("NIMBUS_GATEWAY_SOCKET");
   return v !== undefined && v.length > 0 ? v : undefined;
 }
 
@@ -49,7 +69,7 @@ export function createWindowsPaths(): PlatformPaths {
     configDir,
     dataDir,
     logDir: join(dataDir, "logs"),
-    socketPath: String.raw`\\.\pipe\nimbus-gateway`,
+    socketPath: socketPathOverride() ?? String.raw`\\.\pipe\nimbus-gateway`,
     extensionsDir: join(localAppData, "Nimbus", "extensions"),
     tempDir: join(tmpdir(), "nimbus"),
   };
@@ -63,7 +83,7 @@ export function createDarwinPaths(): PlatformPaths {
     configDir,
     dataDir: root,
     logDir: join(root, "logs"),
-    socketPath: join(tmp, "nimbus-gateway.sock"),
+    socketPath: socketPathOverride() ?? join(tmp, "nimbus-gateway.sock"),
     extensionsDir: join(root, "extensions"),
     tempDir: join(tmpdir(), "nimbus"),
   };
@@ -80,7 +100,7 @@ export function createLinuxPaths(): PlatformPaths {
     configDir,
     dataDir,
     logDir: join(dataDir, "logs"),
-    socketPath: join(runtimeDir, "nimbus-gateway.sock"),
+    socketPath: socketPathOverride() ?? join(runtimeDir, "nimbus-gateway.sock"),
     extensionsDir: join(dataDir, "extensions"),
     tempDir: join(tmpdir(), "nimbus"),
   };


### PR DESCRIPTION
## Summary

**`nimbus init` could never actually index.** Found by running the zero-config funnel against a real gateway for the first time — #887 shipped the sync step covered only by unit tests with an injected fake, so neither bug in here was reachable by the suite.

```
$ nimbus init
Added .../repo to nimbus.toml (code indexing on).
Starting the gateway...
Indexing this repository...
  (indexing did not complete: Invalid serviceId)     ← the headline promise, failing
Next:
  nimbus connector sync filesystem                   ← and this command exits 1
```

Two fixes, plus the end-to-end verification that should have existed before the relaunch.

## Related Issue

Follow-up to #887 (zero-config onboarding) and #888 (cast recut). No tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [x] Test improvement
- [x] Documentation only
- [ ] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors (gateway + cli)
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`)
- [x] New behaviour is covered by tests
- [x] No `any` types introduced — `unknown` is used for external data
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction — the socket override sits in `platform/paths.ts` alongside the existing `NIMBUS_CONFIG_DIR` seam, applied in all three creators
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] N/A — `docs/README.md` is not touched

> **Note on `bun run lint`:** inside `.claude/worktrees/` Biome reports "0 files processed" and exits 1 (known worktree path issue). Validated with `bunx biome check packages scripts` → 2995 files, 0 errors.

## Coverage (if engine/ or vault/ was changed)

- [ ] N/A — neither `engine/` nor `vault/` is touched.

## Testing

- `bun test packages/gateway/src/{ipc,platform,connectors}` → **4170 pass / 0 fail**
- `bun run audit:invariants` → OK
- `lint:markdown` / `audit:doc-refs` / `audit:readme-cli` → all OK
- `tsc` clean on gateway and cli

**Verified end-to-end against a real gateway**, in an isolated config + data dir (`APPDATA`/`LOCALAPPDATA` redirected, distinct socket) so it could not touch a real index:

```
$ nimbus init
Added <sandbox>/repo to nimbus.toml (code indexing on).
Starting the gateway...
Socket: \.\pipe\nimbus-fix-verify          ← the override, now honoured by the gateway
Indexing this repository...
Try it:
  nimbus why src/auth.ts:1   # verifyToken  ← real file:line from the repo
$ nimbus why src/auth.ts:1
## Authorship
- **t · b877723027bf** — 2026-07-28 · add auth helpers
$ nimbus connector sync filesystem
Sync requested: filesystem                  ← was: Invalid serviceId, exit 1
```

## Notes for Reviewers

### 1. The local syncables were unreachable over IPC

`requireRegisteredSchedulerServiceId` admitted only catalog connector ids and `mcp_*` user-MCP ids. But **four** syncables — `filesystem`, `blame`, `openapi`, `obsidian` — are registered straight into the scheduler by `assemble.ts` with no catalog entry, so none of them could be synced on demand. This is wider than the init bug that surfaced it.

Fixed with an explicit `GATEWAY_SYNCABLE_SERVICE_IDS` SSoT rather than by loosening the regex, because an enumerable list is what this codebase uses elsewhere and it keeps the surface auditable.

**Membership only widens which NAMES are addressable.** The `persistedConnectorStatuses(id).length === 0` check still runs immediately after and is what authorises the sync — a covering test asserts a listed-but-unregistered id is still rejected with `Unknown connector`, and that `forceSync` is never reached.

The drift test reads `assemble.ts` and fails in **both** directions: an id here that nothing registers, or a registered non-catalog id missing from the list.

**Indexing was never broken** — the scheduler registers with `nextRunAt = now`, so data landed seconds later regardless. The promise was mistimed, not absent. Worth knowing when judging severity.

### 2. `NIMBUS_GATEWAY_SOCKET` was CLI-only

Read by `cli/src/paths.ts` and never by the gateway, so setting it produced the worst kind of failure: the gateway comes up healthy, the CLI waits on a socket that will never be bound, and `nimbus start` burns its full 60s timeout before failing. Cost me a run before I spotted it.

Deliberately kept **separate** from `NIMBUS_CONFIG_DIR` rather than folding both into one "isolation" variable — one variable moving config *and* socket would let a test-isolation mistake silently reroute live IPC. Also documented that it does **not** move the data directory, since a gateway started with it still reads the real index (that gap is why the #887 e2e stops at `--no-sync`).

### 3. Why the test suite missed both

`init`'s effects are injected (`InitDeps`), which made the CLI logic testable but meant `syncFilesystem` was a fake that always succeeded. The demo cast (#888) didn't catch it either — it runs against a fake gateway that answers anything, so it happily depicted `Sync requested: filesystem` for a command that returned `Invalid serviceId` in reality.

Both are reasonable test designs; neither can catch a contract mismatch with the real gateway. The new `lifecycle.test.ts` cases close the specific hole at the RPC boundary, but the general lesson is that this funnel needs a real-gateway smoke test before the relaunch, which is what found these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
