### PR TITLE
feat(ci): close out P4b — after-measurement, co-gate enforcement, sweep proof

### DIFF
--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -114,7 +114,7 @@ Design of record:
 | P2 | Release Train | ✅ done — both phases (run 30231918767) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, when a release phantoms, when an npm package is tagged but unpublished, or when a consumer's **lockfile-resolved** dependency lags npm `@latest`. Red-proved on a real phantom and on three real dependency edges; green after both, `OK (12 edges current)`. |
 | P3 | Review Layer | 🔨 first step done (#846) | The monorepo now carries a tuned `.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and the PAL ban — closing the satellites→monorepo direction of the pattern above. **Note:** the previously-stated gate ("an invariant violation is caught in CI") was already met — `_structure.yml` runs `audit:invariants` and all 17 static checks execute there; the one branch `--binary-only` excludes is a census that always exits 0. |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
-| P4b | Latency | ✅ measurement + tuning shipped | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 13-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. |
+| P4b | Latency | ✅ done — `ci-latency` green in sweep run `30356357605` | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 12-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. **Measured after (run `30353595114`): 105 → 77 jobs, DAG wait 60.5 → 2.5 min, wall clock 36-74 → 20 min.** `audit:coverage-gate-pal` keeps the platform classification honest, co-gates included. |
 | P5 | Org Legibility | ✅ both gates green (run 30231918767) | `audit:secret-inventory` fails on any workflow secret missing from the credential registry **or** `ci-secrets.md`; `audit:actions-allowlist` fails on an unpermitted action **or** any workflow whose latest run ended in `startup_failure`. The second found a live nightly outage on its first correct run. Remaining: the legibility dashboard. |
 | P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
 
@@ -467,19 +467,38 @@ moves to P6).
   measured against — not 33.4.**
 - **`audit:ci-latency` cannot prove this worked**, since it gates execution
   while the win lands in queue and DAG wait. `scripts/ci-latency/probe-dag.ts`
-  and `probe-concurrency.ts` are the instrument; the before figures above are
-  recorded, but the **after figures are not yet measured** — that requires
-  this branch to be merged and at least one push run to `main` to have
-  completed under the new workflow. Once that run exists, re-run
-  `bun scripts/ci-latency/probe-dag.ts` and
-  `bun scripts/ci-latency/probe-concurrency.ts` against `main` and record the
-  actual numbers here — never a predicted figure.
-- **Fast-follow — one enforcement gap is known and stated, not closed.** An
-  allowlist entry names a single gate, and rule 3 cross-checks only that gate.
-  `index/sqlite-vec-load.ts` reaches BOTH `Embedding` and `DB layer`, so
-  demoting `Embedding` is caught while demoting `DB layer` is not. The entry's
-  comment says so rather than claiming protection the code does not provide.
-  Closing it needs a co-gate field on `PlatformFileEntry`.
+  and `probe-concurrency.ts` are the instrument.
+- **AFTER MEASUREMENT (2026-07-28, run `30353595114` — the first green push run
+  under the new workflow).** Measured, not predicted:
+
+  | metric | before (2026-07-28, n=15) | after (n=1) |
+  | --- | --- | --- |
+  | DAG wait per `E2E Desktop` leg | 60.5 min median (max 110.8) | **2.5 min** |
+  | job that gated E2E | coverage shards (ubuntu 24× / macOS 18× / win 3×) | **`CI — Rust/Tauri (ubuntu-24.04)` 3×** |
+  | jobs per run | 105 | **77** |
+  | created-but-waiting at peak | 32–41 | **19** |
+  | wall clock | 36–74 min | **20 min** |
+
+  Coverage legs land exactly as designed: **ubuntu 24 / macOS 9 / windows 9 = 42**.
+
+  Two honesties about these numbers. The count is **77, not the 75 this document
+  predicted** — the estimate omitted the two skipped `Packaging` placeholder jobs
+  on windows/macOS; the measurement governs. And **n=1**: the DAG-wait collapse
+  (60.5 → 2.5 min) is far too large to be noise, and the binding-job row is
+  categorical rather than statistical — E2E is now gated by `ci-rust`, which is
+  the change itself — but re-run both probes once ~15 green push runs have
+  accumulated for a like-for-like median. Use `--runs 1` to isolate post-change
+  runs; the default window of 15 is still dominated by pre-tuning runs.
+- **The co-gate enforcement gap is CLOSED.** `PlatformFileEntry` gained
+  `coGates`, and rule 3 now checks the primary gate and every co-gate
+  identically, so demoting **either** `Embedding` or `DB layer` is caught.
+  Previously an entry named one gate and the other rested on a comment.
+- **Sweep proof (2026-07-28, run `30356357605`):** the `ci-latency` job is
+  **green**, which is P4b's bar — a gate is done when it runs green in the sweep
+  and would go red on regression. Stated precisely because the sweep run as a
+  whole is red: `release-staleness` failed on the **known, unrelated** P2 edge
+  (`client:Nimbus`, 0.5.0 vs npm 0.12.1 — seven `0.x` minors, deliberately left
+  for its own reviewed PR). 15 of 16 jobs green. Do not read that red as P4b.
 - **Guarded against silent decay:** `audit:coverage-gate-pal` fails when a
   platform-branching file is unclassified, when a classified file's gate is not
   `pal: true`, when a new matrix entry carries no explicit `pal` field, when an

