### PR TITLE
feat(ci): split secret-health's "expiring" from "dead" so a new failure is visible

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -415,6 +415,36 @@ Findings are filed as a single, de-duped **`release-health`** GitHub issue
 (opened or updated in place per run, not re-created every week) — see
 `scripts/release/open-health-issue.ts`.
 
+#### Two failures that must never be confused: *rejected* vs *dated*
+
+A credential can be in trouble in two unrelated ways, and the remedy, the
+urgency, and the evidence differ:
+
+| | **Rejected** | **Dated** |
+| --- | --- | --- |
+| statuses | `dead`, `insufficient`, `expired`, `missing-provenance`, `source-mismatch` | `deadline-approaching`, `deadline-critical`, `expiring`, `stale` |
+| evidence | a **live probe** came back bad, just now | a **date** in `scripts/release/credential-registry.ts` |
+| is anything broken? | yes, already | not yet |
+| exits non-zero? | always | only `deadline-critical` / `expired` |
+
+The issue body is therefore **sectioned, not one flat table**: a
+`## ❌ BROKEN` section, a `## 🟡 SCHEDULED` section, and a collapsed
+`## ✅ Healthy` section, with a headline count above all three. This is not
+cosmetic. A `deadline-approaching` row keeps the `release-health` issue open for
+up to 76 consecutive days; in a flat 45-row table a credential that died
+overnight would arrive as one more row among forty-five, one word different in
+the status column. Under sections it appears beneath a heading that was empty,
+and an approaching expiry can never appear there. The run's GitHub Actions
+annotations carry the same split: `::warning::` for dated rows, `::error::` for
+rejected ones.
+
+**Escalation.** A hard deadline enters the body as `deadline-approaching` at
+`HARD_DEADLINE_LEAD_DAYS` (90) — a warning, the job stays green — and becomes
+`deadline-critical`, a hard failure, at `HARD_DEADLINE_CRITICAL_DAYS` (**14**).
+14 days is two weekly cron runs, so one lost or evicted scheduled run still
+leaves an alarm while the credential is alive; 7 would leave only one, and 21
+would buy a third run at the price of a third week of standing red.
+
 **Responding to an alert** — the fix depends on which kind of row fired,
 "rotate" is only correct for the first:
 
@@ -422,6 +452,14 @@ Findings are filed as a single, de-duped **`release-health`** GitHub issue
   the three PATs, the three cert pairs): rotate the flagged secret using the
   per-secret runbook earlier in this document, confirm the new value is
   stored under the correct scope (repo secret vs. the `release` environment).
+- **A `deadline-approaching` row**: nothing is broken and nothing authenticates
+  any worse than last week. Schedule the replacement — the row names the date
+  and the day it escalates. **Do not** treat it as a rotation emergency, and do
+  not silence it; it is the only lead time this monitor can give for a credential
+  whose expiry the API does not expose.
+- **A `deadline-critical` row**: the same credential, now inside the replacement
+  window. Replace it this week; the job is red until the registry entry's
+  `hardDeadline` is updated to the new expiry.
 - **A `missing-provenance` or `source-mismatch` provenance row**: this is not
   a credential problem, so there is nothing to rotate. Either unpublish the
   affected version within npm's 72-hour unpublish window, or once that window

--- a/docs/superpowers/plans/2026-07-28-cicd-improvements.md
+++ b/docs/superpowers/plans/2026-07-28-cicd-improvements.md
@@ -289,6 +289,32 @@ exits 1. The deadline entered the 90-day lead window when #841 corrected the dat
 The consequence is not the red itself (rotation is a real action) but that **a newly dead
 credential would be indistinguishable from the standing red.**
 
