### PR TITLE
fix(cast-driver): normalize macOS's /private tmpdir alias — unbreaks main on macOS

### DIFF
--- a/scripts/cast-driver/normalize.test.ts
+++ b/scripts/cast-driver/normalize.test.ts
@@ -160,3 +160,48 @@ describe("placeholder path separators — cross-platform snapshot stability", ()
     expect(twice).toBe(once);
   });
 });
+
+describe("tmp-prefix — the macOS /private alias", () => {
+  // `/var` is a symlink to `/private/var` on macOS, so os.tmpdir() reports
+  // `/var/folders/…` while a resolved path prints `/private/var/folders/…`.
+  // Replacing only the unresolved prefix produced `/private<TMP>` and kept
+  // `main` red on macOS alone, deterministically, for days.
+  const macCtx = { tmpDirPrefix: "/var/folders/pd/abc123/T/harness", homePrefix: "/Users/runner" };
+  const nMac = (s: string): string => applyNormalization(new TextEncoder().encode(s), macCtx);
+
+  test("a RESOLVED macOS temp path normalises to <TMP>, not /private<TMP>", () => {
+    expect(
+      nMac("Added /private/var/folders/pd/abc123/T/harness/sample-repo to nimbus.toml\n"),
+    ).toBe("Added <TMP>/sample-repo to nimbus.toml\n");
+  });
+
+  test("the UNRESOLVED form still normalises, so both spellings agree", () => {
+    // Both must land on the same text or the snapshot depends on which form a
+    // given command happened to print.
+    expect(nMac("Added /var/folders/pd/abc123/T/harness/sample-repo to nimbus.toml\n")).toBe(
+      "Added <TMP>/sample-repo to nimbus.toml\n",
+    );
+  });
+
+  test("a macOS transcript matches the Linux one byte-for-byte", () => {
+    // The actual regression: the committed snapshot is recorded on Linux, and
+    // macOS must reproduce it exactly.
+    const linux = applyNormalization(
+      new TextEncoder().encode("Added /tmp/cast-driver-xyz/sample-repo to nimbus.toml\n"),
+      ctx,
+    );
+    expect(
+      nMac("Added /private/var/folders/pd/abc123/T/harness/sample-repo to nimbus.toml\n"),
+    ).toBe(linux);
+  });
+
+  test("an unrelated /private path is untouched", () => {
+    // The rule must key on the harness tmpdir, not on the literal "/private".
+    expect(nMac("see /private/etc/hosts\n")).toBe("see /private/etc/hosts\n");
+  });
+
+  test("idempotent", () => {
+    const once = nMac("Added /private/var/folders/pd/abc123/T/harness/x to nimbus.toml\n");
+    expect(applyNormalization(new TextEncoder().encode(once), macCtx)).toBe(once);
+  });
+});

