### PR TITLE
feat(ci): widen audit:org-settings-drift from 2 settings to 12 across 4 endpoints

### DIFF
--- a/.github/org-access.json
+++ b/.github/org-access.json
@@ -1,8 +1,27 @@
 {
-  "$comment": "Desired org-access config. `settings` is audited by check-org-settings-drift.ts; `team_reachability.exempt` by check-team-reachability.ts. See docs/infrastructure-roadmap.md.",
+  "$comment": "Desired org-access config. `settings` and every block under `actions` are audited by check-org-settings-drift.ts (one block per read endpoint — see ORG_SETTING_SOURCES); `team_reachability.exempt` by check-team-reachability.ts. Every key here is a setting whose reversion in the UI would otherwise be undetectable: the org is on the Free plan, so `GET /orgs/{org}/audit-log` is unavailable and a revert cannot be reconstructed after the fact. See docs/infrastructure-roadmap.md.",
   "settings": {
     "members_can_create_repositories": false,
-    "default_repository_permission": "none"
+    "members_can_create_public_repositories": false,
+    "members_can_create_private_repositories": false,
+    "default_repository_permission": "none",
+    "two_factor_requirement_enabled": true,
+    "members_can_fork_private_repositories": false,
+    "members_can_delete_repositories": false,
+    "members_can_change_repo_visibility": false
+  },
+  "actions": {
+    "$comment": "The three org Actions policy endpoints, none of which is part of GET /orgs/{org}. `sha_pinning_required` is the highest-value entry: it is the only real-time unpinned-`uses:` control covering the repos outside the weekly sha-pins matrix, and it is a single UI toggle. `approval_policy` records the CURRENT value so a loosening is caught — tightening it to `all_external_contributors` is a deliberate change to this file AND the org setting, in one reviewed diff.",
+    "permissions": {
+      "sha_pinning_required": true
+    },
+    "workflow": {
+      "default_workflow_permissions": "read",
+      "can_approve_pull_request_reviews": false
+    },
+    "fork_pr_contributor_approval": {
+      "approval_policy": "first_time_contributors"
+    }
   },
   "team_reachability": { "exempt": [] }
 }

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -203,6 +203,31 @@ moves to P6).
   members read). Both were **red** before the apply (they detect the un-applied
   state) and green after: the gate would go red on regression, which is this
   file's definition of *done*.
+- **Widened (2026-07-28) — 2 settings → 12, across 4 endpoints:** a settings
+  audit found the gate watching `members_can_create_repositories` and
+  `default_repository_permission` while `GET /orgs/nimbus-agent` returns about
+  twenty security-relevant fields and the Actions policy endpoints were not
+  consulted at all — the gate was scoped to the two settings whose reversion had
+  bitten at the time it was written. `.github/org-access.json` now also declares
+  `two_factor_requirement_enabled`, `members_can_fork_private_repositories`,
+  `members_can_delete_repositories`, `members_can_change_repo_visibility`, the
+  public/private repo-creation flags, and an `actions` block covering
+  `sha_pinning_required` (`actions/permissions`),
+  `default_workflow_permissions` + `can_approve_pull_request_reviews`
+  (`actions/permissions/workflow`) and `approval_policy`
+  (`actions/permissions/fork-pr-contributor-approval`). `sha_pinning_required`
+  is the highest-value addition: it is a single UI toggle and the only
+  real-time unpinned-`uses:` control covering the public repos outside the
+  8-repo `sha-pins` matrix. `ORG_SETTING_SOURCES` holds the endpoint→block
+  mapping, so a further setting on an already-listed endpoint is a
+  one-line JSON change with no code edit. Read failures are classified rather
+  than collapsed: a 404 on a declared endpoint is drift, a 403/5xx is
+  indeterminate and warns without ever being recorded as compliance, and drift
+  found on a readable endpoint is never discarded because another endpoint
+  failed. `approval_policy` records the **current** value
+  (`first_time_contributors`) so a loosening is caught; tightening it to
+  `all_external_contributors` remains a separate, deliberate change to this file
+  and the org setting together.
 - **Deferred:** the CLA (own spec) and a higher-privilege **bypass-actor audit**
   (the CI App token cannot read `bypass_actors`; a future owner-`gh`-run check,
   no PAT). Private-repo ruleset protection stays **blocked-on-Team** (Free plan).