--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -510,6 +510,62 @@ describe("auditCoverageGatePal", () => {
     expect(errors[0]).toContain('coverage gate "Ghost"');
   });
 
+  test("rule 3 — a co-gate that is not pal: true is a finding, not just the named gate", () => {
+    // The gap this closes: `sqlite-vec-load.ts` is reachable from BOTH Embedding
+    // and DB layer, but an entry named only one. Demoting the OTHER passed rule 3
+    // while its coverage denominator still held platform-branching code — the
+    // audit stayed green on exactly the loss it exists to prevent.
+    const errors = auditFixture({}, [
+      {
+        file: "packages/gateway/src/vault/factory.ts",
+        gate: "Vault", // pal: true in the fixture — the NAMED gate is fine
+        coGates: ["Engine"], // pal: false — only the CO-gate is wrong
+        why: "reachable from a second gate",
+      },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('gate "Engine"');
+    expect(errors[0]).toContain("not `pal: true`");
+  });
+
+  test("rule 3 — every co-gate is checked, not merely the first", () => {
+    const errors = auditFixture({}, [
+      {
+        file: "packages/gateway/src/vault/factory.ts",
+        gate: "Vault",
+        coGates: ["Engine", "Ghost"],
+        why: "two bad co-gates",
+      },
+    ]);
+    // One finding for the pal:false gate, one for the gate that does not exist.
+    expect(errors).toHaveLength(2);
+    expect(errors.some((e) => e.includes('gate "Engine"'))).toBe(true);
+    expect(errors.some((e) => e.includes('coverage gate "Ghost"'))).toBe(true);
+  });
+
+  test("rule 3 — an entry whose co-gates are all pal: true is clean", () => {
+    // The fixture ships one PAL gate by default, so a second is supplied here;
+    // otherwise this would pass for the wrong reason (an absent gate is its own
+    // finding, which is what an earlier draft of this test actually asserted).
+    expect(
+      auditFixture(
+        {
+          palGates:
+            '          - name: Vault\n            script: "test:coverage:vault"\n            pal: true\n' +
+            '          - name: Sandbox\n            script: "test:coverage:sandbox"\n            pal: true\n',
+        },
+        [
+          {
+            file: "packages/gateway/src/vault/factory.ts",
+            gate: "Vault",
+            coGates: ["Sandbox"],
+            why: "both pal: true",
+          },
+        ],
+      ),
+    ).toEqual([]);
+  });
+
   test("rule 4 — a matrix entry with no explicit pal field is a finding", () => {
     const errors = auditFixture({
       linuxGates: '          - name: Engine\n            script: "test:coverage:engine"\n',

--- a/scripts/structure-audit/check-coverage-gate-pal.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.ts
@@ -429,19 +429,27 @@ export function auditCoverageGatePal(repoRoot: string, deps: AuditDeps = {}): Au
     }
   }
 
-  // 3. declared gate must be pal: true
+  // 3. EVERY declared gate must be pal: true — the primary and every co-gate.
+  //
+  // Checking only `gate` left a hole: a file reachable from two gates named one
+  // of them, so demoting the OTHER passed rule 3 while its coverage denominator
+  // still contained platform-branching code. `coGates` closes it, and the loop
+  // below deliberately treats primary and co-gates identically so the two can
+  // never drift apart again.
   for (const entry of allowlist) {
-    if (entry.gate === "none") continue;
-    if (!palByName.has(entry.gate)) {
-      errors.push(
-        `${entry.file}: declares coverage gate "${entry.gate}", which is not in the ${TEST_SUITE} matrix`,
-      );
-      continue;
-    }
-    if (palByName.get(entry.gate) !== true) {
-      errors.push(
-        `${entry.file}: branches on platform and is covered by gate "${entry.gate}", but that gate is not \`pal: true\` — its coverage would run on Linux only`,
-      );
+    const declared = [entry.gate, ...(entry.coGates ?? [])].filter((g) => g !== "none");
+    for (const gate of declared) {
+      if (!palByName.has(gate)) {
+        errors.push(
+          `${entry.file}: declares coverage gate "${gate}", which is not in the ${TEST_SUITE} matrix`,
+        );
+        continue;
+      }
+      if (palByName.get(gate) !== true) {
+        errors.push(
+          `${entry.file}: branches on platform and is covered by gate "${gate}", but that gate is not \`pal: true\` — its coverage would run on Linux only`,
+        );
+      }
     }
   }
 

--- a/scripts/structure-audit/platform-branching-allowlist.ts
+++ b/scripts/structure-audit/platform-branching-allowlist.ts
@@ -22,6 +22,10 @@
  * the Embedding and DB layer gates via static imports. Both were promoted to
  * `pal: true`. When adding an entry, follow the static imports before writing
  * "none".
+ *
+ * A file reachable from more than one gate lists the others in `coGates`. Rule 3
+ * checks every declared gate identically, so demoting ANY of them is caught —
+ * naming only one used to leave the rest resting on a comment.
  */
 
 export interface PlatformFileEntry {
@@ -29,6 +33,15 @@ export interface PlatformFileEntry {
   readonly file: string;
   /** Coverage-gate `name` from the _test-suite.yml matrix, or "none". */
   readonly gate: string;
+  /**
+   * Additional gates whose coverage ALSO loads this file.
+   *
+   * A file reachable from two gates used to name only one, so demoting the
+   * unnamed gate to `pal: false` slipped past rule 3 — the audit stayed green
+   * while a gate whose denominator still contained platform-branching code went
+   * Linux-only. Every gate listed here is checked exactly like `gate`.
+   */
+  readonly coGates?: readonly string[];
   readonly why: string;
 }
 
@@ -101,7 +114,8 @@ export const PLATFORM_BRANCHING_ALLOWLIST: readonly PlatformFileEntry[] = [
   {
     file: "packages/gateway/src/index/sqlite-vec-load.ts",
     gate: "Embedding",
-    why: "per-OS native extension filename; reaches BOTH the Embedding and the DB layer gates through static imports — embedding/lazy-scheduler.ts (plus create-routing-runtime.ts and embedding-worker.ts) and index/migrations/runner.ts each import it, so it lands in both gates' coverage denominators. Both were promoted to `pal: true` together. ENFORCEMENT GAP, stated rather than overclaimed: an entry names ONE gate, and rule 3 cross-checks only that gate — so demoting `Embedding` is caught, but demoting `DB layer` is NOT. Closing it needs a co-gate field on this type; until then `DB layer` rests on this comment alone",
+    coGates: ["DB layer"],
+    why: "per-OS native extension filename; reaches BOTH the Embedding and the DB layer gates through static imports — embedding/lazy-scheduler.ts (plus create-routing-runtime.ts and embedding-worker.ts) and index/migrations/runner.ts each import it, so it lands in both gates' coverage denominators. Both are now ENFORCED: rule 3 checks `gate` and every `coGates` entry identically, so demoting EITHER is caught (this previously rested on a comment alone)",
   },
 
   // ── Not covered by any coverage-threshold gate ────────────────────────────


### PR DESCRIPTION
## Summary

Closes out P4b. Three things, all of which the tuning PR (#894) explicitly deferred rather than silently dropped.

### 1. The after-measurement — taken, and recorded as measured

`audit:ci-latency` gates *execution* time, while this slice's win landed in *queue* and *DAG wait*, which that gate reports and never fails on. So the gate structurally could not prove the change worked; the two promoted probes are the instrument. Both sample `status=success` push runs only, and there was no green push run until `main` was un-broken on macOS (#899).

Run `30353595114`, the first green push run under the new workflow:

| metric | before (2026-07-28, n=15) | after (n=1) |
| --- | --- | --- |
| DAG wait per `E2E Desktop` leg | 60.5 min median (max 110.8) | **2.5 min** |
| job that gated E2E | coverage shards (ubuntu 24× / macOS 18× / win 3×) | **`CI — Rust/Tauri (ubuntu-24.04)` 3×** |
| jobs per run | 105 | **77** |
| created-but-waiting at peak | 32–41 | **19** |
| wall clock | 36–74 min | **20 min** |

Coverage legs land exactly as designed: **ubuntu 24 / macOS 9 / windows 9 = 42**.

The binding-job row is the cleanest evidence: E2E is now gated by `CI — Rust/Tauri` — the 1.17–1.72 min job the edge was narrowed to — rather than by a coverage shard.

**Two honesties, both written into the roadmap rather than smoothed over.** The count is **77, not the 75 the design predicted**; the estimate omitted the two skipped `Packaging` placeholder jobs on windows/macOS, and the measurement governs. And this is **n=1** — the DAG-wait collapse is far too large to be noise and the binding-job change is categorical rather than statistical, but the roadmap says to re-run once ~15 green push runs accumulate, and to pass `--runs 1` because the default window is still dominated by pre-tuning runs.

### 2. The co-gate enforcement gap — closed

The whole-branch review of #894 found that an allowlist entry names **one** gate while rule 3 cross-checks only that one. `index/sqlite-vec-load.ts` reaches **both** `Embedding` and `DB layer` through static imports, so demoting `DB layer` would have passed the audit while its coverage denominator still held platform-branching code — precisely the silent loss this audit exists to prevent, for one of the two gates it claimed to protect. It shipped with the entry's comment stating the gap honestly rather than overclaiming.

`PlatformFileEntry` now takes `coGates`, and rule 3 checks the primary gate and every co-gate **identically** — deliberately one loop, so the two paths cannot drift apart again.

### 3. P4b's sweep proof-run number — recorded

The program's own bar is that a sub-program is done when its gate is green in a sweep run and would go red on regression. P1/P2/P5 all carry a proof-run number; P4b did not.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — the co-gate enforcement hole
- [x] CI / tooling
- [x] Documentation only — the roadmap record

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome) — verified as `bunx biome check --error-on-warnings packages scripts`
- [x] All existing tests pass — `bun test scripts/` 916 pass / 0 fail
- [x] New behaviour is covered by tests
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear anywhere
- [x] Platform-specific code behind `PlatformServices` — n/a, no production code changed
- [x] The HITL consent gate has not been touched

## Coverage

n/a — neither `engine/` nor `vault/` was modified.

## Testing

- `bun run audit:coverage-gate-pal` → OK
- `bun test scripts/` → 916 pass / 0 fail
- `bunx tsc -p scripts/tsconfig.json --noEmit` → exit 0
- `bun run lint:markdown` → exit 0; `bun run audit:doc-refs` → 625 refs resolve
- **Red-proved:** reverting rule 3 to `[entry.gate]` fails 2 of the 3 new tests (37 pass / 2 fail → 39 pass / 0 fail restored). The mutation was verified in the file before trusting the result.

Three tests were added: a co-gate that is not `pal: true` is a finding even when the *named* gate is fine; **every** co-gate is checked rather than merely the first (asserting two distinct findings); and an entry whose co-gates are all `pal: true` is clean.

## Notes for Reviewers

The third test supplies a second PAL gate to the fixture on purpose. An earlier draft used a gate absent from the fixture, so it passed for the wrong reason — an absent gate is its own separate finding. Worth knowing if that fixture is edited later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