--- a/scripts/cast-driver/normalize.ts
+++ b/scripts/cast-driver/normalize.ts
@@ -60,7 +60,21 @@ export const NORMALIZATION_RULES: ReadonlyArray<Rule> = [
     name: "tmp-prefix",
     apply: (t, ctx) => {
       if (ctx.tmpDirPrefix.length === 0) return t;
-      return t.replace(new RegExp(escapeForRegex(ctx.tmpDirPrefix), "g"), "<TMP>");
+      // macOS reports `os.tmpdir()` as `/var/folders/…` while the RESOLVED path
+      // is `/private/var/folders/…` — `/var` is a symlink to `/private/var`. A
+      // command that prints a resolved path (`nimbus init` prints its repo
+      // root) therefore emits the `/private` form, and replacing only the
+      // unresolved prefix rewrote it to the nonsense `/private<TMP>`.
+      //
+      // That drifted the snapshot on macOS ONLY, deterministically, and kept
+      // `main` red: ubuntu and windows have no such alias, so the committed
+      // snapshot recorded there never contained it.
+      //
+      // The `/private` form is replaced FIRST because it is the longer match;
+      // doing it second would leave the `/private` fragment stranded.
+      return t
+        .replace(new RegExp(escapeForRegex(`/private${ctx.tmpDirPrefix}`), "g"), "<TMP>")
+        .replace(new RegExp(escapeForRegex(ctx.tmpDirPrefix), "g"), "<TMP>");
     },
   },
   {


### PR DESCRIPTION
## Summary

Fixes the macOS-only failure that has kept `main` red since #888.

`Unit + Coverage — macos-15` failed on the `zero-config` cast snapshot. #897 made the drift printable instead of reporting a bare hash, and on its very first run it showed the cause in one line:

```diff
-Added <TMP>/sample-repo to nimbus.toml (code indexing on).
+Added /private<TMP>/sample-repo to nimbus.toml (code indexing on).
```

## Root cause

On macOS `/var` is a symlink to `/private/var`. So `os.tmpdir()` reports `/var/folders/…`, while any command printing a **resolved** path — `nimbus init` prints its repo root — emits `/private/var/folders/…`.

The `tmp-prefix` normalisation rule replaced only the unresolved prefix, so the resolved form was rewritten into the nonsense string `/private<TMP>`.

ubuntu and windows have no such alias, so the committed snapshot — recorded there — never contained it. That is why the drift was **macOS-only** and **deterministic**: byte-identical hash `c957257a1b7c` across two independent runs on different commits, which is what ruled out a leaked random temp path early on.

## The fix

Replace the resolved `/private`-prefixed form **first** (it is the longer match), then the unresolved form. Replacing it second would strand the `/private` fragment.

**No re-record is required.** macOS now produces exactly what Linux recorded; the committed hash `52230bd9f728` is unchanged, and `bun scripts/cast-driver/run.ts --check` still passes locally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome) — verified as `bunx biome check --error-on-warnings scripts`
- [x] All existing tests pass — `bun test scripts/` 913 pass / 0 fail
- [x] New behaviour is covered by tests
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear anywhere
- [x] Platform-specific code behind `PlatformServices` — n/a; this is recording-time transcript normalisation in `scripts/`, not gateway business logic
- [x] The HITL consent gate has not been touched

## Coverage

n/a — neither `engine/` nor `vault/` was modified.

## Testing

- `bun test scripts/cast-driver/` → 84 pass / 0 fail
- `bun test scripts/` → 913 pass / 0 fail
- `bunx tsc -p scripts/tsconfig.json --noEmit` → exit 0
- `bun scripts/cast-driver/run.ts --check` → both snapshots OK, hashes unchanged
- **Red-proved:** reverting the fix fails exactly the two tests that assert resolved-path handling (28 pass / 2 fail → 30 pass / 0 fail restored)

Five tests were added, covering the resolved form, the unresolved form, cross-platform agreement, a negative case, and idempotency:

- a resolved macOS temp path normalises to `<TMP>`, not `/private<TMP>`
- the unresolved form still normalises, so **both spellings agree** — otherwise the snapshot would depend on which form a given command happened to print
- a macOS transcript matches the Linux one **byte-for-byte**, which is the actual regression
- an unrelated `/private/etc/hosts` is left untouched, pinning that the rule keys on the harness tmpdir rather than on the literal string `/private`
- idempotency, matching the existing convention in this file

## Notes for Reviewers

The `/private` literal is deliberate rather than a `realpathSync` call: `normalize.ts` is a pure function over recorded text with no filesystem access, and keeping it pure is what makes the whole rule set unit-testable. The alias is a documented, stable macOS property.

This is the third and final PR in a chain: #894 cut the CI fan-out, #897 made this drift diagnosable, and this one fixes the drift itself. It should return `main` to green on all three platforms — which in turn unblocks the P4b after-measurement, since both latency probes sample only `status=success` push runs and there has not been one since the tuning landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
