### PR TITLE
docs(credentials): credential health design, plan, and both review rounds

### DIFF
--- a/docs/superpowers/plans/2026-07-28-credential-health-review-response.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health-review-response.md
@@ -1,0 +1,122 @@
+# Implementation Plan Review Response: Credential Health
+
+Response to [`2026-07-28-credential-health-review.md`](./2026-07-28-credential-health-review.md).
+
+**Four points accepted as suggested, one accepted in substance but rejected as
+written.** Two accepted points gained more than was asked for, because the
+suggested fix left a false-green path open. Nothing deferred.
+
+---
+
+## 1.1 — `parse_error` classification · **FIXED, and widened**
+
+**Correct, and the plan had a genuine hole**: Task 8 mapped `ok` and
+`http_error` but never said what happens to `parse_error`, so it would have
+fallen through to whatever the implementer guessed.
+
+The suggestion — map it to `{ kind: "ok" }` because HTTP 2xx means the
+credential authenticated — is right for the dominant case. **But taken
+literally it opens a false green.** A well-known anti-pattern is answering an
+expired session with **200 plus an HTML login page** instead of 401. Under an
+unconditional `parse_error → ok`, a dead credential would report healthy — the
+exact defect class this whole feature exists to catch, and the same shape as the
+400-reads-`ok` bug the *design* review caught.
+
+Applied instead:
+
+1. `parse_error` now carries `body` (Task 2), like `http_error` does.
+2. It maps to `{ kind: "http", status: 200, body }`.
+3. `classifyAuthOutcome` checks auth-rejection markers **before** the 2xx
+   short-circuit, so a benign unparseable body stays `ok` while a login page is
+   caught.
+
+Two tests added to Task 4's table:
+
+```ts
+["200 with a login page", http(200, "<html><title>Sign in</title>Unauthorized</html>"), "auth-failure"],
+["200 with unparseable but benign body", http(200, "not json at all"), "ok"],
+```
+
+Net effect: the suggested behaviour for the common case, without the hole.
+
+## 1.2 — XML / SOAP error bodies · **FIXED**
+
+Accepted as written, and it matters more than it first appears: the connectors
+most likely to sit behind enterprise middleware are exactly the self-hosted ones
+(Jenkins, on-prem Jira/GitLab, ArgoCD), and those are also the ones with no
+OAuth path, so they are over-represented among the opaque credentials this
+feature is built for.
+
+`looksLikeHtml` → `looksLikeMarkup`, now matching `<?xml`, namespaced roots
+(`<soap:Envelope`, `<ns:Error`), and `<error` / `<response`. Extraction gained a
+SOAP/XML fault-string pass between the `<title>` check and the strip-everything
+fallback, so a `<faultstring>Invalid credentials supplied</faultstring>` yields
+the message rather than a tag salad. Fallback text changed from
+`"HTML error page"` to `"markup error page"`.
+
+Two tests added — a full SOAP envelope, and an XML body asserting no raw tags
+survive.
+
+## 2.1 — `suffixOf` splitting · **ACCEPTED IN SUBSTANCE, REJECTED AS WRITTEN**
+
+The review hedged this correctly: *"If all vault keys follow a strict
+`<connector_id>.<key_name>` pattern (exactly one dot), this is fine."*
+
+Verified rather than assumed — **all 174 keys in the manifest have exactly one
+dot; there are no multi-dot keys.** So the premise holds and `indexOf` is safe
+today.
+
+More importantly, switching to `lastIndexOf` would be **wrong**, not merely
+unnecessary. Keys are `<connector_id>.<name>`. If a name ever contained a dot —
+`a.b.c` meaning connector `a`, name `b.c` — then:
+
+- `indexOf` yields `b.c` — the whole name, correct
+- `lastIndexOf` yields `c` — a *fragment* of the name, silently mis-classified
+
+So the suggested change would introduce the bug it was guarding against, for
+precisely the case that motivated it.
+
+The real risk is not the split, it is that the one-dot invariant is undocumented
+and unenforced. Applied instead: `suffixOf` gained a comment explaining why the
+first dot is correct and warning against `lastIndexOf`, plus a **guard test**
+asserting every manifest key is exactly `<connector>.<name>`. A future multi-dot
+key now fails loudly and forces a deliberate decision.
+
+## 2.2 — Cursor atomicity comment · **FIXED**
+
+Accepted exactly as suggested. The review's own analysis is right — the code is
+already safe because read-and-increment completes synchronously before the first
+`await` — and the value is entirely in stopping a future refactor from moving
+the increment after an await, which would produce duplicate probes visible only
+under concurrency. Comment added saying precisely that.
+
+## 2.3 — Concurrency test · **FIXED, using the supplied snippet**
+
+Accepted, and the review was right to flag it: "add a test asserting no more
+than N in flight" without showing how is a placeholder by the plan skill's own
+standard, and I should not have left it.
+
+The supplied counter snippet is used verbatim as the basis. Two additions:
+
+- `expect(maxActive).toBeGreaterThan(1)` — without it the test still passes if
+  the worker pool collapses to serial execution, a performance regression the
+  cap alone cannot detect.
+- A second test asserting **every connector is probed exactly once** — none
+  skipped, none doubled. That is the actual behavioural guarantee the atomic
+  claim in 2.2 provides, and it deserves a test rather than only a comment.
+
+---
+
+## Summary
+
+| Point | Verdict | Note |
+| --- | --- | --- |
+| 1.1 `parse_error` | **Fixed, widened** | Straight `→ ok` would have let a 200+login-page read healthy |
+| 1.2 XML / SOAP | **Fixed** | + SOAP faultstring extraction |
+| 2.1 `suffixOf` | **Substance accepted, code change rejected** | `lastIndexOf` would introduce the bug it guards against; guard test added instead |
+| 2.2 Atomicity comment | **Fixed** | As suggested |
+| 2.3 Concurrency test | **Fixed** | Snippet used + serial-collapse and exactly-once assertions |
+
+The through-line matches the design review: three of five changes close paths
+where the system could have reported health it had not observed. The plan's
+centre of gravity is now firmly on refusing to assert what it has not seen.

--- a/docs/superpowers/plans/2026-07-28-credential-health-review-response.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health-review-response.md
@@ -76,7 +76,14 @@ unnecessary. Keys are `<connector_id>.<name>`. If a name ever contained a dot â€
 So the suggested change would introduce the bug it was guarding against, for
 precisely the case that motivated it.
 
-The real risk is not the split, it is that the one-dot invariant is undocumented
+To be explicit about the apparent contradiction between these two statements:
+**today the invariant is exactly one dot, and the guard test enforces it.** The
+`indexOf` reasoning describes what would be correct *if that invariant were ever
+deliberately relaxed* â€” it is the reason the guard fails loudly rather than the
+code silently guessing. The guard is the contract; `indexOf` is what makes
+relaxing it safe later.
+
+The real risk is not the split, it is that the one-dot invariant was undocumented
 and unenforced. Applied instead: `suffixOf` gained a comment explaining why the
 first dot is correct and warning against `lastIndexOf`, plus a **guard test**
 asserting every manifest key is exactly `<connector>.<name>`. A future multi-dot

--- a/docs/superpowers/plans/2026-07-28-credential-health-review.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health-review.md
@@ -1,0 +1,79 @@
+# Implementation Plan Review: Credential Health
+
+This document contains a review of the implementation plan [2026-07-28-credential-health.md](./2026-07-28-credential-health.md), listing open questions, potential edge cases, and suggested improvements for the tasks.
+
+---
+
+## 1. Open Questions & Edge Cases
+
+### 1.1. Classification of `parse_error` Outcomes in Task 8
+
+During a sync attempt, a fetch can return `parse_error` (meaning the HTTP request succeeded with 2xx but the body could not be parsed as JSON).
+
+* **The Question**: Does a `parse_error` count as a healthy credential check?
+* **Impact**: If the HTTP status was 200, the credentials succeeded in authenticating. If we do not record this as `ok`, we might degrade the credential to `unknown`.
+* **Suggestion**: In Task 8, explicitly map `parse_error` to `{ kind: "ok" }` for the purpose of credential health, since any successful HTTP 2xx response implies valid credentials regardless of whether the JSON parser succeeded on the body.
+
+### 1.2. Handling XML and SOAP Error Bodies in Task 3
+
+In `extract-error-detail.ts`, the function `looksLikeHtml` is used to strip markup from error pages.
+
+* **The Question**: What if a connector interacts with an enterprise system that returns XML/SOAP errors (e.g. some Jenkins plugins, or on-premise Active Directory/Exchange)?
+* **Impact**: The XML tags might remain in the extracted error detail if it doesn't match `looksLikeHtml`, leading to messy string details containing XML tags.
+* **Suggestion**: Extend `looksLikeHtml` to also detect XML (e.g. checking if it starts with `<?xml` or `<ns:`), or generalize it to a `looksLikeMarkup` check that strips tags for both HTML and XML.
+
+---
+
+## 2. Improvements & Code Suggestions
+
+### 2.1. Task 1: Robust Suffix Matching for `suffixOf`
+
+In `credential-keys.ts`, `suffixOf(key)` splits the key by dot:
+
+```ts
+function suffixOf(key: string): string {
+  const dot = key.indexOf(".");
+  return dot === -1 ? key : key.slice(dot + 1);
+}
+```
+
+* **Suggestion**: For vault keys with multiple dots (if any exist, e.g., `service.sub.credential`), `indexOf(".")` only strips the first segment. If all vault keys follow a strict `<connector_id>.<key_name>` pattern (exactly one dot), this is fine. If there are keys with multiple dots, `key.slice(key.lastIndexOf(".") + 1)` would be safer to get only the final suffix.
+
+### 2.2. Task 11: Cursor Safety in Concurrent Probes
+
+In `checkAllCredentials`, the concurrent worker is:
+
+```ts
+  const worker = async (): Promise<void> => {
+    while (cursor < queue.length) {
+      const connectorId = queue[cursor++];
+      ...
+```
+
+* **Issue**: Since JavaScript is single-threaded, the synchronous increment `cursor++` is safe from race conditions, but if `cursor` is shared, we must ensure `cursor++` occurs atomically before any `await` statement. The current code does:
+
+  ```ts
+  const connectorId = queue[cursor++];
+  if (connectorId === undefined) return;
+  const cls = await probeConnector(deps, connectorId);
+  ```
+
+  This is fully safe because the lookup and increment occur before the first `await`. However, adding a small comment clarifying this atomic property prevents future refactoring from introducing concurrency bugs.
+
+### 2.3. Task 11: `checkAllCredentials` Concurrency Test
+
+The plan suggests adding a test asserting no more than `MAX_CONCURRENT_PROBES` are in flight.
+
+* **Suggestion**: Provide a code snippet or guidance for how this test can be written deterministically using a mock delay inside `callListTool` and tracking a counter. E.g.:
+
+  ```ts
+  let active = 0;
+  let maxActive = 0;
+  const callListTool = async () => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise(r => setTimeout(r, 10));
+    active--;
+    return { kind: "ok" as const };
+  };
+  ```

--- a/docs/superpowers/plans/2026-07-28-credential-health.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health.md
@@ -100,6 +100,20 @@ describe("isSecretKey", () => {
     expect(secretKeysFor("does-not-exist")).toEqual([]);
   });
 
