### PR TITLE
feat(audit): detect when main is red

### DIFF
--- a/scripts/ci-latency/check.ts
+++ b/scripts/ci-latency/check.ts
@@ -17,8 +17,14 @@ import { join } from "node:path";
 import { isStrict, strictSkip } from "../structure-audit/_gh-audit.ts";
 import { computeUpdatedBaseline, parseBaseline, serializeBaseline } from "./baseline.ts";
 import { collectAll } from "./collect.ts";
-import { MAX_READ_FAILURE_RATIO, MIN_REPORTED_QUEUE_MIN, SAMPLE_EVENT } from "./constants.ts";
+import {
+  AUDITED_REPOS,
+  MAX_READ_FAILURE_RATIO,
+  MIN_REPORTED_QUEUE_MIN,
+  SAMPLE_EVENT,
+} from "./constants.ts";
 import { evaluate } from "./evaluate.ts";
+import { fetchMainHealth, formatMainHealth } from "./main-health.ts";
 import { summarize } from "./summarize.ts";
 
 const BASELINE_PATH = join(
@@ -93,6 +99,32 @@ if (import.meta.main) {
     console.warn(
       `::warning::${label}: no observation carried a non-zero dagWait — if any sampled workflow uses \`needs:\`, the created_at eligibility assumption may have changed`,
     );
+  }
+
+  // Is main actually red? Nothing else answers this: collect.ts fetches only
+  // status=success runs, so a permanently-failing workflow produces zero
+  // observations and reads as "no data" rather than "broken". On 2026-07-28
+  // main was red for 4.75h across six pushes and only a human noticed.
+  //
+  // Reported always; fails only under --strict (the scheduled sweep), because
+  // a contributor's PR cannot fix a main that someone else broke.
+  const redRepos: string[] = [];
+  for (const repo of AUDITED_REPOS) {
+    const health = fetchMainHealth(repo);
+    if (health === null) {
+      console.warn(`::warning::${label}: could not read main health for ${repo}`);
+      continue;
+    }
+    if (health.red) {
+      redRepos.push(formatMainHealth(repo, health));
+      console.error(`::error::${label}: ${formatMainHealth(repo, health)}`);
+    } else if (!health.known) {
+      console.warn(`::warning::${label}: ${formatMainHealth(repo, health)}`);
+    }
+  }
+  if (strict && redRepos.length > 0) {
+    console.error(`${label}: ${redRepos.length} repo(s) have a red main`);
+    process.exit(1);
   }
 
   const summaries = summarize(observations);

--- a/scripts/ci-latency/main-health.test.ts
+++ b/scripts/ci-latency/main-health.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { assessMainHealth, type PushRun } from "./main-health.ts";
+
+const NOW = Date.parse("2026-07-28T18:00:00Z");
+const HOUR = 3_600_000;
+
+const run = (conclusion: string | null, hoursAgo: number, sha = "abc1234"): PushRun => ({
+  conclusion,
+  createdAt: new Date(NOW - hoursAgo * HOUR).toISOString(),
+  headSha: sha,
+});
+
+describe("assessMainHealth", () => {
+  test("a green head is not red", () => {
+    const h = assessMainHealth([run("success", 1), run("success", 3)], NOW);
+    expect(h.red).toBe(false);
+    expect(h.consecutiveFailures).toBe(0);
+    expect(h.redSinceIso).toBeNull();
+  });
+
+  test("a failing head is red and counts the streak", () => {
+    const h = assessMainHealth(
+      [run("failure", 1, "aaa"), run("failure", 3, "bbb"), run("success", 5, "ccc")],
+      NOW,
+    );
+    expect(h.red).toBe(true);
+    expect(h.consecutiveFailures).toBe(2);
+    expect(h.redForHours).toBe(3); // since the OLDEST run in the failing streak
+  });
+
+  // The real incident: main was red for 4.75h across six consecutive pushes and
+  // nothing noticed, because the collector only ever fetched successful runs.
+  test("reports a long multi-push outage", () => {
+    const runs = [0.25, 1, 2, 3, 4, 4.75].map((h, i) => run("failure", h, `sha${i}`));
+    const h = assessMainHealth(runs, NOW);
+    expect(h.red).toBe(true);
+    expect(h.consecutiveFailures).toBe(6);
+    expect(h.redForHours).toBeCloseTo(4.75, 1);
+  });
+
+  test("in-progress runs are ignored, not treated as failures", () => {
+    // conclusion === null means still running. Counting it red would make the
+    // gate flap every time a push is mid-flight.
+    const h = assessMainHealth([run(null, 0.1), run("success", 2)], NOW);
+    expect(h.red).toBe(false);
+    expect(h.consecutiveFailures).toBe(0);
+  });
+
+  test("a cancelled run is not a failure", () => {
+    // Cancellations are usually concurrency evictions, not breakage. Treating
+    // them as red would manufacture outages from ordinary CI behaviour.
+    const h = assessMainHealth([run("cancelled", 1), run("success", 2)], NOW);
+    expect(h.red).toBe(false);
+  });
+
+  test("a cancelled run does not break a real failing streak either", () => {
+    const h = assessMainHealth(
+      [run("failure", 1), run("cancelled", 2), run("failure", 3), run("success", 4)],
+      NOW,
+    );
+    expect(h.red).toBe(true);
+    expect(h.consecutiveFailures).toBe(2); // the two failures; the cancel is skipped
+  });
+
+  test("no completed runs yields unknown, not green", () => {
+    // Absence of evidence must not read as health — the whole point of the gate.
+    const h = assessMainHealth([run(null, 0.1)], NOW);
+    expect(h.red).toBe(false);
+    expect(h.known).toBe(false);
+  });
+
+  test("an empty list is unknown", () => {
+    const h = assessMainHealth([], NOW);
+    expect(h.known).toBe(false);
+    expect(h.red).toBe(false);
+  });
+
+  test("timed_out and startup_failure count as failures", () => {
+    for (const c of ["timed_out", "startup_failure", "action_required"]) {
+      expect(assessMainHealth([run(c, 1), run("success", 2)], NOW).red).toBe(true);
+    }
+  });
+});

--- a/scripts/ci-latency/main-health.ts
+++ b/scripts/ci-latency/main-health.ts
@@ -1,0 +1,168 @@
+/**
+ * Is `main` red, and for how long?
+ *
+ * Nothing in this repo answered that question. `collect.ts` fetches
+ * `actions/runs?...&status=success` — failed runs are never retrieved at all —
+ * and then drops any job whose conclusion is not `success`. A workflow that
+ * fails 100% of the time therefore produces ZERO observations and is reported
+ * as nothing rather than as broken.
+ *
+ * On 2026-07-28 `main` was red for 4.75 hours across six consecutive pushes and
+ * the only reason anyone noticed is that a human happened to be looking.
+ *
+ * This module is the answer, and it deliberately adds no CI job: `check.ts`
+ * already runs on a schedule, so the assessment rides along with it.
+ */
+
+import { isRecord, runGh } from "../structure-audit/_gh-audit.ts";
+
+/** One push-triggered workflow run on the default branch. */
+export interface PushRun {
+  /** `null` while the run is still in progress. */
+  conclusion: string | null;
+  createdAt: string;
+  headSha: string;
+}
+
+export interface MainHealth {
+  /** False when no run has completed yet — absence of evidence, not health. */
+  known: boolean;
+  red: boolean;
+  /** Consecutive non-success runs at the head, ignoring cancellations. */
+  consecutiveFailures: number;
+  /** When the current red streak began. */
+  redSinceIso: string | null;
+  redForHours: number | null;
+  latestConclusion: string | null;
+}
+
+/**
+ * Conclusions that mean the build is broken.
+ *
+ * `startup_failure` is included deliberately: this org has had a scheduled
+ * workflow fail at startup for weeks, which no success-only collector could see.
+ */
+const FAILURE_CONCLUSIONS: ReadonlySet<string> = new Set([
+  "failure",
+  "timed_out",
+  "startup_failure",
+  "action_required",
+]);
+
+/**
+ * Conclusions that say nothing about health and are skipped entirely — they
+ * neither start a red streak nor end one.
+ *
+ * Cancellations are usually concurrency evictions. Counting them red would
+ * manufacture outages out of ordinary CI behaviour; counting them green would
+ * let a cancel mask a genuine failure behind it.
+ */
+const NEUTRAL_CONCLUSIONS: ReadonlySet<string> = new Set(["cancelled", "skipped", "neutral"]);
+
+const HOUR_MS = 3_600_000;
+
+/**
+ * Assess default-branch health from push runs, newest first.
+ *
+ * `now` is injected so this stays pure and testable.
+ */
+export function assessMainHealth(runs: readonly PushRun[], now: number): MainHealth {
+  const decisive = runs.filter(
+    (r) => r.conclusion !== null && !NEUTRAL_CONCLUSIONS.has(r.conclusion),
+  );
+
+  if (decisive.length === 0) {
+    return {
+      known: false,
+      red: false,
+      consecutiveFailures: 0,
+      redSinceIso: null,
+      redForHours: null,
+      latestConclusion: null,
+    };
+  }
+
+  const latest = decisive[0] as PushRun;
+  const latestConclusion = latest.conclusion;
+
+  if (latestConclusion === null || !FAILURE_CONCLUSIONS.has(latestConclusion)) {
+    return {
+      known: true,
+      red: false,
+      consecutiveFailures: 0,
+      redSinceIso: null,
+      redForHours: null,
+      latestConclusion,
+    };
+  }
+
+  let streak = 0;
+  let oldest: PushRun = latest;
+  for (const r of decisive) {
+    if (r.conclusion === null || !FAILURE_CONCLUSIONS.has(r.conclusion)) break;
+    streak += 1;
+    oldest = r;
+  }
+
+  const redSince = Date.parse(oldest.createdAt);
+  return {
+    known: true,
+    red: true,
+    consecutiveFailures: streak,
+    redSinceIso: oldest.createdAt,
+    redForHours: Number.isNaN(redSince) ? null : (now - redSince) / HOUR_MS,
+    latestConclusion,
+  };
+}
+
+/** Human-readable one-liner for the gate output. */
+export function formatMainHealth(repo: string, h: MainHealth): string {
+  if (!h.known) return `${repo}: main health UNKNOWN — no completed push run`;
+  if (!h.red) return `${repo}: main is green`;
+  const hours = h.redForHours === null ? "?" : h.redForHours.toFixed(1);
+  return `${repo}: main is RED — ${h.consecutiveFailures} consecutive failing push run(s) over ${hours}h (since ${h.redSinceIso})`;
+}
+
+// ---------------------------------------------------------------- fetch
+
+/** How many recent push runs to inspect per repo. */
+const MAIN_RUN_PAGE = 30;
+
+function parsePushRuns(stdout: string): PushRun[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed["workflow_runs"])) return [];
+  const out: PushRun[] = [];
+  for (const raw of parsed["workflow_runs"]) {
+    if (!isRecord(raw)) continue;
+    const createdAt = typeof raw["created_at"] === "string" ? raw["created_at"] : null;
+    if (createdAt === null) continue;
+    out.push({
+      conclusion: typeof raw["conclusion"] === "string" ? raw["conclusion"] : null,
+      createdAt,
+      headSha: typeof raw["head_sha"] === "string" ? raw["head_sha"] : "",
+    });
+  }
+  return out;
+}
+
+/**
+ * Fetch recent push runs on the default branch — **without** a status filter.
+ *
+ * The missing filter is the entire point. `collect.ts` asks for
+ * `status=success`, which is why a permanently-failing workflow is invisible
+ * to it.
+ */
+export function fetchMainHealth(repo: string, now: number = Date.now()): MainHealth | null {
+  const res = runGh([
+    "gh",
+    "api",
+    `repos/nimbus-agent/${repo}/actions/runs?per_page=${MAIN_RUN_PAGE}&event=push&branch=main`,
+  ]);
+  if (!res.ok) return null;
+  return assessMainHealth(parsePushRuns(res.stdout), now);
+}


