### PR TITLE
fix(cli): make `nimbus init` fail loudly when the Gateway never starts

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,6 +33,7 @@ Index the git repository in the current directory. Needs no credentials, no API 
 cd ~/code/your-project
 nimbus init
 nimbus init --no-sync           # Write the config only; do not start or sync
+nimbus init --help              # Usage and the exit-code table
 ```
 
 What it does:
@@ -44,10 +45,19 @@ What it does:
 
 Re-running is safe and idempotent — a root that is already configured reports `Already configured` and is not duplicated.
 
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The repository was indexed. A concrete `nimbus why` target may or may not have been found — if the index had nothing to suggest yet, `init` says so and prints the generic next step. |
+| `1` | The current directory is not a git repository. Nothing was written. |
+| `2` | The Gateway never became ready, so **nothing was indexed**. The failure names what happened, inlines the tail of the gateway log, and tells you what to run next. |
+| `3` | The Gateway is reachable but this repository was still not indexed — the `filesystem` sync failed, or a Gateway that is already running has to be restarted before it can see the new root. |
+
 Two behaviours worth knowing:
 
-- **If a Gateway is already running**, it cannot see a root that was just added: filesystem roots are read once at startup. `nimbus init` says so and asks you to `nimbus stop && nimbus start` rather than syncing nothing or restarting your daemon for you.
-- **If anything after the config write fails** — the Gateway will not start, the sync errors, or the index has no symbols yet — `init` still exits 0 and falls back to printing the generic `nimbus why <file>:<line>` next step. The config edit is the durable half of the work.
+- **If a Gateway is already running**, it cannot see a root that was just added: filesystem roots are read once at startup. `nimbus init` says so and asks you to `nimbus stop && nimbus start` rather than syncing nothing or restarting your daemon for you (exit `3`).
+- **The config edit is the durable half of the work** and survives every failure above — a second `nimbus init` after fixing the Gateway will not duplicate it. What does *not* survive is the pretence that the command succeeded: a run that indexed nothing exits non-zero and never prints a next step it cannot back up.
 
 `NIMBUS_CONFIG_DIR` overrides the config directory this command writes to (the Gateway honours the same variable). It moves the config directory only — never the data directory.
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,10 +7,16 @@ import type { CliPlatformPaths } from "../paths.ts";
 import {
   applyInitPlan,
   asDemoSymbol,
+  awaitGatewayState,
   defaultInitDeps,
+  type GatewayLogTail,
+  gatewayLogLines,
+  INIT_EXIT,
   type InitDeps,
+  initExitCode,
   initPlan,
   nextStepLines,
+  readGatewayLogTail,
   runInit,
 } from "./init.ts";
 
@@ -108,6 +114,10 @@ function fakeDeps(over: Partial<InitDeps> = {}): { deps: InitDeps; rec: Recorded
       rec.synced += 1;
     },
     demoSymbol: async () => ({ file: "src/auth.ts", line: 42, name: "verifyToken" }),
+    gatewayLogTail: () => ({
+      path: join(dir, "data", "logs", "gateway-2026-07-29.log"),
+      lines: ["initializing platform services", "starting embedding runtime"],
+    }),
     log: (l) => rec.out.push(l),
     error: (l) => rec.err.push(l),
     ...over,
@@ -162,31 +172,318 @@ test("an already-configured root syncs against the running gateway", async () =>
   expect(rec.out.join("\n")).toContain("nimbus why src/auth.ts:42");
 });
 
-test("degrades to the generic next step when the gateway will not start", async () => {
+// ------------------------------------------- runInit: gateway never ready
+//
+// The whole point of this block. A gateway that never came up indexed nothing,
+// so `init` must say so and exit non-zero — printing the generic `Next:` block
+// and exiting 0 is what made #925 and #928 invisible for as long as they were.
+
+test("a gateway that never became ready is a FAILURE, not a degraded success", async () => {
   const { deps, rec } = fakeDeps({ startGateway: async () => false });
   await runInit([], deps);
+  expect(process.exitCode).toBe(INIT_EXIT.gatewayUnavailable);
+  expect(process.exitCode).not.toBe(0);
   expect(rec.synced).toBe(0);
-  expect(rec.out.join("\n")).toContain("nimbus why <file>:<line>");
 });
 
-test("degrades to the generic next step when the sync fails", async () => {
-  // A failed sync must not turn `init` into a failed command — the config edit
-  // already succeeded and is the durable half of the work.
+test("the gateway-never-ready failure names the failure and never prints a next step", async () => {
+  const { deps, rec } = fakeDeps({ startGateway: async () => false });
+  await runInit([], deps);
+  const err = rec.err.join("\n");
+  // What actually failed, in the failure stream.
+  expect(err).toContain("Gateway never became ready");
+  expect(err).toContain("nothing was indexed");
+  // What to do next.
+  expect(err).toContain("nimbus doctor");
+  expect(err).toContain("nimbus start");
+  // The lie this test exists to prevent: a "Next:"/"Try it:" block implying the
+  // command did its job.
+  const all = [...rec.out, ...rec.err].join("\n");
+  expect(all).not.toContain("Try it:");
+  expect(all).not.toContain("nimbus why <file>:<line>");
+});
+
+test("the gateway-never-ready failure inlines the tail of the gateway log", async () => {
+  const logPath = join(dir, "data", "logs", "gateway-2026-07-29.log");
+  const { deps, rec } = fakeDeps({
+    startGateway: async () => false,
+    gatewayLogTail: () => ({
+      path: logPath,
+      lines: ["initializing platform services", "fatal: PlatformInitError: Vault operation failed"],
+    }),
+  });
+  await runInit([], deps);
+  const err = rec.err.join("\n");
+  // A path the user has to go read is exactly why this went unnoticed: inline it.
+  expect(err).toContain(logPath);
+  expect(err).toContain("fatal: PlatformInitError: Vault operation failed");
+});
+
+test("the gateway-never-ready failure never claims log lines it does not have", async () => {
+  const { deps, rec } = fakeDeps({ startGateway: async () => false, gatewayLogTail: () => null });
+  await runInit([], deps);
+  expect(process.exitCode).toBe(INIT_EXIT.gatewayUnavailable);
+  const err = rec.err.join("\n");
+  expect(err).toContain("no Gateway log");
+  expect(err).not.toContain("  | ");
+});
+
+// -------------------------------------- runInit: partial vs total failure
+
+test("a sync failure is reported as a failure, distinct from a dead gateway", async () => {
   const { deps, rec } = fakeDeps({
     syncFilesystem: async () => {
       throw new Error("connector unavailable");
     },
   });
   await runInit([], deps);
-  expect(process.exitCode ?? 0).toBe(0);
+  expect(process.exitCode).toBe(INIT_EXIT.notIndexed);
+  expect(INIT_EXIT.notIndexed).not.toBe(INIT_EXIT.gatewayUnavailable);
+  const err = rec.err.join("\n");
+  expect(err).toContain("indexing did not complete");
+  expect(err).toContain("connector unavailable");
+  expect([...rec.out, ...rec.err].join("\n")).not.toContain("Try it:");
+});
+
+test("indexing that found no symbol is still a SUCCESS, with an honest note", async () => {
+  // Gateway fine, sync fine, index simply has nothing worth suggesting yet.
+  // That is a partial success and must stay distinguishable from a failure.
+  const { deps, rec } = fakeDeps({ demoSymbol: async () => null });
+  await runInit([], deps);
+  expect(process.exitCode ?? 0).toBe(INIT_EXIT.ok);
+  expect(rec.synced).toBe(1);
+  const out = rec.out.join("\n");
+  expect(out).toContain("no symbol to suggest yet");
+  expect(out).toContain("nimbus why <file>:<line>");
+  expect(out).not.toContain("nimbus why src/");
+});
+
+test("a demo-symbol lookup that throws does not fail a repository that DID index", async () => {
+  const { deps, rec } = fakeDeps({
+    demoSymbol: async () => {
+      throw new Error("index.demoSymbol unavailable");
+    },
+  });
+  await runInit([], deps);
+  expect(process.exitCode ?? 0).toBe(INIT_EXIT.ok);
+  expect(rec.synced).toBe(1);
   expect(rec.out.join("\n")).toContain("nimbus why <file>:<line>");
 });
 
-test("degrades to the generic next step when the index has no symbol yet", async () => {
-  const { deps, rec } = fakeDeps({ demoSymbol: async () => null });
+test("a running gateway that must be restarted did not index either — non-zero", async () => {
+  const { deps, rec } = fakeDeps({ gatewayRunning: async () => true });
   await runInit([], deps);
-  expect(rec.synced).toBe(1);
-  expect(rec.out.join("\n")).toContain("nimbus why <file>:<line>");
+  expect(process.exitCode).toBe(INIT_EXIT.notIndexed);
+  expect(rec.err.join("\n")).toContain("not indexed");
+  expect([...rec.out, ...rec.err].join("\n")).not.toContain("Try it:");
+});
+
+// ---------------------------------------------------------- initExitCode
+
+test("initExitCode maps every outcome to its documented code", () => {
+  expect(initExitCode({ kind: "indexed", demo: null })).toBe(0);
+  expect(initExitCode({ kind: "config-only" })).toBe(0);
+  expect(initExitCode({ kind: "not-a-repo" })).toBe(1);
+  expect(initExitCode({ kind: "gateway-unavailable" })).toBe(2);
+  expect(initExitCode({ kind: "restart-required" })).toBe(3);
+  expect(initExitCode({ kind: "index-failed", message: "boom" })).toBe(3);
+});
+
+test("every failure outcome is non-zero and total failure is not collapsed into partial", () => {
+  // The guard, stated once: a gateway that never came up can never share an
+  // exit code with a run that actually indexed something.
+  const failures = [
+    initExitCode({ kind: "not-a-repo" }),
+    initExitCode({ kind: "gateway-unavailable" }),
+    initExitCode({ kind: "restart-required" }),
+    initExitCode({ kind: "index-failed", message: "boom" }),
+  ];
+  for (const code of failures) {
+    expect(code).not.toBe(0);
+  }
+  expect(initExitCode({ kind: "gateway-unavailable" })).not.toBe(
+    initExitCode({ kind: "index-failed", message: "boom" }),
+  );
+  expect(new Set(failures).size).toBe(3);
+});
+
+// ------------------------------------------------------- gatewayLogLines
+
+test("gatewayLogLines inlines the tail under its path", () => {
+  const tail: GatewayLogTail = { path: "/logs/gateway.log", lines: ["a", "b"] };
+  expect(gatewayLogLines(tail).join("\n")).toContain("/logs/gateway.log");
+  expect(gatewayLogLines(tail).join("\n")).toContain("  | a");
+  expect(gatewayLogLines(tail).join("\n")).toContain("  | b");
+});
+
+test("gatewayLogLines says so rather than implying an empty log is a clean one", () => {
+  expect(gatewayLogLines({ path: "/logs/gateway.log", lines: [] }).join("\n")).toContain(
+    "no readable lines",
+  );
+  expect(gatewayLogLines(null).join("\n")).toContain("no Gateway log");
+});
+
+// ---------------------------------------------------- readGatewayLogTail
+
+test("readGatewayLogTail returns null when there is no log directory at all", () => {
+  expect(readGatewayLogTail(join(dir, "definitely-absent"))).toBeNull();
+});
+
+test("readGatewayLogTail returns null when the directory holds no gateway log", () => {
+  const logDir = join(dir, "logs-empty");
+  mkdirSync(logDir, { recursive: true });
+  writeFileSync(join(logDir, "cli-2026-07-29.log"), "not a gateway log\n", "utf8");
+  expect(readGatewayLogTail(logDir)).toBeNull();
+});
+
+test("readGatewayLogTail picks the newest gateway log and returns its last lines", async () => {
+  const logDir = join(dir, "logs");
+  mkdirSync(logDir, { recursive: true });
+  const older = join(logDir, "gateway-2026-07-28.log");
+  const newer = join(logDir, "gateway-2026-07-29.log");
+  writeFileSync(older, "[gateway] yesterday\n", "utf8");
+  // Distinct mtimes without relying on filename ordering.
+  await new Promise((r) => setTimeout(r, 10));
+  writeFileSync(newer, "[gateway] one\n[gateway] two\n[gateway] three\n\n", "utf8");
+
+  const tail = readGatewayLogTail(logDir, 2);
+  expect(tail?.path).toBe(newer);
+  // Last two non-empty lines, in order, with the `[gateway] ` prefix stripped.
+  expect(tail?.lines).toEqual(["two", "three"]);
+});
+
+test("readGatewayLogTail ignores a directory that happens to be named like a log", () => {
+  const logDir = join(dir, "logs-dir-entry");
+  mkdirSync(join(logDir, "gateway-decoy.log"), { recursive: true });
+  expect(readGatewayLogTail(logDir)).toBeNull();
+});
+
+test("readGatewayLogTail never emits a fragment when the log exceeds its read window", () => {
+  // A long-lived gateway log is far bigger than the tail window, so the read
+  // starts mid-line. That leading fragment is not a log line and must not be
+  // shown as one.
+  const logDir = join(dir, "logs-big");
+  mkdirSync(logDir, { recursive: true });
+  const p = join(logDir, "gateway-2026-07-29.log");
+  const body = Array.from({ length: 4000 }, (_, i) => `[gateway] line ${String(i)}`).join("\n");
+  writeFileSync(p, `${body}\n`, "utf8");
+  expect(body.length).toBeGreaterThan(16_384);
+
+  const tail = readGatewayLogTail(logDir, 3);
+  expect(tail?.lines).toEqual(["line 3997", "line 3998", "line 3999"]);
+  // Ask for far more than the window holds: every line returned is a whole one.
+  for (const line of readGatewayLogTail(logDir, 5000)?.lines ?? []) {
+    expect(line).toMatch(/^line \d+$/);
+  }
+});
+
+test("readGatewayLogTail reports an empty log as empty rather than as missing", () => {
+  const logDir = join(dir, "logs-blank");
+  mkdirSync(logDir, { recursive: true });
+  const p = join(logDir, "gateway-2026-07-29.log");
+  writeFileSync(p, "", "utf8");
+  expect(readGatewayLogTail(logDir)).toEqual({ path: p, lines: [] });
+});
+
+// ------------------------------------------------- awaitGatewayState (race)
+//
+// The gateway binds its IPC socket and only THEN writes gateway.json
+// (packages/gateway/src/index.ts: `await platform.ipc.start()` precedes
+// `writeGatewayStateFile`). `runStart` returns as soon as the socket answers,
+// so a one-shot state read straight afterwards can miss a gateway that is
+// perfectly healthy — and now that a dead gateway exits 2, that miss would be
+// a FALSE failure on a working machine.
+
+test("awaitGatewayState waits out the bind→state-file gap instead of failing", async () => {
+  let reads = 0;
+  const ok = await awaitGatewayState({
+    readState: async () => {
+      reads += 1;
+      // Absent for the first two polls, exactly like the real race.
+      return reads > 2 ? { pid: 1, socketPath: "s" } : undefined;
+    },
+    timeoutMs: 5_000,
+    pollMs: 10,
+    now: () => 0,
+    sleep: async () => {},
+  });
+  expect(ok).toBe(true);
+  expect(reads).toBe(3);
+});
+
+test("awaitGatewayState still gives up — a state file that never lands is a failure", async () => {
+  let clock = 0;
+  const ok = await awaitGatewayState({
+    readState: async () => undefined,
+    timeoutMs: 100,
+    pollMs: 10,
+    now: () => clock,
+    sleep: async (ms) => {
+      clock += ms;
+    },
+  });
+  expect(ok).toBe(false);
+});
+
+test("awaitGatewayState does not poll at all when the state file is already there", async () => {
+  let reads = 0;
+  const ok = await awaitGatewayState({
+    readState: async () => {
+      reads += 1;
+      return { pid: 1, socketPath: "s" };
+    },
+    timeoutMs: 5_000,
+    pollMs: 10,
+    sleep: async () => {
+      throw new Error("must not sleep when the gateway is already registered");
+    },
+  });
+  expect(ok).toBe(true);
+  expect(reads).toBe(1);
+});
+
+test("awaitGatewayState defaults terminate against a real clock", async () => {
+  // No injected clock: proves the production defaults cannot spin forever.
+  expect(
+    await awaitGatewayState({ readState: async () => undefined, timeoutMs: 1, pollMs: 1 }),
+  ).toBe(false);
+});
+
+// ------------------------------------------------------------------ --help
+
+test("--help documents every exit code and does no work", async () => {
+  const { deps, rec } = fakeDeps();
+  await runInit(["--help"], deps);
+  const out = rec.out.join("\n");
+  for (const code of ["0", "1", "2", "3"]) {
+    expect(out).toContain(`  ${code}  `);
+  }
+  expect(out).toContain("Exit codes:");
+  expect(out).toContain("--no-sync");
+  // Help must not start a gateway or write config.
+  expect(rec.started).toBe(0);
+  expect(rec.synced).toBe(0);
+  expect(existsSync(join(configDir, "nimbus.toml"))).toBe(false);
+  expect(process.exitCode ?? 0).toBe(0);
+});
+
+test("-h is the same help", async () => {
+  const { deps, rec } = fakeDeps();
+  await runInit(["-h"], deps);
+  expect(rec.out.join("\n")).toContain("Exit codes:");
+  expect(rec.started).toBe(0);
+});
+
+test("a thrown non-Error still reaches the failure report", async () => {
+  // Rejections cross an IPC boundary, so they are not guaranteed to be Errors.
+  const { deps, rec } = fakeDeps({
+    syncFilesystem: async () => {
+      throw "filesystem connector exploded";
+    },
+  });
+  await runInit([], deps);
+  expect(process.exitCode).toBe(INIT_EXIT.notIndexed);
+  expect(rec.err.join("\n")).toContain("filesystem connector exploded");
 });
 
 afterEach(() => {
@@ -247,6 +544,18 @@ test("defaultInitDeps effects fail loudly when the gateway is absent", async () 
   const deps = defaultInitDeps(fakePaths());
   await expect(deps.syncFilesystem()).rejects.toThrow(/Gateway is not running/);
   await expect(deps.demoSymbol("/repo")).rejects.toThrow(/Gateway is not running/);
+});
+
+test("defaultInitDeps reads the gateway log tail from the supplied logDir", () => {
+  const paths = fakePaths();
+  expect(defaultInitDeps(paths).gatewayLogTail()).toBeNull();
+  mkdirSync(paths.logDir, { recursive: true });
+  const p = join(paths.logDir, "gateway-2026-07-29.log");
+  writeFileSync(p, "[gateway] starting embedding runtime\n", "utf8");
+  expect(defaultInitDeps(paths).gatewayLogTail()).toEqual({
+    path: p,
+    lines: ["starting embedding runtime"],
+  });
 });
 
 test("defaultInitDeps log/error write to the console without throwing", () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,17 @@
-import { existsSync, readFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
 import { hasFlag } from "../lib/flag-parsing.ts";
+import { extractLatestMessage, truncatePreview } from "../lib/gateway-log-tail.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { appendFilesystemRoot, hasFilesystemRoot } from "../lib/toml-append.ts";
 import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
@@ -22,6 +32,60 @@ export type InitPlan =
  */
 export type DemoSymbolLike = { file: string; line: number; name: string };
 
+/** The tail of the gateway log, with the path it came from. */
+export type GatewayLogTail = { path: string; lines: readonly string[] };
+
+/**
+ * What actually happened. `runInit` derives both the report and the exit code
+ * from this, so the two can never disagree.
+ */
+export type InitOutcome =
+  /** Gateway reachable and the sync ran. `demo` is a hint, not a success criterion. */
+  | { kind: "indexed"; demo: DemoSymbolLike | null }
+  /** `--no-sync`: the config edit was the whole job. */
+  | { kind: "config-only" }
+  | { kind: "not-a-repo" }
+  /** The gateway never came up. Nothing was indexed. */
+  | { kind: "gateway-unavailable" }
+  /** A gateway is running but cannot see the new root until it restarts. */
+  | { kind: "restart-required" }
+  /** Gateway reachable, sync attempted and failed. */
+  | { kind: "index-failed"; message: string };
+
+/**
+ * The documented exit codes. Distinct on purpose: `init` is the first command a
+ * new user runs, and "the Gateway never came up" (2) must never be
+ * indistinguishable from "indexed, nothing to suggest yet" (0).
+ *
+ * Kept in step with the `Exit codes:` block in HELP_LINES and the
+ * `nimbus init` section of docs/cli-reference.md.
+ */
+export const INIT_EXIT = {
+  /** Indexed. A `nimbus why` target may or may not have been found. */
+  ok: 0,
+  /** Usage: not a git repository. Nothing was written. */
+  usage: 1,
+  /** The Gateway never became ready. Nothing was indexed. */
+  gatewayUnavailable: 2,
+  /** The Gateway is reachable, but this repository was not indexed. */
+  notIndexed: 3,
+} as const;
+
+export function initExitCode(outcome: InitOutcome): number {
+  switch (outcome.kind) {
+    case "indexed":
+    case "config-only":
+      return INIT_EXIT.ok;
+    case "not-a-repo":
+      return INIT_EXIT.usage;
+    case "gateway-unavailable":
+      return INIT_EXIT.gatewayUnavailable;
+    case "restart-required":
+    case "index-failed":
+      return INIT_EXIT.notIndexed;
+  }
+}
+
 export type InitDeps = {
   cwd: string;
   configDir: string;
@@ -30,9 +94,29 @@ export type InitDeps = {
   startGateway: () => Promise<boolean>;
   syncFilesystem: () => Promise<void>;
   demoSymbol: (repoRoot: string) => Promise<DemoSymbolLike | null>;
+  /** Last few gateway log lines, or null when there is no log to show. */
+  gatewayLogTail: () => GatewayLogTail | null;
   log: (line: string) => void;
   error: (line: string) => void;
 };
+
+const HELP_LINES: readonly string[] = [
+  "nimbus init — index the git repository in the current directory",
+  "",
+  "Usage:",
+  "  nimbus init [--no-sync]",
+  "",
+  "Flags:",
+  "  --no-sync   write nimbus.toml only; do not start the Gateway and do not index",
+  "  --help      this message",
+  "",
+  "Exit codes:",
+  "  0  the repository was indexed (a `nimbus why` target may not exist yet)",
+  "  1  the current directory is not a git repository — nothing was written",
+  "  2  the Gateway never became ready — nothing was indexed",
+  "  3  the Gateway is reachable, but this repository was not indexed",
+  "     (the sync failed, or a running Gateway must restart to see the new root)",
+];
 
 /** Pure decision step, so the behaviour is testable without touching disk. */
 export function initPlan(opts: InitOptions): InitPlan {
@@ -71,7 +155,162 @@ export function nextStepLines(demo: DemoSymbolLike | null): string[] {
 }
 
 /**
- * Bring a gateway up if needed, or explain why we will not.
+ * Render the gateway log tail for a failure report.
+ *
+ * Printing a path the user then has to go and read is exactly why #925/#928
+ * stayed invisible, so the lines are inlined. The empty and missing cases get
+ * their own wording: an empty log must never be rendered as a clean one.
+ */
+export function gatewayLogLines(tail: GatewayLogTail | null): string[] {
+  if (tail === null) {
+    return ["Found no Gateway log to show — the Gateway may not have got far enough to write one."];
+  }
+  if (tail.lines.length === 0) {
+    return [`Gateway log: ${tail.path} (no readable lines)`];
+  }
+  return [`Gateway log: ${tail.path}`, ...tail.lines.map((l) => `  | ${l}`)];
+}
+
+const GATEWAY_LOG_TAIL_LINES = 6;
+/** Read window for the tail. Bounded so a multi-megabyte log stays cheap. */
+const GATEWAY_LOG_TAIL_BYTES = 16_384;
+const GATEWAY_LOG_LINE_MAX = 160;
+
+/**
+ * The newest `gateway-<date>.log` in `logDir`, or undefined when there is none.
+ *
+ * Newest by mtime rather than by filename: after a rotation the name that sorts
+ * last is only coincidentally the one being written to.
+ */
+function newestGatewayLog(logDir: string): string | undefined {
+  let entries: string[];
+  try {
+    entries = readdirSync(logDir);
+  } catch {
+    return undefined;
+  }
+  let best: { path: string; mtimeMs: number } | undefined;
+  for (const name of entries) {
+    if (!name.startsWith("gateway-") || !name.endsWith(".log")) {
+      continue;
+    }
+    const path = join(logDir, name);
+    try {
+      const st = statSync(path);
+      if (st.isFile() && (best === undefined || st.mtimeMs > best.mtimeMs)) {
+        best = { path, mtimeMs: st.mtimeMs };
+      }
+    } catch {
+      /* unreadable entry: skip it rather than fail the whole report */
+    }
+  }
+  return best?.path;
+}
+
+function tailLines(path: string, maxLines: number): string[] {
+  let fd: number;
+  try {
+    fd = openSync(path, "r");
+  } catch {
+    return [];
+  }
+  try {
+    const size = fstatSync(fd).size;
+    const start = Math.max(0, size - GATEWAY_LOG_TAIL_BYTES);
+    const len = size - start;
+    if (len <= 0) {
+      return [];
+    }
+    const buf = Buffer.alloc(len);
+    readSync(fd, buf, 0, len, start);
+    const raw = buf.toString("utf8").split(/\r?\n/);
+    if (start > 0) {
+      // The read window began mid-line; that fragment is not a log line.
+      raw.shift();
+    }
+    const out: string[] = [];
+    for (let i = raw.length - 1; i >= 0 && out.length < maxLines; i--) {
+      const line = raw[i]?.trim() ?? "";
+      if (line.length === 0) {
+        continue;
+      }
+      out.unshift(truncatePreview(extractLatestMessage(line), GATEWAY_LOG_LINE_MAX));
+    }
+    return out;
+  } catch {
+    return [];
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Last few lines of the newest gateway log under `logDir`.
+ *
+ * Returns null only when no gateway log exists at all. A log that exists but
+ * yields nothing comes back with `lines: []`, so the report can say "empty"
+ * instead of "missing" — two different things to someone debugging a startup.
+ */
+export function readGatewayLogTail(
+  logDir: string,
+  maxLines: number = GATEWAY_LOG_TAIL_LINES,
+): GatewayLogTail | null {
+  const path = newestGatewayLog(logDir);
+  if (path === undefined) {
+    return null;
+  }
+  return { path, lines: tailLines(path, maxLines) };
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** How long a just-started gateway may take to register itself. */
+const GATEWAY_STATE_SETTLE_MS = 5_000;
+const GATEWAY_STATE_POLL_MS = 50;
+
+export type GatewayStateWait = {
+  /** Resolves to the gateway state, or undefined while it is not there yet. */
+  readState: () => Promise<unknown>;
+  timeoutMs?: number;
+  pollMs?: number;
+  /** Seams so the loop is testable without a real clock. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Wait for the gateway to register itself, bounded.
+ *
+ * The gateway binds its IPC socket and only THEN writes the state file
+ * (`gateway/src/index.ts`: `await platform.ipc.start()` precedes
+ * `writeGatewayStateFile`), so `runStart` — which returns as soon as the
+ * socket answers — can hand back a healthy gateway whose state file is a few
+ * milliseconds away. Everything `init` does next goes through
+ * `withGatewayIpc`, which reads that file, so a one-shot check here would
+ * report a working machine as "the Gateway never became ready". Now that that
+ * verdict exits non-zero, guessing it is not an option.
+ */
+export async function awaitGatewayState(w: GatewayStateWait): Promise<boolean> {
+  const timeoutMs = w.timeoutMs ?? GATEWAY_STATE_SETTLE_MS;
+  const pollMs = w.pollMs ?? GATEWAY_STATE_POLL_MS;
+  const now = w.now ?? Date.now;
+  const sleep = w.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const start = now();
+  for (;;) {
+    if ((await w.readState()) !== undefined) {
+      return true;
+    }
+    if (now() - start >= timeoutMs) {
+      return false;
+    }
+    await sleep(pollMs);
+  }
+}
+
+/**
+ * Bring a gateway up if needed, or report why we will not.
  *
  * A gateway that was ALREADY running cannot see a root we just appended:
  * `platform/assemble.ts` reads `[[filesystem.roots]]` once at startup. Syncing
@@ -82,50 +321,130 @@ export function nextStepLines(demo: DemoSymbolLike | null): string[] {
 async function ensureSyncableGateway(
   deps: InitDeps,
   addedRoot: boolean,
-): Promise<"ready" | "declined"> {
-  const running = await deps.gatewayRunning();
-  if (running) {
-    if (!addedRoot) {
-      return "ready";
-    }
-    deps.log("");
-    deps.log("A gateway is already running and loads filesystem roots at startup.");
-    deps.log("Restart it to pick up the new root:");
-    deps.log("  nimbus stop");
-    deps.log("  nimbus start");
-    return "declined";
+): Promise<"ready" | "restart-required" | "unavailable"> {
+  if (await deps.gatewayRunning()) {
+    return addedRoot ? "restart-required" : "ready";
   }
   deps.log("");
   deps.log("Starting the gateway...");
-  return (await deps.startGateway()) ? "ready" : "declined";
+  return (await deps.startGateway()) ? "ready" : "unavailable";
+}
+
+/**
+ * The demo symbol is a hint, not the job.
+ *
+ * A lookup that throws leaves an indexed repository indexed, so it degrades to
+ * `null` — the generic next step — rather than failing a run that did its work.
+ */
+async function pickDemo(deps: InitDeps, repoRoot: string): Promise<DemoSymbolLike | null> {
+  try {
+    return await deps.demoSymbol(repoRoot);
+  } catch (e) {
+    deps.log(`  (could not read a demo symbol: ${errorMessage(e)})`);
+    return null;
+  }
 }
 
 /**
  * Sync, then ask the index for a demo symbol.
  *
- * Every failure here degrades to `null` rather than propagating: the config
- * edit already succeeded and is the durable half of the work, so a connector
- * hiccup must not turn `init` into a failed command.
+ * A sync that throws is a real failure and is returned as one. It used to be
+ * swallowed into the generic next step, which is how a `nimbus init` that
+ * indexed nothing still exited 0.
  */
-async function syncAndPickDemo(deps: InitDeps, repoRoot: string): Promise<DemoSymbolLike | null> {
+async function indexRepository(deps: InitDeps, repoRoot: string): Promise<InitOutcome> {
+  deps.log("Indexing this repository...");
   try {
-    deps.log("Indexing this repository...");
     await deps.syncFilesystem();
-    return await deps.demoSymbol(repoRoot);
   } catch (e) {
-    deps.log(`  (indexing did not complete: ${e instanceof Error ? e.message : String(e)})`);
-    return null;
+    return { kind: "index-failed", message: errorMessage(e) };
+  }
+  return { kind: "indexed", demo: await pickDemo(deps, repoRoot) };
+}
+
+function reportGatewayUnavailable(deps: InitDeps): void {
+  deps.error("");
+  deps.error("nimbus init: the Gateway never became ready, so nothing was indexed.");
+  deps.error("  The nimbus.toml edit above is done — re-running init will not repeat it.");
+  deps.error("");
+  for (const line of gatewayLogLines(deps.gatewayLogTail())) {
+    deps.error(line);
+  }
+  deps.error("");
+  deps.error("What to try:");
+  deps.error("  nimbus doctor      # check the OS prerequisites the Gateway needs");
+  deps.error("  nimbus start       # start it again and read the error in full");
+  deps.error("Then re-run: nimbus init");
+}
+
+function reportIndexFailed(deps: InitDeps, message: string): void {
+  deps.error("");
+  deps.error("nimbus init: indexing did not complete — the Gateway is up, but the sync failed.");
+  deps.error(`  ${message}`);
+  deps.error("");
+  for (const line of gatewayLogLines(deps.gatewayLogTail())) {
+    deps.error(line);
+  }
+  deps.error("");
+  deps.error("What to try:");
+  deps.error("  nimbus connector sync filesystem   # re-run just the sync");
+  deps.error("  nimbus doctor");
+}
+
+function reportRestartRequired(deps: InitDeps): void {
+  deps.log("");
+  deps.log("A gateway is already running and loads filesystem roots at startup.");
+  deps.log("Restart it to pick up the new root:");
+  deps.log("  nimbus stop");
+  deps.log("  nimbus start");
+  deps.error(
+    "nimbus init: this repository was not indexed — restart the running Gateway, then re-run nimbus init.",
+  );
+}
+
+function reportIndexed(deps: InitDeps, demo: DemoSymbolLike | null): void {
+  if (demo === null) {
+    deps.log("");
+    deps.log("Indexed this repository — no symbol to suggest yet.");
+  }
+  for (const line of nextStepLines(demo)) {
+    deps.log(line);
   }
 }
 
-export async function runInit(args: string[], deps: InitDeps = defaultInitDeps()): Promise<void> {
+/** The single place an outcome becomes output. */
+function reportOutcome(outcome: InitOutcome, deps: InitDeps): void {
+  switch (outcome.kind) {
+    case "not-a-repo":
+      deps.error("nimbus init: run this inside a git repository.");
+      return;
+    case "config-only":
+      for (const line of nextStepLines(null)) {
+        deps.log(line);
+      }
+      return;
+    case "indexed":
+      reportIndexed(deps, outcome.demo);
+      return;
+    case "gateway-unavailable":
+      reportGatewayUnavailable(deps);
+      return;
+    case "restart-required":
+      reportRestartRequired(deps);
+      return;
+    case "index-failed":
+      reportIndexFailed(deps, outcome.message);
+      return;
+  }
+}
+
+/** Everything up to the report: config edit, gateway, sync. */
+async function initOutcome(args: string[], deps: InitDeps): Promise<InitOutcome> {
   const opts: InitOptions = { cwd: deps.cwd, configDir: deps.configDir };
   const plan = initPlan(opts);
 
   if (plan.kind === "not-a-repo") {
-    deps.error("nimbus init: run this inside a git repository.");
-    process.exitCode = 1;
-    return;
+    return { kind: "not-a-repo" };
   }
 
   if (plan.kind === "already-configured") {
@@ -136,18 +455,34 @@ export async function runInit(args: string[], deps: InitDeps = defaultInitDeps()
   }
 
   if (hasFlag(args, "--no-sync")) {
-    for (const line of nextStepLines(null)) {
-      deps.log(line);
-    }
-    return;
+    return { kind: "config-only" };
   }
 
   const gateway = await ensureSyncableGateway(deps, plan.kind === "add-root");
-  const demo = gateway === "ready" ? await syncAndPickDemo(deps, plan.repoRoot) : null;
-
-  for (const line of nextStepLines(demo)) {
-    deps.log(line);
+  if (gateway === "restart-required") {
+    return { kind: "restart-required" };
   }
+  if (gateway === "unavailable") {
+    return { kind: "gateway-unavailable" };
+  }
+  return await indexRepository(deps, plan.repoRoot);
+}
+
+export async function runInit(args: string[], deps: InitDeps = defaultInitDeps()): Promise<void> {
+  if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
+    for (const line of HELP_LINES) {
+      deps.log(line);
+    }
+    process.exitCode = INIT_EXIT.ok;
+    return;
+  }
+
+  const outcome = await initOutcome(args, deps);
+  reportOutcome(outcome, deps);
+  // Assigned unconditionally: the exit code is derived from the outcome that
+  // was just reported, so no earlier writer (runStart's failure signal, say)
+  // can leave the two disagreeing.
+  process.exitCode = initExitCode(outcome);
 }
 
 /**
@@ -188,22 +523,28 @@ export function defaultInitDeps(paths: CliPlatformPaths = getCliPlatformPaths())
     gatewayRunning: async () => (await readGatewayState(paths)) !== undefined,
     startGateway: async () => {
       // Delegate rather than re-implement: runStart already owns spawning, the
-      // readiness wait, and the log-tail diagnostics on failure.
+      // readiness wait, and the log-tail diagnostics on failure. It reports
+      // failure through process.exitCode, so clear it first — what is read
+      // back afterwards has to be runStart's own verdict and nothing else.
+      process.exitCode = 0;
       await runStart(["--no-wizard"]);
-      // runStart signals failure through process.exitCode; clear it so a
-      // gateway that would not start degrades `init` to the generic next step
-      // instead of failing the command outright.
-      const ok = (await readGatewayState(paths)) !== undefined;
-      if (ok) {
-        process.exitCode = 0;
+      const startFailed = (process.exitCode ?? 0) !== 0;
+      // Clear it again either way: runInit derives init's own code from the
+      // outcome, and a stale 1 here would shadow the more specific one.
+      process.exitCode = 0;
+      if (startFailed) {
+        return false;
       }
-      return ok;
+      // The socket answered. Give the gateway its (millisecond) window to write
+      // the state file everything downstream reads. See awaitGatewayState.
+      return await awaitGatewayState({ readState: () => readGatewayState(paths) });
     },
     syncFilesystem: async () => {
       await withGatewayIpc((c) => c.call("connector.sync", { serviceId: "filesystem" }), paths);
     },
     demoSymbol: async (repoRoot) =>
       asDemoSymbol(await withGatewayIpc((c) => c.call("index.demoSymbol", { repoRoot }), paths)),
+    gatewayLogTail: () => readGatewayLogTail(paths.logDir),
     log: (line) => {
       console.log(line);
     },


### PR DESCRIPTION
## The bug both #925 and #928 share

`nimbus init` could not fail. `syncAndPickDemo()` caught everything after the config write, logged a parenthetical, and returned `null`:

```ts
const demo = gateway === "ready" ? await syncAndPickDemo(deps, plan.repoRoot) : null;
```

So a Gateway that never bound its socket produced the generic `Next:` block and **exit 0**. The first command a new user ever runs reported success and produced nothing, while the real cause sat in a gateway log whose path was printed but whose contents never were. That is why the headless-Linux Vault failure (#925) and the MiniLM cold-start block (#928) both presented as "it worked".

## What changed

Every path now resolves to an explicit `InitOutcome`; the report **and** the exit code are both derived from it, so they cannot disagree.

| Code | Meaning |
| --- | --- |
| `0` | Indexed. A `nimbus why` target may or may not have been found. |
| `1` | Not a git repository — nothing written. |
| `2` | The Gateway never became ready — **nothing was indexed**. |
| `3` | The Gateway is reachable but this repo was not indexed (sync failed, or a running Gateway must restart to see the new root). |

- **Total failure is loud.** It names what failed, inlines the last few gateway log lines *under* their path, and says what to run next. Printing a path the user has to go and read is precisely why this went unnoticed, so the lines come inline.
- **It never prints a next step it cannot back up.** No `Next:` / `Try it:` block on any failing outcome.
- **Partial success stays success.** Gateway fine, index simply has nothing to suggest yet → exit `0` with an honest note plus the generic next step. A demo-symbol lookup that *throws* no longer fails a repository that did index — that lookup is a hint, not the job.
- **Missing vs empty log are worded differently.** An empty log is never rendered as a clean one.
- **`nimbus init --help`** now exists and carries the exit-code table. It previously ran the command for real. `docs/cli-reference.md` gets the same table; its "`init` still exits 0" paragraph was the same lie in prose.

`--no-sync` output is byte-identical (the `zero-config` cast golden asserts it).

## A latent race this uncovered

Raising the stakes on the readiness verdict exposed a bug the injected-effect tests could not see, and a live run caught in the second attempt:

```ts
await platform.ipc.start();     // socket answers → runStart returns "ready"
writeGatewayStateFile(...);     // ...only now does gateway.json exist
```

`runStart` returns as soon as the socket answers, so the one-shot `readGatewayState()` immediately after it misses a **healthy** gateway roughly half the time. Silent before (degraded to exit 0); it would now be a false exit `2` on a working machine. `awaitGatewayState()` waits out that millisecond window, bounded at 5 s, and short-circuits on `runStart`'s own failure signal so a genuinely dead gateway still fails fast.

## Verification

Injected-effect tests prove the decisions; a real gateway proves the wiring (a green fake has lied here before):

- never-ready (`NIMBUS_START_READY_TIMEOUT_MS` forced short) → **exit 2**, log tail inlined, ending exactly where #928's does:
  ```
  nimbus init: the Gateway never became ready, so nothing was indexed.
    The nimbus.toml edit above is done — re-running init will not repeat it.

  Gateway log: .../logs/gateway-2026-07-29.log
    | initializing platform services

  What to try:
    nimbus doctor      # check the OS prerequisites the Gateway needs
    nimbus start       # start it again and read the error in full
  Then re-run: nimbus init
  ```
- three consecutive real cold starts → **exit 0**, `Try it: nimbus why src/auth.ts:1   # verifyToken` (before the race fix, 1 of 2 falsely failed).