+  // Guard: the one-dot invariant that makes suffixOf's indexOf split correct.
+  // Verified true for all 174 keys as of 2026-07-28. If this ever fails,
+  // decide deliberately — do NOT reach for lastIndexOf, which would return
+  // only the final segment and mis-classify a dotted name.
+  test("every vault key is exactly <connector_id>.<name>", () => {
+    const multiDot: string[] = [];
+    for (const keys of Object.values(CONNECTOR_VAULT_SECRET_KEYS)) {
+      for (const k of keys as string[]) {
+        if (k.split(".").length !== 2) multiDot.push(k);
+      }
+    }
+    expect(multiDot).toEqual([]);
+  });
+
   // Guard: every key in the manifest must be classified deliberately.
   test("every manifest key matches a known secret or config suffix", () => {
     const unclassified: string[] = [];
@@ -147,6 +161,13 @@ export const CONFIG_SUFFIXES: ReadonlySet<string> = new Set([
   "publisher_id", "workspace", "org", "account", "instance", "tenant",
 ]);
 
+/**
+ * Vault keys are `<connector_id>.<name>`. Split on the FIRST dot, not the last:
+ * if a name ever contained a dot (`a.b.c` = connector `a`, name `b.c`),
+ * `lastIndexOf` would return `c` and silently mis-classify part of a name as
+ * the whole name. A guard test below pins the one-dot invariant, so a
+ * multi-dot key forces a deliberate decision rather than a silent misread.
+ */
 function suffixOf(key: string): string {
   const dot = key.indexOf(".");
   return dot === -1 ? key : key.slice(dot + 1);
@@ -239,8 +260,15 @@ const MAX_ERROR_BODY = 4096;
 export type FetchOutcome =
   | { kind: "ok"; parsed: unknown; bytes: number }
   | { kind: "http_error"; bytes: number; status: number; body: string }
-  | { kind: "parse_error"; bytes: number };
+  | { kind: "parse_error"; bytes: number; body: string };
 ```
+
+`parse_error` carries a body too. It means "HTTP 2xx but not JSON", which is
+*usually* a healthy credential and a schema surprise — but a well-known
+anti-pattern is answering an expired session with **200 plus an HTML login
+page** instead of 401. Without the body there is no way to tell those apart,
+and defaulting to `ok` would manufacture a false green. Task 8 uses the body to
+distinguish them.
 
 and in `connectorFetch`, replace the `if (!res.ok)` return with:
 
@@ -249,6 +277,13 @@ and in `connectorFetch`, replace the `if (!res.ok)` return with:
     ctx.logger.warn({ serviceId, status: res.status, url }, "connector fetch failed");
     return { kind: "http_error", bytes, status: res.status, body: text.slice(0, MAX_ERROR_BODY) };
   }
+```
+
+and change the `parse_error` return in the same function's `catch` to carry the
+body as well:
+
+```ts
+    return { kind: "parse_error", bytes, body: text.slice(0, MAX_ERROR_BODY) };
 ```
 
 - [ ] **Step 4: Run the tests**
@@ -300,9 +335,21 @@ describe("extractErrorDetail", () => {
     expect(extractErrorDetail(html, 502)).toContain("502 Bad Gateway");
   });
 
-  test("falls back when HTML has no title", () => {
+  test("falls back when markup has no title", () => {
     expect(extractErrorDetail("<html><body>   </body></html>", 403))
-      .toBe("HTML error page (HTTP 403)");
+      .toBe("markup error page (HTTP 403)");
+  });
+
+  test("extracts a SOAP faultstring", () => {
+    const soap = `<?xml version="1.0"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+      <soap:Body><soap:Fault><faultstring>Invalid credentials supplied</faultstring></soap:Fault></soap:Body></soap:Envelope>`;
+    expect(extractErrorDetail(soap, 500)).toContain("Invalid credentials supplied");
+  });
+
+  test("strips XML tags rather than storing them raw", () => {
+    const xml = '<?xml version="1.0"?><error><code>401</code></error>';
+    const d = extractErrorDetail(xml, 401);
+    expect(d).not.toContain("<code>");
   });
 
   // ORDERING: extract -> strip -> redact -> cap. Redaction must run LAST, so a
@@ -339,14 +386,29 @@ import { redactAuditPayload } from "../audit/format-audit-payload.ts";
 
 const MAX_DETAIL_BYTES = 256;
 
-function looksLikeHtml(body: string): boolean {
-  const head = body.trimStart().slice(0, 15).toLowerCase();
-  return head.startsWith("<!doctype html") || head.startsWith("<html");
+/**
+ * HTML *and* XML/SOAP. On-premise systems (Jenkins plugins, Exchange, older
+ * enterprise APIs) answer with `<?xml …>` or a SOAP envelope, which would
+ * otherwise be stored raw, tags and all.
+ */
+function looksLikeMarkup(body: string): boolean {
+  const head = body.trimStart().slice(0, 20).toLowerCase();
+  return (
+    head.startsWith("<!doctype html") ||
+    head.startsWith("<html") ||
+    head.startsWith("<?xml") ||
+    /^<[a-z]+:[a-z]+/.test(head) || // namespaced root: <soap:Envelope, <ns:Error
+    head.startsWith("<error") ||
+    head.startsWith("<response")
+  );
 }
 
-function fromHtml(body: string, status: number): string {
+function fromMarkup(body: string, status: number): string {
+  // HTML <title>, else a SOAP/XML fault string, else all remaining text.
   const title = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(body)?.[1]?.trim();
   if (title !== undefined && title.length > 0) return title;
+  const fault = /<(?:\w+:)?(?:faultstring|message|Message|error)[^>]*>([\s\S]*?)<\//.exec(body)?.[1]?.trim();
+  if (fault !== undefined && fault.length > 0) return fault;
   const text = body
     .replace(/<!--[\s\S]*?-->/g, " ")
     .replace(/<script[\s\S]*?<\/script>/gi, " ")
@@ -354,7 +416,7 @@ function fromHtml(body: string, status: number): string {
     .replace(/<[^>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-  return text.length > 0 ? text : `HTML error page (HTTP ${status})`;
+  return text.length > 0 ? text : `markup error page (HTTP ${status})`;
 }
 
 /**
@@ -367,7 +429,7 @@ function fromHtml(body: string, status: number): string {
 export function extractErrorDetail(body: string, status: number): string {
   const trimmed = body.trim();
   if (trimmed.length === 0) return `HTTP ${status}`;
-  const extracted = looksLikeHtml(trimmed) ? fromHtml(trimmed, status) : trimmed;
+  const extracted = looksLikeMarkup(trimmed) ? fromMarkup(trimmed, status) : trimmed;
   const redacted = redactAuditPayload(extracted, MAX_DETAIL_BYTES);
   return redacted.slice(0, MAX_DETAIL_BYTES);
 }
@@ -1203,7 +1265,46 @@ function recordCredentialHealth(
 }
 ```
 
-Call it in both the success and failure paths. Map a thrown network error to `{ kind: "network" }` and a `FetchOutcome` of `http_error` to `{ kind: "http", status, body }`.
+Call it in both the success and failure paths. Map the `FetchOutcome` variants
+to a `ClassifiableOutcome` like this — all four cases, none defaulted:
+
+```ts
+function toClassifiable(outcome: FetchOutcome): ClassifiableOutcome {
+  switch (outcome.kind) {
+    case "ok":
+      return { kind: "ok" };
+    case "http_error":
+      return { kind: "http", status: outcome.status, body: outcome.body };
+    case "parse_error":
+      // HTTP was 2xx, so the credential authenticated — UNLESS the server
+      // answered an expired session with 200 + a login page instead of 401.
+      // Reuse the auth-marker check rather than assuming health.
+      return { kind: "http", status: 200, body: outcome.body };
+  }
+}
+```
+
+Passing `status: 200` is deliberate: `classifyAuthOutcome` returns `ok` for 2xx
+*before* consulting the body, so a genuine schema surprise stays `ok`. To catch
+the login-page case, move the marker check ahead of the 2xx short-circuit in
+`classify-auth-outcome.ts`:
+
+```ts
+    case "http": {
+      const { status, body } = outcome;
+      if (bodyIndicatesAuthRejection(body)) return "auth-failure"; // even on 2xx
+      if (status >= 200 && status < 300) return "ok";
+      // …unchanged from here
+```
+
+and add the covering test to Task 4's table:
+
+```ts
+    ["200 with a login page", http(200, "<html><title>Sign in</title>Unauthorized</html>"), "auth-failure"],
+    ["200 with unparseable but benign body", http(200, "not json at all"), "ok"],
+```
+
+A thrown network error maps to `{ kind: "network" }`.
 
 **This must never throw.** Wrap the call in `try { … } catch { /* health is best-effort */ }` — a health-recording bug must not break a sync.
 
@@ -1530,6 +1631,11 @@ export async function checkAllCredentials(db: Database, deps: CheckDeps): Promis
   let cursor = 0;
   const worker = async (): Promise<void> => {
     while (cursor < queue.length) {
+      // ATOMIC CLAIM: read-and-increment happens synchronously, before the
+      // first await below. JS is single-threaded, so no two workers can claim
+      // the same index. If you refactor this, the increment must STAY ahead of
+      // every await — moving it after one introduces a duplicate-probe bug
+      // that only shows up under concurrency.
       const connectorId = queue[cursor++];
       if (connectorId === undefined) return;
       const cls = await probeConnector(deps, connectorId);
@@ -1554,9 +1660,52 @@ export async function checkAllCredentials(db: Database, deps: CheckDeps): Promis
 }
 ```
 
-Add a test asserting no more than `MAX_CONCURRENT_PROBES` probes are in flight
-at once (increment a counter on entry, decrement on exit, assert the observed
-maximum). Then add the CLI subcommand `nimbus creds check [connector]`.
+Add these tests — the first proves the cap holds, the second proves the atomic
+claim (no connector probed twice, none skipped):
+
+```ts
+// packages/gateway/src/credentials/credential-probe.test.ts — append
+test("never exceeds MAX_CONCURRENT_PROBES in flight", async () => {
+  const db = new Database(":memory:");
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  let active = 0;
+  let maxActive = 0;
+  const callListTool = async () => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((r) => setTimeout(r, 10));
+    active--;
+    return { kind: "ok" as const };
+  };
+  await checkAllCredentials(db, {
+    callListTool,
+    configuredConnectors: () => ["jira", "github", "linear", "notion", "zoom", "slack", "gitlab"],
+    now: () => 1,
+  });
+  expect(maxActive).toBeLessThanOrEqual(5);
+  expect(maxActive).toBeGreaterThan(1); // proves it is actually concurrent
+});
+
+test("probes every connector exactly once", async () => {
+  const db = new Database(":memory:");
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  const seen: string[] = [];
+  const callListTool = async (id: string) => {
+    seen.push(id);
+    await new Promise((r) => setTimeout(r, 1));
+    return { kind: "ok" as const };
+  };
+  const connectors = ["jira", "github", "linear", "notion", "zoom", "slack", "gitlab"];
+  await checkAllCredentials(db, { callListTool, configuredConnectors: () => connectors, now: () => 1 });
+  expect(seen.sort()).toEqual([...connectors].sort()); // none skipped, none doubled
+});
+```
+
+The `toBeGreaterThan(1)` assertion matters: without it the test would still
+pass if the worker pool collapsed to serial execution, which is a performance
+regression the cap alone cannot detect.
+
+Then add the CLI subcommand `nimbus creds check [connector]`.
 
 - [ ] **Step 6: Commit**
 

--- a/docs/superpowers/plans/2026-07-28-credential-health.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health.md
@@ -1,0 +1,1764 @@
+# Credential Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Nimbus notice that a connector credential is dead, dying, or unverifiable — instead of discovering it when something fails.
+
+**Architecture:** One SQLite table (`credential_health`, V45) written by three sources — a free by-product of every connector sync, a user-declared expiry date, and an explicitly-invoked active probe — and read by `nimbus creds` plus one line in `nimbus doctor`. All three writers share a single classifier so 97 connectors agree on what "authentication failed" means. The feature never writes a credential.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6.x strict, `bun:sqlite`, Biome, `bun test`.
+
+**Spec:** [`../specs/2026-07-28-credential-health-design.md`](../specs/2026-07-28-credential-health-design.md) · review applied in [`-review-response.md`](../specs/2026-07-28-credential-health-design-review-response.md)
+
+## Global Constraints
+
+- **No `any`.** Use `unknown` for external data. TypeScript strict is non-negotiable.
+- **All SQLite writes go through `dbRun` / `dbExec` / `dbStmtRun`** from `packages/gateway/src/db/write.ts`. Raw `db.run()` fails the static check D12 (invariant I14). Identifiers via `escapeIdentifier`; values always bound parameters.
+- **This feature never writes a credential.** No call to `vault.set` / `vault.delete` anywhere in it. Those are in the HITL frozen set (`packages/gateway/src/engine/executor.ts:107-108`, I2/I4).
+- **No secret value may reach the database, a log, or IPC.** `detail` is redacted via `redactAuditPayload` from `packages/gateway/src/audit/format-audit-payload.ts:68`, always as the **last** transformation before storage.
+- **Migrations are forward-only and append-only.** Never edit an existing step.
+- Cross-platform: build paths with `path.join()`, never hardcoded separators.
+- Every new source file gets a sibling `*.test.ts`, matching `packages/gateway/src/egress/`.
+- Run `bun run lint` and `bun run typecheck` before every commit.
+
+## File Structure
+
+**New subsystem — `packages/gateway/src/credentials/`** (flat files with sibling tests, mirroring `packages/gateway/src/egress/`):
+
+| File | Responsibility |
+| --- | --- |
+| `credential-keys.ts` | Split each connector's vault keys into *secret* vs *config*. Needed for failure attribution. |
+| `classify-auth-outcome.ts` | The single classifier: outcome → `auth-failure` \| `transient` \| `indeterminate` \| `ok`. |
+| `extract-error-detail.ts` | HTML/JSON body → short human string; then redact; then cap. |
+| `credential-health-store.ts` | All reads/writes of the `credential_health` table. |
+| `credential-status.ts` | Pure derivation of display status from a row + now. |
+| `credential-probe.ts` | Writer 3 — the generic active probe. |
+
+**Modified:**
+
+| File | Change |
+| --- | --- |
+| `packages/gateway/src/index/credential-health-v45-sql.ts` | **new** — the `CREATE TABLE` (mirrors `egress-ledger-v44-sql.ts`) |
+| `packages/gateway/src/index/migrations/runner.ts:407` | append `simpleStep(44, 45, …)` |
+| `packages/gateway/src/index/local-index.ts:265` | `CURRENT_SCHEMA_VERSION` 44 → 45 |
+| `packages/gateway/src/connectors/_lib/fetch-outcome.ts` | `http_error` gains `body: string` |
+| `packages/gateway/src/ipc/credentials-rpc.ts` | **new** — `credentials.*` read methods |
+| `packages/cli/src/commands/creds.ts` | **new** — the `nimbus creds` command |
+| `packages/cli/src/index.ts` | register `creds` handler |
+| `packages/cli/src/commands/registry.ts` | add `"creds"` to `COMMAND_NAMES` |
+
+**Milestone:** Tasks 1–9 ship a working feature on their own (passive observation + `nimbus creds`). Tasks 10–14 add declared expiry, the active probe, and polish.
+
+---
+
+### Task 1: Split secret keys from config keys
+
+`CONNECTOR_VAULT_SECRET_KEYS` mixes credentials and configuration — `jira: ["jira.api_token", "jira.email", "jira.base_url"]`. Only the first is a credential. Attribution (Task 6) must not mark `jira.base_url` dead.
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/credential-keys.ts`
+- Test: `packages/gateway/src/credentials/credential-keys.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CONNECTOR_VAULT_SECRET_KEYS` from `packages/gateway/src/connectors/connector-secrets-manifest.ts`
+- Produces: `isSecretKey(key: string): boolean`, `secretKeysFor(connectorId: string): string[]`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/credential-keys.test.ts
+import { describe, expect, test } from "bun:test";
+import { CONNECTOR_VAULT_SECRET_KEYS } from "../connectors/connector-secrets-manifest.ts";
+import { isSecretKey, secretKeysFor } from "./credential-keys.ts";
+
+describe("isSecretKey", () => {
+  test("credential suffixes are secrets", () => {
+    for (const k of [
+      "jira.api_token", "github.pat", "zoom.oauth", "linear.api_key",
+      "teams.bot_app_password", "wiz.client_secret", "slack.bot_token",
+    ]) {
+      expect(isSecretKey(k)).toBe(true);
+    }
+  });
+
+  test("configuration suffixes are not secrets", () => {
+    for (const k of [
+      "jira.email", "jira.base_url", "gitlab.api_base", "bitbucket.username",
+      "wiz.api_url", "gcp.project_id", "aws.default_region",
+    ]) {
+      expect(isSecretKey(k)).toBe(false);
+    }
+  });
+
+  test("secretKeysFor filters a connector's declared keys", () => {
+    expect(secretKeysFor("jira")).toEqual(["jira.api_token"]);
+  });
+
+  test("unknown connector yields no keys", () => {
+    expect(secretKeysFor("does-not-exist")).toEqual([]);
+  });
+
+  // Guard: every key in the manifest must be classified deliberately.
+  test("every manifest key matches a known secret or config suffix", () => {
+    const unclassified: string[] = [];
+    for (const keys of Object.values(CONNECTOR_VAULT_SECRET_KEYS)) {
+      for (const k of keys as string[]) {
+        const suffix = k.slice(k.indexOf(".") + 1);
+        if (!SECRET_SUFFIXES.has(suffix) && !CONFIG_SUFFIXES.has(suffix)) {
+          unclassified.push(k);
+        }
+      }
+    }
+    expect(unclassified).toEqual([]);
+  });
+});
+
+import { CONFIG_SUFFIXES, SECRET_SUFFIXES } from "./credential-keys.ts";
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/credentials/credential-keys.test.ts`
+Expected: FAIL — `Cannot find module './credential-keys.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// packages/gateway/src/credentials/credential-keys.ts
+import { CONNECTOR_VAULT_SECRET_KEYS } from "../connectors/connector-secrets-manifest.ts";
+
+/**
+ * Vault keys whose value is a credential. A failure to authenticate is
+ * attributable to these and never to configuration.
+ */
+export const SECRET_SUFFIXES: ReadonlySet<string> = new Set([
+  "api_key", "api_token", "token", "pat", "oauth", "secret", "client_secret",
+  "password", "bot_token", "app_token", "bot_app_password", "access_token",
+  "app_password", "private_key", "jwt_secret", "refresh_token", "signing_key",
+]);
+
+/** Vault keys that are configuration, not credentials. */
+export const CONFIG_SUFFIXES: ReadonlySet<string> = new Set([
+  "email", "base_url", "api_base", "api_url", "auth_url", "url", "host",
+  "port", "username", "user", "project_id", "default_region", "region",
+  "profile", "mailbox", "credentials_json_path", "bot_app_id", "client_id",
+  "publisher_id", "workspace", "org", "account", "instance", "tenant",
+]);
+
+function suffixOf(key: string): string {
+  const dot = key.indexOf(".");
+  return dot === -1 ? key : key.slice(dot + 1);
+}
+
+/** True when the vault key holds a credential rather than configuration. */
+export function isSecretKey(key: string): boolean {
+  return SECRET_SUFFIXES.has(suffixOf(key));
+}
+
+/** The credential (non-config) vault keys a connector declares. */
+export function secretKeysFor(connectorId: string): string[] {
+  const declared = (CONNECTOR_VAULT_SECRET_KEYS as Record<string, readonly string[] | undefined>)[
+    connectorId
+  ];
+  if (declared === undefined) return [];
+  return declared.filter(isSecretKey);
+}
+```
+
+- [ ] **Step 4: Run the test — expect the classification guard to fail**
+
+Run: `bun test packages/gateway/src/credentials/credential-keys.test.ts`
+
+The last test will list any manifest key matching neither set. **Add each to whichever set is correct** — a `*_id` that identifies rather than authenticates is config; anything that grants access is a secret. Re-run until it passes. Do not delete the guard: it is what forces a deliberate decision when a connector adds a key.
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/credentials/
+git commit -m "feat(credentials): classify vault keys as secret or config"
+```
+
+---
+
+### Task 2: Carry the error body on `FetchOutcome`
+
+The classifier must match provider bodies like `invalid_grant`, but `connectorFetch` currently discards the body on `http_error`, returning only `status` and `bytes`.
+
+**Files:**
+
+- Modify: `packages/gateway/src/connectors/_lib/fetch-outcome.ts`
+- Test: `packages/gateway/src/connectors/_lib/fetch-outcome.test.ts`
+
+**Interfaces:**
+
+- Produces: `FetchOutcome` with `{ kind: "http_error"; bytes: number; status: number; body: string }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to packages/gateway/src/connectors/_lib/fetch-outcome.test.ts
+test("http_error carries the response body for classification", async () => {
+  const ctx = makeTestSyncContext(); // existing helper in this file
+  const fetchFn = async () =>
+    new Response('{"error":"invalid_grant"}', { status: 400 });
+  const out = await connectorFetch(ctx, "github", "https://x.test", {}, fetchFn);
+  expect(out.kind).toBe("http_error");
+  if (out.kind !== "http_error") throw new Error("unreachable");
+  expect(out.status).toBe(400);
+  expect(out.body).toContain("invalid_grant");
+});
+
+test("http_error body is capped so a large HTML page cannot bloat memory", async () => {
+  const ctx = makeTestSyncContext();
+  const huge = `<html><body>${"x".repeat(50_000)}</body></html>`;
+  const fetchFn = async () => new Response(huge, { status: 502 });
+  const out = await connectorFetch(ctx, "github", "https://x.test", {}, fetchFn);
+  if (out.kind !== "http_error") throw new Error("unreachable");
+  expect(out.body.length).toBeLessThanOrEqual(4096);
+});
+```
+
+If `makeTestSyncContext` does not exist in that file, read the file's existing tests and reuse whatever context helper they use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/connectors/_lib/fetch-outcome.test.ts`
+Expected: FAIL — `body` is not a property of the outcome.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/connectors/_lib/fetch-outcome.ts
+/** Upper bound on the retained error body. Enough for any JSON error envelope
+ *  or an HTML <title>; small enough that a 50 MB proxy page cannot bloat us. */
+const MAX_ERROR_BODY = 4096;
+
+export type FetchOutcome =
+  | { kind: "ok"; parsed: unknown; bytes: number }
+  | { kind: "http_error"; bytes: number; status: number; body: string }
+  | { kind: "parse_error"; bytes: number };
+```
+
+and in `connectorFetch`, replace the `if (!res.ok)` return with:
+
+```ts
+  if (!res.ok) {
+    ctx.logger.warn({ serviceId, status: res.status, url }, "connector fetch failed");
+    return { kind: "http_error", bytes, status: res.status, body: text.slice(0, MAX_ERROR_BODY) };
+  }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test packages/gateway/src/connectors/_lib/fetch-outcome.test.ts`
+Expected: PASS
+
+Then run every consumer, because the type widened:
+Run: `bun run typecheck`
+Expected: exit 0. Widening a union member with a new required field only breaks *constructors* of that member — fix any other site that builds an `http_error` literal by adding `body`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run lint
+git add packages/gateway/src/connectors/_lib/
+git commit -m "feat(connectors): retain a capped error body on FetchOutcome"
+```
+
+---
+
+### Task 3: Extract a human-readable detail from an error body
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/extract-error-detail.ts`
+- Test: `packages/gateway/src/credentials/extract-error-detail.test.ts`
+
+**Interfaces:**
+
+- Consumes: `redactAuditPayload` from `packages/gateway/src/audit/format-audit-payload.ts`
+- Produces: `extractErrorDetail(body: string, status: number): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/extract-error-detail.test.ts
+import { describe, expect, test } from "bun:test";
+import { extractErrorDetail } from "./extract-error-detail.ts";
+
+describe("extractErrorDetail", () => {
+  test("keeps a JSON error envelope", () => {
+    const d = extractErrorDetail('{"error":"invalid_grant","error_description":"Token has been expired or revoked."}', 400);
+    expect(d).toContain("invalid_grant");
+  });
+
+  test("uses the <title> of an HTML error page", () => {
+    const html = "<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body><h1>nginx</h1></body></html>";
+    expect(extractErrorDetail(html, 502)).toContain("502 Bad Gateway");
+  });
+
+  test("falls back when HTML has no title", () => {
+    expect(extractErrorDetail("<html><body>   </body></html>", 403))
+      .toBe("HTML error page (HTTP 403)");
+  });
+
+  // ORDERING: extract -> strip -> redact -> cap. Redaction must run LAST, so a
+  // secret hidden in markup cannot be re-introduced by extraction.
+  test("a token hidden in an HTML comment never survives", () => {
+    const html = `<html><head><title>403 Forbidden</title></head>
+      <!-- token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -->
+      <body>denied</body></html>`;
+    const d = extractErrorDetail(html, 403);
+    expect(d).toContain("403 Forbidden");
+    expect(d).not.toContain("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+  });
+
+  test("output is capped at 256 bytes", () => {
+    expect(extractErrorDetail("z".repeat(5000), 500).length).toBeLessThanOrEqual(256);
+  });
+
+  test("empty body yields a status-only detail", () => {
+    expect(extractErrorDetail("", 404)).toBe("HTTP 404");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/credentials/extract-error-detail.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/credentials/extract-error-detail.ts
+import { redactAuditPayload } from "../audit/format-audit-payload.ts";
+
+const MAX_DETAIL_BYTES = 256;
+
+function looksLikeHtml(body: string): boolean {
+  const head = body.trimStart().slice(0, 15).toLowerCase();
+  return head.startsWith("<!doctype html") || head.startsWith("<html");
+}
+
+function fromHtml(body: string, status: number): string {
+  const title = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(body)?.[1]?.trim();
+  if (title !== undefined && title.length > 0) return title;
+  const text = body
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > 0 ? text : `HTML error page (HTTP ${status})`;
+}
+
+/**
+ * Turn a provider error body into a short, safe, human-readable detail.
+ *
+ * Order is load-bearing: extract -> strip -> redact -> cap. Redaction runs LAST
+ * so that extracting text out of markup cannot surface a secret that redaction
+ * had already neutralised.
+ */
+export function extractErrorDetail(body: string, status: number): string {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return `HTTP ${status}`;
+  const extracted = looksLikeHtml(trimmed) ? fromHtml(trimmed, status) : trimmed;
+  const redacted = redactAuditPayload(extracted, MAX_DETAIL_BYTES);
+  return redacted.slice(0, MAX_DETAIL_BYTES);
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test packages/gateway/src/credentials/extract-error-detail.test.ts`
+Expected: PASS.
+
+If the HTML-comment test fails, `redactAuditPayload` does not recognise that token shape. Do **not** weaken the test — instead strip comments before redaction (already done above) and confirm; if it still leaks, the redactor needs the pattern and that belongs in `format-audit-payload.ts` with its own test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/credentials/
+git commit -m "feat(credentials): extract a safe detail from provider error bodies"
+```
+
+---
+
+### Task 4: The classifier
+
+The single most important unit. Every writer routes through it so all connectors agree on what "authentication failed" means.
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/classify-auth-outcome.ts`
+- Test: `packages/gateway/src/credentials/classify-auth-outcome.test.ts`
+
+**Interfaces:**
+
+- Consumes: `FetchOutcome` (Task 2)
+- Produces: `type AuthClass = "auth-failure" | "transient" | "indeterminate" | "ok"`, `classifyAuthOutcome(outcome: ClassifiableOutcome): AuthClass`, `type ClassifiableOutcome`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/classify-auth-outcome.test.ts
+import { describe, expect, test } from "bun:test";
+import { type AuthClass, classifyAuthOutcome } from "./classify-auth-outcome.ts";
+
+const http = (status: number, body = "") => ({ kind: "http" as const, status, body });
+
+describe("classifyAuthOutcome", () => {
+  // Real bodies from the 2026-07-28 incident. Not invented fixtures.
+  const cases: Array<[string, ReturnType<typeof http> | { kind: "network" } | { kind: "timeout" } | { kind: "ok" }, AuthClass]> = [
+    ["google invalid_grant", http(400, '{"error":"invalid_grant","error_description":"Token has been expired or revoked."}'), "auth-failure"],
+    ["google invalid_client", http(401, '{"error":"invalid_client","error_description":"The provided client secret is invalid."}'), "auth-failure"],
+    ["amo unknown issuer", http(401, '{"detail":"Unknown JWT iss (issuer)."}'), "auth-failure"],
+    ["amo bad signature", http(401, '{"detail":"Error decoding signature."}'), "auth-failure"],
+    ["bare 403", http(403), "auth-failure"],
+    ["rate limited", http(429), "transient"],
+    ["bad gateway", http(502), "transient"],
+    ["network error", { kind: "network" }, "transient"],
+    ["timeout", { kind: "timeout" }, "transient"],
+    ["request timeout status", http(408), "transient"],
+    // These four are the regression tests for a false green in the first draft.
+    ["schema change", http(400, '{"message":"unknown field \\'limit\\'"}'), "indeterminate"],
+    ["not found", http(404), "indeterminate"],
+    ["conflict", http(409), "indeterminate"],
+    ["unprocessable", http(422), "indeterminate"],
+    ["success", { kind: "ok" }, "ok"],
+  ];
+
+  for (const [name, outcome, expected] of cases) {
+    test(`${name} -> ${expected}`, () => {
+      expect(classifyAuthOutcome(outcome)).toBe(expected);
+    });
+  }
+
+  test("a 400 without a known auth marker is NEVER ok", () => {
+    // The first draft of the spec classified this 'ok', which would have
+    // reported a structurally broken probe as a healthy credential.
+    expect(classifyAuthOutcome(http(400, "totally unrelated"))).not.toBe("ok");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/credentials/classify-auth-outcome.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/credentials/classify-auth-outcome.ts
+
+/** How an attempt to use a credential turned out. */
+export type AuthClass = "auth-failure" | "transient" | "indeterminate" | "ok";
+
+/** Transport-agnostic view of an attempt, so sync and probe share one classifier. */
+export type ClassifiableOutcome =
+  | { kind: "ok" }
+  | { kind: "network" }
+  | { kind: "timeout" }
+  | { kind: "http"; status: number; body: string };
+
+/**
+ * Provider bodies that mean "your credential was rejected" even when the status
+ * code alone would not say so (Google answers invalid_grant with HTTP 400).
+ */
+const AUTH_REJECTION_MARKERS: readonly string[] = [
+  "invalid_grant",
+  "invalid_client",
+  "invalid_token",
+  "unknown jwt iss",
+  "error decoding signature",
+  "expired or revoked",
+  "unauthorized",
+  "authentication failed",
+];
+
+function bodyIndicatesAuthRejection(body: string): boolean {
+  const hay = body.toLowerCase();
+  return AUTH_REJECTION_MARKERS.some((m) => hay.includes(m));
+}
+
+/**
+ * Classify one attempt.
+ *
+ * `ok` means HTTP 2xx — never "anything left over". An earlier design defined
+ * it as "anything that returned data", which classified a 400 from a changed
+ * request schema as a healthy credential: a false green.
+ */
+export function classifyAuthOutcome(outcome: ClassifiableOutcome): AuthClass {
+  switch (outcome.kind) {
+    case "ok":
+      return "ok";
+    case "network":
+    case "timeout":
+      return "transient";
+    case "http": {
+      const { status, body } = outcome;
+      if (status >= 200 && status < 300) return "ok";
+      if (status === 401 || status === 403) return "auth-failure";
+      if (status === 408 || status === 429 || status >= 500) return "transient";
+      if (bodyIndicatesAuthRejection(body)) return "auth-failure";
+      return "indeterminate";
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test packages/gateway/src/credentials/classify-auth-outcome.test.ts`
+Expected: PASS — 16 tests.
+
+- [ ] **Step 5: Red-prove the four load-bearing guards**
+
+This repo's convention is that a guard which has never failed is a guard nobody has verified. One at a time:
+
+1. Change `if (status === 408 || status === 429 || status >= 500) return "transient";` to `return "auth-failure";`. Run the tests. The `rate limited`, `bad gateway` and `request timeout status` cases **must** fail. Revert.
+2. Change the final `return "indeterminate";` to `return "ok";`. Run the tests. The four indeterminate cases **and** the explicit "never ok" test **must** fail. Revert.
+
+Run after each: `bun test packages/gateway/src/credentials/classify-auth-outcome.test.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/credentials/
+git commit -m "feat(credentials): single auth-outcome classifier shared by all connectors"
+```
+
+---
+
+### Task 5: The V45 migration
+
+**Files:**
+
+- Create: `packages/gateway/src/index/credential-health-v45-sql.ts`
+- Modify: `packages/gateway/src/index/migrations/runner.ts` (import + one `simpleStep`)
+- Modify: `packages/gateway/src/index/local-index.ts:265` (44 → 45)
+- Test: `packages/gateway/src/index/migrations/runner-v45.test.ts`
+
+**Interfaces:**
+
+- Produces: table `credential_health`; `CURRENT_SCHEMA_VERSION === 45`
+
+- [ ] **Step 1: Write the failing test**
+
+Read `packages/gateway/src/index/migrations/runner-v44.test.ts` first and mirror its structure exactly — it is the closest precedent (a new table at the head of the chain).
+
+```ts
+// packages/gateway/src/index/migrations/runner-v45.test.ts
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { CURRENT_SCHEMA_VERSION } from "../local-index.ts";
+
+// Use whatever helper runner-v44.test.ts uses to build a migrated DB.
+import { migrateToCurrent } from "./runner.ts"; // adjust to the real export name
+
+describe("v45 — credential_health", () => {
+  test("CURRENT_SCHEMA_VERSION is 45", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(45);
+  });
+
+  test("the table exists with the expected columns", () => {
+    const db = new Database(":memory:");
+    migrateToCurrent(db);
+    const cols = db
+      .query("PRAGMA table_info(credential_health)")
+      .all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "connector_id", "detail", "expires_at", "expiry_source",
+      "last_checked_at", "last_ok_at", "observed_status", "observed_via", "vault_key",
+    ]);
+  });
+
+  test("vault_key is the primary key", () => {
+    const db = new Database(":memory:");
+    migrateToCurrent(db);
+    db.run("INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES ('a.token','a','ok','sync')");
+    expect(() =>
+      db.run("INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES ('a.token','a','dead','sync')"),
+    ).toThrow();
+  });
+
+  test("connector_id is indexed for the roll-up read", () => {
+    const db = new Database(":memory:");
+    migrateToCurrent(db);
+    const idx = db.query("PRAGMA index_list(credential_health)").all() as Array<{ name: string }>;
+    expect(idx.some((i) => i.name.includes("connector"))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/index/migrations/runner-v45.test.ts`
+Expected: FAIL — `CURRENT_SCHEMA_VERSION` is 44 and the table does not exist.
+
+- [ ] **Step 3: Write the SQL**
+
+```ts
+// packages/gateway/src/index/credential-health-v45-sql.ts
+/**
+ * V45 — credential_health.
+ *
+ * One row per vault key that holds a credential. Stores health metadata only:
+ * the key NAME, never its value. `detail` is redacted before insert.
+ */
+export const CREDENTIAL_HEALTH_V45_SQL = `
+CREATE TABLE IF NOT EXISTS credential_health (
+  vault_key       TEXT PRIMARY KEY,
+  connector_id    TEXT NOT NULL,
+  observed_status TEXT NOT NULL CHECK (observed_status IN ('ok','dead','unknown')),
+  observed_via    TEXT NOT NULL CHECK (observed_via IN ('sync','probe')),
+  last_checked_at INTEGER,
+  last_ok_at      INTEGER,
+  detail          TEXT,
+  expires_at      INTEGER,
+  expiry_source   TEXT CHECK (expiry_source IN ('provider','declared'))
+);
+CREATE INDEX IF NOT EXISTS idx_credential_health_connector
+  ON credential_health (connector_id);
+`;
+```
+
+- [ ] **Step 4: Register the step and bump the version**
+
+In `packages/gateway/src/index/migrations/runner.ts`, add next to the other imports:
+
+```ts
+import { CREDENTIAL_HEALTH_V45_SQL } from "../credential-health-v45-sql.ts";
+```
+
+and append **after** the existing V44 line (never edit it):
+
+```ts
+  simpleStep(44, 45, "credential_health (credential liveness v45)", CREDENTIAL_HEALTH_V45_SQL),
+```
+
+In `packages/gateway/src/index/local-index.ts:265`:
+
+```ts
+export const CURRENT_SCHEMA_VERSION = 45;
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+bun test packages/gateway/src/index/migrations/
+```
+
+Expected: PASS, including the pre-existing v44 and runner tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/index/
+git commit -m "feat(db): V45 credential_health table"
+```
+
+---
+
+### Task 6: The store
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/credential-health-store.ts`
+- Test: `packages/gateway/src/credentials/credential-health-store.test.ts`
+
+**Interfaces:**
+
+- Consumes: `dbRun` from `packages/gateway/src/db/write.ts`; `secretKeysFor` (Task 1)
+- Produces:
+  - `type CredentialHealthRow = { vaultKey: string; connectorId: string; observedStatus: "ok" | "dead" | "unknown"; observedVia: "sync" | "probe"; lastCheckedAt: number | null; lastOkAt: number | null; detail: string | null; expiresAt: number | null; expirySource: "provider" | "declared" | null }`
+  - `recordObservation(db, o: { connectorId: string; vaultKeys: string[]; status: "ok" | "dead" | "unknown"; via: "sync" | "probe"; now: number; detail?: string; expiresAt?: number }): void`
+  - `recordTransient(db, connectorId: string, vaultKeys: string[], now: number): void`
+  - `setDeclaredExpiry(db, vaultKey: string, connectorId: string, expiresAt: number): void`
+  - `listHealth(db): CredentialHealthRow[]`
+  - `deleteHealthForConnector(db, connectorId: string): void`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/credential-health-store.test.ts
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { CREDENTIAL_HEALTH_V45_SQL } from "../index/credential-health-v45-sql.ts";
+import {
+  deleteHealthForConnector, listHealth, recordObservation,
+  recordTransient, setDeclaredExpiry,
+} from "./credential-health-store.ts";
+
+let db: Database;
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+});
+
+describe("credential health store", () => {
+  test("records a successful observation", () => {
+    recordObservation(db, {
+      connectorId: "zoom", vaultKeys: ["zoom.oauth"], status: "ok", via: "sync", now: 1000,
+    });
+    const [row] = listHealth(db);
+    expect(row.vaultKey).toBe("zoom.oauth");
+    expect(row.observedStatus).toBe("ok");
+    expect(row.lastOkAt).toBe(1000);
+  });
+
+  test("a failure marks every supplied key and shares one detail", () => {
+    recordObservation(db, {
+      connectorId: "jira", vaultKeys: ["jira.api_token", "jira.other_secret"],
+      status: "dead", via: "sync", now: 2000, detail: "HTTP 401",
+    });
+    const rows = listHealth(db).sort((a, b) => a.vaultKey.localeCompare(b.vaultKey));
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.observedStatus === "dead")).toBe(true);
+    expect(rows.every((r) => r.detail === "HTTP 401")).toBe(true);
+  });
+
+  test("last_ok_at survives a later failure", () => {
+    recordObservation(db, { connectorId: "z", vaultKeys: ["z.token"], status: "ok", via: "sync", now: 100 });
+    recordObservation(db, { connectorId: "z", vaultKeys: ["z.token"], status: "dead", via: "sync", now: 200, detail: "nope" });
+    const [row] = listHealth(db);
+    expect(row.observedStatus).toBe("dead");
+    expect(row.lastOkAt).toBe(100); // preserved — "dead since" needs it
+    expect(row.lastCheckedAt).toBe(200);
+  });
+
+  test("a transient failure moves last_checked_at but NOT status", () => {
+    recordObservation(db, { connectorId: "z", vaultKeys: ["z.token"], status: "ok", via: "sync", now: 100 });
+    recordTransient(db, "z", ["z.token"], 300);
+    const [row] = listHealth(db);
+    expect(row.observedStatus).toBe("ok"); // a network blip is not death
+    expect(row.lastCheckedAt).toBe(300);
+  });
+
+  test("declared expiry can be set before any observation exists", () => {
+    setDeclaredExpiry(db, "github.pat", "github", 999);
+    const [row] = listHealth(db);
+    expect(row.expiresAt).toBe(999);
+    expect(row.expirySource).toBe("declared");
+    expect(row.observedStatus).toBe("unknown");
+  });
+
+  test("declared expiry survives a later observation", () => {
+    setDeclaredExpiry(db, "github.pat", "github", 999);
+    recordObservation(db, { connectorId: "github", vaultKeys: ["github.pat"], status: "ok", via: "sync", now: 100 });
+    const [row] = listHealth(db);
+    expect(row.expiresAt).toBe(999);
+    expect(row.expirySource).toBe("declared");
+  });
+
+  test("removing a connector removes its health rows", () => {
+    recordObservation(db, { connectorId: "a", vaultKeys: ["a.token"], status: "ok", via: "sync", now: 1 });
+    recordObservation(db, { connectorId: "b", vaultKeys: ["b.token"], status: "ok", via: "sync", now: 1 });
+    deleteHealthForConnector(db, "a");
+    expect(listHealth(db).map((r) => r.connectorId)).toEqual(["b"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/credentials/credential-health-store.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/credentials/credential-health-store.ts
+import type { Database } from "bun:sqlite";
+import { dbRun } from "../db/write.ts";
+
+export type ObservedStatus = "ok" | "dead" | "unknown";
+export type ObservedVia = "sync" | "probe";
+
+export interface CredentialHealthRow {
+  vaultKey: string;
+  connectorId: string;
+  observedStatus: ObservedStatus;
+  observedVia: ObservedVia;
+  lastCheckedAt: number | null;
+  lastOkAt: number | null;
+  detail: string | null;
+  expiresAt: number | null;
+  expirySource: "provider" | "declared" | null;
+}
+
+interface DbRow {
+  vault_key: string;
+  connector_id: string;
+  observed_status: ObservedStatus;
+  observed_via: ObservedVia;
+  last_checked_at: number | null;
+  last_ok_at: number | null;
+  detail: string | null;
+  expires_at: number | null;
+  expiry_source: "provider" | "declared" | null;
+}
+
+export interface Observation {
+  connectorId: string;
+  vaultKeys: string[];
+  status: ObservedStatus;
+  via: ObservedVia;
+  now: number;
+  detail?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Upsert one observation across every supplied key.
+ *
+ * `last_ok_at` is only advanced on success and is never cleared, so a later
+ * failure can still render "dead since <when>". A provider-supplied expiry
+ * never overwrites a user-declared one.
+ */
+export function recordObservation(db: Database, o: Observation): void {
+  for (const key of o.vaultKeys) {
+    dbRun(
+      db,
+      `INSERT INTO credential_health
+         (vault_key, connector_id, observed_status, observed_via,
+          last_checked_at, last_ok_at, detail, expires_at, expiry_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(vault_key) DO UPDATE SET
+         connector_id    = excluded.connector_id,
+         observed_status = excluded.observed_status,
+         observed_via    = excluded.observed_via,
+         last_checked_at = excluded.last_checked_at,
+         last_ok_at      = COALESCE(excluded.last_ok_at, credential_health.last_ok_at),
+         detail          = excluded.detail,
+         expires_at      = CASE WHEN credential_health.expiry_source = 'declared'
+                                THEN credential_health.expires_at
+                                ELSE COALESCE(excluded.expires_at, credential_health.expires_at) END,
+         expiry_source   = CASE WHEN credential_health.expiry_source = 'declared'
+                                THEN 'declared'
+                                ELSE COALESCE(excluded.expiry_source, credential_health.expiry_source) END`,
+      [
+        key,
+        o.connectorId,
+        o.status,
+        o.via,
+        o.now,
+        o.status === "ok" ? o.now : null,
+        o.detail ?? null,
+        o.expiresAt ?? null,
+        o.expiresAt === undefined ? null : "provider",
+      ],
+    );
+  }
+}
+
+/** A transient failure proves nothing about the credential: touch only the clock. */
+export function recordTransient(
+  db: Database,
+  connectorId: string,
+  vaultKeys: string[],
+  now: number,
+): void {
+  for (const key of vaultKeys) {
+    dbRun(
+      db,
+      `INSERT INTO credential_health
+         (vault_key, connector_id, observed_status, observed_via, last_checked_at)
+       VALUES (?, ?, 'unknown', 'sync', ?)
+       ON CONFLICT(vault_key) DO UPDATE SET last_checked_at = excluded.last_checked_at`,
+      [key, connectorId, now],
+    );
+  }
+}
+
+/** Record a deadline the user knows about. Pure metadata; touches no secret. */
+export function setDeclaredExpiry(
+  db: Database,
+  vaultKey: string,
+  connectorId: string,
+  expiresAt: number,
+): void {
+  dbRun(
+    db,
+    `INSERT INTO credential_health
+       (vault_key, connector_id, observed_status, observed_via, expires_at, expiry_source)
+     VALUES (?, ?, 'unknown', 'sync', ?, 'declared')
+     ON CONFLICT(vault_key) DO UPDATE SET
+       expires_at = excluded.expires_at,
+       expiry_source = 'declared'`,
+    [vaultKey, connectorId, expiresAt],
+  );
+}
+
+export function listHealth(db: Database): CredentialHealthRow[] {
+  const rows = db
+    .query(
+      `SELECT vault_key, connector_id, observed_status, observed_via,
+              last_checked_at, last_ok_at, detail, expires_at, expiry_source
+         FROM credential_health
+        ORDER BY connector_id, vault_key`,
+    )
+    .all() as DbRow[];
+  return rows.map((r) => ({
+    vaultKey: r.vault_key,
+    connectorId: r.connector_id,
+    observedStatus: r.observed_status,
+    observedVia: r.observed_via,
+    lastCheckedAt: r.last_checked_at,
+    lastOkAt: r.last_ok_at,
+    detail: r.detail,
+    expiresAt: r.expires_at,
+    expirySource: r.expiry_source,
+  }));
+}
+
+/** Called from connector removal so no orphaned rows survive. */
+export function deleteHealthForConnector(db: Database, connectorId: string): void {
+  dbRun(db, "DELETE FROM credential_health WHERE connector_id = ?", [connectorId]);
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test packages/gateway/src/credentials/credential-health-store.test.ts`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/credentials/
+git commit -m "feat(credentials): credential_health store"
+```
+
+---
+
+### Task 7: Status derivation
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/credential-status.ts`
+- Test: `packages/gateway/src/credentials/credential-status.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CredentialHealthRow` (Task 6)
+- Produces: `type DisplayStatus = "OK" | "DEAD" | "EXPIRED" | "EXPIRING" | "UNKNOWN"`, `deriveStatus(row, now, opts?: { warnBeforeExpiryMs?: number; staleAfterMs?: number }): { status: DisplayStatus; note: string }`, `DEFAULT_WARN_BEFORE_EXPIRY_MS`, `DEFAULT_STALE_AFTER_MS`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/credential-status.test.ts
+import { describe, expect, test } from "bun:test";
+import type { CredentialHealthRow } from "./credential-health-store.ts";
+import { deriveStatus } from "./credential-status.ts";
+
+const DAY = 86_400_000;
+const NOW = 1_000 * DAY;
+
+const row = (o: Partial<CredentialHealthRow> = {}): CredentialHealthRow => ({
+  vaultKey: "x.token", connectorId: "x", observedStatus: "ok", observedVia: "sync",
+  lastCheckedAt: NOW, lastOkAt: NOW, detail: null, expiresAt: null, expirySource: null, ...o,
+});
+
+describe("deriveStatus", () => {
+  test("fresh success is OK", () => {
+    expect(deriveStatus(row(), NOW).status).toBe("OK");
+  });
+
+  test("dead is DEAD and reports since when", () => {
+    const r = deriveStatus(row({ observedStatus: "dead", lastOkAt: NOW - 3 * DAY }), NOW);
+    expect(r.status).toBe("DEAD");
+    expect(r.note).toContain("3");
+  });
+
+  test("never observed is UNKNOWN", () => {
+    expect(deriveStatus(row({ observedStatus: "unknown", lastCheckedAt: null, lastOkAt: null }), NOW).status)
+      .toBe("UNKNOWN");
+  });
+
+  test("a stale ok degrades to UNKNOWN — absence of evidence is not evidence", () => {
+    const r = deriveStatus(row({ lastCheckedAt: NOW - 12 * DAY, lastOkAt: NOW - 12 * DAY }), NOW);
+    expect(r.status).toBe("UNKNOWN");
+    expect(r.note).toContain("stale");
+  });
+
+  test("expiry inside the warn window is EXPIRING", () => {
+    const r = deriveStatus(row({ expiresAt: NOW + 6 * DAY, expirySource: "declared" }), NOW);
+    expect(r.status).toBe("EXPIRING");
+    expect(r.note).toContain("6");
+  });
+
+  test("expiry in the past is EXPIRED", () => {
+    expect(deriveStatus(row({ expiresAt: NOW - DAY, lastOkAt: NOW - 5 * DAY }), NOW).status)
+      .toBe("EXPIRED");
+  });
+
+  // Salesforce synthesises a 30-minute expiry because the API omits expires_in.
+  // A working credential must not be reported EXPIRED because metadata lied.
+  test("a more recent success beats a stale expires_at", () => {
+    const r = deriveStatus(row({ expiresAt: NOW - DAY, lastOkAt: NOW - 60_000 }), NOW);
+    expect(r.status).toBe("OK");
+  });
+
+  test("dead outranks expiring", () => {
+    expect(deriveStatus(row({ observedStatus: "dead", expiresAt: NOW + DAY }), NOW).status)
+      .toBe("DEAD");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/credentials/credential-status.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/credentials/credential-status.ts
+import type { CredentialHealthRow } from "./credential-health-store.ts";
+
+const DAY_MS = 86_400_000;
+
+/** Console-trip credentials need more than a week's notice to be actionable. */
+export const DEFAULT_WARN_BEFORE_EXPIRY_MS = 30 * DAY_MS;
+/** Longer than this without an observation and there is no current evidence. */
+export const DEFAULT_STALE_AFTER_MS = 7 * DAY_MS;
+
+export type DisplayStatus = "OK" | "DEAD" | "EXPIRED" | "EXPIRING" | "UNKNOWN";
+
+export interface DerivedStatus {
+  status: DisplayStatus;
+  note: string;
+}
+
+const days = (ms: number): number => Math.max(0, Math.round(ms / DAY_MS));
+
+/**
+ * Derive display status fresh on every read. Nothing here is stored: "expiring
+ * in 6 days" is a function of now, and persisting it would go stale the moment
+ * nothing runs — the failure this feature exists to prevent.
+ */
+export function deriveStatus(
+  row: CredentialHealthRow,
+  now: number,
+  opts: { warnBeforeExpiryMs?: number; staleAfterMs?: number } = {},
+): DerivedStatus {
+  const warnMs = opts.warnBeforeExpiryMs ?? DEFAULT_WARN_BEFORE_EXPIRY_MS;
+  const staleMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+
+  if (row.observedStatus === "dead") {
+    const note =
+      row.lastOkAt === null
+        ? (row.detail ?? "never worked")
+        : `dead — last worked ${days(now - row.lastOkAt)}d ago`;
+    return { status: "DEAD", note };
+  }
+
+  if (row.expiresAt !== null) {
+    // Observation beats metadata: providers synthesise expiries that are wrong.
+    const observedAfterExpiry = row.lastOkAt !== null && row.lastOkAt > row.expiresAt;
+    if (!observedAfterExpiry) {
+      if (row.expiresAt <= now) return { status: "EXPIRED", note: "expired" };
+      if (row.expiresAt - now <= warnMs) {
+        return { status: "EXPIRING", note: `expires in ${days(row.expiresAt - now)}d` };
+      }
+    }
+  }
+
+  if (row.lastCheckedAt === null) return { status: "UNKNOWN", note: "not checked yet" };
+
+  if (now - row.lastCheckedAt > staleMs) {
+    return { status: "UNKNOWN", note: `stale — last checked ${days(now - row.lastCheckedAt)}d ago` };
+  }
+
+  if (row.observedStatus === "ok") return { status: "OK", note: "" };
+  return { status: "UNKNOWN", note: row.detail ?? "unverified" };
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test packages/gateway/src/credentials/credential-status.test.ts`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 5: Red-prove the staleness guard**
+
+Delete the `now - row.lastCheckedAt > staleMs` block. Run the tests — the "stale ok degrades" test **must** fail. Restore it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/credentials/
+git commit -m "feat(credentials): derive display status from a health row"
+```
+
+---
+
+### Task 8: Writer 1 — record health from every sync
+
+**Files:**
+
+- Modify: the connector sync driver that calls each connector's `sync()` and handles its errors. Find it with:
+  `rg -n "itemsUpserted" packages/gateway/src/sync --glob '!*.test.ts'`
+  The driver is the file that consumes `SyncResult` (`packages/gateway/src/sync/types.ts:50`) in a `try`/`catch`.
+- Test: a sibling `*.test.ts` of that driver.
+
+**Interfaces:**
+
+- Consumes: `classifyAuthOutcome`, `extractErrorDetail`, `recordObservation`, `recordTransient`, `secretKeysFor`
+- Produces: no new exports — a side effect on every sync
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// in the sync driver's sibling test file
+import { CREDENTIAL_HEALTH_V45_SQL } from "../index/credential-health-v45-sql.ts";
+import { listHealth } from "../credentials/credential-health-store.ts";
+
+test("a successful sync records ok for the connector's secret keys", async () => {
+  const db = makeTestDb(); // reuse the driver test's existing DB helper
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  await runSyncForTest(db, "jira", { ok: true });
+  const rows = listHealth(db);
+  expect(rows.map((r) => r.vaultKey)).toEqual(["jira.api_token"]); // NOT .email / .base_url
+  expect(rows[0].observedStatus).toBe("ok");
+});
+
+test("a 401 marks the connector's secret keys dead, config keys untouched", async () => {
+  const db = makeTestDb();
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  await runSyncForTest(db, "jira", { httpStatus: 401, body: "" });
+  const rows = listHealth(db);
+  expect(rows.every((r) => r.observedStatus === "dead")).toBe(true);
+  expect(rows.map((r) => r.vaultKey)).not.toContain("jira.base_url");
+});
+
+test("a 502 does NOT mark the credential dead", async () => {
+  const db = makeTestDb();
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  await runSyncForTest(db, "jira", { ok: true });
+  await runSyncForTest(db, "jira", { httpStatus: 502, body: "" });
+  expect(listHealth(db)[0].observedStatus).toBe("ok");
+});
+```
+
+Adapt `makeTestDb` / `runSyncForTest` to whatever the driver's existing tests use. Do not invent a parallel harness.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test <the driver's test file>`
+Expected: FAIL — no rows recorded.
+
+- [ ] **Step 3: Implement**
+
+In the sync driver, after a sync attempt resolves or throws:
+
+```ts
+import { classifyAuthOutcome, type ClassifiableOutcome } from "../credentials/classify-auth-outcome.ts";
+import { extractErrorDetail } from "../credentials/extract-error-detail.ts";
+import { recordObservation, recordTransient } from "../credentials/credential-health-store.ts";
+import { secretKeysFor } from "../credentials/credential-keys.ts";
+
+function recordCredentialHealth(
+  db: Database,
+  connectorId: string,
+  outcome: ClassifiableOutcome,
+  now: number,
+): void {
+  const keys = secretKeysFor(connectorId);
+  if (keys.length === 0) return; // nothing to attribute (e.g. cloud-cred reuse)
+
+  const cls = classifyAuthOutcome(outcome);
+  if (cls === "transient") {
+    recordTransient(db, connectorId, keys, now);
+    return;
+  }
+  if (cls === "ok") {
+    recordObservation(db, { connectorId, vaultKeys: keys, status: "ok", via: "sync", now });
+    return;
+  }
+  const detail =
+    outcome.kind === "http" ? extractErrorDetail(outcome.body, outcome.status) : "unavailable";
+  recordObservation(db, {
+    connectorId,
+    vaultKeys: keys,
+    status: cls === "auth-failure" ? "dead" : "unknown",
+    via: "sync",
+    now,
+    detail,
+  });
+}
+```
+
+Call it in both the success and failure paths. Map a thrown network error to `{ kind: "network" }` and a `FetchOutcome` of `http_error` to `{ kind: "http", status, body }`.
+
+**This must never throw.** Wrap the call in `try { … } catch { /* health is best-effort */ }` — a health-recording bug must not break a sync.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test <the driver's test file>`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/
+git commit -m "feat(credentials): record credential health from every sync"
+```
+
+---
+
+### Task 9: IPC + `nimbus creds` + the doctor line
+
+Ships the milestone: passive observation is now visible.
+
+**Files:**
+
+- Create: `packages/gateway/src/ipc/credentials-rpc.ts` (+ test)
+- Create: `packages/cli/src/commands/creds.ts` (+ test)
+- Modify: `packages/cli/src/index.ts` — add `creds: runCreds` to `COMMAND_HANDLERS`
+- Modify: `packages/cli/src/commands/registry.ts` — add `"creds"` to `COMMAND_NAMES`
+- Modify: `packages/cli/src/commands/doctor-core.ts` — one summary line
+
+**Interfaces:**
+
+- Consumes: `listHealth`, `deriveStatus`
+- Produces: IPC `credentials.list` → `{ credentials: Array<{ vaultKey; connectorId; status; note; detail }> }`; CLI `runCreds(argv: string[]): Promise<void>`
+
+- [ ] **Step 1: Write the failing IPC test**
+
+Read an existing small RPC module first — `packages/gateway/src/ipc/audit-rpc.ts` — and mirror its registration shape and `dispatchByMethod` usage.
+
+```ts
+// packages/gateway/src/ipc/credentials-rpc.test.ts
+test("credentials.list returns derived statuses, never a secret value", async () => {
+  const db = new Database(":memory:");
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  recordObservation(db, {
+    connectorId: "zoom", vaultKeys: ["zoom.oauth"], status: "dead",
+    via: "sync", now: Date.now(), detail: "HTTP 401",
+  });
+  const res = await handleCredentialsRpc({ method: "credentials.list", params: {} }, { db, now: Date.now() });
+  expect(res.credentials[0].status).toBe("DEAD");
+  expect(JSON.stringify(res)).not.toContain("secret");
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL (module not found)**
+
+Run: `bun test packages/gateway/src/ipc/credentials-rpc.test.ts`
+
+- [ ] **Step 3: Implement the RPC module**
+
+Follow `audit-rpc.ts` exactly: one exported handler using `dispatchByMethod` from `packages/gateway/src/ipc/_lib/dispatch-by-method.ts`, mapping `credentials.list` to `listHealth(db).map(r => ({ ...deriveStatus(r, now), vaultKey: r.vaultKey, connectorId: r.connectorId, detail: r.detail }))`. Register it wherever the other `*-rpc` modules are registered (grep for `auditRpc` to find the site).
+
+**Do not add these methods to the Tauri `ALLOWED_METHODS`** in this task — see Task 14.
+
+- [ ] **Step 4: Write the failing CLI test, then the command**
+
+```ts
+// packages/cli/src/commands/creds.test.ts
+test("prints a line per credential with its status", async () => {
+  const out = await runCredsWithFakeClient([
+    { vaultKey: "zoom.oauth", connectorId: "zoom", status: "DEAD", note: "dead — last worked 2d ago", detail: "HTTP 401" },
+    { vaultKey: "github.pat", connectorId: "github", status: "OK", note: "", detail: null },
+  ]);
+  expect(out).toContain("zoom.oauth");
+  expect(out).toContain("DEAD");
+  expect(out).toContain("1 need attention");
+});
+
+test("--json emits machine-readable output", async () => {
+  const out = await runCredsWithFakeClient([...], ["--json"]);
+  expect(() => JSON.parse(out)).not.toThrow();
+});
+```
+
+Model `creds.ts` on `packages/cli/src/commands/security.ts` — same `--json` convention, same table style. Inject the client rather than using `mock.module` (this repo has had Linux-only CI failures from `mock.module` contamination).
+
+- [ ] **Step 5: Add `nimbus creds fix <connector>`**
+
+The spec's fix path. It builds nothing new — it makes the *existing* remedy
+discoverable at the moment the user learns they need it, and deliberately
+delegates so the credential write still passes through the HITL gate.
+
+```ts
+// packages/cli/src/commands/creds.test.ts
+test("fix delegates to connector auth rather than writing a credential", async () => {
+  const calls: string[] = [];
+  await runCredsFix("zoom", { runConnectorAuth: async (id) => { calls.push(id); } });
+  expect(calls).toEqual(["zoom"]);
+});
+
+test("fix on an unknown connector errors instead of silently doing nothing", async () => {
+  await expect(runCredsFix("nope", { runConnectorAuth: async () => {} }))
+    .rejects.toThrow(/unknown connector/i);
+});
+```
+
+```ts
+// packages/cli/src/commands/creds.ts
+export interface CredsFixDeps {
+  runConnectorAuth: (connectorId: string) => Promise<void>;
+}
+
+/**
+ * Re-authenticate a connector. This does NOT write a credential itself — it
+ * invokes the existing `nimbus connector auth` flow, whose vault.set passes
+ * through the HITL gate (I2). Keeping the delegation explicit is what stops
+ * this feature from ever acquiring credential-write capability.
+ */
+export async function runCredsFix(connectorId: string, deps: CredsFixDeps): Promise<void> {
+  if (secretKeysFor(connectorId).length === 0) {
+    throw new Error(`unknown connector or no credentials to fix: ${connectorId}`);
+  }
+  await deps.runConnectorAuth(connectorId);
+}
+```
+
+Render the hint in the `nimbus creds` output for every `DEAD`/`EXPIRED` row:
+`-> nimbus creds fix <connectorId>`.
+
+- [ ] **Step 6: Add the doctor line**
+
+In `doctor-core.ts`, add one check that calls `credentials.list` and reports `N need attention` (count of `DEAD`/`EXPIRED`/`EXPIRING`), with its own test.
+
+- [ ] **Step 7: Register the command**
+
+```ts
+// packages/cli/src/index.ts — inside COMMAND_HANDLERS
+  creds: runCreds,
+```
+
+```ts
+// packages/cli/src/commands/registry.ts — inside COMMAND_NAMES, alphabetical
+  "creds",
+```
+
+- [ ] **Step 8: Run the gates**
+
+```bash
+bun test packages/gateway/src/ipc/credentials-rpc.test.ts packages/cli/src/commands/creds.test.ts
+bun run audit:readme-cli    # COMMAND_NAMES must stay in sync with the docs
+bun run lint && bun run typecheck
+```
+
+`audit:readme-cli` will fail until `nimbus creds` is documented — add a `### \`nimbus creds\`` section to `docs/cli-reference.md` covering `creds`,`creds fix <connector>`, and (after Tasks 10–11)`creds expires` and `creds check`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/gateway/src/ipc/ packages/cli/src/ docs/cli-reference.md
+git commit -m "feat(credentials): credentials.list IPC, nimbus creds, doctor line"
+```
+
+**Milestone reached.** `nimbus creds` now reports real health gathered passively. Tasks 10–14 extend it.
+
+---
+
+### Task 10: Writer 2 — `nimbus creds expires`
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/credentials-rpc.ts` (+ test) — add `credentials.setExpiry`
+- Modify: `packages/cli/src/commands/creds.ts` (+ test) — add the `expires` subcommand
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("credentials.setExpiry stores a declared expiry", async () => {
+  const db = new Database(":memory:");
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  await handleCredentialsRpc(
+    { method: "credentials.setExpiry", params: { vaultKey: "github.pat", connectorId: "github", expiresAt: "2026-09-20" } },
+    { db, now: Date.now() },
+  );
+  const [row] = listHealth(db);
+  expect(row.expirySource).toBe("declared");
+});
+
+test("an unparseable date is rejected, not silently stored", async () => {
+  await expect(handleCredentialsRpc(
+    { method: "credentials.setExpiry", params: { vaultKey: "a.token", connectorId: "a", expiresAt: "not-a-date" } },
+    { db, now: Date.now() },
+  )).rejects.toThrow(/date/i);
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `bun test packages/gateway/src/ipc/credentials-rpc.test.ts`
+
+- [ ] **Step 3: Implement** — parse `YYYY-MM-DD` with `Date.parse`, reject `NaN`, then call `setDeclaredExpiry`. Wire the CLI subcommand `nimbus creds expires <vault_key> <YYYY-MM-DD>`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `bun test packages/gateway/src/ipc/credentials-rpc.test.ts packages/cli/src/commands/creds.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/ipc/ packages/cli/src/
+git commit -m "feat(credentials): declared expiry for opaque tokens"
+```
+
+---
+
+### Task 11: Writer 3 — the active probe
+
+**Files:**
+
+- Create: `packages/gateway/src/credentials/credential-probe.ts` (+ test)
+- Modify: `packages/gateway/src/ipc/credentials-rpc.ts` — add `credentials.check`
+- Modify: `packages/cli/src/commands/creds.ts` — add the `check` subcommand
+
+**Interfaces:**
+
+- Produces: `probeConnector(deps, connectorId, opts?: { timeoutMs?: number }): Promise<AuthClass>`, `DEFAULT_PROBE_TIMEOUT_MS = 10_000`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/credentials/credential-probe.test.ts
+test("a hung host times out and yields unknown, never dead", async () => {
+  const never = () => new Promise<never>(() => {});
+  const cls = await probeConnector({ callListTool: never }, "jenkins", { timeoutMs: 20 });
+  expect(cls).toBe("transient"); // -> unknown, NOT dead
+});
+
+test("a 401 from the list tool yields auth-failure", async () => {
+  const cls = await probeConnector(
+    { callListTool: async () => ({ kind: "http" as const, status: 401, body: "" }) },
+    "jira",
+  );
+  expect(cls).toBe("auth-failure");
+});
+
+test("a connector whose server will not spawn yields transient, not dead", async () => {
+  const cls = await probeConnector(
+    { callListTool: async () => { throw new Error("spawn ENOENT"); } },
+    "argocd",
+  );
+  expect(cls).toBe("transient");
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `bun test packages/gateway/src/credentials/credential-probe.test.ts`
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/credentials/credential-probe.ts
+import { type AuthClass, type ClassifiableOutcome, classifyAuthOutcome } from "./classify-auth-outcome.ts";
+
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+export interface ProbeDeps {
+  /** Calls `<connectorId>_list` with the smallest possible limit. */
+  callListTool: (connectorId: string) => Promise<ClassifiableOutcome>;
+}
+
+/**
+ * Exercise one connector's credential via its mandatory `list` tool.
+ *
+ * A timeout is transient, never dead: a host that did not answer has told us
+ * nothing about the credential. Self-hosted instances (Jenkins, ArgoCD, GitLab)
+ * routinely hang rather than refuse.
+ */
+export async function probeConnector(
+  deps: ProbeDeps,
+  connectorId: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<AuthClass> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const outcome = await Promise.race<ClassifiableOutcome>([
+      deps.callListTool(connectorId),
+      new Promise<ClassifiableOutcome>((resolve) => {
+        timer = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+      }),
+    ]);
+    return classifyAuthOutcome(outcome);
+  } catch {
+    return "transient"; // could not ask != the answer was no
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `bun test packages/gateway/src/credentials/credential-probe.test.ts`
+
+- [ ] **Step 5: Wire `credentials.check`**
+
+```ts
+// packages/gateway/src/credentials/credential-probe.ts — append
+const MAX_CONCURRENT_PROBES = 5;
+
+export interface CheckDeps extends ProbeDeps {
+  configuredConnectors: () => string[];
+  now: () => number;
+}
+
+/**
+ * Probe every configured connector. Explicitly invoked only — never on a timer
+ * and never during sync, because this makes real API calls against up to 97
+ * live services.
+ */
+export async function checkAllCredentials(db: Database, deps: CheckDeps): Promise<void> {
+  const queue = deps.configuredConnectors().filter((c) => secretKeysFor(c).length > 0);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < queue.length) {
+      const connectorId = queue[cursor++];
+      if (connectorId === undefined) return;
+      const cls = await probeConnector(deps, connectorId);
+      const keys = secretKeysFor(connectorId);
+      const now = deps.now();
+      if (cls === "transient") {
+        recordTransient(db, connectorId, keys, now);
+      } else {
+        recordObservation(db, {
+          connectorId,
+          vaultKeys: keys,
+          status: cls === "auth-failure" ? "dead" : cls === "ok" ? "ok" : "unknown",
+          via: "probe",
+          now,
+        });
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(MAX_CONCURRENT_PROBES, queue.length) }, worker),
+  );
+}
+```
+
+Add a test asserting no more than `MAX_CONCURRENT_PROBES` probes are in flight
+at once (increment a counter on entry, decrement on exit, assert the observed
+maximum). Then add the CLI subcommand `nimbus creds check [connector]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run lint && bun run typecheck
+git add packages/gateway/src/ packages/cli/src/
+git commit -m "feat(credentials): generic active probe over the mandatory list tool"
+```
+
+---
+
+### Task 12: Clean up health rows on connector removal
+
+**Files:**
+
+- Modify: the `connector.remove` handler — find it with `rg -n "connector.remove" packages/gateway/src/ipc --glob '!*.test.ts'`
+- Test: its sibling test
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("removing a connector leaves no orphaned credential_health rows", async () => {
+  // arrange: a connector with health rows, then remove it
+  expect(listHealth(db).filter((r) => r.connectorId === "zoom")).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL (rows survive)**
+
+- [ ] **Step 3: Implement** — call `deleteHealthForConnector(db, connectorId)` inside the same transaction that deletes the connector's vault entries and index rows.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/
+git commit -m "fix(credentials): drop health rows when a connector is removed"
+```
+
+---
+
+### Task 13: Config keys in `nimbus.toml`
+
+**Files:**
+
+- Modify: `packages/gateway/src/config/nimbus-toml.ts` (+ test) — add optional `[credentials]` with `warn_before_expiry_days` (default 30) and `stale_after_days` (default 7)
+
+**Interfaces:**
+
+- Produces: `CredentialsConfig = { warnBeforeExpiryDays: number; staleAfterDays: number }` on the parsed config object
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/gateway/src/config/nimbus-toml.test.ts — append
+test("[credentials] defaults apply when the section is absent", () => {
+  const cfg = parseNimbusToml("");            // use this file's existing parse entry point
+  expect(cfg.credentials.warnBeforeExpiryDays).toBe(30);
+  expect(cfg.credentials.staleAfterDays).toBe(7);
+});
+
+test("[credentials] values override the defaults", () => {
+  const cfg = parseNimbusToml(`
+[credentials]
+warn_before_expiry_days = 14
+stale_after_days = 3
+`);
+  expect(cfg.credentials.warnBeforeExpiryDays).toBe(14);
+  expect(cfg.credentials.staleAfterDays).toBe(3);
+});
+
+test("a non-numeric value is rejected rather than coerced", () => {
+  expect(() => parseNimbusToml(`
+[credentials]
+warn_before_expiry_days = "soon"
+`)).toThrow(/warn_before_expiry_days/);
+});
+```
+
+Read the existing tests in that file first and reuse their parse entry point —
+do not introduce a second parser.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/config/nimbus-toml.test.ts`
+Expected: FAIL — `cfg.credentials` is undefined.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/gateway/src/config/nimbus-toml.ts
+export interface CredentialsConfig {
+  /** Days of notice before a known expiry. Console-trip credentials need >1 week. */
+  warnBeforeExpiryDays: number;
+  /** Days without an observation after which health is treated as absent, not ok. */
+  staleAfterDays: number;
+}
+
+const DEFAULT_CREDENTIALS_CONFIG: CredentialsConfig = {
+  warnBeforeExpiryDays: 30,
+  staleAfterDays: 7,
+};
+
+function parseCredentialsSection(raw: unknown): CredentialsConfig {
+  if (raw === undefined || raw === null) return { ...DEFAULT_CREDENTIALS_CONFIG };
+  const section = raw as Record<string, unknown>;
+  const num = (key: string, fallback: number): number => {
+    const v = section[key];
+    if (v === undefined) return fallback;
+    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) {
+      throw new Error(`[credentials] ${key} must be a positive number`);
+    }
+    return v;
+  };
+  return {
+    warnBeforeExpiryDays: num("warn_before_expiry_days", DEFAULT_CREDENTIALS_CONFIG.warnBeforeExpiryDays),
+    staleAfterDays: num("stale_after_days", DEFAULT_CREDENTIALS_CONFIG.staleAfterDays),
+  };
+}
+```
+
+Add `credentials: CredentialsConfig` to the exported config interface and
+`credentials: parseCredentialsSection(parsed.credentials)` where the other
+sections are assembled.
+
+- [ ] **Step 4: Run tests, then thread the values through**
+
+Run: `bun test packages/gateway/src/config/nimbus-toml.test.ts`
+Expected: PASS
+
+In `credentials-rpc.ts`, convert days to milliseconds and pass them to
+`deriveStatus`:
+
+```ts
+const DAY_MS = 86_400_000;
+deriveStatus(row, now, {
+  warnBeforeExpiryMs: cfg.credentials.warnBeforeExpiryDays * DAY_MS,
+  staleAfterMs: cfg.credentials.staleAfterDays * DAY_MS,
+});
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/config/ packages/gateway/src/ipc/
+git commit -m "feat(credentials): configurable warn and stale thresholds"
+```
+
+---
+
+### Task 14: Prompt for expiry at auth time, and expose to the desktop UI
+
+Sequenced last on purpose: the feature is complete without it, and it must never block the core.
+
+**Files:**
+
+- Modify: `packages/cli/src/commands/connector.ts` — after an opaque credential is stored
+- Modify: `packages/ui/src-tauri/src/gateway_bridge.rs` — add the read-only methods to `ALLOWED_METHODS`
+
+- [ ] **Step 1: Write the failing CLI test**
+
+```ts
+test("prompts for expiry after storing an opaque credential", async () => { /* … */ });
+
+test("does NOT prompt when stdin is not a TTY", async () => {
+  // connector auth is scripted in CI; an unconditional prompt would hang it.
+});
+
+test("does NOT prompt when --json is passed", async () => { /* … */ });
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+- [ ] **Step 3: Implement** — prompt only when `process.stdin.isTTY === true` and `--json` is absent; an empty answer skips and leaves `expires_at` NULL.
+- [ ] **Step 4: Add `"credentials.list"` and `"credentials.check"` to `ALLOWED_METHODS`**
+
+Read the `nimbus-tauri-allowlist` skill first. Both are read-only and safe to expose. **Bump the `assert_eq!(ALLOWED_METHODS.len(), N)` count** at `gateway_bridge.rs:518` — it is currently 101, so it becomes 103. Do **not** expose `credentials.setExpiry` (a write).
+
+- [ ] **Step 5: Run the gates**
+
+```bash
+bun test packages/cli/src/commands/connector.test.ts
+cd packages/ui/src-tauri && cargo test allowlist && cd ../../..
+bun run preflight:fast
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/ packages/ui/src-tauri/
+git commit -m "feat(credentials): capture expiry at auth time; expose reads to the renderer"
+```
+
+---
+
+## Final verification
+
+- [ ] `bun run preflight:fast` — all 21 gates green
+- [ ] `bun test packages/gateway/src/credentials/` — every unit passes
+- [ ] `bun run audit:invariants` — D10–D22 static checks pass
+- [ ] Confirm no `vault.set` / `vault.delete` appears anywhere under `packages/gateway/src/credentials/`:
+      `rg -n "vault\.(set|delete)" packages/gateway/src/credentials/` → **must return nothing**
+- [ ] Confirm no secret can reach the table: `bun test packages/gateway/src/credentials/extract-error-detail.test.ts`
+- [ ] Update `docs/CHANGELOG.md` with a dated entry
+- [ ] Update `CLAUDE.md` **and** `GEMINI.md`: schema `V44` → `V45` (they are mirrors — edit both)

--- a/docs/superpowers/plans/2026-07-28-credential-health.md
+++ b/docs/superpowers/plans/2026-07-28-credential-health.md
@@ -20,6 +20,12 @@
 - Cross-platform: build paths with `path.join()`, never hardcoded separators.
 - Every new source file gets a sibling `*.test.ts`, matching `packages/gateway/src/egress/`.
 - Run `bun run lint` and `bun run typecheck` before every commit.
+- **Work on a `dev/<you>/<topic>` branch — never `main` or `develop`.** Verify with
+  `git rev-parse --abbrev-ref HEAD` before the first commit.
+- **Run `bun run preflight:fast` before pushing**, and the full `bun run preflight`
+  when logic or tests changed. `test:ci` is NOT the full gate set. The per-task
+  commit steps below show `lint`/`typecheck` only because those are the fast
+  inner loop; they do not replace preflight before a PR.
 
 ## File Structure
 
@@ -622,6 +628,7 @@ Read `packages/gateway/src/index/migrations/runner-v44.test.ts` first and mirror
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { CURRENT_SCHEMA_VERSION } from "../local-index.ts";
+import { dbRun } from "../../db/write.ts";
 
 // Use whatever helper runner-v44.test.ts uses to build a migrated DB.
 import { migrateToCurrent } from "./runner.ts"; // adjust to the real export name
@@ -640,16 +647,21 @@ describe("v45 — credential_health", () => {
     const names = cols.map((c) => c.name).sort();
     expect(names).toEqual([
       "connector_id", "detail", "expires_at", "expiry_source",
-      "last_checked_at", "last_ok_at", "observed_status", "observed_via", "vault_key",
+      "last_attempt_at", "last_checked_at", "last_ok_at",
+      "observed_status", "observed_via", "vault_key",
     ]);
   });
 
   test("vault_key is the primary key", () => {
     const db = new Database(":memory:");
     migrateToCurrent(db);
-    db.run("INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES ('a.token','a','ok','sync')");
+    // dbRun, not raw db.run() — the D12 static check forbids raw writes, and
+    // this plan's own Global Constraints say so. Tests are not exempt.
+    dbRun(db, "INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES (?,?,?,?)",
+      ["a.token", "a", "ok", "sync"]);
     expect(() =>
-      db.run("INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES ('a.token','a','dead','sync')"),
+      dbRun(db, "INSERT INTO credential_health (vault_key, connector_id, observed_status, observed_via) VALUES (?,?,?,?)",
+        ["a.token", "a", "dead", "sync"]),
     ).toThrow();
   });
 
@@ -684,6 +696,7 @@ CREATE TABLE IF NOT EXISTS credential_health (
   observed_status TEXT NOT NULL CHECK (observed_status IN ('ok','dead','unknown')),
   observed_via    TEXT NOT NULL CHECK (observed_via IN ('sync','probe')),
   last_checked_at INTEGER,
+  last_attempt_at INTEGER,
   last_ok_at      INTEGER,
   detail          TEXT,
   expires_at      INTEGER,
@@ -894,14 +907,16 @@ export function recordObservation(db: Database, o: Observation): void {
       db,
       `INSERT INTO credential_health
          (vault_key, connector_id, observed_status, observed_via,
-          last_checked_at, last_ok_at, detail, expires_at, expiry_source)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          last_checked_at, last_attempt_at, last_ok_at, detail, expires_at, expiry_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(vault_key) DO UPDATE SET
          connector_id    = excluded.connector_id,
          observed_status = excluded.observed_status,
          observed_via    = excluded.observed_via,
          last_checked_at = excluded.last_checked_at,
-         last_ok_at      = COALESCE(excluded.last_ok_at, credential_health.last_ok_at),
+         last_attempt_at = excluded.last_attempt_at,
+         last_ok_at      = MAX(COALESCE(excluded.last_ok_at, 0),
+                               COALESCE(credential_health.last_ok_at, 0)),
          detail          = excluded.detail,
          expires_at      = CASE WHEN credential_health.expiry_source = 'declared'
                                 THEN credential_health.expires_at
@@ -915,6 +930,7 @@ export function recordObservation(db: Database, o: Observation): void {
         o.status,
         o.via,
         o.now,
+        o.now,
         o.status === "ok" ? o.now : null,
         o.detail ?? null,
         o.expiresAt ?? null,
@@ -924,21 +940,29 @@ export function recordObservation(db: Database, o: Observation): void {
   }
 }
 
-/** A transient failure proves nothing about the credential: touch only the clock. */
+/**
+ * A transient failure proves nothing about the credential.
+ *
+ * It therefore advances `last_attempt_at` and NOT `last_checked_at`. Advancing
+ * the latter would make a credential that has been unreachable for weeks keep
+ * reporting a fresh OK, because the reader's staleness degradation keys off
+ * `last_checked_at`. Separate columns are what keep that guard armed.
+ */
 export function recordTransient(
   db: Database,
   connectorId: string,
   vaultKeys: string[],
   now: number,
+  via: ObservedVia,
 ): void {
   for (const key of vaultKeys) {
     dbRun(
       db,
       `INSERT INTO credential_health
-         (vault_key, connector_id, observed_status, observed_via, last_checked_at)
-       VALUES (?, ?, 'unknown', 'sync', ?)
-       ON CONFLICT(vault_key) DO UPDATE SET last_checked_at = excluded.last_checked_at`,
-      [key, connectorId, now],
+         (vault_key, connector_id, observed_status, observed_via, last_attempt_at)
+       VALUES (?, ?, 'unknown', ?, ?)
+       ON CONFLICT(vault_key) DO UPDATE SET last_attempt_at = excluded.last_attempt_at`,
+      [key, connectorId, via, now],
     );
   }
 }
@@ -1245,7 +1269,7 @@ function recordCredentialHealth(
 
   const cls = classifyAuthOutcome(outcome);
   if (cls === "transient") {
-    recordTransient(db, connectorId, keys, now);
+    recordTransient(db, connectorId, keys, now, "sync");
     return;
   }
   if (cls === "ok") {
@@ -1504,7 +1528,28 @@ test("an unparseable date is rejected, not silently stored", async () => {
 
 Run: `bun test packages/gateway/src/ipc/credentials-rpc.test.ts`
 
-- [ ] **Step 3: Implement** — parse `YYYY-MM-DD` with `Date.parse`, reject `NaN`, then call `setDeclaredExpiry`. Wire the CLI subcommand `nimbus creds expires <vault_key> <YYYY-MM-DD>`.
+- [ ] **Step 3: Implement**
+
+Validate BOTH the date and the key before writing:
+
+```ts
+// in the credentials.setExpiry handler
+const allowed = secretKeysFor(connectorId);
+if (!allowed.includes(vaultKey)) {
+  // Without this a caller can create health rows for configuration keys
+  // (jira.base_url) or invent connector/key pairs that never existed.
+  throw new Error(`${vaultKey} is not a credential of ${connectorId}`);
+}
+const ms = Date.parse(expiresAt);
+if (Number.isNaN(ms)) throw new Error(`unparseable date: ${expiresAt}`);
+setDeclaredExpiry(db, vaultKey, connectorId, ms);
+```
+
+Note `Date.parse` accepts some surprising inputs (`"2026-02-30"` rolls over to
+March 2). Add a test asserting a strict `^\d{4}-\d{2}-\d{2}$` shape check runs
+BEFORE `Date.parse`, and reject anything else.
+
+Wire the CLI subcommand `nimbus creds expires <vault_key> <YYYY-MM-DD>`.
 
 - [ ] **Step 4: Run tests, verify pass**
 
@@ -1614,6 +1659,12 @@ Run: `bun test packages/gateway/src/credentials/credential-probe.test.ts`
 
 ```ts
 // packages/gateway/src/credentials/credential-probe.ts — append
+// These imports are required by checkAllCredentials and are NOT in the
+// classifier-only import block at the top of this file — add them.
+import type { Database } from "bun:sqlite";
+import { recordObservation, recordTransient } from "./credential-health-store.ts";
+import { secretKeysFor } from "./credential-keys.ts";
+
 const MAX_CONCURRENT_PROBES = 5;
 
 export interface CheckDeps extends ProbeDeps {
@@ -1642,7 +1693,7 @@ export async function checkAllCredentials(db: Database, deps: CheckDeps): Promis
       const keys = secretKeysFor(connectorId);
       const now = deps.now();
       if (cls === "transient") {
-        recordTransient(db, connectorId, keys, now);
+        recordTransient(db, connectorId, keys, now, "probe");
       } else {
         recordObservation(db, {
           connectorId,
@@ -1728,10 +1779,20 @@ git commit -m "feat(credentials): generic active probe over the mandatory list t
 
 ```ts
 test("removing a connector leaves no orphaned credential_health rows", async () => {
-  // arrange: a connector with health rows, then remove it
-  expect(listHealth(db).filter((r) => r.connectorId === "zoom")).toHaveLength(0);
+  const db = makeTestDb();
+  db.exec(CREDENTIAL_HEALTH_V45_SQL);
+  recordObservation(db, { connectorId: "zoom", vaultKeys: ["zoom.oauth"], status: "ok", via: "sync", now: 1 });
+  recordObservation(db, { connectorId: "jira", vaultKeys: ["jira.api_token"], status: "ok", via: "sync", now: 1 });
+  expect(listHealth(db)).toHaveLength(2);          // PRE-CONDITION: rows exist
+
+  await removeConnector(db, "zoom");                // the path under test
+
+  expect(listHealth(db).map((r) => r.connectorId)).toEqual(["jira"]);
 });
 ```
+
+The pre-condition assertion is the point: without it the test passes on an empty
+database even when cleanup is entirely absent, so it would never have gone red.
 
 - [ ] **Step 2: Run it — expect FAIL (rows survive)**
 
@@ -1906,8 +1967,12 @@ git commit -m "feat(credentials): capture expiry at auth time; expose reads to t
 - [ ] `bun run preflight:fast` — all 21 gates green
 - [ ] `bun test packages/gateway/src/credentials/` — every unit passes
 - [ ] `bun run audit:invariants` — D10–D22 static checks pass
-- [ ] Confirm no `vault.set` / `vault.delete` appears anywhere under `packages/gateway/src/credentials/`:
-      `rg -n "vault\.(set|delete)" packages/gateway/src/credentials/` → **must return nothing**
+- [ ] Confirm no `vault.set` / `vault.delete` was added by this feature. Scoping
+      the search to `credentials/` alone would miss a call added in the sync
+      driver, the RPC module or the CLI — check every file the feature touched:
+      `git diff --name-only origin/main...HEAD | xargs rg -n "vault\.(set|delete)"`
+      → **must return nothing** (the existing `connector auth` path is untouched
+      by this feature and should not appear in the diff at all)
 - [ ] Confirm no secret can reach the table: `bun test packages/gateway/src/credentials/extract-error-detail.test.ts`
 - [ ] Update `docs/CHANGELOG.md` with a dated entry
 - [ ] Update `CLAUDE.md` **and** `GEMINI.md`: schema `V44` → `V45` (they are mirrors — edit both)

--- a/docs/superpowers/specs/2026-07-28-credential-health-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-28-credential-health-design-review-response.md
@@ -1,0 +1,154 @@
+# Design Review Response: Credential Health
+
+Response to [`2026-07-28-credential-health-design-review.md`](./2026-07-28-credential-health-design-review.md).
+
+**All six points accepted and applied.** Three were accepted with an additional
+constraint the review did not raise; one exposed a false-green defect in the
+original classifier. Applying the review surfaced a seventh issue, recorded
+below. Nothing was deferred.
+
+---
+
+## 1.1 — HTTP 400 / 404 classification · **FIXED**
+
+**The review was right, and this was the most serious finding in the set.**
+
+The original classifier ended with `ok : anything else that returned data`. A
+`400 Bad Request` from a changed request schema returns data, is not 401/403,
+and is not transient — so it would have been classified **`ok`**. A connector
+whose probe was structurally broken would have reported a healthy credential.
+
+That is a false green: the exact defect this design exists to prevent, written
+into the design itself. The irony is worth recording rather than quietly fixing.
+
+Applied:
+
+```text
+auth-failure  : 401 | 403 | known auth-rejection bodies
+transient     : network | timeout | 408 | 429 | 5xx
+indeterminate : any other non-2xx (400, 404, 409, 422, …)
+ok            : HTTP 2xx
+```
+
+`ok` now means **2xx**, not "everything left over". `indeterminate` writes
+`unknown` with the redacted detail — never `ok`, never `dead`. A 404 on a
+renamed endpoint says nothing about the credential; asserting either answer
+would be a lie in a different direction.
+
+Both cases are added to the classifier test table and **red-proved**. They are
+the regression test for a defect caught before implementation.
+
+## 1.2 — Attributing a failure to a specific `vault_key` · **FIXED**
+
+Real gap: the design keyed health by `vault_key` but never said how a bare 401
+maps to one of a connector's nine credentials.
+
+The review offered "all three, or only the primary token". Applied a two-rule
+version, which differs slightly from both:
+
+1. **Attribute precisely when the failure identifies the credential** — an OAuth
+   refresh rejection belongs to that connector's `*.oauth` key alone.
+2. **Otherwise mark the credential *set*** — every *secret* key the connector
+   declares, excluding non-secret config (hosts, regions, usernames), sharing
+   one `detail`.
+
+Rule 2 is deliberately blunt, and the reasoning matters: **a 401 proves the set
+failed to authenticate; it does not prove which member is at fault.** Guessing a
+"primary" key would manufacture a precise-looking claim the evidence cannot
+support, and guessing wrong is the worse failure — the real culprit would keep
+reading `ok`. Excluding config keys matters too: a wrong `jira.host` should not
+mark `jira.api_token` dead.
+
+Readers group by connector, so a nine-key connector renders one line.
+
+## 1.3 — Staleness threshold undefined · **FIXED**
+
+Correct — the spec referenced a staleness threshold it never defined. Both
+thresholds are now explicit and configurable under `[credentials]`:
+
+| Threshold | Default |
+| --- | --- |
+| `warn_before_expiry` | 30 days |
+| `stale_after` | 7 days |
+
+The review suggested 7 days, which is adopted. Worth stating why the two differ
+rather than sharing one value: they measure different things. One asks "how long
+until this dies?", the other "how long since anyone checked?". Seven days
+without observation means there is no current evidence; thirty days of warning
+is what a console-trip credential needs to be actionable.
+
+## 2.1 — HTML error body sanitisation · **FIXED, plus an ordering constraint**
+
+Accepted, and it is not an edge case here: the self-hosted connectors
+(GitLab, Jenkins, ArgoCD, Grafana, Jira) are exactly the ones sitting behind
+proxies that answer with HTML.
+
+Applied: when the body is HTML — by `Content-Type` or a leading `<` — extract
+the `<title>` text, else the first text node, falling back to
+`"HTML error page (HTTP <status>)"`.
+
+**Added beyond the review:** the pipeline order is now specified as
+**extract → strip → redact → cap**, with redaction explicitly last. The review
+proposed stripping before capping but did not address where redaction sits, and
+the order is load-bearing — redacting *first* and extracting *after* could lift
+a secret out of an HTML attribute or comment the redactor had already
+neutralised, re-introducing it into the stored string. A test asserts this: a
+proxy page whose title is `502 Bad Gateway` and whose body hides a token-shaped
+string in a comment must store the title and not the token.
+
+## 2.2 — Prompt for expiry during `connector auth` · **FIXED, with constraints**
+
+Accepted, and it is more than convenience: relying on the user to remember a
+second command reproduces precisely the human-memory failure this design
+criticises. The moment of entry is the only moment the expiry is known.
+
+Applied as a skippable prompt after an opaque credential is stored.
+
+**Added beyond the review:** the prompt is suppressed entirely when stdin is not
+a TTY or `--json` is passed. `nimbus connector auth` is scripted in CI, and an
+unconditional prompt would hang non-interactive callers — turning a health
+feature into an outage. Skipping leaves `expires_at` NULL, which reads as
+`UNKNOWN`, never as `ok`.
+
+Sequencing note: this touches a different subsystem's UX and the feature is
+complete without it, so it is sequenced **last** in implementation. It must
+never block the core.
+
+## 2.3 — Active probe timeouts · **FIXED**
+
+Accepted. Applied as a hard per-probe deadline, default **10 s**, configurable.
+
+**Added beyond the review:** the classification of a timeout is specified — it
+is `transient`, therefore `unknown`, **never `dead`**. A host that did not
+answer has told us nothing about the credential. Without this the timeout
+safeguard would have introduced the very false-positive the classifier exists to
+prevent. A timeout row is added to the classifier test table.
+
+---
+
+## Found while applying the review · **FIXED**
+
+**Orphaned health rows on connector removal.** `nimbus connector remove` deletes
+a connector's Vault entries and index rows atomically. Nothing in the original
+design removed its `credential_health` rows, so a removed connector would keep
+reporting health for credentials that no longer exist — stale state that looks
+authoritative. Health rows are now deleted in the same transaction, with a test.
+
+---
+
+## Summary
+
+| Point | Verdict | Note |
+| --- | --- | --- |
+| 1.1 400/404 classification | **Fixed** | Was a false green in the spec itself |
+| 1.2 Multi-key attribution | **Fixed** | Mark the set, never guess a primary |
+| 1.3 Staleness threshold | **Fixed** | 7 days, distinct from the 30-day warn window |
+| 2.1 HTML sanitisation | **Fixed** | + redaction ordering constraint |
+| 2.2 Prompt at auth time | **Fixed** | + TTY/`--json` suppression; sequenced last |
+| 2.3 Probe timeout | **Fixed** | + timeout classifies as transient, not dead |
+| Orphaned rows | **Fixed** | Found while applying the review |
+
+Four of the seven changes are guards against **false greens** — a broken probe
+reading `ok`, a timeout reading `dead`, a stale row reading current, a removed
+connector still reporting. That is the correct centre of gravity for this
+design, and the review moved it there.

--- a/docs/superpowers/specs/2026-07-28-credential-health-design-review.md
+++ b/docs/superpowers/specs/2026-07-28-credential-health-design-review.md
@@ -1,0 +1,64 @@
+# Design Review: Credential Health
+
+This document contains a design review of the [credential-health-design.md](./2026-07-28-credential-health-design.md) specification, detailing open questions, suggestions, and potential improvements.
+
+**Response:** [`2026-07-28-credential-health-design-review-response.md`](./2026-07-28-credential-health-design-review-response.md) — all six points accepted and applied.
+
+---
+
+## 1. Open Questions
+
+### 1.1. Classification of Non-Auth API Errors (e.g., HTTP 400 / 404)
+
+The proposed classifier logic is:
+
+```text
+auth-failure : HTTP 401 | 403, or a provider body matching the known
+               auth-rejection set (invalid_grant, invalid_client, ...)
+transient    : network error | HTTP 408 | 429 | 5xx
+ok           : anything else that returned data
+```
+
+* **The Question**: How are HTTP 400 (Bad Request) or HTTP 404 (Not Found) errors handled if they do *not* contain one of the specific strings in the `auth-rejection` set?
+* **Impact**: If a connector's active probe (`<name>_list` at `limit=1`) fails with a 400 due to a schema validation change or a missing optional parameter, it doesn't return successful data, nor is it a transient network error, nor is it a 401/403. Under the current rules, would it fall into `unknown` or be incorrectly classified as `ok` because it is "anything else"?
+* **Suggestion**: Define an explicit fallback category for client/api errors that are neither auth failures nor transient network errors (e.g., mapping them to `unknown` or a specific API configuration error state).
+
+### 1.2. Mapping Auth Failures to Specific `vault_key` Rows
+
+For connectors that consume multiple vault keys (e.g., a Client ID, Client Secret, and a Token):
+
+* **The Question**: If a sync or active probe fails with a 401/403, how does the writer determine which specific `vault_key` is `dead`?
+* **Impact**: If a connector uses 3 credentials, does a single auth failure mark all 3 credentials as `dead`, or only the primary token?
+* **Suggestion**: Clarify the mapping strategy. If a connector invocation fails, all Vault keys configured and used for that sync attempt should probably transition to `dead` (or at least share the status), unless the classifier can distinguish a client-secret failure from a token expiry failure.
+
+### 1.3. Definition of the Staleness Threshold for `last_checked_at`
+
+The status reader transitions status to `UNKNOWN (stale)` if `last_checked_at older than stale`.
+
+* **The Question**: What is the default staleness threshold (e.g., 7 days, 14 days)? Is it configurable via `nimbus.toml`?
+* **Suggestion**: Define a sensible default (e.g., 7 days) and specify if it can be configured alongside the 30-day warning window.
+
+---
+
+## 2. Improvements & Suggestions
+
+### 2.1. HTML Error Body Sanitization for `detail`
+
+Providers behind enterprise SSO, API gateways (like Cloudflare), or misconfigured reverse proxies often return large HTML pages (e.g., 502 Bad Gateway or 403 Forbidden pages) instead of JSON.
+
+* **The Risk**: Capping `detail` at 256 bytes on a raw HTML response will store useless snippets like `<!DOCTYPE html><html><head><title>...`.
+* **Improvement**: If the response `Content-Type` is HTML or starts with `<html`, extract the text content of the `<title>` tag or `<body>` header, or strip HTML tags before capping at 256 bytes.
+
+### 2.2. Interactive Prompting for Declared Expiry
+
+Since opaque tokens require manual expiration tracking via `nimbus creds expires <vault_key> <ISO-date>`:
+
+* **Improvement**: Integrate this metadata entry into the `nimbus connector auth` interactive CLI flow. After a user configures an opaque token, prompt them:
+  > *"Does this credential have a known expiration date? [YYYY-MM-DD / Enter to skip]:"*
+  This captures the metadata at creation time rather than relying on the user remembering to run the command separately later.
+
+### 2.3. Active Probe Timeout Safeguards
+
+Some connectors talk to slow or poorly responsive self-hosted instances (e.g., an on-premise Jira or Gitlab instance).
+
+* **Improvement**: Active probes must execute with a strict, short timeout (e.g., max 10-15 seconds) so that a single hung host does not block the entire concurrency queue or lock the CLI.

--- a/docs/superpowers/specs/2026-07-28-credential-health-design.md
+++ b/docs/superpowers/specs/2026-07-28-credential-health-design.md
@@ -139,6 +139,28 @@ The third row is the load-bearing behaviour. **A network blip must never mark a
 credential dead.** False positives in this direction train users to ignore the
 feature.
 
+#### Which key does a failure belong to?
+
+A connector may hold many credentials — ProtonMail holds nine — and a bare 401
+does not say which one was rejected. Two rules:
+
+1. **Attribute precisely where the failure identifies the credential.** An OAuth
+   refresh rejection is attributable to that connector's `*.oauth` key; only
+   that row changes.
+2. **Otherwise mark the credential *set*.** Every *secret* key the connector
+   declares (excluding non-secret config — hosts, regions, usernames) takes the
+   status and shares one `detail`.
+
+Rule 2 is deliberately blunt. A 401 proves the set failed to authenticate; it
+does not prove which member is at fault. Marking the set is honest and
+actionable — the fix is the same either way — whereas guessing a single key
+would manufacture a precise-looking claim the evidence does not support. The
+alternative failure is worse: attributing to the wrong key leaves the real
+culprit reading `ok`.
+
+`detail` therefore carries the connector-level error, and the reader groups by
+connector so a nine-key connector renders one line, not nine.
+
 ### Writer 2 — declared expiry
 
 `nimbus creds expires <vault_key> <ISO-date>` sets `expires_at` and
@@ -147,6 +169,19 @@ feature.
 This is the *only* mechanism that makes a known deadline on an opaque token
 visible — the class of credential that today is guarded by nothing but human
 memory.
+
+**Captured at the moment the user knows it.** Relying on someone remembering to
+run a second command later reproduces the failure this design criticises, so
+`nimbus connector auth` prompts once after storing an opaque credential:
+
+```text
+Does this credential expire? [YYYY-MM-DD, Enter to skip]:
+```
+
+Constraints: the prompt is skippable, never blocks the auth flow, and is
+suppressed entirely when stdin is not a TTY or `--json` is passed — the flow is
+scripted in CI and must stay non-interactive there. Skipping leaves
+`expires_at` NULL, which reads as `UNKNOWN`, not as `ok`.
 
 ### Writer 3 — active probe
 
@@ -158,18 +193,39 @@ routed **through** each connector's existing rate limiter rather than around it.
 A connector whose MCP server fails to spawn yields `unknown`, not `dead` — "I
 could not ask" is not "the answer was no".
 
+**Every probe carries a hard timeout, default 10 s, configurable.** Many
+connectors point at self-hosted instances — Jira, GitLab, Jenkins, ArgoCD,
+Grafana — where an unreachable or wedged host does not refuse the connection, it
+simply never answers. Without a deadline, one such host occupies a concurrency
+slot indefinitely and `nimbus creds check` hangs. A timeout classifies as
+`transient` (hence `unknown`), never `dead`: a host that did not answer has told
+us nothing about the credential.
+
 ### The classifier
 
 One shared function beside `FetchOutcome`, so all 97 connectors classify
 identically rather than each inventing its own notion of authentication failure.
 
 ```text
-auth-failure : HTTP 401 | 403, or a provider body matching the known
-               auth-rejection set (invalid_grant, invalid_client,
-               Unknown JWT iss, Error decoding signature)
-transient    : network error | HTTP 408 | 429 | 5xx
-ok           : anything else that returned data
+auth-failure  : HTTP 401 | 403, or a provider body matching the known
+                auth-rejection set (invalid_grant, invalid_client,
+                Unknown JWT iss, Error decoding signature)
+transient     : network error | timeout | HTTP 408 | 429 | 5xx
+indeterminate : any other non-2xx (400, 404, 409, 422, …)
+ok            : HTTP 2xx
 ```
+
+`ok` means **2xx**, never "anything that wasn't one of the above". An earlier
+draft of this spec defined it as "anything else that returned data", which would
+have classified a `400 Bad Request` from a changed request schema as a healthy
+credential — a false green, the precise defect this whole design exists to
+prevent. The catch came from design review.
+
+`indeterminate` writes `unknown` with the redacted `detail`, never `ok` and
+never `dead`. A 404 on a renamed endpoint or a 400 from a schema change says
+nothing about the credential; claiming either answer would be a lie in a
+different direction. `unknown` with a stored reason is the honest result, and it
+still surfaces in `nimbus creds` so the user can see something is wrong.
 
 ### Readers — status derived fresh on every read
 
@@ -182,9 +238,18 @@ ok                                → OK
 never observed                    → UNKNOWN   "not checked yet"
 ```
 
-Warn window defaults to **30 days**, configurable. Thirty rather than seven
-because the credentials that hurt require a console trip, and a week is not
-enough notice to be useful.
+Two thresholds, both configurable under `[credentials]` in `nimbus.toml`:
+
+| Threshold | Default | Why |
+| --- | --- | --- |
+| `warn_before_expiry` | **30 days** | The credentials that hurt require a console trip; a week is not enough notice to act on. |
+| `stale_after` | **7 days** | A credential unobserved for longer than a week has no current evidence behind it. |
+
+`stale_after` is shorter than `warn_before_expiry` on purpose — they measure
+different things. One asks "how long before this dies?", the other "how long
+since anyone checked?". A stale `ok` is not a reassuring `ok`; it is an absence
+of evidence, and rendering it as `UNKNOWN (stale — last checked 12 days ago)`
+says so.
 
 `nimbus creds` prints the roll-up (and `--json`, matching
 `nimbus security scan`). `nimbus doctor` gains one summary line.
@@ -205,8 +270,26 @@ enough notice to be useful.
 4. **Secret leakage via `detail`** — the one place a credential could escape.
    Provider auth errors echo credentials routinely. `redactAuditPayload` at a
    256-byte cap, the same path the egress ledger uses.
-5. **Probe blast radius** — up to 97 live APIs. Explicit invocation, capped
-   concurrency, `limit=1`, existing rate limiters.
+5. **HTML error bodies** — providers behind SSO, a CDN or a misconfigured
+   reverse proxy answer with an HTML page, not JSON. Capping that at 256 bytes
+   stores `<!DOCTYPE html><html><head><title>` and nothing useful. This is not
+   an edge case here: self-hosted connectors (GitLab, Jenkins, ArgoCD, Grafana,
+   Jira) sit behind exactly such proxies. When the body is HTML — by
+   `Content-Type` or a leading `<`— extract the `<title>` text, else the first
+   text node, and fall back to `"HTML error page (HTTP <status>)"` when neither
+   yields anything.
+
+   **Ordering is load-bearing: extract → strip → redact → cap, in that order.**
+   Redaction must be the last transformation before storage. Redacting first and
+   then extracting could lift a secret out of an attribute or comment that the
+   redactor had already neutralised, re-introducing it into the stored string.
+6. **Probe blast radius** — up to 97 live APIs. Explicit invocation, capped
+   concurrency, `limit=1`, per-probe timeout, existing rate limiters.
+7. **Orphaned rows on connector removal** — `nimbus connector remove` deletes a
+   connector's Vault entries and index rows atomically. `credential_health` rows
+   must be removed in that same transaction, or a removed connector keeps
+   reporting health for credentials that no longer exist. (Not raised in review;
+   found while applying it.)
 
 ## Testing
 
@@ -222,19 +305,35 @@ human hypothesis:
 | `{"detail":"Error decoding signature."}` | auth-failure |
 | HTTP 429 + `Retry-After` | transient |
 | HTTP 502 / `ECONNRESET` | transient |
+| probe exceeds the 10 s deadline | transient |
+| HTTP 400, body `{"message":"unknown field 'limit'"}` | **indeterminate** |
+| HTTP 404, empty body | **indeterminate** |
+| HTTP 200 with a valid payload | ok |
 
-The two transient rows are **red-proved** per the repo convention: break the
-guard deliberately, watch it fail, restore it. A guard that has never failed is
-a guard nobody has verified.
+The two transient rows and **both indeterminate rows** are **red-proved** per
+the repo convention: break the guard deliberately, watch it fail, restore it. A
+guard that has never failed is a guard nobody has verified.
+
+The indeterminate rows exist because the first draft of this spec would have
+classified them `ok`. They are the regression test for a false green that design
+review caught before implementation — the highest-value tests in the file.
 
 **Redaction as a Vault-class assertion.** Feed the classifier an error body
 containing a token-shaped string; assert it appears nowhere in the stored row.
 Vault tests already prove no secret escapes through *any* interface; `detail` is
 a new interface and inherits that bar.
 
-**Behavioural tests**, one per failure mode: transient does not mark dead; stale
-`ok` degrades to `UNKNOWN`; newer `last_ok_at` overrides a bogus `expires_at`;
-un-spawnable connector reports `unknown`. Plus the V45 migration test and an
+**HTML extraction, with the ordering asserted.** Feed a proxy error page whose
+`<title>` is `502 Bad Gateway` and whose body embeds a token-shaped string in an
+HTML comment; assert `detail` contains the title text and **not** the token.
+This proves extract → strip → redact → cap runs in that order — redaction last.
+
+**Behavioural tests**, one per failure mode: transient does not mark dead; a
+400/404 marks `unknown` rather than `ok`; stale `ok` degrades to `UNKNOWN`;
+newer `last_ok_at` overrides a bogus `expires_at`; un-spawnable connector
+reports `unknown`; a timed-out probe reports `unknown`; an unattributable 401 on
+a multi-key connector marks every *secret* key and no config key; and
+`connector remove` leaves no orphaned health rows. Plus the V45 migration and an
 E2E run — real gateway subprocess, mock MCP server returning 401, asserting
 `nimbus creds` shows `DEAD`.
 

--- a/docs/superpowers/specs/2026-07-28-credential-health-design.md
+++ b/docs/superpowers/specs/2026-07-28-credential-health-design.md
@@ -1,0 +1,276 @@
+# Credential Health — design
+
+> **Status:** design of record, 2026-07-28. Scope is the *product* capability —
+> health for a user's connector credentials. The release pipeline's own
+> publishing secrets are out of scope; they are served by the separate
+> `store-credential-check` workflow (nimbus-web-clipper#26).
+
+## The problem
+
+Nothing in Nimbus notices that a credential has died until something tries to
+use it and fails.
+
+That is not hypothetical. On 2026-07-28 a public release failed at both
+store-upload steps on credentials recorded as "configured" since 2026-07-19 and
+never once exercised. Three independent defects, none visible to any control:
+
+1. **Silent expiry.** An OAuth refresh token minted while the provider's consent
+   screen was in *Testing* mode. The provider expires those after 7 days. It
+   died on 07-26; nothing noticed until 07-28.
+2. **Partial rotation.** The client secret was rotated and stored while the
+   freshly minted refresh token was not. A credential set was half-updated with
+   no signal whatsoever.
+3. **Shape damage.** An issuer stored with one trailing whitespace character —
+   valid-looking, and rejected by the provider.
+
+Four rounds of hypothesis failed to locate the cause. What found all three, on
+its first run, was instrumenting the real environment and printing what was
+actually stored.
+
+The generalisable failure is **presence treated as validity**. Every credential
+control in the codebase today answers "is a secret set?" None answers "does it
+work?"
+
+### Why this is the product's own thesis
+
+Nimbus ships a Vault across three platforms and manages credentials for 97
+connectors. It is a tool whose purpose is to remove exactly this class of toil
+for its users. The project falling to it is either an embarrassment or a product
+insight; this design takes the second reading.
+
+## Measured ground truth
+
+| Fact | Value | Measured from |
+| --- | --- | --- |
+| Connectors declaring secrets | 97 | `connector-secrets-manifest.ts` |
+| Distinct keys in that manifest | 174 | ditto (includes non-secret config: hosts, regions, usernames) |
+| Opaque token / key / secret keys | 53 | ditto, matching `.api_key`/`.token`/`.secret`/`.pat`/… |
+| `OAuthProvider` union members | 12 | `auth/oauth-registry.ts` |
+| Distinct `*.oauth` vault keys | 22 | gateway-wide; Google and Microsoft fan out to per-service keys (`google_drive.oauth`, `outlook.oauth`, …) in `connector-vault.ts` |
+
+The two families are counted from different files and must not be divided into
+one another. The load-bearing fact is qualitative and holds regardless:
+
+**Opaque credentials substantially outnumber refreshable ones, and only OAuth
+credentials can self-heal or report their own expiry.** The design is therefore
+built for the opaque majority; OAuth support is the easy case that comes free.
+
+Existing substrate this design reuses rather than reinvents:
+
+- **`sync_state`** (`connector_id`, `last_sync_at`, …) — precedent for
+  per-connector state.
+- **Mandatory `list`/`get`/`search`** — asserted by the connector contract test,
+  which turns an active probe into *one* generic implementation, not 97.
+- **`_lib/fetch-outcome.ts`** — `FetchOutcome` already carries
+  `{ kind: "http_error"; status: number }`, the signal the classifier needs.
+- **`StoredOAuthTokens.expiresAt`** — expiry already stored for the 12 OAuth
+  providers; this design only surfaces it.
+- **`nimbus doctor` / `nimbus security scan`** — the established read-only,
+  HITL-free diagnostic family this belongs to.
+- **`redactAuditPayload`** — the hardened redaction path the egress ledger uses.
+
+## Non-goals
+
+- **Unattended rotation.** `vault.set` and `vault.delete` are in the HITL frozen
+  set (`engine/executor.ts:107-108`, invariant I2/I4). Any agent-initiated
+  credential write requires the owner's consent and cannot be configured away.
+  This design honours that: **it never writes a credential.** The only operation
+  touching a secret is the existing `nimbus connector auth` flow, which passes
+  through the gate exactly as it does today.
+- **A migration of connectors to OAuth.** Researched and rejected as a program;
+  see the appendix.
+- **A background scheduler or daemon.** Sync is the heartbeat.
+- **Push notifications.** Deliberately deferred; adding IPC notification surface
+  later is additive.
+
+## Architecture
+
+One record, three writers, two readers, one pre-existing fix path.
+
+```text
+WRITERS                              RECORD                 READERS
+1. sync observer (free)   ─┐
+2. declared expiry        ─┼──►  credential_health  ──┬──►  nimbus creds
+3. active probe           ─┘        (V45)             └──►  nimbus doctor
+
+FIX PATH (existing, unchanged — only made discoverable)
+nimbus creds fix <connector>
+   └─► nimbus connector auth  ─► vault.set ─► HITL gate (I2)
+```
+
+### Data model — `credential_health` (V45)
+
+```sql
+CREATE TABLE credential_health (
+  vault_key       TEXT PRIMARY KEY,   -- "zoom.oauth" — a NAME, never a value
+  connector_id    TEXT NOT NULL,
+  observed_status TEXT NOT NULL,      -- 'ok' | 'dead' | 'unknown'
+  observed_via    TEXT NOT NULL,      -- 'sync' | 'probe'
+  last_checked_at INTEGER,
+  last_ok_at      INTEGER,
+  detail          TEXT,               -- redacted, capped at 256 bytes
+  expires_at      INTEGER,
+  expiry_source   TEXT                -- 'provider' | 'declared' | NULL
+);
+```
+
+Decisions:
+
+- **Keyed by vault key, not connector.** ProtonMail alone holds nine
+  credentials. Rolling them up would hide the half-updated case that caused
+  defect 2 above.
+- **`expiring` is never stored.** Only `ok`/`dead`/`unknown` are observed facts;
+  "expires in 6 days" is a function of `expires_at` and *now*. Storing it would
+  go stale the moment nothing runs — the exact failure this design exists to
+  prevent.
+- **Rows exist only for configured connectors** — ~10–30 on a real machine.
+
+### Writer 1 — sync observer
+
+Every sync already authenticates, so health is a free by-product.
+
+| Sync outcome | Written |
+| --- | --- |
+| Success | `ok`, `last_ok_at = now`; if OAuth also `expires_at` from `StoredOAuthTokens.expiresAt`, `expiry_source='provider'` |
+| Auth failure (401/403, `invalid_grant`) | `dead` + redacted `detail` |
+| Transient (network, 429, 5xx) | **status untouched**; only `last_checked_at` moves |
+
+The third row is the load-bearing behaviour. **A network blip must never mark a
+credential dead.** False positives in this direction train users to ignore the
+feature.
+
+### Writer 2 — declared expiry
+
+`nimbus creds expires <vault_key> <ISO-date>` sets `expires_at` and
+`expiry_source='declared'`. Pure metadata; touches no secret; idempotent.
+
+This is the *only* mechanism that makes a known deadline on an opaque token
+visible — the class of credential that today is guarded by nothing but human
+memory.
+
+### Writer 3 — active probe
+
+`nimbus creds check [connector]` calls each configured connector's mandatory
+`<name>_list` at `limit=1`, through the same classifier.
+
+Constraints: explicitly invoked only (never implicit), capped concurrency, and
+routed **through** each connector's existing rate limiter rather than around it.
+A connector whose MCP server fails to spawn yields `unknown`, not `dead` — "I
+could not ask" is not "the answer was no".
+
+### The classifier
+
+One shared function beside `FetchOutcome`, so all 97 connectors classify
+identically rather than each inventing its own notion of authentication failure.
+
+```text
+auth-failure : HTTP 401 | 403, or a provider body matching the known
+               auth-rejection set (invalid_grant, invalid_client,
+               Unknown JWT iss, Error decoding signature)
+transient    : network error | HTTP 408 | 429 | 5xx
+ok           : anything else that returned data
+```
+
+### Readers — status derived fresh on every read
+
+```text
+dead                              → DEAD      "since <last_ok_at>"
+expires_at < now                  → EXPIRED
+expires_at within warn window     → EXPIRING  "in N days"
+last_checked_at older than stale  → UNKNOWN   "(stale — last checked <when>)"
+ok                                → OK
+never observed                    → UNKNOWN   "not checked yet"
+```
+
+Warn window defaults to **30 days**, configurable. Thirty rather than seven
+because the credentials that hurt require a console trip, and a week is not
+enough notice to be useful.
+
+`nimbus creds` prints the roll-up (and `--json`, matching
+`nimbus security scan`). `nimbus doctor` gains one summary line.
+
+## Error handling
+
+1. **Transient misread as death** — mitigated by the classifier, plus always
+   rendering `last_ok_at`. "Dead 3 minutes ago" and "dead 3 weeks ago" demand
+   different reactions; a bare red dot discards that.
+2. **Stale health read as current health** — an `ok` from three weeks ago must
+   not render like one from five minutes ago. Beyond the staleness threshold the
+   status degrades to `UNKNOWN (stale)` rather than continuing to claim `ok`.
+   This is defect 1 re-encoded, and the single most important safeguard here.
+3. **Provider expiry metadata that lies** — Salesforce omits `expires_in`, so
+   Nimbus *synthesises* a 30-minute expiry. Rule: **a more recent observation
+   beats older metadata.** If `last_ok_at > expires_at`, report `ok`.
+   Observation is evidence; metadata is a claim.
+4. **Secret leakage via `detail`** — the one place a credential could escape.
+   Provider auth errors echo credentials routinely. `redactAuditPayload` at a
+   256-byte cap, the same path the egress ledger uses.
+5. **Probe blast radius** — up to 97 live APIs. Explicit invocation, capped
+   concurrency, `limit=1`, existing rate limiters.
+
+## Testing
+
+**The classifier, table-driven, using the real 2026-07-28 error bodies** — not
+invented fixtures. These are the exact strings that defeated four rounds of
+human hypothesis:
+
+| Fixture | Expected |
+| --- | --- |
+| `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}` | auth-failure |
+| `{"error":"invalid_client","error_description":"The provided client secret is invalid."}` | auth-failure |
+| `{"detail":"Unknown JWT iss (issuer)."}` | auth-failure |
+| `{"detail":"Error decoding signature."}` | auth-failure |
+| HTTP 429 + `Retry-After` | transient |
+| HTTP 502 / `ECONNRESET` | transient |
+
+The two transient rows are **red-proved** per the repo convention: break the
+guard deliberately, watch it fail, restore it. A guard that has never failed is
+a guard nobody has verified.
+
+**Redaction as a Vault-class assertion.** Feed the classifier an error body
+containing a token-shaped string; assert it appears nowhere in the stored row.
+Vault tests already prove no secret escapes through *any* interface; `detail` is
+a new interface and inherits that bar.
+
+**Behavioural tests**, one per failure mode: transient does not mark dead; stale
+`ok` degrades to `UNKNOWN`; newer `last_ok_at` overrides a bogus `expires_at`;
+un-spawnable connector reports `unknown`. Plus the V45 migration test and an
+E2E run — real gateway subprocess, mock MCP server returning 401, asserting
+`nimbus creds` shows `DEAD`.
+
+### Testing principle earned on 2026-07-28
+
+> **The test harness must never be more forgiving than production.**
+
+The local verification scripts written during the incident called `.Trim()` on
+pasted input where `gh secret set` does not. They therefore returned green on
+the precise defect breaking CI. A diagnostic more lenient than the real path
+does not merely fail to help — it converts an unknown into a confident wrong
+answer.
+
+Concretely: no normalising in test helpers that production does not perform, and
+the E2E path exercises the *same* classifier the sync path uses, never a double.
+
+## Appendix — why not migrate connectors to OAuth
+
+Considered, because OAuth credentials self-heal and carry expiry. Rejected as a
+program; retained as a per-connector judgement.
+
+1. **Users supply their own OAuth client credentials.** There is no shipped
+   Nimbus OAuth app — `oauth-env-help-messages.ts` instructs the user to create
+   their own Desktop client in the provider's console. Migration therefore
+   *multiplies* the console ritual it was meant to remove.
+2. **~14 of the 53 cannot move at all** — argocd, jenkins, flux, imap,
+   protonmail, elasticsearch, superset, metabase, airflow, dagster, prefect,
+   sonarqube, dependencytrack, grafana are self-hosted or protocol-level. There
+   is no central authority to register with; the user *is* the provider.
+3. **OAuth credentials die silently too.** Defect 1 above *was* an OAuth
+   credential with a refresh token, and OAuth supplied the
+   client-id/secret/token triple that then half-updated. A static key has one
+   part and cannot fail that way.
+4. **Cost:** a 6-file exhaustive-`never`-switch co-edit per provider
+   (`oauth-registry.ts`, `pkce.ts`, `connector-catalog.ts`,
+   `connector-vault.ts`, `lazy-mesh/credential-orchestration.ts`, help text).
+
+OAuth reduces how often a credential dies. It does nothing about noticing when
+one does. The two are orthogonal, and this design addresses the second.

--- a/docs/superpowers/specs/2026-07-28-credential-health-design.md
+++ b/docs/superpowers/specs/2026-07-28-credential-health-design.md
@@ -104,13 +104,14 @@ nimbus creds fix <connector>
 CREATE TABLE credential_health (
   vault_key       TEXT PRIMARY KEY,   -- "zoom.oauth" — a NAME, never a value
   connector_id    TEXT NOT NULL,
-  observed_status TEXT NOT NULL,      -- 'ok' | 'dead' | 'unknown'
-  observed_via    TEXT NOT NULL,      -- 'sync' | 'probe'
-  last_checked_at INTEGER,
+  observed_status TEXT NOT NULL CHECK (observed_status IN ('ok','dead','unknown')),
+  observed_via    TEXT NOT NULL CHECK (observed_via IN ('sync','probe')),
+  last_checked_at INTEGER,   -- last CONCLUSIVE observation (ok / dead / indeterminate)
+  last_attempt_at INTEGER,   -- last attempt of any kind, including transient
   last_ok_at      INTEGER,
   detail          TEXT,               -- redacted, capped at 256 bytes
   expires_at      INTEGER,
-  expiry_source   TEXT                -- 'provider' | 'declared' | NULL
+  expiry_source   TEXT CHECK (expiry_source IN ('provider','declared'))
 );
 ```
 
@@ -133,11 +134,24 @@ Every sync already authenticates, so health is a free by-product.
 | --- | --- |
 | Success | `ok`, `last_ok_at = now`; if OAuth also `expires_at` from `StoredOAuthTokens.expiresAt`, `expiry_source='provider'` |
 | Auth failure (401/403, `invalid_grant`) | `dead` + redacted `detail` |
-| Transient (network, 429, 5xx) | **status untouched**; only `last_checked_at` moves |
+| Transient (network, 429, 5xx) | **status untouched**; only `last_attempt_at` moves — **`last_checked_at` must NOT advance** |
 
-The third row is the load-bearing behaviour. **A network blip must never mark a
-credential dead.** False positives in this direction train users to ignore the
-feature.
+The third row is the load-bearing behaviour, and it has **two** halves that are
+easy to get half-right:
+
+1. **A network blip must never mark a credential dead.** False positives in this
+   direction train users to ignore the feature.
+2. **A network blip must never make a stale credential look freshly verified.**
+   This is why `last_checked_at` and `last_attempt_at` are separate columns.
+   `last_checked_at` means *"when did we last actually learn something"*; a
+   transient teaches nothing, so it may not advance it.
+
+Collapsing those into one timestamp produces a false green: a credential that is
+unreachable for weeks — every attempt transient — would keep reporting a fresh
+`OK`, because the clock advanced while the status never changed. The staleness
+degradation in the reader is the safeguard, and a shared timestamp silently
+disarms it. Caught in review; it is the third instance of this failure class in
+this document's history, which is itself the argument for the design.
 
 #### Which key does a failure belong to?
 
@@ -229,23 +243,36 @@ still surfaces in `nimbus creds` so the user can see something is wrong.
 
 ### Readers — status derived fresh on every read
 
+Evaluated strictly in this order; the first match wins. The ordering **is** the
+precedence rule — an earlier draft stated the expiry rows and the
+observation-beats-metadata rule separately, which let the same row yield two
+contradictory answers:
+
 ```text
-dead                              → DEAD      "since <last_ok_at>"
-expires_at < now                  → EXPIRED
-expires_at within warn window     → EXPIRING  "in N days"
-last_checked_at older than stale  → UNKNOWN   "(stale — last checked <when>)"
-ok                                → OK
-never observed                    → UNKNOWN   "not checked yet"
+1. observed_status = dead                     → DEAD      "since <last_ok_at>"
+2. expires_at set AND last_ok_at > expires_at → (fall through — see below)
+3. expires_at <= now                          → EXPIRED
+4. expires_at - now <= warn window            → EXPIRING  "in N days"
+5. last_checked_at is null                    → UNKNOWN   "not checked yet"
+6. now - last_checked_at > stale window       → UNKNOWN   "stale — last checked <when>"
+7. observed_status = ok                       → OK
+8. otherwise                                  → UNKNOWN   <detail>
 ```
+
+**Rule 2 is the precedence statement**: a successful observation *more recent
+than* the recorded expiry proves the expiry metadata wrong, so rows 3 and 4 are
+skipped entirely. Salesforce omits `expires_in`, so Nimbus synthesises a
+30-minute expiry — without rule 2 every working Salesforce credential would
+render `EXPIRED`. Observation is evidence; metadata is a claim.
 
 Two thresholds, both configurable under `[credentials]` in `nimbus.toml`:
 
 | Threshold | Default | Why |
 | --- | --- | --- |
-| `warn_before_expiry` | **30 days** | The credentials that hurt require a console trip; a week is not enough notice to act on. |
-| `stale_after` | **7 days** | A credential unobserved for longer than a week has no current evidence behind it. |
+| `warn_before_expiry_days` | **30 days** | The credentials that hurt require a console trip; a week is not enough notice to act on. |
+| `stale_after_days` | **7 days** | A credential unobserved for longer than a week has no current evidence behind it. |
 
-`stale_after` is shorter than `warn_before_expiry` on purpose — they measure
+`stale_after_days` is shorter than `warn_before_expiry_days` on purpose — they measure
 different things. One asks "how long before this dies?", the other "how long
 since anyone checked?". A stale `ok` is not a reassuring `ok`; it is an absence
 of evidence, and rendering it as `UNKNOWN (stale — last checked 12 days ago)`


### PR DESCRIPTION
Design of record and implementation plan for **credential health**: making Nimbus notice a connector credential is dead, dying, or unverifiable instead of discovering it when something fails.

Docs only — no runtime code. Four files, two review rounds applied.

## Why

On 2026-07-28 the web-clipper v0.2.0 release failed at **both** store-upload steps on credentials recorded as "configured" since 07-19 and never once exercised. Three independent defects, none visible to any control:

1. **Silent expiry** — an OAuth refresh token minted while the consent screen was in *Testing* mode; the provider expires those after 7 days. It died on 07-26.
2. **Partial rotation** — the client secret was rotated and stored while the freshly minted token was not. A credential set half-updated with no signal.
3. **Shape damage** — an issuer stored with one trailing whitespace character.

Four rounds of hypothesis failed. What found all three, first run, was instrumenting the real environment and printing what was actually stored.

The generalisable defect: **presence treated as validity.** Every credential control in this codebase answers "is a secret set?" — none answers "does it work?"

## What is designed

One record, three writers, two readers, one pre-existing fix path.

- **Writer 1 — sync observer.** Free: every sync already authenticates, so health is a by-product. No scheduler, no daemon, no new network calls.
- **Writer 2 — declared expiry.** The only mechanism that makes a known deadline on an opaque token visible. `VSCE_PAT` expires 2026-09-20 and is guarded today by human memory alone.
- **Writer 3 — active probe.** **One** implementation, not 97, because `list`/`get`/`search` are contractually mandatory per the connector contract test.
- **Readers** — `nimbus creds` plus one line in `nimbus doctor`.

### It never writes a credential

`vault.set` and `vault.delete` are in the HITL frozen set (`engine/executor.ts:107-108`, I2/I4). Unattended rotation would require weakening a non-negotiable. The only operation touching a secret is the existing `nimbus connector auth` flow, invoked by explicit delegation from `nimbus creds fix` so the gate still applies. Final verification includes `rg "vault\.(set|delete)"` over the new subsystem returning **nothing** — a mechanical check that the non-goal held.

## Measured, not assumed

| Fact | Value | Source |
| --- | --- | --- |
| Connectors declaring secrets | 97 | `connector-secrets-manifest.ts` |
| Opaque token/key/secret keys | 53 | ditto |
| `OAuthProvider` union members | 12 | `auth/oauth-registry.ts` |
| Distinct `*.oauth` vault keys | 22 | gateway-wide (Google/Microsoft fan out per service) |

Opaque credentials substantially outnumber refreshable ones, and only OAuth credentials self-heal or report their own expiry — so the design targets the opaque majority.

## Two blockers found while mapping the real seams

Now Tasks 1–2 rather than surprises mid-implementation:

- **`connectorFetch` discards the error body.** `FetchOutcome` was `{ kind: "http_error"; bytes; status }`. Google returns `invalid_grant` with HTTP **400**, so without widening that type the classifier would have silently degraded to status-codes-only and missed the exact failure that started this.
- **`CONNECTOR_VAULT_SECRET_KEYS` mixes credentials with configuration** — `jira: ["jira.api_token", "jira.email", "jira.base_url"]` — with no marker. The attribution rule had nothing to key off. Task 1 adds the split behind a guard that fails when a new key matches neither set.

## Review rounds

Two rounds, both applied. Highlights:

- **The design review caught a false green in the spec itself.** My classifier ended `ok : anything else that returned data`, so a 400 from a changed request schema would have been classified **healthy**. `ok` now means 2xx; everything else non-2xx is `indeterminate` → `unknown`.
- **The plan review caught the same class again** in `parse_error`: mapping it straight to `ok` would let a server answering an expired session with *200 + a login page* read healthy. The auth-marker check now runs ahead of the 2xx short-circuit.
- **One suggestion was rejected as written.** Switching `suffixOf` to `lastIndexOf` would have introduced the bug it guarded against — for `a.b.c` it returns a name *fragment*. Verified all 174 keys have exactly one dot, kept `indexOf`, and added a guard test pinning the invariant.

Across both rounds, **seven of twelve changes close paths where the system could have reported health it had not observed.**

## Files

| File | |
| --- | --- |
| `docs/superpowers/specs/2026-07-28-credential-health-design.md` | design of record |
| `docs/superpowers/specs/…-design-review.md` | round 1 |
| `docs/superpowers/specs/…-design-review-response.md` | round 1 applied |
| `docs/superpowers/plans/2026-07-28-credential-health.md` | 14 tasks, 86 TDD steps |
| `docs/superpowers/plans/…-review.md` / `…-review-response.md` | round 2 |

Tasks 1–9 are a shippable milestone on their own (passive observation + `nimbus creds`); 10–14 add declared expiry, the probe, config and the auth-time prompt.

## Verification

`lint:markdown` 0 issues · `audit:doc-refs` 627 refs all resolve · `lychee` 8/8 links OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Credential Health design and implementation planning documentation.
  - Documented credential status reporting, expiry tracking, active checks, configurable staleness thresholds, and connector cleanup behavior.
  - Clarified handling for authentication failures, transient errors, malformed responses, and XML/SOAP error messages.
  - Recorded design and implementation review decisions, testing expectations, concurrency safeguards, and security requirements for redacted error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->