--- a/scripts/structure-audit/check-org-settings-drift.test.ts
+++ b/scripts/structure-audit/check-org-settings-drift.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, test } from "bun:test";
 
-import { diffOrgSettings, type OrgSettings } from "./check-org-settings-drift.ts";
+import {
+  buildJqProjection,
+  type DesiredValues,
+  decideExit,
+  diffOrgSettings,
+  loadOrgAccess,
+  ORG_SETTING_SOURCES,
+  type SourceOutcome,
+} from "./check-org-settings-drift.ts";
 
-const DESIRED: OrgSettings = {
+const DESIRED: DesiredValues = {
   members_can_create_repositories: false,
   default_repository_permission: "none",
 };
+
+const ok = (label: string): SourceOutcome => ({ label, status: "read", errors: [] });
+const drift = (label: string, ...errors: string[]): SourceOutcome => ({
+  label,
+  status: "read",
+  errors,
+});
 
 describe("diffOrgSettings", () => {
   test("passes when live matches desired", () => {
@@ -48,5 +63,157 @@ describe("diffOrgSettings", () => {
     const result = diffOrgSettings(DESIRED, { members_can_create_repositories: false });
     expect(result.ok).toBe(false);
     expect(result.errors.join("\n")).toContain("default_repository_permission");
+  });
+
+  test("diffs an Actions-endpoint block with the same code path", () => {
+    // sha_pinning_required is the reason this gate grew past GET /orgs/{org}:
+    // it is a single UI toggle and the only real-time unpinned-`uses:` control
+    // on the repos outside the weekly sha-pins matrix.
+    const result = diffOrgSettings({ sha_pinning_required: true }, { sha_pinning_required: false });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("sha_pinning_required");
+    expect(result.errors[0]).toContain("expected true");
+  });
+});
+
+describe("buildJqProjection", () => {
+  test("projects the declared keys", () => {
+    expect(
+      buildJqProjection(["default_workflow_permissions", "can_approve_pull_request_reviews"]),
+    ).toBe("{default_workflow_permissions, can_approve_pull_request_reviews}");
+    expect(buildJqProjection(["sha_pinning_required"])).toBe("{sha_pinning_required}");
+  });
+
+  test("rejects a key that could inject jq", () => {
+    expect(() => buildJqProjection(["ok_key", "x} | env | {y"])).toThrow("invalid setting key");
+  });
+
+  test("rejects an empty block", () => {
+    expect(() => buildJqProjection([])).toThrow("no keys declared");
+  });
+});
+
+describe("decideExit", () => {
+  test("green when every source read clean", () => {
+    const result = decideExit({
+      outcomes: [ok("org"), ok("actions/permissions")],
+      strict: true,
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("OK (2 sources)");
+  });
+
+  test("red on drift, and names the source", () => {
+    const result = decideExit({
+      outcomes: [
+        ok("org"),
+        drift("actions/permissions", "sha_pinning_required: expected true, got false"),
+      ],
+      strict: true,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("actions/permissions: sha_pinning_required");
+  });
+
+  test("drift on a readable source survives another source being unreadable", () => {
+    // The load-bearing rule: a 403 on one endpoint must never swallow real
+    // drift found on another.
+    const result = decideExit({
+      outcomes: [
+        drift("org", "two_factor_requirement_enabled: expected true, got false"),
+        { label: "actions/permissions/workflow", status: "indeterminate", errors: [] },
+      ],
+      strict: true,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("two_factor_requirement_enabled");
+    expect(result.message).toContain("WARNING — could not read: actions/permissions/workflow");
+  });
+
+  test("a 404 on a declared endpoint is a finding, not a skip", () => {
+    const result = decideExit({
+      outcomes: [
+        ok("org"),
+        { label: "actions/permissions/fork-pr-contributor-approval", status: "absent", errors: [] },
+      ],
+      strict: true,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("declared but absent");
+  });
+
+  test("partial read with no drift is green, with the gap named", () => {
+    const result = decideExit({
+      outcomes: [ok("org"), { label: "actions/permissions", status: "indeterminate", errors: [] }],
+      strict: true,
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("OK (1 sources)");
+    expect(result.message).toContain("could not read actions/permissions");
+  });
+
+  test("nothing readable is a soft skip locally", () => {
+    const result = decideExit({
+      outcomes: [
+        { label: "org", status: "indeterminate", errors: [] },
+        { label: "actions/permissions", status: "indeterminate", errors: [] },
+      ],
+      strict: false,
+    });
+    expect(result.code).toBe(0);
+    expect(result.message).toContain("::warning::");
+  });
+
+  test("nothing readable is a hard failure in the sweep", () => {
+    const result = decideExit({
+      outcomes: [{ label: "org", status: "indeterminate", errors: [] }],
+      strict: true,
+    });
+    expect(result.code).toBe(1);
+    expect(result.message).toContain("::error::");
+  });
+});
+
+describe("ORG_SETTING_SOURCES <-> .github/org-access.json", () => {
+  const file = loadOrgAccess(process.cwd());
+
+  test("every source resolves to a non-empty declared block", () => {
+    for (const source of ORG_SETTING_SOURCES) {
+      const block = source.select(file);
+      expect(Object.keys(block).length, `${source.label} declares no keys`).toBeGreaterThan(0);
+    }
+  });
+
+  test("every declared key projects into a valid jq program", () => {
+    for (const source of ORG_SETTING_SOURCES) {
+      expect(() => buildJqProjection(Object.keys(source.select(file)))).not.toThrow();
+    }
+  });
+
+  test("the settings the audit called out are all gated", () => {
+    // Named explicitly so removing one from org-access.json fails here rather
+    // than silently shrinking the gate's coverage back down.
+    expect(Object.keys(file.settings)).toEqual(
+      expect.arrayContaining([
+        "members_can_create_repositories",
+        "members_can_create_public_repositories",
+        "members_can_create_private_repositories",
+        "default_repository_permission",
+        "two_factor_requirement_enabled",
+        "members_can_fork_private_repositories",
+      ]),
+    );
+    expect(file.actions.permissions["sha_pinning_required"]).toBe(true);
+    expect(file.actions.workflow["default_workflow_permissions"]).toBe("read");
+    expect(file.actions.fork_pr_contributor_approval["approval_policy"]).toBeTypeOf("string");
+  });
+
+  test("no endpoint carries a leading slash", () => {
+    // gh on Git Bash rewrites `/orgs/...` into a filesystem path and the call
+    // fails as "invalid API endpoint" — which classifies as indeterminate, i.e.
+    // a silently unwatched setting.
+    for (const source of ORG_SETTING_SOURCES) {
+      expect(source.endpoint.startsWith("/")).toBe(false);
+    }
   });
 });

--- a/scripts/structure-audit/check-org-settings-drift.ts
+++ b/scripts/structure-audit/check-org-settings-drift.ts
@@ -2,38 +2,105 @@
 
 /**
  * audit:org-settings-drift — asserts the org's live settings match the desired
- * values in `.github/org-access.json`. Manual UI settings revert silently
- * (`members_can_create_repositories`, `default_repository_permission`); this
- * makes them a gated property. The diff is pure and unit-tested; the CLI reads
- * live config via `gh` and is fail-soft locally / strict in the CI sweep.
+ * values in `.github/org-access.json`. Manual UI settings revert silently and
+ * the Free plan has no audit log to reconstruct a revert from, so every setting
+ * worth keeping has to be a gated property. The diff is pure and unit-tested;
+ * the CLI reads live config via `gh` and is fail-soft locally / strict in the
+ * CI sweep.
+ *
+ * The gate reads FOUR endpoints, not one: `GET /orgs/{org}` carries the member
+ * and 2FA policy, but `sha_pinning_required`, `default_workflow_permissions`
+ * and the fork-PR approval policy each live on a separate Actions endpoint.
+ * `ORG_SETTING_SOURCES` is the single place that mapping lives; adding a
+ * setting from an already-listed endpoint needs no code change at all — just a
+ * key in the matching `.github/org-access.json` block.
  */
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
 
 export interface AuditResult {
   ok: boolean;
   errors: string[];
 }
 
-export interface OrgSettings {
-  members_can_create_repositories: boolean;
-  default_repository_permission: string;
-}
+/** A block of declared `key -> expected value` pairs, diffed generically. */
+export type DesiredValues = Record<string, string | boolean>;
 
 export interface OrgAccessFile {
-  settings: OrgSettings;
+  settings: DesiredValues;
+  actions: {
+    permissions: DesiredValues;
+    workflow: DesiredValues;
+    fork_pr_contributor_approval: DesiredValues;
+  };
   team_reachability: { exempt: string[] };
 }
 
-export function diffOrgSettings(desired: OrgSettings, live: unknown): AuditResult {
+/** One live-state read: which endpoint to ask, and which declared block to diff it against. */
+export interface OrgSettingSource {
+  /** Prefix on every error line, so a drift report names the endpoint it came from. */
+  readonly label: string;
+  /** `gh api` path, no leading slash (Git Bash rewrites a leading slash to a filesystem path). */
+  readonly endpoint: string;
+  /** Picks this source's declared block out of the parsed access file. */
+  readonly select: (file: OrgAccessFile) => DesiredValues;
+}
+
+/**
+ * The read plan. Order is stable so the CLI's output is deterministic, and
+ * `orgs/…` stays first because it is the read whose failure most often means
+ * "no auth at all".
+ */
+export const ORG_SETTING_SOURCES: readonly OrgSettingSource[] = [
+  {
+    label: "org",
+    endpoint: "orgs/nimbus-agent",
+    select: (f) => f.settings,
+  },
+  {
+    label: "actions/permissions",
+    endpoint: "orgs/nimbus-agent/actions/permissions",
+    select: (f) => f.actions.permissions,
+  },
+  {
+    label: "actions/permissions/workflow",
+    endpoint: "orgs/nimbus-agent/actions/permissions/workflow",
+    select: (f) => f.actions.workflow,
+  },
+  {
+    label: "actions/permissions/fork-pr-contributor-approval",
+    endpoint: "orgs/nimbus-agent/actions/permissions/fork-pr-contributor-approval",
+    select: (f) => f.actions.fork_pr_contributor_approval,
+  },
+];
+
+/** GitHub setting keys are lowercase snake_case; anything else is a typo, not a field. */
+const SETTING_KEY = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * Builds the `--jq` projection for a block: `{key_a, key_b}`. Projecting rather
+ * than fetching the whole object keeps a failure legible — a key GitHub stopped
+ * returning shows up as `got undefined` against the declared name instead of
+ * being lost in a 60-field payload. Keys are validated because they come from a
+ * checked-in file and are interpolated into the jq program.
+ */
+export function buildJqProjection(keys: string[]): string {
+  if (keys.length === 0) throw new Error("no keys declared");
+  for (const key of keys) {
+    if (!SETTING_KEY.test(key)) throw new Error(`invalid setting key: ${JSON.stringify(key)}`);
+  }
+  return `{${keys.join(", ")}}`;
+}
+
+export function diffOrgSettings(desired: DesiredValues, live: unknown): AuditResult {
   if (!isRecord(live)) {
     return { ok: false, errors: ["org settings response is not an object"] };
   }
   const errors: string[] = [];
-  for (const key of Object.keys(desired) as (keyof OrgSettings)[]) {
+  for (const key of Object.keys(desired)) {
     if (live[key] !== desired[key]) {
       errors.push(
         `${key}: expected ${JSON.stringify(desired[key])}, got ${JSON.stringify(live[key])}`,
@@ -43,34 +110,104 @@ export function diffOrgSettings(desired: OrgSettings, live: unknown): AuditResul
   return { ok: errors.length === 0, errors };
 }
 
+/** What one source contributed to the run. */
+export interface SourceOutcome {
+  label: string;
+  /** `read` — diffed. `absent` — HTTP 404, the endpoint is gone. `indeterminate` — 403/5xx/network. */
+  status: "read" | "absent" | "indeterminate";
+  errors: string[];
+}
+
+/**
+ * Decides the CLI's exit code + message from what the per-source loop observed.
+ *
+ * INVARIANT: drift found on a source that WAS readable is never discarded
+ * because a different source's `gh` call failed. Only "nothing was readable at
+ * all" degrades to the soft/strict skip — which keeps the pre-existing
+ * single-endpoint behaviour byte-identical for an unauthenticated local run.
+ *
+ * A 404 is a finding, not a skip: every endpoint here is declared in
+ * `.github/org-access.json`, so its disappearance is drift of the same kind the
+ * gate exists to catch. Anything else (a 403 from a token missing
+ * `organization-administration:read`, a 5xx, a network blip) is indeterminate —
+ * loud in the sweep output, but never silently recorded as compliance.
+ */
+export function decideExit(input: { outcomes: SourceOutcome[]; strict: boolean }): {
+  code: 0 | 1;
+  message: string;
+} {
+  const { outcomes, strict } = input;
+  const label = "audit:org-settings-drift";
+
+  const read = outcomes.filter((o) => o.status === "read");
+  const absent = outcomes.filter((o) => o.status === "absent");
+  const indeterminate = outcomes.filter((o) => o.status === "indeterminate");
+
+  if (read.length === 0 && absent.length === 0) {
+    return strictSkip(label, strict);
+  }
+
+  const lines: string[] = [];
+  for (const outcome of read) {
+    for (const err of outcome.errors) lines.push(`${label}: ${outcome.label}: ${err}`);
+  }
+  for (const outcome of absent) {
+    lines.push(`${label}: ${outcome.label}: endpoint returned HTTP 404 — declared but absent`);
+  }
+
+  const unread = indeterminate.map((o) => o.label).join(", ");
+
+  if (lines.length > 0) {
+    if (indeterminate.length > 0) lines.push(`${label}: WARNING — could not read: ${unread}`);
+    return { code: 1, message: lines.join("\n") };
+  }
+
+  if (indeterminate.length > 0) {
+    return {
+      code: 0,
+      message: `${label}: OK (${read.length} sources) — WARNING: could not read ${unread}`,
+    };
+  }
+
+  return { code: 0, message: `${label}: OK (${read.length} sources)` };
+}
+
 export function loadOrgAccess(repoRoot: string): OrgAccessFile {
   const raw = readFileSync(join(repoRoot, ".github/org-access.json"), "utf8");
   return JSON.parse(raw) as OrgAccessFile;
 }
 
-if (import.meta.main) {
-  const strict = isStrict(process.argv.slice(2), process.env);
-  const desired = loadOrgAccess(process.cwd()).settings;
-
+/** Reads one source and classifies the result. Exported for the CLI only. */
+export function readSource(source: OrgSettingSource, file: OrgAccessFile): SourceOutcome {
+  const desired = source.select(file);
   const res = runGh([
     "gh",
     "api",
-    "orgs/nimbus-agent",
+    source.endpoint,
     "--jq",
-    "{members_can_create_repositories, default_repository_permission}",
+    buildJqProjection(Object.keys(desired)),
   ]);
   if (!res.ok) {
-    const outcome = strictSkip("audit:org-settings-drift", strict);
-    if (outcome.code === 1) console.error(outcome.message);
-    else console.warn(outcome.message);
-    process.exit(outcome.code);
+    const status = classifyReadFailure(res.httpStatus) === "absent" ? "absent" : "indeterminate";
+    return { label: source.label, status, errors: [] };
   }
+  let live: unknown;
+  try {
+    live = JSON.parse(res.stdout);
+  } catch {
+    return { label: source.label, status: "read", errors: ["response was not valid JSON"] };
+  }
+  return { label: source.label, status: "read", errors: diffOrgSettings(desired, live).errors };
+}
 
-  const live: unknown = JSON.parse(res.stdout);
-  const result = diffOrgSettings(desired, live);
-  if (!result.ok) {
-    for (const err of result.errors) console.error(`audit:org-settings-drift: ${err}`);
-    process.exit(1);
-  }
-  console.log("audit:org-settings-drift: OK");
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const file = loadOrgAccess(process.cwd());
+
+  const outcomes = ORG_SETTING_SOURCES.map((source) => readSource(source, file));
+
+  const outcome = decideExit({ outcomes, strict });
+  if (outcome.code === 1) console.error(outcome.message);
+  else console.log(outcome.message);
+  process.exit(outcome.code);
 }


### PR DESCRIPTION
## Why

`audit:org-settings-drift` exists because "manual UI settings revert silently" — that is its own docstring. It watched **2** settings. `GET /orgs/nimbus-agent` returns ~20 security-relevant ones, and the org Actions policy endpoints (which hold `sha_pinning_required`, `default_workflow_permissions` and the fork-PR approval policy) were **not consulted at all**.

The org is on the Free plan, so `GET /orgs/{org}/audit-log` is unavailable: a revert of any of the other eighteen is both undetected *and* unreconstructable after the fact. The gate wasn't wrong — it was scoped to the two settings whose reversion had bitten at the time it was written, which is the pattern this roadmap's opening table exists to break.

## What

`.github/org-access.json` grows from 2 declared settings to 12, across 4 read endpoints.

| Endpoint | Newly gated |
| --- | --- |
| `orgs/nimbus-agent` | `two_factor_requirement_enabled`, `members_can_fork_private_repositories`, `members_can_delete_repositories`, `members_can_change_repo_visibility`, `members_can_create_public_repositories`, `members_can_create_private_repositories` |
| `orgs/nimbus-agent/actions/permissions` | `sha_pinning_required` |
| `orgs/nimbus-agent/actions/permissions/workflow` | `default_workflow_permissions`, `can_approve_pull_request_reviews` |
| `orgs/nimbus-agent/actions/permissions/fork-pr-contributor-approval` | `approval_policy` |

`sha_pinning_required` is the highest-value entry: it is a single UI toggle and the only real-time unpinned-`uses:` control covering the public repos **outside** the 8-repo `sha-pins` matrix. Disarming it today is invisible to every gate in the program.

`ORG_SETTING_SOURCES` is the one place the endpoint → declared-block mapping lives, and `diffOrgSettings` is reused **unchanged** — it already looped over whatever keys the JSON declares. Adding a further setting on an already-listed endpoint is therefore a one-line JSON change with no code edit.

## Failure classification (the part worth reviewing)

`decideExit` mirrors the shape already in `check-ruleset-drift.ts`:

- drift found on a readable endpoint is **never** discarded because a *different* endpoint's `gh` call failed;
- a **404** on a declared endpoint is a finding — it was declared, so its disappearance is drift of exactly the kind this gate catches;
- a **403 / 5xx / network** failure is `indeterminate`: it warns, and is never silently recorded as compliance;
- only "nothing readable at all" degrades to the pre-existing soft-local / strict-CI skip, so an unauthenticated local run behaves **byte-identically** to before.

`buildJqProjection` validates every declared key against `^[a-z][a-z0-9_]*$` before interpolating it into the jq program, and a test asserts no endpoint carries a leading slash (Git Bash rewrites `/orgs/...` into a filesystem path — that failure would classify as `indeterminate`, i.e. a silently unwatched setting).

## Token permissions — no workflow change needed

The sweep already mints its App token with `permission-organization-administration: read`, which is what all three Actions endpoints require. `org-drift-sweep.yml` is untouched. **Watch the first scheduled run**: if any Actions endpoint 403s, the gate warns and stays green rather than going red, and the fix is a token-permission change, not a revert.

## `approval_policy` is deliberately recorded at its *current* value

Live is `first_time_contributors`. Declaring it means a **loosening** is caught. The settings audit separately recommends tightening to `all_external_contributors` — that is an owner decision and a separate, deliberate change to this file **and** the org setting in one reviewed diff, not something this PR smuggles in.

## Verification

- `bun test scripts/structure-audit/` → **357 pass, 0 fail** (26 files)
- `tsc -p scripts/tsconfig.json` → clean
- `bunx biome check packages scripts .github docs` → 3005 files, clean
- `bunx markdownlint-cli2` → 0 issues
- `bun scripts/preflight.ts --fast` → `typecheck` ✓ (the `lint` leg is the documented `.claude/worktrees/` biome false-fail — "Checked 0 files"; validated via the direct invocation above)
- **Live green:** `bun scripts/structure-audit/check-org-settings-drift.ts` → `audit:org-settings-drift: OK (4 sources)` against the real org
- **Red-proved:** flipping the declared `sha_pinning_required` and `two_factor_requirement_enabled` in a copy of the file exits **1** and names both the source and the field:

  ```text
  audit:org-settings-drift: org: two_factor_requirement_enabled: expected false, got true
  audit:org-settings-drift: actions/permissions: sha_pinning_required: expected false, got true
  ```

No new npm script, so `scripts/lib/preflight-gates.ts` needs no manifest entry — `audit:org-settings-drift` is already listed there as sweep-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
