### PR TITLE
docs(ci-secrets): correct the release-environment scope claim

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -4,12 +4,41 @@ This page is the canonical inventory of every GitHub Actions secret the Nimbus
 workflows consume: what each one is for, which workflow reads it, whether it is
 required, and exactly how to mint and store it.
 
-All secrets live under **repo Settings → Secrets and variables → Actions**.
-Release/publish secrets are scoped to the **`release`** GitHub
+**Every secret on this page currently lives at repository scope**, under **repo
+Settings → Secrets and variables → Actions**. The `release`
 [deployment environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment)
-(jobs that read them declare `environment: release`); add those under
-**Settings → Environments → release → Environment secrets**. Everything else is
-a plain repository secret.
+holds **no** environment secrets today.
+
+> **Do not move a secret onto the `release` environment without first checking
+> the table below.** An environment secret is invisible to any job that does not
+> declare `environment: release`, and it fails *silently* — the expression
+> resolves to the empty string rather than erroring. Moving `GPG_SIGNING_SUBKEY`
+> today would not break the environment-scoped `publish-release` job; it would
+> break `release.yml`'s `build-gateway` job, which signs the artifacts and does
+> not declare the environment.
+
+Three jobs declare `environment: release`: `release.yml`'s `publish-release` and
+`update-manifest`, and `secret-health.yml`'s `check`. The environment carries a
+**deployment branch policy** admitting only `main` (for the `secret-health` cron)
+and `v*` tags (for `release.yml`), so a workflow added on a feature branch cannot
+deploy to it.
+
+Which secrets could move to environment scope as the workflows stand:
+
+| Secret | Blocked by (job with no `environment: release`) |
+| --- | --- |
+| `SECRET_AUDITOR_CLIENT_ID` | — read only by `secret-health:check`; **safe to move** |
+| `SECRET_AUDITOR_PRIVATE_KEY` | — read only by `secret-health:check`; **safe to move** |
+| `GPG_SIGNING_SUBKEY`, `GPG_PASSPHRASE` | `release:build-gateway`, `publish-linux-repo` |
+| `UPDATER_SIGNING_KEY` | `release:build-gateway` |
+| `WINGET_PAT` | `publish-package-managers:winget` |
+| `WINDOWS_CERT_PFX_BASE64`, `WINDOWS_CERT_PASSWORD` | `release:build-msi` |
+| `APPLE_*` (7) | `release:build-pkg` |
+| `RELEASE_BOT_CLIENT_ID`, `RELEASE_BOT_PRIVATE_KEY` | `release-please`, `publish-package-managers`, `publish-linux-repo`, `org-drift-sweep` (see the note below) |
+
+Everything not listed (`SONAR_TOKEN`, `BENCHER_API_KEY`, `NIMBUS_CHECKS_TOKEN`,
+`CLA_BOT_*`, `SCORECARD_TOKEN`) is a CI secret with no release role and belongs
+at repository scope.
 
 > **Token hygiene.** The release/publish path now authenticates as the
 > **Nimbus Release Bot** GitHub App for everything it can (see below) — App


### PR DESCRIPTION
## Why

While adding deployment branch policies to the `release` environments across the org, I checked this repo's claim against the live API and the workflow sources. The intro of `docs/ci-secrets.md` was wrong, and wrong in a way that would break a release if someone followed it.

It said:

> Release/publish secrets are scoped to the **`release`** GitHub deployment environment (jobs that read them declare `environment: release`); add those under **Settings → Environments → release → Environment secrets**.

Two problems:

1. **The `release` environment holds zero environment secrets.** All seven repo secrets sit at repository scope:
   ```
   $ gh api repos/nimbus-agent/Nimbus/environments/release/secrets
   {"total_count":0,"secrets":[]}
   ```
2. **Most of them cannot move there as the workflows stand.** Only three jobs declare `environment: release` — `release.yml`'s `publish-release` and `update-manifest`, and `secret-health.yml`'s `check`. Every other consumer would stop seeing the secret.

The second point is the dangerous one, because an environment secret invisible to a job **resolves to the empty string rather than erroring**. Following the old instruction for `GPG_SIGNING_SUBKEY` would not break the environment-scoped `publish-release` job — it would break `release.yml`'s `build-gateway` job, which is what actually signs the artifacts.

The page was also self-contradictory: the RELEASE_BOT_* section already explains this exact mechanism correctly ("`release-please.yml` … mint a token without declaring `environment: release`, so an environment-scoped secret would be invisible to them"). Only the intro was stale.

## What changed

Docs only — one section of `docs/ci-secrets.md`. It now states the real scope, warns about the silent-empty failure mode, and carries a per-secret table naming the job that blocks each move:

| Secret | Blocked by |
|---|---|
| `SECRET_AUDITOR_CLIENT_ID` / `SECRET_AUDITOR_PRIVATE_KEY` | — **safe to move today** |
| `GPG_SIGNING_SUBKEY`, `GPG_PASSPHRASE` | `release:build-gateway`, `publish-linux-repo` |
| `UPDATER_SIGNING_KEY` | `release:build-gateway` |
| `WINGET_PAT` | `publish-package-managers:winget` |
| `WINDOWS_CERT_*` | `release:build-msi` |
| `APPLE_*` (7) | `release:build-pkg` |
| `RELEASE_BOT_*` | `release-please`, `publish-package-managers`, `publish-linux-repo`, `org-drift-sweep` |

Derived by parsing every workflow, attributing each `secrets.*` reference to its job, and checking that job's `environment:` key — not by reading prose.

## Also done (API, outside this PR)

The `release` environment had `protection_rules: []` and `deployment_branch_policy: null` — no gate at all. It now has a deployment branch policy mirroring how `github-pages` is already configured in this repo (`custom_branch_policies: true` + explicit policies):

```
PUT  /repos/nimbus-agent/Nimbus/environments/release
     {"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
POST /repos/nimbus-agent/Nimbus/environments/release/deployment-branch-policies  {"name":"v*","type":"tag"}
POST /repos/nimbus-agent/Nimbus/environments/release/deployment-branch-policies  {"name":"main","type":"branch"}
```

`main` is included deliberately: `secret-health.yml` declares `environment: release` and runs on a Monday cron, which executes from the default branch. A tags-only policy would have broken that job.

## Not done — needs your call

Making the release credentials genuinely non-readable by every job requires adding `environment: release` to `build-gateway`, `build-msi`, `build-pkg`, `publish-linux-repo` and `publish-package-managers:winget`, then moving the secrets. That restructures the release pipeline of a repo that cut v1.5.0 today, so I did not do it unilaterally. Happy to open it as a follow-up if you want it.

## Verification

- `bun run audit:secret-inventory` — `OK (24 secrets referenced, all documented)`
- `bun test scripts/structure-audit/check-secret-inventory.test.ts` — 16 pass, 0 fail
- `bun run audit:doc-refs` — 627 refs across 16 docs, all resolve
- No new links introduced (the one external link is reused from the text it replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