+> **Correction, 2026-07-29 (added while implementing the fix; the original text above is left
+> as written).** Two of the mechanics in this finding are wrong, and the root cause is
+> different — though the conclusion in the last sentence survives and is what the fix targets.
+>
+> 1. **`deadline` was in the `warn` set, not the `hard` set.** Line 140 *is* `"deadline",`, but
+>    the `hard` set closes at line 135 and the `warn` set opens at line 136 — line 140 is the
+>    fourth entry of `warn`. A `deadline` row therefore opened/kept the `release-health` issue
+>    open but returned `hardFailure: false`.
+> 2. **The 2026-07-27 exit 1 came from a different row.** Reading the run log
+>    ([30265485703](https://github.com/nimbus-agent/Nimbus/actions/runs/30265485703)), the only
+>    non-`ok`, non-`deadline` row is:
+>
+>    ```text
+>    | org/CLA_BOT_APP_ID | inventory | undocumented | actions secret in org is absent from credential-registry.ts — add it or delete it
+>    ```
+>
+>    `undocumented` **is** in the `hard` set, and it is the row that failed the job. It is also
+>    a genuine, unactioned finding: an org secret exists that the manifest does not declare.
+>
+> This is a worked example of the finding itself. The standing `deadline` warning kept issue
+> #854 permanently open, so a real new finding — an undeclared org secret — arrived as one more
+> row in an already-open issue and was read as the deadline everyone already knew about. The
+> channel was saturated before the signal arrived, which is exactly what the "indistinguishable
+> from the standing red" sentence predicted; it simply happened one week earlier than expected
+> and to `undocumented` rather than to `dead`.
+
 ### Failure MODES (not individual failures)
 
 All 73 Nimbus failures were classified by the *names of the jobs and steps that failed*, not by

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import {
+  ALL_HEALTH_STATUSES,
+  annotationsFor,
+  BROKEN_HEADING,
   classifyAppMint,
   classifyPatProbe,
   classifyProvenanceOutcome,
   composeProvenanceDetail,
+  describePatOutcome,
   evaluateCertExpiry,
+  HEALTH_STATUS_CATALOGUE_COMPLETE,
+  HEALTHY_HEADING,
   type HealthRow,
   type PatStrategy,
   runSecretHealth,
+  SCHEDULED_HEADING,
   safeParseDate,
+  severityOf,
   summarize,
 } from "./check-secret-health.ts";
 import type { GitHubApi, IssueRef, ProbeResult, Release, RepoPerms } from "./gh-api.ts";
@@ -366,6 +374,78 @@ describe("runSecretHealth (orchestration)", () => {
     expect(api.calls.createIssue.length).toBe(0);
   });
 
+  // --- the guard this split must never weaken ---
+  test("DEAD STILL FAILS: a dead PAT hard-fails even when a deadline row is also present", async () => {
+    // The regression this guards: softening the deadline row (so the weekly job
+    // stops being red on a scheduled expiry) must not soften the row next to it.
+    // A credential the provider just rejected is broken NOW and exits 1, always.
+    const api = createFakeApi({ probeResults: { "dead-token": { status: 401, scopes: null } } });
+    const result = await runSecretHealth({
+      api,
+      now: new Date("2026-07-29T00:00:00Z"),
+      thresholdDays: 21,
+      pats: [
+        { env: "WINGET_PAT", token: "dead-token", strategy: { kind: "alive" } as PatStrategy },
+      ],
+      certs: [],
+      extraRows: [
+        {
+          name: "nimbus-vscode/VSCE_PAT",
+          kind: "inventory",
+          status: "deadline-approaching",
+          detail: "hard deadline 2026-09-20 in 53d",
+        },
+      ],
+    });
+    expect(result.hardFailure).toBe(true);
+    expect(api.calls.createIssue.length).toBe(1);
+    const body = String(api.calls.createIssue[0]?.[1] ?? "");
+    expect(body).toContain(BROKEN_HEADING);
+    expect(body).toContain("WINGET_PAT");
+  });
+
+  test("an approaching deadline alone files the issue but does NOT fail the job", async () => {
+    const api = createFakeApi();
+    const result = await runSecretHealth({
+      api,
+      now: new Date("2026-07-29T00:00:00Z"),
+      thresholdDays: 21,
+      pats: [],
+      certs: [],
+      extraRows: [
+        {
+          name: "nimbus-vscode/VSCE_PAT",
+          kind: "inventory",
+          status: "deadline-approaching",
+          detail: "hard deadline 2026-09-20 in 53d",
+        },
+      ],
+    });
+    expect(result.hardFailure).toBe(false);
+    expect(api.calls.createIssue.length).toBe(1);
+    expect(api.calls.closeIssue.length).toBe(0);
+  });
+
+  test("the same deadline inside the critical window DOES fail the job", async () => {
+    const api = createFakeApi();
+    const result = await runSecretHealth({
+      api,
+      now: new Date("2026-09-10T00:00:00Z"),
+      thresholdDays: 21,
+      pats: [],
+      certs: [],
+      extraRows: [
+        {
+          name: "nimbus-vscode/VSCE_PAT",
+          kind: "inventory",
+          status: "deadline-critical",
+          detail: "hard deadline 2026-09-20 in 10d",
+        },
+      ],
+    });
+    expect(result.hardFailure).toBe(true);
+  });
+
   test("repo-write: a repo perms-lookup error object → indeterminate, NOT a hard failure (T6)", async () => {
     const api = createFakeApi({
       probeResults: { "pm-token": { status: 200, scopes: null } },
@@ -549,11 +629,197 @@ describe("summarize with inventory rows", () => {
     expect(s.hasHardFailure).toBe(true);
   });
 
-  test("stale, deadline, visibility-drift and audit-overdue warn but do not fail", () => {
-    for (const status of ["stale", "deadline", "visibility-drift", "audit-overdue"] as const) {
+  test("stale, deadline-approaching, visibility-drift and audit-overdue warn but do not fail", () => {
+    for (const status of [
+      "stale",
+      "deadline-approaching",
+      "visibility-drift",
+      "audit-overdue",
+    ] as const) {
       const s = summarize([{ name: "org/X", kind: "inventory", status, detail: "d" }]);
       expect(s.hasHardFailure).toBe(false);
       expect(s.hasWarning).toBe(true);
     }
+  });
+
+  test("deadline-critical is a hard failure — the escalated half of the deadline split", () => {
+    const s = summarize([
+      {
+        name: "nimbus-vscode/VSCE_PAT",
+        kind: "inventory",
+        status: "deadline-critical",
+        detail: "d",
+      },
+    ]);
+    expect(s.hasHardFailure).toBe(true);
+  });
+});
+
+// --- expiring vs dead: the two states this monitor must never conflate ---
+
+describe("severityOf", () => {
+  test("a provider-rejected credential is hard — dead is never downgraded", () => {
+    expect(severityOf("dead")).toBe("hard");
+    expect(severityOf("insufficient")).toBe("hard");
+    expect(severityOf("expired")).toBe("hard");
+  });
+
+  test("a calendar deadline with runway left is a warning, and with none is hard", () => {
+    expect(severityOf("deadline-approaching")).toBe("warn");
+    expect(severityOf("deadline-critical")).toBe("hard");
+  });
+
+  test("ok and not-configured are healthy; nothing else is", () => {
+    expect(severityOf("ok")).toBe("healthy");
+    expect(severityOf("not-configured")).toBe("healthy");
+    for (const status of ALL_HEALTH_STATUSES) {
+      if (status === "ok" || status === "not-configured") continue;
+      expect(severityOf(status)).not.toBe("healthy");
+    }
+  });
+
+  test("every declared status is classified — nothing falls through as silently healthy", () => {
+    // `not-configured` sitting in NEITHER the old hard nor warn set is exactly
+    // how an unreported provenance probe once took the issue-CLOSING branch.
+    // Now classification is total: every status names its own severity.
+    for (const status of ALL_HEALTH_STATUSES) {
+      expect(["hard", "warn", "healthy"]).toContain(severityOf(status));
+    }
+  });
+
+  test("the status catalogue covers the whole union (compile-time proof, asserted at runtime)", () => {
+    expect(HEALTH_STATUS_CATALOGUE_COMPLETE).toBe(true);
+    expect(new Set(ALL_HEALTH_STATUSES).size).toBe(ALL_HEALTH_STATUSES.length);
+  });
+
+  test("an unrecognised status fails closed to hard, never to healthy", () => {
+    // A value that slipped past the type system (a renamed action output, a
+    // hand-built row) must alarm, not vanish into the healthy section.
+    // biome-ignore lint/suspicious/noExplicitAny: deliberately bypassing the type system to prove the runtime guard
+    expect(severityOf("something-nobody-declared" as any)).toBe("hard");
+  });
+});
+
+describe("summarize sections", () => {
+  const section = (table: string, heading: string): string => {
+    const start = table.indexOf(heading);
+    if (start < 0) return "";
+    const rest = table.slice(start + heading.length);
+    const nextHeading = rest.search(/^## /m);
+    return nextHeading < 0 ? rest : rest.slice(0, nextHeading);
+  };
+
+  const rows: readonly HealthRow[] = [
+    { name: "WINGET_PAT", kind: "pat", status: "dead", detail: "the provider REJECTED it" },
+    {
+      name: "nimbus-vscode/VSCE_PAT",
+      kind: "inventory",
+      status: "deadline-approaching",
+      detail: "hard deadline 2026-09-20 in 53d",
+    },
+    { name: "org/SONAR_TOKEN", kind: "inventory", status: "ok", detail: "secret last set 10d ago" },
+  ];
+
+  test("a dead credential lands in the BROKEN section and a live deadline in the SCHEDULED one", () => {
+    const { table } = summarize(rows);
+    expect(section(table, BROKEN_HEADING)).toContain("WINGET_PAT");
+    expect(section(table, SCHEDULED_HEADING)).toContain("nimbus-vscode/VSCE_PAT");
+    expect(section(table, HEALTHY_HEADING)).toContain("org/SONAR_TOKEN");
+  });
+
+  test("neither state can appear in the other's section — this is the whole point", () => {
+    const { table } = summarize(rows);
+    expect(section(table, SCHEDULED_HEADING)).not.toContain("WINGET_PAT");
+    expect(section(table, BROKEN_HEADING)).not.toContain("nimbus-vscode/VSCE_PAT");
+  });
+
+  test("the two headings differ in words AND in leading glyph, not just in status text", () => {
+    expect(BROKEN_HEADING).not.toBe(SCHEDULED_HEADING);
+    expect(BROKEN_HEADING).toContain("❌");
+    expect(SCHEDULED_HEADING).toContain("🟡");
+    expect(SCHEDULED_HEADING.toLowerCase()).toContain("nothing here is broken");
+  });
+
+  test("the BROKEN heading is always rendered, so 0 → 1 is visible at a glance", () => {
+    const clean = summarize([
+      { name: "org/SONAR_TOKEN", kind: "inventory", status: "ok", detail: "fresh" },
+    ]);
+    expect(clean.table).toContain(BROKEN_HEADING);
+    expect(section(clean.table, BROKEN_HEADING)).toContain("_None._");
+  });
+
+  test("the headline counts each severity so the summary line alone carries the verdict", () => {
+    const { table } = summarize(rows);
+    expect(table.split("\n")[0]).toBe("**BROKEN: 1 · scheduled: 1 · healthy: 1**");
+  });
+
+  test("the body defines the two vocabularies so no reader has to infer them", () => {
+    const { table } = summarize(rows);
+    expect(table).toContain("live probe");
+    expect(table).toContain("credential-registry.ts");
+  });
+});
+
+describe("annotationsFor", () => {
+  test("an approaching deadline emits a ::warning:: annotation, never ::error::", () => {
+    const [line] = annotationsFor([
+      {
+        name: "nimbus-vscode/VSCE_PAT",
+        kind: "inventory",
+        status: "deadline-approaching",
+        detail: "hard deadline 2026-09-20 in 53d",
+      },
+    ]);
+    expect(line).toStartWith("::warning ");
+    expect(line).toContain("nimbus-vscode/VSCE_PAT");
+    expect(line).toContain("deadline-approaching");
+  });
+
+  test("a dead credential emits ::error::, so the run's annotation list separates them too", () => {
+    const [line] = annotationsFor([
+      { name: "WINGET_PAT", kind: "pat", status: "dead", detail: "rejected" },
+    ]);
+    expect(line).toStartWith("::error ");
+  });
+
+  test("healthy rows emit nothing", () => {
+    expect(annotationsFor([{ name: "X", kind: "pat", status: "ok", detail: "" }])).toEqual([]);
+  });
+
+  test("detail text can never break out of the workflow command", () => {
+    // A workflow command is recognised only at the START of a line, so the
+    // property that matters is that no interpolated text can begin a new one:
+    // every CR/LF must be encoded. (A bare `::` mid-message is inert once that
+    // holds — the runner does not re-scan within a line.) Registry notes are
+    // ours, but secret NAMES arrive from the GitHub API, so escape always.
+    const lines = annotationsFor([
+      {
+        name: "EVIL\n::error::spoofed",
+        kind: "inventory",
+        status: "undocumented",
+        detail: "100% broken\r\nsecond line",
+      },
+    ]);
+    expect(lines).toHaveLength(1);
+    const line = lines[0] ?? "";
+    expect(line.split(/\r|\n/)).toHaveLength(1);
+    // Exactly one command is emitted: the one this function intended.
+    expect(line.split(/^::/gm)).toHaveLength(2);
+    expect(line).toStartWith("::error ");
+    expect(line).toContain("%0A");
+    expect(line).toContain("%0D");
+    expect(line).toContain("%25");
+  });
+});
+
+describe("describePatOutcome", () => {
+  test("a dead PAT says, in words, that the provider rejected it right now", () => {
+    const detail = describePatOutcome("dead", { kind: "alive" });
+    expect(detail.toLowerCase()).toContain("rejected");
+    expect(detail.toLowerCase()).toContain("now");
+  });
+
+  test("a healthy PAT keeps the original strategy-kind detail", () => {
+    expect(describePatOutcome("ok", { kind: "scopes", required: "public_repo" })).toBe("scopes");
   });
 });

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -758,6 +758,22 @@ describe("summarize sections", () => {
     expect(table).toContain("live probe");
     expect(table).toContain("credential-registry.ts");
   });
+
+  test("every row reaches the body exactly once — sectioning can never drop a finding", () => {
+    // Bucketing rows into sections introduces a way for a row to vanish that a
+    // flat table did not have. A dropped row would be a silent false-negative,
+    // so assert the count survives across every status the monitor can emit.
+    const all: HealthRow[] = ALL_HEALTH_STATUSES.map((status, i) => ({
+      name: `CRED_${i}`,
+      kind: "inventory",
+      status,
+      detail: "d",
+    }));
+    const { table } = summarize(all);
+    for (const row of all) {
+      expect(table.split(`| ${row.name} |`)).toHaveLength(2);
+    }
+  });
 });
 
 describe("annotationsFor", () => {

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -281,21 +281,21 @@ export function summarize(rows: readonly HealthRow[]): {
   table: string;
   state: string;
 } {
-  const bySeverity = new Map<Severity, HealthRow[]>([
-    ["hard", []],
-    ["warn", []],
-    ["healthy", []],
-  ]);
-  for (const r of rows) bySeverity.get(severityOf(r.status))?.push(r);
-  const hard = bySeverity.get("hard") ?? [];
-  const warn = bySeverity.get("warn") ?? [];
-  const healthy = bySeverity.get("healthy") ?? [];
+  // A `Record` keyed by the `Severity` union rather than a Map: indexing is
+  // total, so there is no `?.` on the push and therefore no path — present or
+  // future — where a row is silently dropped instead of being reported. Every
+  // input row lands in exactly one bucket.
+  const hard: HealthRow[] = [];
+  const warn: HealthRow[] = [];
+  const healthy: HealthRow[] = [];
+  const bySeverity: Record<Severity, HealthRow[]> = { hard, warn, healthy };
+  for (const r of rows) bySeverity[severityOf(r.status)].push(r);
 
   const parts: string[] = [
     `**BROKEN: ${hard.length} · scheduled: ${warn.length} · healthy: ${healthy.length}**`,
   ];
   for (const section of SECTIONS) {
-    const sectionRows = bySeverity.get(section.severity) ?? [];
+    const sectionRows = bySeverity[section.severity];
     // The BROKEN and SCHEDULED headings are rendered even when empty, so the
     // 0 → 1 transition is a visible change in the body rather than a new row
     // buried mid-table. The healthy section is dropped when empty because "0

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { auditCredentials, type InventoryStatus } from "./credential-audit";
 import { enumerateSecrets } from "./credential-enumerate";
-import { CREDENTIAL_REGISTRY } from "./credential-registry";
+import { CREDENTIAL_REGISTRY, HARD_DEADLINE_CRITICAL_DAYS } from "./credential-registry";
 import { createGitHubApi, type GitHubApi } from "./gh-api.ts";
 import { closeHealthIssue, openOrUpdateHealthIssue } from "./open-health-issue.ts";
 
@@ -109,11 +109,170 @@ export function composeProvenanceDetail(version: string, actionDetail: string): 
   return actionDetail === "" ? versionPart : `${versionPart}: ${actionDetail}`;
 }
 
+export type HealthStatus = PatStatus | CertStatus | ProvenanceStatus | InventoryStatus;
+
 export interface HealthRow {
   readonly name: string;
   readonly kind: "pat" | "cert" | "provenance" | "inventory";
-  readonly status: PatStatus | CertStatus | ProvenanceStatus | InventoryStatus;
+  readonly status: HealthStatus;
   readonly detail: string;
+}
+
+/** How loudly a row speaks. `hard` is the only one that exits non-zero. */
+export type Severity = "hard" | "warn" | "healthy";
+
+/**
+ * Every status any row kind can carry. Its completeness against the union is
+ * proven at COMPILE time by `HEALTH_STATUS_CATALOGUE_COMPLETE` below, so this
+ * list cannot silently fall behind a new status.
+ */
+export const ALL_HEALTH_STATUSES = [
+  "ok",
+  "dead",
+  "insufficient",
+  "indeterminate",
+  "not-configured",
+  "expiring",
+  "expired",
+  "missing-provenance",
+  "source-mismatch",
+  "missing",
+  "present",
+  "undocumented",
+  "stale",
+  "deadline-approaching",
+  "deadline-critical",
+  "visibility-drift",
+  "audit-overdue",
+] as const satisfies readonly HealthStatus[];
+
+/**
+ * `true` only when `ALL_HEALTH_STATUSES` covers the whole `HealthStatus` union.
+ * Adding a status to any of the four unions without cataloguing it here makes
+ * this type `false`, and the `= true` initializer stops compiling.
+ */
+export const HEALTH_STATUS_CATALOGUE_COMPLETE: [
+  Exclude<HealthStatus, (typeof ALL_HEALTH_STATUSES)[number]>,
+] extends [never]
+  ? true
+  : false = true;
+
+/**
+ * An unrecognised status is a bug, not a healthy credential. The `never`
+ * parameter makes omitting a case from `severityOf` a COMPILE error; the body
+ * covers the runtime case where a value reached us past the type system (a
+ * renamed composite-action output, a hand-built row) and fails it closed.
+ */
+function unclassifiedSeverity(status: never): Severity {
+  console.error(
+    `check-secret-health: unclassified status ${JSON.stringify(status)} — treating as a hard failure`,
+  );
+  return "hard";
+}
+
+/**
+ * The single place a status becomes a verdict.
+ *
+ * The load-bearing split is between the two ways a credential can be in
+ * trouble, which an operator must never confuse:
+ *
+ * - **Rejected** (`dead`, `insufficient`, `expired`, and the provenance
+ *   verdicts) — a live probe just came back bad. Something IS broken. Hard.
+ * - **Dated** (`deadline-approaching`, `expiring`, `stale`, …) — a calendar in
+ *   `credential-registry.ts` says this will break later. Nothing is broken yet.
+ *   Warn — with ONE exception: `deadline-critical`, the point at which the
+ *   remaining runway is shorter than the time a replacement takes to arrange
+ *   (`HARD_DEADLINE_CRITICAL_DAYS`), where a date becomes an emergency.
+ *
+ * `dead` is hard unconditionally and is never softened by anything in this
+ * function — that is the guarantee the deadline split must not erode.
+ */
+export function severityOf(status: HealthStatus): Severity {
+  switch (status) {
+    // A provider said no, a signature did not verify, or a credential that must
+    // not exist does. Broken now.
+    case "dead":
+    case "insufficient":
+    case "expired":
+    case "missing-provenance":
+    case "source-mismatch":
+    case "present":
+    // Inventory: a credential nobody recorded is a credential nobody assessed.
+    case "undocumented":
+    case "missing":
+    // A recorded deadline whose replacement runway has run out.
+    case "deadline-critical":
+      return "hard";
+
+    // Dated, inconclusive, or hygiene. Real work, but nothing is rejected.
+    case "expiring":
+    case "indeterminate":
+    case "stale":
+    case "deadline-approaching":
+    case "visibility-drift":
+    case "audit-overdue":
+      return "warn";
+
+    // `not-configured` is healthy only because every credential that may be
+    // legitimately unset is declared `optional`/`forbidden` in the registry; a
+    // `required` one that is absent surfaces as `missing`, above.
+    case "ok":
+    case "not-configured":
+      return "healthy";
+
+    default:
+      return unclassifiedSeverity(status);
+  }
+}
+
+export const BROKEN_HEADING = "## ❌ BROKEN — rejected, absent, or out of runway";
+export const SCHEDULED_HEADING = "## 🟡 SCHEDULED — dated work; nothing here is broken";
+export const HEALTHY_HEADING = "## ✅ Healthy";
+
+/**
+ * Why the issue body is sectioned rather than one flat table.
+ *
+ * A standing warning (an approaching deadline is one for up to 76 days) keeps
+ * this issue permanently open. In a flat 45-row table, a credential that died
+ * overnight arrives as one more row among forty-five — the same shape, the same
+ * place, one word different in the status column. Sections make the two
+ * outcomes structurally different: a newly-dead credential appears under a
+ * heading that was empty, and an approaching expiry can never appear there.
+ */
+const SECTIONS: readonly { severity: Severity; heading: string; blurb: string }[] = [
+  {
+    severity: "hard",
+    heading: BROKEN_HEADING,
+    blurb:
+      "Every row here either failed a **live probe** (a provider rejected the credential) or has run out of the lead time its replacement needs. This section is the only reason this job ever exits non-zero.",
+  },
+  {
+    severity: "warn",
+    heading: SCHEDULED_HEADING,
+    blurb: `No row here has been rejected by anything. These are calendar and hygiene signals with runway left — a deadline row moves up into BROKEN at ${HARD_DEADLINE_CRITICAL_DAYS} days out. The job still succeeds.`,
+  },
+  { severity: "healthy", heading: HEALTHY_HEADING, blurb: "" },
+];
+
+const VOCABULARY_NOTE = [
+  "> **Reading this table.** `dead` / `insufficient` / `expired` come from a **live probe**:",
+  "> a provider rejected the credential just now. `deadline-approaching` /",
+  "> `deadline-critical` come from the **calendar** in",
+  "> `scripts/release/credential-registry.ts`: the credential still authenticates, and the",
+  "> date is when it is expected to stop. They are different findings and never share a",
+  "> section.",
+  ">",
+  "> PATs are checked dead/alive + authorization only — fine-grained PAT *expiry dates* are",
+  "> not exposed by the API, so a dead PAT is caught within one weekly cycle, not ahead.",
+  "> Certs and registered hard deadlines get true N-days-ahead warning.",
+].join("\n");
+
+function renderTable(rows: readonly HealthRow[]): string {
+  return [
+    "| Credential | Kind | Status | Detail |",
+    "|---|---|---|---|",
+    ...rows.map((r) => `| ${r.name} | ${r.kind} | ${r.status} | ${r.detail} |`),
+  ].join("\n");
 }
 
 export function summarize(rows: readonly HealthRow[]): {
@@ -122,37 +281,110 @@ export function summarize(rows: readonly HealthRow[]): {
   table: string;
   state: string;
 } {
-  const hard = new Set<string>([
-    "dead",
-    "insufficient",
-    "expired",
-    "missing-provenance",
-    "source-mismatch",
-    "present",
-    // Inventory: a credential nobody recorded is a credential nobody assessed.
-    "undocumented",
-    "missing",
+  const bySeverity = new Map<Severity, HealthRow[]>([
+    ["hard", []],
+    ["warn", []],
+    ["healthy", []],
   ]);
-  const warn = new Set<string>([
-    "expiring",
-    "indeterminate",
-    "stale",
-    "deadline",
-    "visibility-drift",
-    "audit-overdue",
-  ]);
-  const hasHardFailure = rows.some((r) => hard.has(r.status));
-  const hasWarning = rows.some((r) => warn.has(r.status));
-  const table = [
-    "| Credential | Kind | Status | Detail |",
-    "|---|---|---|---|",
-    ...rows.map((r) => `| ${r.name} | ${r.kind} | ${r.status} | ${r.detail} |`),
-  ].join("\n");
+  for (const r of rows) bySeverity.get(severityOf(r.status))?.push(r);
+  const hard = bySeverity.get("hard") ?? [];
+  const warn = bySeverity.get("warn") ?? [];
+  const healthy = bySeverity.get("healthy") ?? [];
+
+  const parts: string[] = [
+    `**BROKEN: ${hard.length} · scheduled: ${warn.length} · healthy: ${healthy.length}**`,
+  ];
+  for (const section of SECTIONS) {
+    const sectionRows = bySeverity.get(section.severity) ?? [];
+    // The BROKEN and SCHEDULED headings are rendered even when empty, so the
+    // 0 → 1 transition is a visible change in the body rather than a new row
+    // buried mid-table. The healthy section is dropped when empty because "0
+    // healthy" carries no signal.
+    if (sectionRows.length === 0 && section.severity === "healthy") continue;
+    parts.push(
+      section.severity === "healthy"
+        ? `${section.heading} (${sectionRows.length})`
+        : `${section.heading} (${sectionRows.length})\n\n${section.blurb}`,
+    );
+    parts.push(
+      sectionRows.length === 0
+        ? "_None._"
+        : // Healthy rows are the bulk of the body and none of the signal;
+          // collapsing them keeps the two actionable sections above the fold.
+          section.severity === "healthy"
+          ? `<details><summary>Show ${sectionRows.length} healthy rows</summary>\n\n${renderTable(sectionRows)}\n\n</details>`
+          : renderTable(sectionRows),
+    );
+  }
+  parts.push(VOCABULARY_NOTE);
+
   const state = rows
     .map((r) => `${r.name}=${r.status}`)
     .sort()
     .join(";");
-  return { hasHardFailure, hasWarning, table, state };
+  return {
+    hasHardFailure: hard.length > 0,
+    hasWarning: warn.length > 0,
+    table: parts.join("\n\n"),
+    state,
+  };
+}
+
+// --- GitHub Actions annotations ---
+//
+// Workflow commands are line-delimited and `::`-delimited, so any interpolated
+// text must be escaped or a row could terminate the command and inject its own.
+// Registry notes are ours, but secret NAMES arrive from the GitHub API, so this
+// is applied unconditionally. Escape `%` FIRST or the later replacements'
+// own percent signs get double-encoded.
+function escapeAnnotationData(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function escapeAnnotationProperty(value: string): string {
+  return escapeAnnotationData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+/**
+ * One annotation per non-healthy row, at a level that matches its severity.
+ *
+ * The Actions run page groups annotations by level, so the same
+ * expiring-vs-dead separation the issue body makes in sections is also made in
+ * the run summary: an approaching deadline is a yellow warning that leaves the
+ * job green, a rejected credential is a red error.
+ */
+export function annotationsFor(rows: readonly HealthRow[]): string[] {
+  const lines: string[] = [];
+  for (const r of rows) {
+    const severity = severityOf(r.status);
+    if (severity === "healthy") continue;
+    const level = severity === "hard" ? "error" : "warning";
+    const title = severity === "hard" ? "BROKEN credential" : "Scheduled credential work";
+    lines.push(
+      `::${level} title=${escapeAnnotationProperty(`${title}: ${r.name}`)}::${escapeAnnotationData(
+        `${r.name} — ${r.status} — ${r.detail}`,
+      )}`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * The `detail` column for a probed PAT.
+ *
+ * A `dead` row is the single most urgent thing this monitor can say, and the
+ * bare strategy kind ("alive", "scopes") said none of it. Both loud outcomes now
+ * name their own provenance in words, so the row still reads correctly when it
+ * is quoted out of the table — the mirror of what the deadline details do.
+ */
+export function describePatOutcome(status: PatStatus, strategy: PatStrategy): string {
+  if (status === "dead") {
+    return `${strategy.kind} probe: the provider REJECTED this credential — it is revoked or expired NOW`;
+  }
+  if (status === "insufficient") {
+    return `${strategy.kind} probe: authenticates, but lacks the authorization the release path needs`;
+  }
+  return strategy.kind;
 }
 
 // --- I/O orchestration (injected cert decoders so tests never spawn gpg/openssl) ---
@@ -207,7 +439,7 @@ export async function runSecretHealth(deps: {
         name: p.env,
         kind: "pat",
         status,
-        detail: p.strategy.kind,
+        detail: describePatOutcome(status, p.strategy),
       });
     } catch {
       rows.push({ name: p.env, kind: "pat", status: "indeterminate", detail: "probe error" });
@@ -235,13 +467,11 @@ export async function runSecretHealth(deps: {
     });
   }
   const s = summarize(rows);
-  const caveat =
-    "\n\n> Note: PATs are checked dead/alive + authorization only — fine-grained PAT *expiry dates* are not exposed by the API, so a dead PAT is caught within one weekly cycle, not ahead. Certs get true N-days-ahead warning.";
   if (s.hasHardFailure || s.hasWarning) {
     await openOrUpdateHealthIssue(deps.api, {
       key: "secret-health",
       title: "🔑 Release secret-health alert",
-      body: s.table + caveat,
+      body: s.table,
       state: s.state,
     });
   } else {
@@ -252,7 +482,11 @@ export async function runSecretHealth(deps: {
     );
   }
   const summaryPath = process.env["GITHUB_STEP_SUMMARY"];
-  if (summaryPath) await Bun.write(summaryPath, `## Secret health\n\n${s.table}${caveat}\n`);
+  if (summaryPath) await Bun.write(summaryPath, `# Secret health\n\n${s.table}\n`);
+  // Annotations before the table: on the run page they surface at the top of
+  // the job, separated by level, so "expiring" and "dead" are distinguishable
+  // without opening the issue at all.
+  for (const line of annotationsFor(rows)) console.log(line);
   console.log(s.table);
   return { hardFailure: s.hasHardFailure };
 }

--- a/scripts/release/credential-audit.test.ts
+++ b/scripts/release/credential-audit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { auditCredentials, daysBetween, type LiveSecret } from "./credential-audit";
 import {
   type CredentialEntry,
+  HARD_DEADLINE_CRITICAL_DAYS,
   HARD_DEADLINE_LEAD_DAYS,
   LAST_MANUAL_AUDIT,
   MANUAL_AUDIT_MAX_AGE_DAYS,
@@ -114,14 +115,14 @@ describe("auditCredentials", () => {
     expect(row?.detail).not.toContain("NaN");
   });
 
-  test("a hard deadline inside the 90-day lead time warns", () => {
+  test("a hard deadline inside the 90-day lead time warns as approaching, not as broken", () => {
     const rows = auditCredentials(
       [entry({ maxAgeDays: null, hardDeadline: "2026-09-01" })],
       [live()],
       NOW,
     );
     const row = find(rows, "TEST_SECRET");
-    expect(row?.status).toBe("deadline");
+    expect(row?.status).toBe("deadline-approaching");
     expect(row?.detail).toContain("2026-09-01");
   });
 
@@ -141,9 +142,36 @@ describe("auditCredentials", () => {
       NOW,
     );
     const row = find(rows, "TEST_SECRET");
-    expect(row?.status).toBe("deadline");
+    expect(row?.status).toBe("deadline-critical");
     expect(row?.detail).toContain("overdue by 200d");
     expect(row?.detail).not.toContain("in -200d");
+  });
+
+  // The whole point of the two-state split: a calendar row must never be
+  // readable as "a provider rejected this credential". Both deadline details
+  // therefore say, in words, that the credential still authenticates.
+  test("both deadline states state in words that nothing has been rejected", () => {
+    for (const days of [HARD_DEADLINE_LEAD_DAYS, HARD_DEADLINE_CRITICAL_DAYS]) {
+      const rows = auditCredentials(
+        [entry({ maxAgeDays: null, hardDeadline: deadlineDaysOut(days) })],
+        [live()],
+        NOW,
+      );
+      const row = find(rows, "TEST_SECRET");
+      expect(row?.detail).toContain("scheduled expiry");
+      expect(row?.detail).toContain("not a rejected credential");
+    }
+  });
+
+  test("an approaching deadline names the day it escalates, so the warning is actionable", () => {
+    const rows = auditCredentials(
+      [entry({ maxAgeDays: null, hardDeadline: deadlineDaysOut(HARD_DEADLINE_LEAD_DAYS) })],
+      [live()],
+      NOW,
+    );
+    expect(find(rows, "TEST_SECRET")?.detail).toContain(
+      `escalates to a hard failure at ${HARD_DEADLINE_CRITICAL_DAYS}d`,
+    );
   });
 
   test("org visibility differs from declared warns, in either direction", () => {
@@ -241,7 +269,7 @@ describe("auditCredentials", () => {
         [live()],
         NOW,
       );
-      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline");
+      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline-approaching");
     });
 
     test("a hard deadline one day beyond the lead time stays quiet", () => {
@@ -259,7 +287,70 @@ describe("auditCredentials", () => {
         [live()],
         NOW,
       );
-      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline");
+      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline-approaching");
+    });
+
+    // The escalation boundary. `deadline-approaching` warns; `deadline-critical`
+    // fails. One day either side of HARD_DEADLINE_CRITICAL_DAYS is the exact
+    // seam, so pin both sides and the boundary day itself.
+    test("a hard deadline one day beyond the critical window still only warns", () => {
+      const rows = auditCredentials(
+        [
+          entry({
+            maxAgeDays: null,
+            hardDeadline: deadlineDaysOut(HARD_DEADLINE_CRITICAL_DAYS + 1),
+          }),
+        ],
+        [live()],
+        NOW,
+      );
+      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline-approaching");
+    });
+
+    test("a hard deadline exactly at the critical window escalates to critical", () => {
+      const rows = auditCredentials(
+        [entry({ maxAgeDays: null, hardDeadline: deadlineDaysOut(HARD_DEADLINE_CRITICAL_DAYS) })],
+        [live()],
+        NOW,
+      );
+      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline-critical");
+    });
+
+    test("a hard deadline one day inside the critical window is critical", () => {
+      const rows = auditCredentials(
+        [
+          entry({
+            maxAgeDays: null,
+            hardDeadline: deadlineDaysOut(HARD_DEADLINE_CRITICAL_DAYS - 1),
+          }),
+        ],
+        [live()],
+        NOW,
+      );
+      expect(find(rows, "TEST_SECRET")?.status).toBe("deadline-critical");
+    });
+
+    test("a hard deadline landing today is critical, and reads as 0 days, not overdue", () => {
+      const rows = auditCredentials(
+        [entry({ maxAgeDays: null, hardDeadline: deadlineDaysOut(0) })],
+        [live()],
+        NOW,
+      );
+      const row = find(rows, "TEST_SECRET");
+      expect(row?.status).toBe("deadline-critical");
+      expect(row?.detail).toContain("in 0d");
+      expect(row?.detail).not.toContain("overdue");
+    });
+
+    test("a hard deadline one day past is critical and reads as overdue by 1d", () => {
+      const rows = auditCredentials(
+        [entry({ maxAgeDays: null, hardDeadline: deadlineDaysOut(-1) })],
+        [live()],
+        NOW,
+      );
+      const row = find(rows, "TEST_SECRET");
+      expect(row?.status).toBe("deadline-critical");
+      expect(row?.detail).toContain("overdue by 1d");
     });
 
     test("manual audit age exactly at the policy threshold is ok, not overdue", () => {

--- a/scripts/release/credential-audit.ts
+++ b/scripts/release/credential-audit.ts
@@ -2,6 +2,7 @@ import type { HealthRow } from "./check-secret-health";
 import {
   CREDENTIAL_REGISTRY,
   type CredentialEntry,
+  HARD_DEADLINE_CRITICAL_DAYS,
   HARD_DEADLINE_LEAD_DAYS,
   LAST_MANUAL_AUDIT,
   MANUAL_AUDIT_MAX_AGE_DAYS,
@@ -19,13 +20,23 @@ export interface LiveSecret {
   readonly visibility?: "all" | "selected";
 }
 
+/**
+ * `deadline-approaching` and `deadline-critical` are deliberately two statuses,
+ * not one. They are the *same fact* (a date in `credential-registry.ts`) at two
+ * different distances, and only the second one means "act now" — collapsing them
+ * into a single warning meant a blown deadline never escalated, while
+ * collapsing them into a single failure meant 90 days of standing red on a
+ * credential that still works. Neither is the same class of finding as `dead`,
+ * which comes from a provider rejecting the credential in a live probe.
+ */
 export type InventoryStatus =
   | "ok"
   | "missing"
   | "present"
   | "undocumented"
   | "stale"
-  | "deadline"
+  | "deadline-approaching"
+  | "deadline-critical"
   | "visibility-drift"
   | "audit-overdue"
   | "indeterminate";
@@ -129,7 +140,26 @@ export function auditCredentials(
         // must never be phrased as negative time ("in -200d" reads like a
         // countdown that hasn't happened yet).
         const when = remaining < 0 ? `overdue by ${Math.abs(remaining)}d` : `in ${remaining}d`;
-        rows.push(row(name, "deadline", `hard deadline ${e.hardDeadline} ${when} — ${e.note}`));
+        // Both details assert, in words, that this is a CALENDAR finding. A
+        // reader skimming a 45-row table must not be able to mistake it for the
+        // row above it that says a provider rejected a token — the detail
+        // carries that distinction even if the status column is truncated or the
+        // row is quoted out of the table into a chat message.
+        const provenance =
+          "this is a scheduled expiry recorded in credential-registry.ts, not a rejected credential";
+        rows.push(
+          remaining <= HARD_DEADLINE_CRITICAL_DAYS
+            ? row(
+                name,
+                "deadline-critical",
+                `hard deadline ${e.hardDeadline} ${when} — the replacement runway is gone, act now (${provenance}) — ${e.note}`,
+              )
+            : row(
+                name,
+                "deadline-approaching",
+                `hard deadline ${e.hardDeadline} ${when} — still working, nothing is broken yet; escalates to a hard failure at ${HARD_DEADLINE_CRITICAL_DAYS}d (${provenance}) — ${e.note}`,
+              ),
+        );
         continue;
       }
     }

--- a/scripts/release/credential-registry.ts
+++ b/scripts/release/credential-registry.ts
@@ -49,6 +49,32 @@ export interface CredentialEntry {
  *  because a deadline may require investigation, not just a rotation. */
 export const HARD_DEADLINE_LEAD_DAYS = 90;
 
+/**
+ * The point at which an approaching hard deadline stops being *scheduled work*
+ * and becomes a *failure*.
+ *
+ * Between `HARD_DEADLINE_LEAD_DAYS` and this, a deadline row is
+ * `deadline-approaching`: a warning, never an exit-1, because nothing is broken
+ * — the credential still authenticates and the only fact in evidence is a date
+ * on a calendar. At or inside this window it becomes `deadline-critical`, a hard
+ * failure, because the runway a replacement needs is gone.
+ *
+ * **Why 14 and not 7 or 21.** The monitor runs on one weekly cron (Mondays
+ * 09:00 UTC). A 7-day window yields exactly ONE run before the deadline — and
+ * this org has already lost queued scheduled runs to shared-concurrency
+ * eviction, so a single-run alarm can produce zero alarms. 14 days yields TWO
+ * (one at 8–14 days out, one at 1–7), so a lost run still leaves an alarm while
+ * the credential is alive. 21 days (the cert `thresholdDays` default) would buy
+ * a third run at the cost of a third week of standing red, and standing red is
+ * the exact failure mode this split exists to end: the escalation must mean
+ * "act this week", not "act eventually".
+ *
+ * The 76 days before escalation are not silent — they are the
+ * `deadline-approaching` warning, which files/updates the health issue without
+ * failing the job.
+ */
+export const HARD_DEADLINE_CRITICAL_DAYS = 14;
+
 /** Quarterly, matching the default maxAgeDays so the cadences cannot drift apart. */
 export const MANUAL_AUDIT_MAX_AGE_DAYS = 90;
 


### PR DESCRIPTION
## What

`secret-health` could not tell "this credential is expiring" from "this credential is dead". It now can, in both the exit code and the issue body.

## Why this was dangerous

Two things were true at once:

1. **A blown hard deadline never escalated.** `deadline` was one status covering both "90 days out" and "overdue by 200 days", and it lived in the `warn` set. `VSCE_PAT` expires **2026-09-20**; on 2026-09-21 the row would still have been a *warning* reading `overdue by 1d`. The `overdue by Nd` wording in `credential-audit.ts` proves the negative case was anticipated and left non-failing.
2. **The standing warning saturates the channel.** An approaching deadline keeps issue #854 permanently open for up to 76 days, so anything genuinely new arrives as one more row in a 45-row flat table.

That second one already happened. Run [30265485703](https://github.com/nimbus-agent/Nimbus/actions/runs/30265485703) (2026-07-27) exited 1 — but **not** on the deadline row. It exited on:

```text
| org/CLA_BOT_APP_ID | inventory | undocumented | actions secret in org is absent from credential-registry.ts — add it or delete it
```

An org secret that the manifest does not declare. It landed in an issue that was already open on a deadline everyone knew about, and was read as more of the same. See **needs-owner** below.

### Correction to the prior audit

`docs/superpowers/plans/2026-07-28-cicd-improvements.md` (Finding G) states that `deadline` is in the `hard` set at line 140 and is what fails the job. Verified against source: line 140 *is* `"deadline",` but the `hard` set closes at 135 and `warn` opens at 136 — it is the fourth entry of **`warn`**. A dated correction is added to that doc rather than rewriting the original text.

## How

**The split.** `deadline` → `deadline-approaching` (warn) + `deadline-critical` (hard), escalating at a new `HARD_DEADLINE_CRITICAL_DAYS = 14`.

Why 14, specifically: the monitor is one weekly cron. 14 days is **two runs** before the deadline (one at 8–14 days out, one at 1–7), so a lost or evicted scheduled run — a documented failure mode in this org — still leaves an alarm while the credential is alive. 7 gives exactly one, and therefore zero if that run is evicted. 21 buys a third run at the price of a third week of standing red, and standing red is the failure mode this change exists to end. The 76 preceding days are not silent: they are the warning.

**The body.** Sectioned instead of flat:

```text
**BROKEN: 1 · scheduled: 1 · healthy: 44**

## ❌ BROKEN — rejected, absent, or out of runway (1)
## 🟡 SCHEDULED — dated work; nothing here is broken (1)
## ✅ Healthy (44)   ← collapsed
```

Both actionable headings render even when empty, so `0 → 1` is a visible change in the body rather than a new line buried mid-table. Healthy rows collapse into `<details>` so the two sections that matter stay above the fold. A closing note defines the two vocabularies (`dead` = a live probe; `deadline-*` = the calendar in `credential-registry.ts`).

**Classification is now total.** `severityOf` replaces the two ad-hoc `Set<string>`s with an exhaustive `switch` over a `HealthStatus` union:

- omitting a case is a **compile error** (`never` parameter),
- `ALL_HEALTH_STATUSES` is proven complete against the union at compile time (`HEALTH_STATUS_CATALOGUE_COMPLETE`),
- an unrecognised runtime value **fails closed to `hard`**.

That closes the fall-through class documented in `classifyProvenanceOutcome`'s comment, where `not-configured` sat in neither set and a silently-unreported probe took the issue-**closing** branch.

**Annotations.** `::warning::` for dated rows, `::error::` for rejected ones, so the run page separates them without opening the issue. All interpolated text is escaped — secret names come from the GitHub API, not from us.

**Wording.** A `dead` PAT's detail was the bare strategy kind (`alive`, `scopes`). Both loud outcomes now name their own provenance in words, so a row quoted out of its table is still unambiguous.

## The guarantee, red-proved

`dead` is hard unconditionally and nothing here softens it. Proved by breaking it:

| break | result |
| --- | --- |
| move `dead` from the hard to the warn bucket | **10 tests fail**, incl. `DEAD STILL FAILS: a dead PAT hard-fails even when a deadline row is also present` |
| downgrade `deadline-critical` to warn | **3 tests fail** |
| add a status to `InventoryStatus` without classifying it | **`tsc` fails at both compile-time guards** (TS2322 on the catalogue, TS2345 on the `never`) |

Each was restored and re-run green.

## Boundary tests

`credential-audit.test.ts`: lead+1 → `ok` · lead → approaching · critical+1 → approaching · **critical → critical** · critical−1 → critical · 0d → critical (`in 0d`, not "overdue") · −1d → critical (`overdue by 1d`).

`check-secret-health.test.ts`: every status is bucketed · `dead`/deadline land in different sections and neither can appear in the other's · the headings differ in glyph and in words · the headline counts · annotation levels · annotation escaping (no interpolated text can begin a second workflow command).

## Verification

- `bun test scripts/` — 949 pass, 0 fail
- `tsc -p scripts/tsconfig.json` — clean
- `biome check --error-on-warnings packages scripts docs .github` — 3007 files, clean
- `bun run lint:markdown` — 0 issues · `bun run audit:doc-refs` — 627 refs resolve · `bun run audit:links` (lychee) — 632 unique links, **0 errors**
- `bun run preflight:fast` — typecheck green; its lint leg reports "0 files" inside `.claude/worktrees/` (known biome-in-worktree artifact), so lint was validated against explicit paths as above

`docs/CHANGELOG.md` is deliberately untouched: recent infra/CI PRs (#901, #905, #917, #918) do not log there.

## Not in this PR

`nimbus-vscode` gets the matching change in a separate PR — the two repos own different halves (Nimbus owns the calendar, nimbus-vscode owns liveness) and neither needs the other to merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