Every guard was red-proven — broken, watched fail, restored:

| Guard broken | Tests that went red |
| --- | --- |
| `gateway-unavailable` → exit 0 | 4, incl. "a gateway that never became ready is a FAILURE" |
| failure prints `nextStepLines` | "…never prints a next step" |
| log tail reduced to a bare path | "…inlines the tail of the gateway log" |
| newest-log picked by readdir order | "…picks the newest gateway log" |
| `awaitGatewayState` → one-shot read | "…waits out the bind→state-file gap" |

54 tests in `init.test.ts` (was 31); `init.ts` at 93.3% statement / 90.1% branch. `bunx biome check packages scripts` clean, `typecheck` clean, all `preflight:fast` gates pass individually (`bun run lint` is the known [`.claude/worktrees` false-fail](https://github.com/nimbus-agent/Nimbus/blob/main/CLAUDE.md)). Cast-driver and zero-config e2e suites pass.

## Scope

`packages/cli/src/commands/init.ts` + its tests, plus the `nimbus init` section of `docs/cli-reference.md` (the exit codes had to be documented somewhere durable). No gateway or `doctor` files touched — the deeper fixes for #925 (a Vault probe that actually probes) and #928 (bind before embeddings) belong there and are not in this PR. This makes both **visible and non-zero** rather than silent.

Refs #925
Refs #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
