### PR TITLE
fix(cast-driver): print the diff on DRIFT so a macOS-only failure is diagnosable

### DIFF
--- a/scripts/cast-driver/driver.test.ts
+++ b/scripts/cast-driver/driver.test.ts
@@ -133,6 +133,72 @@ describe("runDriver", () => {
     expect(existsSync(join(artifactsDir, "z.diff"))).toBe(true);
     expect(existsSync(join(artifactsDir, "z.cast"))).toBe(true);
   });
+
+  test("a mismatch carries the diff even when NO artifacts dir is given", async () => {
+    // The failing path in CI runs without --artifacts-dir, so attaching the
+    // diff only when artifacts were requested left the drift undiagnosable:
+    // a macOS-only drift sat red on `main` reporting nothing but a hash.
+    const { yamlPath, fixturesRoot, demosRoot } = scaffold(
+      workDir,
+      "d",
+      MIN_YAML.replace("x/events", "d/events"),
+      MIN_EVENTS,
+    );
+
+    await runDriver({
+      mode: "update",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("original output\n"),
+    });
+
+    const result = await runDriver({
+      mode: "check",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("MUTATED output\n"),
+    });
+
+    expect(result.summaries[0]?.action).toBe("mismatch");
+    const diff = result.summaries[0]?.diff ?? "";
+    // Both sides must be identifiable — a diff naming only one is useless.
+    expect(diff).toContain("original output");
+    expect(diff).toContain("MUTATED output");
+  });
+
+  test("a match carries no diff", async () => {
+    const { yamlPath, fixturesRoot, demosRoot } = scaffold(
+      workDir,
+      "m",
+      MIN_YAML.replace("x/events", "m/events"),
+      MIN_EVENTS,
+    );
+
+    await runDriver({
+      mode: "update",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("stable output\n"),
+    });
+
+    const result = await runDriver({
+      mode: "check",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("stable output\n"),
+    });
+
+    expect(result.summaries[0]?.action).toBe("matched");
+    expect(result.summaries[0]?.diff).toBeUndefined();
+  });
 });
 
 describe("runDriver — the .cast is a publishable artifact", () => {

--- a/scripts/cast-driver/driver.test.ts
+++ b/scripts/cast-driver/driver.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runDriver } from "./driver.ts";
+import { formatDiffForLog, runDriver } from "./driver.ts";
 import type { HarnessRun } from "./harness.ts";
 
 let workDir: string;
@@ -48,6 +48,39 @@ function scaffold(
 
 const MIN_YAML = `name: x\ndescription: t\nevents: x/events.json\nsteps:\n  - input: nimbus test\n`;
 const MIN_EVENTS = '{"steps":[]}';
+
+describe("formatDiffForLog", () => {
+  const hint = "see /tmp/x.diff";
+
+  test("a diff at exactly the limit is shown whole, with no 'more' line", () => {
+    // The bug this guards: `unifiedDiff` ends with "\n", so a naive split()
+    // produced a synthetic trailing "" — making 60 real lines look like 61,
+    // truncating the last real line and claiming one extra line existed.
+    const diff = `${Array.from({ length: 60 }, (_, i) => `line${i + 1}`).join("\n")}\n`;
+    const { body, more } = formatDiffForLog(diff, 60, hint);
+    expect(more).toBeNull();
+    expect(body.split("\n")).toHaveLength(60);
+    expect(body.endsWith("line60")).toBe(true);
+  });
+
+  test("a diff one line over the limit reports exactly one more", () => {
+    const diff = `${Array.from({ length: 61 }, (_, i) => `line${i + 1}`).join("\n")}\n`;
+    const { body, more } = formatDiffForLog(diff, 60, hint);
+    expect(body.split("\n")).toHaveLength(60);
+    expect(more).toBe(`… 1 more diff line(s) — ${hint}`);
+  });
+
+  test("the hint is carried through verbatim", () => {
+    const diff = `${Array.from({ length: 5 }, (_, i) => `l${i}`).join("\n")}\n`;
+    expect(formatDiffForLog(diff, 2, "custom hint").more).toContain("custom hint");
+  });
+
+  test("a diff with no trailing newline is not mis-counted either", () => {
+    const { body, more } = formatDiffForLog("a\nb", 60, hint);
+    expect(body).toBe("a\nb");
+    expect(more).toBeNull();
+  });
+});
 
 describe("runDriver", () => {
   test("--update-snapshots writes hash, txt, and cast files", async () => {
@@ -198,6 +231,49 @@ describe("runDriver", () => {
 
     expect(result.summaries[0]?.action).toBe("matched");
     expect(result.summaries[0]?.diff).toBeUndefined();
+  });
+
+  test("a mismatch reports whether a committed .hash existed at all", async () => {
+    // An ABSENT hash and a STALE one both mismatch, but the operator's next
+    // step differs — "create it" vs "re-record it" — so the reporter needs to
+    // tell them apart rather than hedging.
+    const { yamlPath, fixturesRoot, demosRoot } = scaffold(
+      workDir,
+      "h",
+      MIN_YAML.replace("x/events", "h/events"),
+      MIN_EVENTS,
+    );
+
+    await runDriver({
+      mode: "update",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("some output\n"),
+    });
+
+    const present = await runDriver({
+      mode: "check",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("CHANGED output\n"),
+    });
+    expect(present.summaries[0]?.baselineHashPresent).toBe(true);
+
+    rmSync(join(demosRoot, "snapshots", "h.hash"));
+    const absent = await runDriver({
+      mode: "check",
+      scriptPaths: [yamlPath],
+      demosRoot,
+      fixturesRoot,
+      artifactsDir: undefined,
+      harness: fakeHarness("CHANGED output\n"),
+    });
+    expect(absent.summaries[0]?.action).toBe("mismatch");
+    expect(absent.summaries[0]?.baselineHashPresent).toBe(false);
   });
 });
 

--- a/scripts/cast-driver/driver.ts
+++ b/scripts/cast-driver/driver.ts
@@ -18,10 +18,15 @@ export interface DriverOpts {
   readonly harness: (opts: HarnessOpts) => Promise<HarnessRun>;
 }
 
+/** Bounds the diff printed to a CI log; the full text is in the artifacts dir. */
+export const MAX_DIFF_LINES = 60;
+
 export interface ScriptSummary {
   readonly name: string;
   readonly action: "matched" | "written" | "mismatch";
   readonly hash: string;
+  /** Unified diff, baseline vs actual. Present only on `mismatch`. */
+  readonly diff?: string;
 }
 
 export interface DriverResult {
@@ -125,12 +130,17 @@ export async function runDriver(opts: DriverOpts): Promise<DriverResult> {
       continue;
     }
 
-    summaries.push({ name, action: "mismatch", hash });
+    // Computed unconditionally, NOT only when artifacts were requested. The
+    // failing path in CI runs without --artifacts-dir, so a drift reported as a
+    // bare hash is undiagnosable by anyone lacking that platform: a macOS-only
+    // drift sat red on `main` printing `zero-config: DRIFT (hash=…)` and
+    // nothing else.
+    const diff = unifiedDiff(baselineTxt, transcript, `${name}.txt`, `${name}.actual.txt`);
+    summaries.push({ name, action: "mismatch", hash, diff });
     exitCode = 1;
 
     if (opts.artifactsDir !== undefined) {
       await atomicWriteFile(join(opts.artifactsDir, `${name}.actual.txt`), transcript);
-      const diff = unifiedDiff(baselineTxt, transcript, `${name}.txt`, `${name}.actual.txt`);
       await atomicWriteFile(join(opts.artifactsDir, `${name}.diff`), diff);
       const cast = writeCastBytes(allChunks);
       await atomicWriteFile(

--- a/scripts/cast-driver/driver.ts
+++ b/scripts/cast-driver/driver.ts
@@ -21,12 +21,37 @@ export interface DriverOpts {
 /** Bounds the diff printed to a CI log; the full text is in the artifacts dir. */
 export const MAX_DIFF_LINES = 60;
 
+/**
+ * Renders a diff for a log, truncated to `maxLines`.
+ *
+ * Pure and exported so the boundary is testable: `unifiedDiff` ends with a
+ * newline, so a naive `split("\n")` yields a synthetic trailing "" that both
+ * hides the last real line and claims one extra line exists.
+ */
+export function formatDiffForLog(
+  diff: string,
+  maxLines: number,
+  fullTextHint: string,
+): { body: string; more: string | null } {
+  const trimmed = diff.endsWith("\n") ? diff.slice(0, -1) : diff;
+  const lines = trimmed.split("\n");
+  const body = lines.slice(0, maxLines).join("\n");
+  if (lines.length <= maxLines) return { body, more: null };
+  return { body, more: `… ${lines.length - maxLines} more diff line(s) — ${fullTextHint}` };
+}
+
 export interface ScriptSummary {
   readonly name: string;
   readonly action: "matched" | "written" | "mismatch";
   readonly hash: string;
   /** Unified diff, baseline vs actual. Present only on `mismatch`. */
   readonly diff?: string;
+  /**
+   * Whether a committed `.hash` existed at all. Only meaningful on `mismatch`:
+   * an ABSENT hash and a STALE one both mismatch, but the operator's next step
+   * differs, so the reporter must not conflate them.
+   */
+  readonly baselineHashPresent?: boolean;
 }
 
 export interface DriverResult {
@@ -136,7 +161,13 @@ export async function runDriver(opts: DriverOpts): Promise<DriverResult> {
     // drift sat red on `main` printing `zero-config: DRIFT (hash=…)` and
     // nothing else.
     const diff = unifiedDiff(baselineTxt, transcript, `${name}.txt`, `${name}.actual.txt`);
-    summaries.push({ name, action: "mismatch", hash, diff });
+    summaries.push({
+      name,
+      action: "mismatch",
+      hash,
+      diff,
+      baselineHashPresent: baselineHash !== null,
+    });
     exitCode = 1;
 
     if (opts.artifactsDir !== undefined) {

--- a/scripts/cast-driver/run.ts
+++ b/scripts/cast-driver/run.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { type DriverMode, MAX_DIFF_LINES, runDriver } from "./driver.ts";
+import { type DriverMode, formatDiffForLog, MAX_DIFF_LINES, runDriver } from "./driver.ts";
 import { runHarness } from "./harness.ts";
 
 function parseArgs(argv: ReadonlyArray<string>): {
@@ -58,21 +58,26 @@ async function main(): Promise<void> {
       // transcript changed and nothing about WHAT changed, which makes a
       // platform-specific drift undiagnosable by anyone without that platform.
       if (summary.diff === "") {
-        // Hash differs while the transcript text matches byte-for-byte: the
-        // committed .hash is stale relative to its own .txt, not a content
-        // change. Saying so beats printing DRIFT and nothing else.
+        // The transcript text matches byte-for-byte, so this is not a content
+        // change. An ABSENT `.hash` and a STALE one both land here and need
+        // different actions, so they are reported separately rather than
+        // collapsed into one hedged sentence.
         console.error(
-          `  transcript text is IDENTICAL to the committed .txt — the committed .hash is stale; re-run \`bun run record-casts\``,
+          summary.baselineHashPresent === false
+            ? `  transcript text is IDENTICAL to the committed .txt, and no committed .hash exists — run \`bun run record-casts\` to create it`
+            : `  transcript text is IDENTICAL to the committed .txt — the committed .hash is stale; re-run \`bun run record-casts\``,
         );
       } else if (summary.diff !== undefined) {
-        const lines = summary.diff.split("\n");
-        const shown = lines.slice(0, MAX_DIFF_LINES).join("\n");
-        console.error(shown);
-        if (lines.length > MAX_DIFF_LINES) {
-          console.error(
-            `… ${lines.length - MAX_DIFF_LINES} more diff line(s) — re-run with --artifacts-dir <dir> for the full text`,
-          );
-        }
+        // When artifacts were requested the full diff is already on disk;
+        // telling the reader to re-run with a flag they already passed is the
+        // kind of dead-end instruction this whole change exists to remove.
+        const hint =
+          artifactsDir !== undefined
+            ? `see ${join(artifactsDir, `${summary.name}.diff`)}`
+            : "re-run with --artifacts-dir <dir> for the full text";
+        const { body, more } = formatDiffForLog(summary.diff, MAX_DIFF_LINES, hint);
+        console.error(body);
+        if (more !== null) console.error(more);
       }
     }
   }

--- a/scripts/cast-driver/run.ts
+++ b/scripts/cast-driver/run.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { type DriverMode, runDriver } from "./driver.ts";
+import { type DriverMode, MAX_DIFF_LINES, runDriver } from "./driver.ts";
 import { runHarness } from "./harness.ts";
 
 function parseArgs(argv: ReadonlyArray<string>): {
@@ -54,6 +54,26 @@ async function main(): Promise<void> {
       console.log(`${summary.name}: OK (hash=${summary.hash.slice(0, 12)})`);
     } else {
       console.error(`${summary.name}: DRIFT (hash=${summary.hash.slice(0, 12)})`);
+      // Print the diff, not just the hash. A hash tells a reader THAT the
+      // transcript changed and nothing about WHAT changed, which makes a
+      // platform-specific drift undiagnosable by anyone without that platform.
+      if (summary.diff === "") {
+        // Hash differs while the transcript text matches byte-for-byte: the
+        // committed .hash is stale relative to its own .txt, not a content
+        // change. Saying so beats printing DRIFT and nothing else.
+        console.error(
+          `  transcript text is IDENTICAL to the committed .txt — the committed .hash is stale; re-run \`bun run record-casts\``,
+        );
+      } else if (summary.diff !== undefined) {
+        const lines = summary.diff.split("\n");
+        const shown = lines.slice(0, MAX_DIFF_LINES).join("\n");
+        console.error(shown);
+        if (lines.length > MAX_DIFF_LINES) {
+          console.error(
+            `… ${lines.length - MAX_DIFF_LINES} more diff line(s) — re-run with --artifacts-dir <dir> for the full text`,
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`main` is red on macOS and has been since #888, but the failure was undiagnosable by anyone without a Mac.

`Unit + Coverage — macos-15` fails on `cast-driver e2e (incident-response committed snapshot)`, and the entire output is:

```
incident-response: OK (hash=2cb4d6f912e7)
zero-config: DRIFT (hash=c957257a1b7c)
```

A hash says *that* the transcript changed and nothing about *what* changed. This PR does not fix the drift — it makes the drift readable, so the next macOS run reports the actual difference.

**What is already established about the drift** (this PR does not depend on it, but it is why the gap mattered):

- **Deterministic, not flaky.** Byte-identical drift hash `c957257a1b7c` across two independent runs on different commits (`30333319359`, `30334421390`). That rules out a leaked random temp path, which would vary per run.
- **macOS only.** ubuntu and windows pass the identical check; the committed hash `52230bd9f728…` reproduces exactly on Windows.
- So it is a stable, macOS-specific rendering difference in the `zero-config` cast.

## The change

`driver.ts` already computed a unified diff — it just wrote it to disk **only when `--artifacts-dir` was passed**, and the failing path (`scripts/cast-driver/e2e.test.ts`) does not pass it. So the diff existed and was thrown away exactly when it was needed.

- the diff is now computed unconditionally and carried on the `mismatch` summary
- `run.ts` prints it on DRIFT, bounded to `MAX_DIFF_LINES` (60), pointing at `--artifacts-dir` for the full text
- the confusing case where the hash differs but the transcript text is **byte-identical** now says so explicitly — a stale committed `.hash`, not a content change. Previously that rendered as `DRIFT` with no explanation whatsoever.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome) — verified as `bunx biome check --error-on-warnings scripts`
- [x] All existing tests pass — `bun test scripts/` 903 pass / 0 fail
- [x] New behaviour is covered by tests
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear anywhere
- [x] Platform-specific code behind `PlatformServices` — n/a, no production code changed
- [x] The HITL consent gate has not been touched

## Coverage

n/a — neither `engine/` nor `vault/` was modified.

## Testing

Both drift shapes were exercised end-to-end against the real `zero-config` snapshot by mutating it locally and restoring afterwards.

**Text differs** (the real macOS shape):

```
zero-config: DRIFT (hash=52230bd9f728)
--- zero-config.txt
+++ zero-config.actual.txt
@@ -1,22 +1,21 @@
 Added <TMP>/sample-repo to nimbus.toml (code indexing on).
```

**Stale hash, identical text:**

```
zero-config: DRIFT (hash=52230bd9f728)
  transcript text is IDENTICAL to the committed .txt — the committed .hash is stale; re-run `bun run record-casts`
```

- `bun test scripts/cast-driver/` → 74 pass / 0 fail
- `bun test scripts/` → 903 pass / 0 fail
- `bunx tsc -p scripts/tsconfig.json --noEmit` → exit 0
- **Red-proved:** removing `diff` from the mismatch summary fails the new test (8 pass / 1 fail). The test asserts both sides appear in the diff — one side alone would be useless.

## Notes for Reviewers

The two new tests deliberately pass `artifactsDir: undefined`, because that is the configuration the failing CI path actually uses. A test that passed an artifacts dir would have gone green against the old code and proved nothing.

This is diagnostic instrumentation, not a fix for the underlying macOS difference. Once a macOS run reports the actual diff, the root cause can be fixed with evidence instead of a guess — which is the reason I did not attempt the fix blind from a Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI drift reports now include readable transcript differences when snapshot checks fail.
  * Long differences are truncated for concise output, with guidance for accessing the full diff.
  * Reports identify stale hash files when transcript content matches.

* **Bug Fixes**
  * Snapshot mismatch details are now available even without an artifacts directory.
  * Matching snapshots no longer produce unnecessary diff output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->