### PR DESCRIPTION
Nothing in this repo answered **"is `main` broken?"** — and on 2026-07-28 `main` was red for **4.75 hours across six consecutive pushes**, noticed only because a human happened to be looking.

## The blindness is structural

`collect.ts:157` requests:

```
actions/runs?...&event=push&status=success
```

Failed runs are **never fetched at all**, and the collector then drops any job whose conclusion isn't `success`. A workflow that fails 100% of the time therefore produces **zero observations** and is reported as *nothing* rather than as *broken*.

That is not hypothetical either: the scheduled `Performance Reference Run` has **11 runs and 0 successes** and is invisible to every existing control for exactly this reason.

## What this adds

`assessMainHealth()` — pure, clock injected — plus a fetcher that asks for push runs on `main` **without the status filter**. The missing filter is the entire point.

Four deliberate behaviours, each with a **red-proved** test:

| Behaviour | Why |
|---|---|
| A **cancelled** run is neutral — skipped entirely, neither starting nor ending a red streak | Cancellations here are usually concurrency evictions. Counting them red manufactures outages from ordinary CI behaviour; counting them green lets a cancel mask a real failure behind it. |
| An **in-progress** run is ignored, not treated as failing | Otherwise the gate flaps every time a push is mid-flight. |
| **No completed run yields `known: false`, not green** | Absence of evidence reported as absence — the same rule the credential-health design turns on, and the exact failure mode this gate exists to close. |
| **`startup_failure` counts as a failure** | A workflow that dies at startup is precisely what a success-only collector cannot see. |

## Where it runs, and when it fails

Wired into the existing `audit:ci-latency` entry point — **adds no CI job.** That job already runs on a schedule, so the assessment rides along.

**Reported always; fails only under `--strict`** (the scheduled sweep). A contributor's PR cannot fix a `main` that someone else broke, and a gate that reds for something nobody can act on is one everybody learns to ignore. That's the same rule `check.ts` already applies to queue and DAG wait, stated in its own header.

## Verification

9 new tests (96 across the module) · `typecheck` exit 0 · `lint` exit 0

Both load-bearing guards were red-proved — breaking the cancelled-is-neutral rule fails 1 test, breaking absence-is-not-health fails 2.

Implements Finding B from the CI/CD improvement plan (#911).

🤖 Generated with [Claude Code](https://claude.com/claude-code)