### PR TITLE
fix(vault): probe the Linux Secret Service instead of secret-tool's PATH

### DIFF
--- a/packages/cli/src/commands/doctor-core.ts
+++ b/packages/cli/src/commands/doctor-core.ts
@@ -8,6 +8,277 @@ import type { CliPlatformPaths } from "../paths.ts";
 const LINUX_SECRET_TOOL_HINT =
   "secret-tool not found. Install libsecret-tools (Debian/Ubuntu) or libsecret (Fedora/Arch) to use the OS vault on Linux.";
 
+// ---------------------------------------------------------------------------
+// Linux Vault health (issue #925)
+//
+// `Bun.which("secret-tool") !== null` is a PATH check, not a health check.
+// libsecret is only a client: it reaches a Secret Service provider over the
+// D-Bus session bus, and that provider must expose an unlocked default
+// collection before one credential can be stored. On a headless box the binary
+// is present and every Vault operation still fails, so doctor must probe the
+// service, not the binary.
+//
+// Measured on ubuntu:24.04 — `secret-tool lookup <absent>` exits 1 with empty
+// stderr, and `secret-tool search --all <absent>` exits 0, in the working state
+// AND in both broken-collection states. Only the Secret Service itself
+// separates them, hence the D-Bus reads below.
+// ---------------------------------------------------------------------------
+
+export type DoctorVaultState =
+  | "not-applicable"
+  | "ok"
+  | "not-installed"
+  | "no-session-bus"
+  | "no-secret-service"
+  | "no-collection"
+  | "locked"
+  | "unverified";
+
+export interface DoctorVaultRun {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface DoctorVaultExec {
+  readonly findSecretTool: () => string | null;
+  /** Runs `secret-tool` and returns stderr only — stdout is discarded so a looked-up secret cannot leak. */
+  readonly lookupStderr: (exe: string, args: readonly string[]) => string;
+  readonly hasBinary: (name: string) => boolean;
+  readonly runQuery: (cmd: readonly string[]) => DoctorVaultRun;
+}
+
+export interface DoctorVaultStatus {
+  readonly state: DoctorVaultState;
+  readonly exit: number;
+  readonly detail: string;
+}
+
+/**
+ * Attributes for the read-only probe lookup. `application` is deliberately not
+ * `nimbus`, so the lookup cannot match a real credential and cannot create,
+ * modify or leave behind anything.
+ */
+export const DOCTOR_VAULT_PROBE_ATTRS: readonly string[] = [
+  "application",
+  "nimbus-vault-probe",
+  "nimbus-key",
+  "__nimbus_secret_service_probe__",
+];
+
+const SECRETS_NAME = "org.freedesktop.secrets";
+const SECRETS_PATH = "/org/freedesktop/secrets";
+const SERVICE_IFACE = "org.freedesktop.Secret.Service";
+const COLLECTION_IFACE = "org.freedesktop.Secret.Collection";
+const VAULT_PROBE_TIMEOUT_MS = 5_000;
+
+const NO_BUS_PATTERN = /autolaunch|DBUS_SESSION_BUS_ADDRESS/i;
+const NO_PROVIDER_PATTERN = /was not provided by any|ServiceUnknown/i;
+const OBJECT_PATH_PATTERN = /(?:^|\s)(?:object path|o)\s+"([^"]*)"/m;
+const BOOL_PATTERN = /(?:^|\s)(?:boolean|b)\s+(true|false)\b/m;
+
+const VAULT_UNLOCK_HINT =
+  "On a headless machine start Nimbus inside a session, e.g. dbus-run-session -- bash -c 'echo \"\" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'.";
+
+const VAULT_REPORT: Readonly<Record<DoctorVaultState, { mark: string; text: string }>> = {
+  "not-applicable": { mark: "[ok]", text: "OS-native store — no Linux Secret Service check." },
+  ok: { mark: "[ok]", text: "Secret Service reachable with an unlocked default keyring." },
+  "not-installed": { mark: "[fail]", text: LINUX_SECRET_TOOL_HINT },
+  "no-session-bus": {
+    mark: "[fail]",
+    text: `secret-tool is installed but there is no D-Bus session bus, so the OS keyring is unreachable and every Vault operation fails. ${VAULT_UNLOCK_HINT}`,
+  },
+  "no-secret-service": {
+    mark: "[fail]",
+    text: `a D-Bus session bus is present but no Secret Service provider owns ${SECRETS_NAME} — install and run gnome-keyring, KWallet, or KeePassXC with Secret Service enabled. ${VAULT_UNLOCK_HINT}`,
+  },
+  "no-collection": {
+    mark: "[fail]",
+    text: `a Secret Service provider is running over D-Bus but exposes no default keyring collection, so every Vault write fails. ${VAULT_UNLOCK_HINT}`,
+  },
+  locked: {
+    mark: "[fail]",
+    text: `the default Secret Service keyring collection is locked over D-Bus, so every Vault write fails. ${VAULT_UNLOCK_HINT}`,
+  },
+  unverified: {
+    mark: "[warn]",
+    text: `a Secret Service provider answered but its keyring state could not be verified — install busctl (systemd) or dbus-send (dbus) for a complete check. ${VAULT_UNLOCK_HINT}`,
+  },
+};
+
+const VAULT_EXIT_BY_MARK: Readonly<Record<string, number>> = {
+  "[ok]": 0,
+  "[warn]": 1,
+  "[fail]": 2,
+};
+
+function secretServiceCommands(kind: "default-collection" | "locked", path: string): string[][] {
+  const dest = `--dest=${SECRETS_NAME}`;
+  if (kind === "default-collection") {
+    return [
+      [
+        "busctl",
+        "--user",
+        "call",
+        SECRETS_NAME,
+        SECRETS_PATH,
+        SERVICE_IFACE,
+        "ReadAlias",
+        "s",
+        "default",
+      ],
+      [
+        "dbus-send",
+        "--session",
+        "--print-reply",
+        dest,
+        SECRETS_PATH,
+        `${SERVICE_IFACE}.ReadAlias`,
+        "string:default",
+      ],
+    ];
+  }
+  return [
+    ["busctl", "--user", "get-property", SECRETS_NAME, path, COLLECTION_IFACE, "Locked"],
+    [
+      "dbus-send",
+      "--session",
+      "--print-reply",
+      dest,
+      path,
+      "org.freedesktop.DBus.Properties.Get",
+      `string:${COLLECTION_IFACE}`,
+      "string:Locked",
+    ],
+  ];
+}
+
+function askSecretService(
+  exec: DoctorVaultExec,
+  kind: "default-collection" | "locked",
+  path: string,
+): DoctorVaultRun | null {
+  for (const cmd of secretServiceCommands(kind, path)) {
+    const bin = cmd[0];
+    if (bin !== undefined && exec.hasBinary(bin)) {
+      return exec.runQuery(cmd);
+    }
+  }
+  return null;
+}
+
+function stateFromDiagnostic(text: string): DoctorVaultState | null {
+  if (NO_BUS_PATTERN.test(text)) return "no-session-bus";
+  if (NO_PROVIDER_PATTERN.test(text)) return "no-secret-service";
+  return null;
+}
+
+function collectionState(exec: DoctorVaultExec): { state: DoctorVaultState; detail: string } {
+  const alias = askSecretService(exec, "default-collection", SECRETS_PATH);
+  if (alias === null) {
+    return { state: "unverified", detail: "no busctl or dbus-send available" };
+  }
+  if (alias.code !== 0) {
+    return {
+      state: stateFromDiagnostic(alias.stderr) ?? "unverified",
+      detail: alias.stderr.trim(),
+    };
+  }
+  const path = OBJECT_PATH_PATTERN.exec(alias.stdout)?.[1];
+  if (path === undefined) {
+    return { state: "unverified", detail: alias.stdout.trim() };
+  }
+  if (path === "/") {
+    return { state: "no-collection", detail: `${SECRETS_NAME} has no default collection` };
+  }
+  const locked = askSecretService(exec, "locked", path);
+  if (locked === null || locked.code !== 0) {
+    return { state: "unverified", detail: locked?.stderr.trim() ?? "" };
+  }
+  const flag = BOOL_PATTERN.exec(locked.stdout)?.[1];
+  if (flag === undefined) {
+    return { state: "unverified", detail: locked.stdout.trim() };
+  }
+  return flag === "true" ? { state: "locked", detail: path } : { state: "ok", detail: path };
+}
+
+export function doctorVaultStatus(
+  os: string,
+  exec: DoctorVaultExec = createDoctorVaultExec(),
+): DoctorVaultStatus {
+  const toStatus = (state: DoctorVaultState, detail: string): DoctorVaultStatus => ({
+    state,
+    detail,
+    exit: VAULT_EXIT_BY_MARK[VAULT_REPORT[state].mark] ?? 2,
+  });
+  if (os !== "linux") {
+    return toStatus("not-applicable", os);
+  }
+  const exe = exec.findSecretTool();
+  if (exe === null) {
+    return toStatus("not-installed", "");
+  }
+  const stderr = exec.lookupStderr(exe, ["lookup", ...DOCTOR_VAULT_PROBE_ATTRS]).trim();
+  const early = stateFromDiagnostic(stderr);
+  if (early !== null) {
+    return toStatus(early, stderr);
+  }
+  const { state, detail } = collectionState(exec);
+  return toStatus(state, detail);
+}
+
+export function formatDoctorVaultLine(status: DoctorVaultStatus): string {
+  const report = VAULT_REPORT[status.state];
+  const suffix =
+    status.state === "not-applicable"
+      ? ` (${status.detail})`
+      : status.detail.length > 0 && status.state !== "ok"
+        ? ` [${status.detail}]`
+        : "";
+  return `${report.mark} Vault: ${report.text}${suffix}`;
+}
+
+export function doctorVaultLine(
+  os: string,
+  exec: DoctorVaultExec = createDoctorVaultExec(),
+): string {
+  return formatDoctorVaultLine(doctorVaultStatus(os, exec));
+}
+
+function createDoctorVaultExec(): DoctorVaultExec {
+  return {
+    findSecretTool: () => Bun.which("secret-tool"),
+    lookupStderr: (exe, args) => {
+      try {
+        const p = Bun.spawnSync({
+          cmd: [exe, ...args],
+          // "ignore", not "pipe": a looked-up secret must have nowhere to go.
+          stdout: "ignore",
+          stderr: "pipe",
+          timeout: VAULT_PROBE_TIMEOUT_MS,
+        });
+        return p.stderr.toString();
+      } catch (err) {
+        return err instanceof Error ? err.message : String(err);
+      }
+    },
+    hasBinary: (name) => Bun.which(name) !== null,
+    runQuery: (cmd) => {
+      try {
+        const p = Bun.spawnSync({
+          cmd: [...cmd],
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: VAULT_PROBE_TIMEOUT_MS,
+        });
+        return { code: p.exitCode, stdout: p.stdout.toString(), stderr: p.stderr.toString() };
+      } catch (err) {
+        return { code: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
 const MIN_BUN_MAJOR = 1;
 const MIN_BUN_MINOR = 2;
 
@@ -77,16 +348,11 @@ function doctorPrintBunCheck(): number {
 }
 
 function doctorPrintVaultCheck(): number {
-  if (platform() === "linux") {
-    if (Bun.which("secret-tool") === null) {
-      console.log(`[fail] Vault: ${LINUX_SECRET_TOOL_HINT}`);
-      return 2;
-    }
-    console.log("[ok] Vault: secret-tool is on PATH.");
-    return 0;
-  }
-  console.log(`[ok] Vault: OS-native store (${platform()}) — no Linux secret-tool check.`);
-  return 0;
+  // One probe per run: the Secret Service reads shell out, so never re-probe
+  // just to render the line.
+  const status = doctorVaultStatus(platform());
+  console.log(formatDoctorVaultLine(status));
+  return status.exit;
 }
 
 export function doctorPrintConfigValidation(val: {

--- a/packages/cli/src/commands/doctor-core.ts
+++ b/packages/cli/src/commands/doctor-core.ts
@@ -73,7 +73,7 @@ const COLLECTION_IFACE = "org.freedesktop.Secret.Collection";
 const VAULT_PROBE_TIMEOUT_MS = 5_000;
 
 const NO_BUS_PATTERN = /autolaunch|DBUS_SESSION_BUS_ADDRESS/i;
-const NO_PROVIDER_PATTERN = /was not provided by any|ServiceUnknown/i;
+const NO_PROVIDER_PATTERN = /not provided by|ServiceUnknown/i;
 const OBJECT_PATH_PATTERN = /(?:^|\s)(?:object path|o)\s+"([^"]*)"/m;
 const BOOL_PATTERN = /(?:^|\s)(?:boolean|b)\s+(true|false)\b/m;
 
@@ -245,37 +245,35 @@ export function doctorVaultLine(
   return formatDoctorVaultLine(doctorVaultStatus(os, exec));
 }
 
+/**
+ * `keepStdout: false` leaves stdout unpiped entirely — used for the secret-tool
+ * lookup so a matched secret has nowhere to go.
+ */
+function spawnCapture(cmd: readonly string[], keepStdout: boolean): DoctorVaultRun {
+  try {
+    const p = Bun.spawnSync({
+      cmd: [...cmd],
+      stdout: keepStdout ? "pipe" : "ignore",
+      stderr: "pipe",
+      timeout: VAULT_PROBE_TIMEOUT_MS,
+    });
+    // stdout is undefined whenever it was not piped, so this is "" by construction.
+    return {
+      code: p.exitCode,
+      stdout: p.stdout?.toString() ?? "",
+      stderr: p.stderr.toString(),
+    };
+  } catch (err) {
+    return { code: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 function createDoctorVaultExec(): DoctorVaultExec {
   return {
     findSecretTool: () => Bun.which("secret-tool"),
-    lookupStderr: (exe, args) => {
-      try {
-        const p = Bun.spawnSync({
-          cmd: [exe, ...args],
-          // "ignore", not "pipe": a looked-up secret must have nowhere to go.
-          stdout: "ignore",
-          stderr: "pipe",
-          timeout: VAULT_PROBE_TIMEOUT_MS,
-        });
-        return p.stderr.toString();
-      } catch (err) {
-        return err instanceof Error ? err.message : String(err);
-      }
-    },
+    lookupStderr: (exe, args) => spawnCapture([exe, ...args], false).stderr,
     hasBinary: (name) => Bun.which(name) !== null,
-    runQuery: (cmd) => {
-      try {
-        const p = Bun.spawnSync({
-          cmd: [...cmd],
-          stdout: "pipe",
-          stderr: "pipe",
-          timeout: VAULT_PROBE_TIMEOUT_MS,
-        });
-        return { code: p.exitCode, stdout: p.stdout.toString(), stderr: p.stderr.toString() };
-      } catch (err) {
-        return { code: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
-      }
-    },
+    runQuery: (cmd) => spawnCapture(cmd, true),
   };
 }
 

--- a/packages/cli/src/commands/doctor-vault.test.ts
+++ b/packages/cli/src/commands/doctor-vault.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  DOCTOR_VAULT_PROBE_ATTRS,
+  type DoctorVaultExec,
+  type DoctorVaultRun,
+  type DoctorVaultStatus,
+  doctorVaultLine,
+  doctorVaultStatus,
+} from "./doctor-core.ts";
+
+// Fixtures captured verbatim from `docker run --rm -i ubuntu:24.04` on 2026-07-29;
+// see packages/gateway/src/platform/linux-vault-probe.test.ts for the full matrix.
+const STDERR_NO_SESSION_BUS = "secret-tool: Cannot autolaunch D-Bus without X11 $DISPLAY\n";
+const STDERR_NO_PROVIDER =
+  "secret-tool: The name org.freedesktop.secrets was not provided by any .service files\n";
+const ALIAS_NONE = 'o "/"\n';
+const ALIAS_LOGIN = 'o "/org/freedesktop/secrets/collection/login"\n';
+const LOCKED_TRUE = "b true\n";
+const LOCKED_FALSE = "b false\n";
+const DBUS_SEND_ALIAS_LOGIN =
+  "method return time=1785346008.372363 sender=:1.1 -> destination=:1.2 serial=7 reply_serial=2\n" +
+  '   object path "/org/freedesktop/secrets/collection/login"\n';
+const DBUS_SEND_LOCKED_FALSE =
+  "method return time=1785345621.279684 sender=org.freedesktop.DBus -> destination=:1.3 serial=3 reply_serial=2\n" +
+  "   variant       boolean false\n";
+
+const SECRET_TOOL = "/usr/bin/secret-tool";
+
+interface Scenario {
+  readonly secretTool?: string | null;
+  readonly stderr?: string;
+  readonly tools?: readonly string[];
+  readonly alias?: DoctorVaultRun;
+  readonly locked?: DoctorVaultRun;
+}
+
+const seen: { commands: string[][] } = { commands: [] };
+
+function makeExec(s: Scenario): DoctorVaultExec {
+  seen.commands = [];
+  const tools = s.tools ?? ["busctl"];
+  return {
+    findSecretTool: () => (s.secretTool === undefined ? SECRET_TOOL : s.secretTool),
+    lookupStderr: () => s.stderr ?? "",
+    hasBinary: (n) => tools.includes(n),
+    runQuery: (cmd) => {
+      seen.commands.push([...cmd]);
+      if (cmd.some((a) => a.includes("Locked"))) {
+        return s.locked ?? { code: 0, stdout: LOCKED_FALSE, stderr: "" };
+      }
+      return s.alias ?? { code: 0, stdout: ALIAS_LOGIN, stderr: "" };
+    },
+  };
+}
+
+function statusOf(s: Scenario): DoctorVaultStatus {
+  return doctorVaultStatus("linux", makeExec(s));
+}
+
+function lineOf(s: Scenario): string {
+  return doctorVaultLine("linux", makeExec(s));
+}
+
+describe("doctorVaultStatus — three distinguishable states on Linux", () => {
+  it("distinguishes not installed from installed-but-no-Secret-Service from working", () => {
+    expect(statusOf({ secretTool: null }).state).toBe("not-installed");
+    expect(statusOf({ stderr: STDERR_NO_PROVIDER }).state).toBe("no-secret-service");
+    expect(statusOf({}).state).toBe("ok");
+  });
+
+  it("reports no-session-bus for the headless stderr", () => {
+    expect(statusOf({ stderr: STDERR_NO_SESSION_BUS }).state).toBe("no-session-bus");
+  });
+
+  it("reports no-collection when the provider has no default collection", () => {
+    expect(statusOf({ alias: { code: 0, stdout: ALIAS_NONE, stderr: "" } }).state).toBe(
+      "no-collection",
+    );
+  });
+
+  it("reports locked when the default collection is locked", () => {
+    expect(statusOf({ locked: { code: 0, stdout: LOCKED_TRUE, stderr: "" } }).state).toBe("locked");
+  });
+
+  it("falls back to dbus-send when busctl is absent", () => {
+    const st = statusOf({
+      tools: ["dbus-send"],
+      alias: { code: 0, stdout: DBUS_SEND_ALIAS_LOGIN, stderr: "" },
+      locked: { code: 0, stdout: DBUS_SEND_LOCKED_FALSE, stderr: "" },
+    });
+    expect(st.state).toBe("ok");
+    expect(seen.commands.every((c) => c[0] === "dbus-send")).toBe(true);
+  });
+
+  it("reports unverified when neither busctl nor dbus-send exists", () => {
+    expect(statusOf({ tools: [] }).state).toBe("unverified");
+  });
+
+  it("never probes at all on non-Linux platforms", () => {
+    expect(doctorVaultStatus("darwin", makeExec({ secretTool: null })).state).toBe(
+      "not-applicable",
+    );
+    expect(doctorVaultStatus("win32", makeExec({ secretTool: null })).state).toBe("not-applicable");
+  });
+});
+
+describe("doctorVaultLine — marks and messages", () => {
+  it("prints [ok] only for a genuinely working keyring", () => {
+    expect(lineOf({})).toStartWith("[ok] Vault:");
+  });
+
+  it("prints an [ok] non-check line on darwin and win32", () => {
+    expect(doctorVaultLine("darwin", makeExec({}))).toStartWith("[ok] Vault:");
+    expect(doctorVaultLine("win32", makeExec({}))).toStartWith("[ok] Vault:");
+  });
+
+  it("keeps the distinct not-installed message", () => {
+    const line = lineOf({ secretTool: null });
+    expect(line).toStartWith("[fail] Vault:");
+    expect(line).toContain("secret-tool not found");
+    expect(line).toContain("libsecret");
+  });
+
+  it("names D-Bus and the unlock remedy for every runtime failure", () => {
+    const failures: Scenario[] = [
+      { stderr: STDERR_NO_SESSION_BUS },
+      { stderr: STDERR_NO_PROVIDER },
+      { alias: { code: 0, stdout: ALIAS_NONE, stderr: "" } },
+      { locked: { code: 0, stdout: LOCKED_TRUE, stderr: "" } },
+    ];
+    for (const s of failures) {
+      const line = lineOf(s);
+      expect(line).toStartWith("[fail] Vault:");
+      expect(line).toContain("D-Bus");
+      expect(line).toContain("dbus-run-session");
+      expect(line).toContain("gnome-keyring-daemon --unlock");
+      // The old message blamed the wrong thing.
+      expect(line).not.toContain("secret-tool is on PATH");
+    }
+  });
+
+  it("warns — never fails, never oks — when the keyring state is unverifiable", () => {
+    expect(lineOf({ tools: [] })).toStartWith("[warn] Vault:");
+  });
+});
+
+describe("doctor must not report a PATH check as a health check", () => {
+  // This is the exact defect from issue #925: `Bun.which("secret-tool") !== null`
+  // printed "[ok] Vault: secret-tool is on PATH." on a machine where every Vault
+  // operation fails. Each row has secret-tool resolvable and a provably dead
+  // Secret Service; if the PATH check returns, these all go green on [ok].
+  const brokenButOnPath: Array<[string, Scenario]> = [
+    ["no session bus", { stderr: STDERR_NO_SESSION_BUS }],
+    ["no Secret Service provider", { stderr: STDERR_NO_PROVIDER }],
+    ["no default collection", { alias: { code: 0, stdout: ALIAS_NONE, stderr: "" } }],
+    ["locked collection", { locked: { code: 0, stdout: LOCKED_TRUE, stderr: "" } }],
+  ];
+
+  it.each(brokenButOnPath)("%s: reports a failure, not [ok]", (_name, s) => {
+    const exec = makeExec(s);
+    expect(exec.findSecretTool()).toBe(SECRET_TOOL);
+    const line = doctorVaultLine("linux", makeExec(s));
+    expect(line).not.toStartWith("[ok]");
+    expect(line).toStartWith("[fail]");
+    expect(doctorVaultStatus("linux", makeExec(s)).exit).toBe(2);
+  });
+
+  it("never prints the old PATH-check wording", () => {
+    for (const [, s] of brokenButOnPath) {
+      expect(lineOf(s)).not.toContain("secret-tool is on PATH");
+    }
+  });
+
+  it("actually shells out rather than trusting resolution", () => {
+    const exec = makeExec({});
+    doctorVaultStatus("linux", exec);
+    expect(seen.commands.length).toBeGreaterThan(0);
+  });
+});
+
+describe("doctor probe is read-only", () => {
+  it("uses probe attributes that cannot collide with a stored Nimbus secret", () => {
+    const i = DOCTOR_VAULT_PROBE_ATTRS.indexOf("application");
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(DOCTOR_VAULT_PROBE_ATTRS[i + 1]).not.toBe("nimbus");
+  });
+
+  it("issues no mutating command", () => {
+    doctorVaultStatus("linux", makeExec({}));
+    const flat = seen.commands.flat().join(" ");
+    for (const mutating of ["store", "clear", "Delete", "CreateItem", "Lock ", "Unlock"]) {
+      expect(flat).not.toContain(mutating);
+    }
+  });
+});

--- a/packages/gateway/src/platform/linux-vault-probe.test.ts
+++ b/packages/gateway/src/platform/linux-vault-probe.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "bun:test";
+import { platform } from "node:os";
+
+import { PlatformInitError } from "./errors.ts";
+import {
+  assertLinuxSecretToolAvailable,
+  describeLinuxVaultState,
+  isFatalLinuxVaultState,
+  LINUX_VAULT_PROBE_ATTRS,
+  type LinuxProbeCommandResult,
+  type LinuxVaultProbeExec,
+  type LinuxVaultState,
+  probeLinuxVault,
+} from "./linux.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures captured from a real `docker run --rm -i ubuntu:24.04` session on
+// 2026-07-29. Every string below is verbatim command output, not invented:
+// asserting against paraphrased text would let the probe pass on shapes libsecret
+// never actually emits.
+//
+//   A  no session bus            : apt install libsecret-tools; secret-tool lookup ...
+//   C2 bus, no provider          : dbus-run-session -- secret-tool lookup ...
+//   C  provider, no collection   : + gnome-keyring installed, never unlocked
+//   D  collection exists, locked : keyring seeded in an earlier session, not unlocked
+//   B  working                   : + `echo "" | gnome-keyring-daemon --unlock --components=secrets`
+// ---------------------------------------------------------------------------
+
+/** State A. `secret-tool` exits 1 with this on stderr when there is no session bus. */
+const STDERR_NO_SESSION_BUS = "secret-tool: Cannot autolaunch D-Bus without X11 $DISPLAY\n";
+
+/** State C2. A session bus exists but nothing owns `org.freedesktop.secrets`. */
+const STDERR_NO_PROVIDER =
+  "secret-tool: The name org.freedesktop.secrets was not provided by any .service files\n";
+
+/** busctl `ReadAlias default` when the provider has no default collection (state C). */
+const BUSCTL_ALIAS_NONE = 'o "/"\n';
+
+/** busctl `ReadAlias default` when a default collection exists (states B and D). */
+const BUSCTL_ALIAS_LOGIN = 'o "/org/freedesktop/secrets/collection/login"\n';
+
+/** busctl `get-property ... Locked` — state D (locked) and state B (working). */
+const BUSCTL_LOCKED_TRUE = "b true\n";
+const BUSCTL_LOCKED_FALSE = "b false\n";
+
+/** dbus-send equivalents, used when busctl is absent. */
+const DBUS_SEND_ALIAS_LOGIN =
+  "method return time=1785346008.372363 sender=:1.1 -> destination=:1.2 serial=7 reply_serial=2\n" +
+  '   object path "/org/freedesktop/secrets/collection/login"\n';
+const DBUS_SEND_ALIAS_NONE =
+  "method return time=1785346008.372363 sender=:1.1 -> destination=:1.2 serial=7 reply_serial=2\n" +
+  '   object path "/"\n';
+const DBUS_SEND_LOCKED_FALSE =
+  "method return time=1785345621.279684 sender=org.freedesktop.DBus -> destination=:1.3 serial=3 reply_serial=2\n" +
+  "   variant       boolean false\n";
+const DBUS_SEND_SERVICE_UNKNOWN =
+  "Error org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.secrets was not provided by any .service files\n";
+
+const SECRET_TOOL_PATH = "/usr/bin/secret-tool";
+
+interface FakeExecOptions {
+  readonly secretTool?: string | null;
+  readonly probe?: { code: number | null; stderr: string };
+  readonly tools?: readonly string[];
+  readonly alias?: LinuxProbeCommandResult;
+  readonly locked?: LinuxProbeCommandResult;
+  readonly display?: boolean;
+}
+
+function ok(stdout: string): LinuxProbeCommandResult {
+  return { code: 0, stdout, stderr: "" };
+}
+
+/**
+ * Builds an exec double. `queries` records every argv the probe ran so tests can
+ * assert the probe really shelled out rather than short-circuiting on PATH.
+ */
+function makeExec(o: FakeExecOptions): {
+  exec: LinuxVaultProbeExec;
+  queries: string[][];
+  probeArgs: string[][];
+} {
+  const queries: string[][] = [];
+  const probeArgs: string[][] = [];
+  const tools = o.tools ?? ["busctl"];
+  const exec: LinuxVaultProbeExec = {
+    resolveSecretTool: () => (o.secretTool === undefined ? SECRET_TOOL_PATH : o.secretTool),
+    probeSecretTool: (exe, args) => {
+      probeArgs.push([exe, ...args]);
+      return o.probe ?? { code: 1, stderr: "" };
+    },
+    which: (name) => (tools.includes(name) ? `/usr/bin/${name}` : null),
+    query: (cmd) => {
+      queries.push([...cmd]);
+      const isLocked = cmd.some((a) => a.includes("Locked"));
+      if (isLocked) {
+        return o.locked ?? ok(BUSCTL_LOCKED_FALSE);
+      }
+      return o.alias ?? ok(BUSCTL_ALIAS_LOGIN);
+    },
+    hasInteractiveDisplay: () => o.display ?? false,
+  };
+  return { exec, queries, probeArgs };
+}
+
+function stateOf(o: FakeExecOptions): LinuxVaultState {
+  return probeLinuxVault(makeExec(o).exec).state;
+}
+
+// ---------------------------------------------------------------------------
+
+describe("probeLinuxVault — the three required states", () => {
+  it("reports not-installed when secret-tool cannot be resolved", () => {
+    const { exec, probeArgs } = makeExec({ secretTool: null });
+    expect(probeLinuxVault(exec).state).toBe("not-installed");
+    expect(probeArgs).toHaveLength(0);
+  });
+
+  it("reports no-session-bus from the real headless stderr", () => {
+    expect(stateOf({ probe: { code: 1, stderr: STDERR_NO_SESSION_BUS } })).toBe("no-session-bus");
+  });
+
+  it("reports no-secret-service when the bus has no org.freedesktop.secrets owner", () => {
+    expect(stateOf({ probe: { code: 1, stderr: STDERR_NO_PROVIDER } })).toBe("no-secret-service");
+  });
+
+  it("reports ok only when a default collection exists and is unlocked", () => {
+    expect(stateOf({ alias: ok(BUSCTL_ALIAS_LOGIN), locked: ok(BUSCTL_LOCKED_FALSE) })).toBe("ok");
+  });
+});
+
+describe("probeLinuxVault — states a lookup-only probe cannot see", () => {
+  // Measured: in BOTH of the states below `secret-tool lookup <absent>` exits 1
+  // with empty stderr and `secret-tool search --all <absent>` exits 0 — exactly
+  // as in the working state. Only the Secret Service collection reveals them.
+  it("reports no-collection when ReadAlias(default) returns the null object path", () => {
+    expect(stateOf({ alias: ok(BUSCTL_ALIAS_NONE) })).toBe("no-collection");
+  });
+
+  it("reports locked when the default collection exists but Locked is true", () => {
+    expect(stateOf({ alias: ok(BUSCTL_ALIAS_LOGIN), locked: ok(BUSCTL_LOCKED_TRUE) })).toBe(
+      "locked",
+    );
+  });
+});
+
+describe("probeLinuxVault — transport fallbacks", () => {
+  it("falls back to dbus-send when busctl is absent", () => {
+    const { exec, queries } = makeExec({
+      tools: ["dbus-send"],
+      alias: ok(DBUS_SEND_ALIAS_LOGIN),
+      locked: ok(DBUS_SEND_LOCKED_FALSE),
+    });
+    expect(probeLinuxVault(exec).state).toBe("ok");
+    expect(queries.every((q) => q[0] === "dbus-send")).toBe(true);
+  });
+
+  it("parses the dbus-send null object path as no-collection", () => {
+    expect(stateOf({ tools: ["dbus-send"], alias: ok(DBUS_SEND_ALIAS_NONE) })).toBe(
+      "no-collection",
+    );
+  });
+
+  it("maps a ServiceUnknown D-Bus error to no-secret-service", () => {
+    expect(stateOf({ alias: { code: 1, stdout: "", stderr: DBUS_SEND_SERVICE_UNKNOWN } })).toBe(
+      "no-secret-service",
+    );
+  });
+
+  it("reports unverified — never ok — when no D-Bus query tool is installed", () => {
+    expect(stateOf({ tools: [] })).toBe("unverified");
+  });
+
+  it("reports unverified when the Locked property cannot be read", () => {
+    expect(stateOf({ locked: { code: 1, stdout: "", stderr: "boom" } })).toBe("unverified");
+  });
+});
+
+describe("probeLinuxVault — read-only guarantee", () => {
+  it("only ever runs `lookup`, never store/clear/lock", () => {
+    const { exec, probeArgs, queries } = makeExec({});
+    probeLinuxVault(exec);
+    expect(probeArgs[0]?.[1]).toBe("lookup");
+    const everyArg = [...probeArgs.flat(), ...queries.flat()].join(" ");
+    for (const mutating of ["store", "clear", "lock", "unlock", "Delete", "CreateItem"]) {
+      expect(everyArg).not.toContain(mutating);
+    }
+  });
+
+  it("uses probe attributes that can never collide with a stored Nimbus secret", () => {
+    // Nimbus writes `application=nimbus`; the probe must use a different
+    // application so the lookup is structurally guaranteed to miss.
+    const appIdx = LINUX_VAULT_PROBE_ATTRS.indexOf("application");
+    expect(appIdx).toBeGreaterThanOrEqual(0);
+    expect(LINUX_VAULT_PROBE_ATTRS[appIdx + 1]).not.toBe("nimbus");
+  });
+});
+
+describe("isFatalLinuxVaultState", () => {
+  const alwaysFatal: LinuxVaultState[] = [
+    "not-installed",
+    "no-session-bus",
+    "no-secret-service",
+    "no-collection",
+  ];
+  it.each(alwaysFatal)("treats %s as fatal regardless of display", (state) => {
+    expect(isFatalLinuxVaultState(state, true)).toBe(true);
+    expect(isFatalLinuxVaultState(state, false)).toBe(true);
+  });
+
+  it("treats a locked collection as fatal only when headless", () => {
+    // With a display libsecret can raise an unlock prompt; headless it cannot,
+    // and `secret-tool store` fails with "Cannot create an item in a locked collection".
+    expect(isFatalLinuxVaultState("locked", false)).toBe(true);
+    expect(isFatalLinuxVaultState("locked", true)).toBe(false);
+  });
+
+  it("never treats ok or unverified as fatal", () => {
+    expect(isFatalLinuxVaultState("ok", false)).toBe(false);
+    expect(isFatalLinuxVaultState("unverified", false)).toBe(false);
+  });
+});
+
+describe("describeLinuxVaultState", () => {
+  it("keeps the distinct not-installed message", () => {
+    const msg = describeLinuxVaultState("not-installed", "");
+    expect(msg).toContain("secret-tool not found");
+    expect(msg).toContain("libsecret-tools");
+    // The install hint must NOT be reused for the runtime failures.
+    expect(msg).not.toContain("dbus-run-session");
+  });
+
+  const runtimeFailures: LinuxVaultState[] = [
+    "no-session-bus",
+    "no-secret-service",
+    "no-collection",
+  ];
+  it.each(runtimeFailures)("names the real cause and an actionable remedy for %s", (state) => {
+    const msg = describeLinuxVaultState(state, "");
+    expect(msg).toContain("D-Bus");
+    expect(msg).toContain("dbus-run-session");
+    expect(msg).toContain("gnome-keyring-daemon --unlock");
+    // "just install libsecret" was the misleading old message.
+    expect(msg).not.toContain("secret-tool not found");
+  });
+
+  it("includes the underlying diagnostic when one is available", () => {
+    const msg = describeLinuxVaultState("no-session-bus", STDERR_NO_SESSION_BUS.trim());
+    expect(msg).toContain("Cannot autolaunch D-Bus");
+  });
+});
+
+describe("assertLinuxSecretToolAvailable", () => {
+  it("throws PlatformInitError for every fatal state", () => {
+    const fatal: FakeExecOptions[] = [
+      { secretTool: null },
+      { probe: { code: 1, stderr: STDERR_NO_SESSION_BUS } },
+      { probe: { code: 1, stderr: STDERR_NO_PROVIDER } },
+      { alias: ok(BUSCTL_ALIAS_NONE) },
+      { alias: ok(BUSCTL_ALIAS_LOGIN), locked: ok(BUSCTL_LOCKED_TRUE) },
+    ];
+    for (const o of fatal) {
+      expect(() => {
+        assertLinuxSecretToolAvailable(makeExec(o).exec);
+      }).toThrow(PlatformInitError);
+    }
+  });
+
+  it("does not throw for a working keyring", () => {
+    expect(() => {
+      assertLinuxSecretToolAvailable(makeExec({}).exec);
+    }).not.toThrow();
+  });
+
+  it("does not throw when the collection is locked but a display can prompt", () => {
+    expect(() => {
+      assertLinuxSecretToolAvailable(
+        makeExec({ alias: ok(BUSCTL_ALIAS_LOGIN), locked: ok(BUSCTL_LOCKED_TRUE), display: true })
+          .exec,
+      );
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for the defect this file exists to close.
+// ---------------------------------------------------------------------------
+
+describe("the probe must not degenerate back into a PATH check", () => {
+  // Every case below has secret-tool resolvable — i.e. `Bun.which("secret-tool")
+  // !== null`, the old check — and a Secret Service that provably cannot serve a
+  // single Vault write. If someone reintroduces the PATH check these all go green
+  // on `ok`, so each assertion is a live tripwire.
+  const brokenButOnPath: Array<[string, FakeExecOptions]> = [
+    ["no session bus", { probe: { code: 1, stderr: STDERR_NO_SESSION_BUS } }],
+    ["no Secret Service provider", { probe: { code: 1, stderr: STDERR_NO_PROVIDER } }],
+    ["no default collection", { alias: ok(BUSCTL_ALIAS_NONE) }],
+    ["locked collection", { alias: ok(BUSCTL_ALIAS_LOGIN), locked: ok(BUSCTL_LOCKED_TRUE) }],
+  ];
+
+  it.each(brokenButOnPath)("%s: secret-tool is on PATH yet the probe refuses ok", (_name, o) => {
+    const { exec } = makeExec(o);
+    expect(exec.resolveSecretTool()).toBe(SECRET_TOOL_PATH);
+    expect(probeLinuxVault(exec).state).not.toBe("ok");
+    expect(() => {
+      assertLinuxSecretToolAvailable(exec);
+    }).toThrow(PlatformInitError);
+  });
+
+  it("actually executes the probe instead of trusting resolution", () => {
+    const { exec, probeArgs, queries } = makeExec({});
+    probeLinuxVault(exec);
+    expect(probeArgs.length).toBeGreaterThan(0);
+    expect(queries.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-machine check: proves the probe leaves nothing behind.
+// ---------------------------------------------------------------------------
+
+describe("probeLinuxVault on the host", () => {
+  it.skipIf(platform() !== "linux")(
+    "runs and stores nothing",
+    () => {
+      const secretTool = Bun.which("secret-tool");
+      if (secretTool === null) {
+        return;
+      }
+      const result = probeLinuxVault();
+      expect(typeof result.state).toBe("string");
+
+      // Nothing may exist under the probe's own attributes afterwards.
+      const search = Bun.spawnSync({
+        cmd: [secretTool, "search", "--all", "application", "nimbus-vault-probe"],
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 10_000,
+      });
+      expect(search.stdout.toString().trim()).toBe("");
+    },
+    30_000,
+  );
+});

--- a/packages/gateway/src/platform/linux.ts
+++ b/packages/gateway/src/platform/linux.ts
@@ -22,7 +22,7 @@ export type LinuxVaultState =
   | "ok"
   /** The `secret-tool` binary is absent. */
   | "not-installed"
-  /** No D-Bus session bus, so libsecret cannot reach any provider. */
+  /** No D-Bus session bus, so libsecret cannot reach a provider at all. */
   | "no-session-bus"
   /** A session bus exists but nothing owns `org.freedesktop.secrets`. */
   | "no-secret-service"
@@ -83,8 +83,8 @@ const PROBE_TIMEOUT_MS = 5_000;
 
 /** `secret-tool: Cannot autolaunch D-Bus without X11 $DISPLAY` and friends. */
 const NO_SESSION_BUS_RE = /autolaunch|DBUS_SESSION_BUS_ADDRESS/i;
-/** `The name org.freedesktop.secrets was not provided by any .service files`. */
-const NO_PROVIDER_RE = /was not provided by any|ServiceUnknown/i;
+/** Matches `The name org.freedesktop.secrets was not provided by ... .service files`. */
+const NO_PROVIDER_RE = /not provided by|ServiceUnknown/i;
 const OBJECT_PATH_RE = /(?:^|\s)(?:object path|o)\s+"([^"]*)"/m;
 const BOOLEAN_RE = /(?:^|\s)(?:boolean|b)\s+(true|false)\b/m;
 

--- a/packages/gateway/src/platform/linux.ts
+++ b/packages/gateway/src/platform/linux.ts
@@ -7,15 +7,328 @@ import type { PlatformServices } from "./types.ts";
 const SECRET_TOOL_INSTALL_HINT =
   "secret-tool not found. Install libsecret-tools (Debian/Ubuntu) or libsecret (Fedora/Arch) to use Nimbus on Linux.";
 
-export function assertLinuxSecretToolAvailable(): void {
-  if (process.env["NIMBUS_LINUX_VAULT_PROBE_STRICT_PATH"] === "1") {
-    if (Bun.which("secret-tool") === null) {
-      throw new PlatformInitError(SECRET_TOOL_INSTALL_HINT);
+/**
+ * Outcome of the Linux Vault preflight.
+ *
+ * `secret-tool` being on PATH says nothing about whether the Vault works:
+ * libsecret is only a *client*. It reaches a Secret Service provider over the
+ * D-Bus session bus, and that provider must expose an unlocked default
+ * collection before a single credential can be written. On a headless box —
+ * server, container, SSH session, WSL — none of that is guaranteed, so a PATH
+ * check reports a healthy Vault on a machine where every Vault write fails.
+ */
+export type LinuxVaultState =
+  /** A default collection exists and is unlocked; Vault writes will succeed. */
+  | "ok"
+  /** The `secret-tool` binary is absent. */
+  | "not-installed"
+  /** No D-Bus session bus, so libsecret cannot reach any provider. */
+  | "no-session-bus"
+  /** A session bus exists but nothing owns `org.freedesktop.secrets`. */
+  | "no-secret-service"
+  /** A provider is running but has no default collection: writes fail. */
+  | "no-collection"
+  /** A default collection exists but is locked: writes fail without a prompt. */
+  | "locked"
+  /** Provider reachable, but its collection state could not be determined. */
+  | "unverified";
+
+export interface LinuxVaultProbe {
+  readonly state: LinuxVaultState;
+  /** Underlying diagnostic: stderr and D-Bus paths only, never secret material. */
+  readonly detail: string;
+}
+
+export interface LinuxProbeCommandResult {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface LinuxVaultProbeExec {
+  readonly resolveSecretTool: () => string | null;
+  /**
+   * Runs `secret-tool` with the given arguments. Implementations MUST discard
+   * stdout: the return type has no stdout field precisely so that a looked-up
+   * secret has nowhere to leak into a log line or an error message.
+   */
+  readonly probeSecretTool: (
+    exe: string,
+    args: readonly string[],
+  ) => { code: number | null; stderr: string };
+  readonly which: (name: string) => string | null;
+  readonly query: (cmd: readonly string[]) => LinuxProbeCommandResult;
+  readonly hasInteractiveDisplay: () => boolean;
+}
+
+/**
+ * Attributes for the read-only probe lookup. `application` is deliberately NOT
+ * `nimbus` (the value `LinuxSecretToolVault` writes), so the lookup is
+ * structurally guaranteed to miss: it can never read back a real credential, and
+ * a lookup neither creates, modifies nor leaves anything behind.
+ */
+export const LINUX_VAULT_PROBE_ATTRS: readonly string[] = [
+  "application",
+  "nimbus-vault-probe",
+  "nimbus-key",
+  "__nimbus_secret_service_probe__",
+];
+
+const SECRETS_BUS_NAME = "org.freedesktop.secrets";
+const SECRETS_SERVICE_PATH = "/org/freedesktop/secrets";
+const SECRETS_SERVICE_IFACE = "org.freedesktop.Secret.Service";
+const SECRETS_COLLECTION_IFACE = "org.freedesktop.Secret.Collection";
+const NULL_OBJECT_PATH = "/";
+const PROBE_TIMEOUT_MS = 5_000;
+
+/** `secret-tool: Cannot autolaunch D-Bus without X11 $DISPLAY` and friends. */
+const NO_SESSION_BUS_RE = /autolaunch|DBUS_SESSION_BUS_ADDRESS/i;
+/** `The name org.freedesktop.secrets was not provided by any .service files`. */
+const NO_PROVIDER_RE = /was not provided by any|ServiceUnknown/i;
+const OBJECT_PATH_RE = /(?:^|\s)(?:object path|o)\s+"([^"]*)"/m;
+const BOOLEAN_RE = /(?:^|\s)(?:boolean|b)\s+(true|false)\b/m;
+
+function readAliasCommands(): readonly (readonly string[])[] {
+  return [
+    [
+      "busctl",
+      "--user",
+      "call",
+      SECRETS_BUS_NAME,
+      SECRETS_SERVICE_PATH,
+      SECRETS_SERVICE_IFACE,
+      "ReadAlias",
+      "s",
+      "default",
+    ],
+    [
+      "dbus-send",
+      "--session",
+      "--print-reply",
+      `--dest=${SECRETS_BUS_NAME}`,
+      SECRETS_SERVICE_PATH,
+      `${SECRETS_SERVICE_IFACE}.ReadAlias`,
+      "string:default",
+    ],
+  ];
+}
+
+function collectionLockedCommands(objectPath: string): readonly (readonly string[])[] {
+  return [
+    [
+      "busctl",
+      "--user",
+      "get-property",
+      SECRETS_BUS_NAME,
+      objectPath,
+      SECRETS_COLLECTION_IFACE,
+      "Locked",
+    ],
+    [
+      "dbus-send",
+      "--session",
+      "--print-reply",
+      `--dest=${SECRETS_BUS_NAME}`,
+      objectPath,
+      "org.freedesktop.DBus.Properties.Get",
+      `string:${SECRETS_COLLECTION_IFACE}`,
+      "string:Locked",
+    ],
+  ];
+}
+
+function runFirstAvailable(
+  exec: LinuxVaultProbeExec,
+  candidates: readonly (readonly string[])[],
+): LinuxProbeCommandResult | null {
+  for (const cmd of candidates) {
+    const bin = cmd[0];
+    if (bin !== undefined && exec.which(bin) !== null) {
+      return exec.query(cmd);
     }
-    return;
   }
-  if (resolveSecretToolExecutable() === null) {
-    throw new PlatformInitError(SECRET_TOOL_INSTALL_HINT);
+  return null;
+}
+
+function stateFromDiagnostic(text: string): LinuxVaultState | null {
+  if (NO_SESSION_BUS_RE.test(text)) {
+    return "no-session-bus";
+  }
+  if (NO_PROVIDER_RE.test(text)) {
+    return "no-secret-service";
+  }
+  return null;
+}
+
+/** Resolves the default collection's object path, or a terminal probe result. */
+function defaultCollectionPath(exec: LinuxVaultProbeExec): LinuxVaultProbe | string {
+  const alias = runFirstAvailable(exec, readAliasCommands());
+  if (alias === null) {
+    return {
+      state: "unverified",
+      detail: "neither busctl nor dbus-send is installed, so the keyring state is unknown",
+    };
+  }
+  if (alias.code !== 0) {
+    const err = alias.stderr.trim();
+    return { state: stateFromDiagnostic(err) ?? "unverified", detail: err };
+  }
+  const parsed = OBJECT_PATH_RE.exec(alias.stdout);
+  if (parsed?.[1] === undefined) {
+    return { state: "unverified", detail: `unparseable ReadAlias reply: ${alias.stdout.trim()}` };
+  }
+  return parsed[1];
+}
+
+/**
+ * Functionally probes the Linux Vault backend. Strictly read-only: one
+ * `secret-tool lookup` for a key that cannot exist, plus at most two D-Bus
+ * property reads.
+ */
+export function probeLinuxVault(
+  exec: LinuxVaultProbeExec = createDefaultProbeExec(),
+): LinuxVaultProbe {
+  const exe = exec.resolveSecretTool();
+  if (exe === null) {
+    return { state: "not-installed", detail: "" };
+  }
+
+  const lookup = exec.probeSecretTool(exe, ["lookup", ...LINUX_VAULT_PROBE_ATTRS]);
+  const lookupErr = lookup.stderr.trim();
+  const fromStderr = stateFromDiagnostic(lookupErr);
+  if (fromStderr !== null) {
+    return { state: fromStderr, detail: lookupErr };
+  }
+
+  // A clean miss means the provider answered — but a miss looks *identical*
+  // whether the default collection is present, absent or locked (measured: exit
+  // 1, empty stderr in all three). Only the Secret Service can tell them apart.
+  const collection = defaultCollectionPath(exec);
+  if (typeof collection !== "string") {
+    return collection;
+  }
+  if (collection === NULL_OBJECT_PATH) {
+    return { state: "no-collection", detail: `${SECRETS_BUS_NAME} has no default collection` };
+  }
+
+  const locked = runFirstAvailable(exec, collectionLockedCommands(collection));
+  if (locked === null || locked.code !== 0) {
+    return { state: "unverified", detail: locked?.stderr.trim() ?? "" };
+  }
+  const flag = BOOLEAN_RE.exec(locked.stdout);
+  if (flag?.[1] === undefined) {
+    return { state: "unverified", detail: `unparseable Locked reply: ${locked.stdout.trim()}` };
+  }
+  return flag[1] === "true"
+    ? { state: "locked", detail: collection }
+    : { state: "ok", detail: collection };
+}
+
+const FATAL_LINUX_VAULT_STATES: ReadonlySet<LinuxVaultState> = new Set<LinuxVaultState>([
+  "not-installed",
+  "no-session-bus",
+  "no-secret-service",
+  "no-collection",
+]);
+
+/**
+ * A locked-but-present collection is fatal only when nothing can raise an unlock
+ * prompt. With a display libsecret prompts and the write succeeds; headless it
+ * fails with "Cannot create an item in a locked collection".
+ */
+export function isFatalLinuxVaultState(
+  state: LinuxVaultState,
+  hasInteractiveDisplay: boolean,
+): boolean {
+  if (FATAL_LINUX_VAULT_STATES.has(state)) {
+    return true;
+  }
+  return state === "locked" && !hasInteractiveDisplay;
+}
+
+const HEADLESS_REMEDY = [
+  "Nimbus keeps credentials in the OS keyring through libsecret, which needs BOTH a",
+  "D-Bus session bus AND an unlocked Secret Service keyring — installing secret-tool",
+  "alone is not enough. On a headless machine, start Nimbus inside a session:",
+  "  dbus-run-session -- bash -c 'echo \"\" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'",
+].join("\n");
+
+const STATE_HEADLINES: Readonly<Record<LinuxVaultState, string>> = {
+  ok: "Linux Vault backend is available.",
+  "not-installed": SECRET_TOOL_INSTALL_HINT,
+  "no-session-bus":
+    "secret-tool is installed but there is no D-Bus session bus, so the OS keyring is unreachable and every Vault operation fails.",
+  "no-secret-service":
+    "A D-Bus session bus is present but no Secret Service provider owns org.freedesktop.secrets. Install and run one (gnome-keyring, KWallet, or KeePassXC with Secret Service enabled).",
+  "no-collection":
+    "A Secret Service provider is running but exposes no default keyring collection, so every Vault write fails.",
+  locked:
+    "The default Secret Service keyring collection is locked and nothing can prompt to unlock it, so every Vault write fails.",
+  unverified:
+    "A Secret Service provider answered but its keyring state could not be verified. Install systemd's busctl or dbus's dbus-send for a complete check.",
+};
+
+export function describeLinuxVaultState(state: LinuxVaultState, detail: string): string {
+  const parts = [STATE_HEADLINES[state]];
+  if (state !== "ok" && state !== "not-installed") {
+    parts.push(HEADLESS_REMEDY);
+  }
+  if (detail.length > 0) {
+    parts.push(`Diagnostic: ${detail}`);
+  }
+  return parts.join("\n");
+}
+
+function createDefaultProbeExec(): LinuxVaultProbeExec {
+  return {
+    resolveSecretTool: () =>
+      process.env["NIMBUS_LINUX_VAULT_PROBE_STRICT_PATH"] === "1"
+        ? Bun.which("secret-tool")
+        : resolveSecretToolExecutable(),
+    probeSecretTool: (exe, args) => {
+      try {
+        const p = Bun.spawnSync({
+          cmd: [exe, ...args],
+          // "ignore", not "pipe": a looked-up secret must have nowhere to go.
+          stdout: "ignore",
+          stderr: "pipe",
+          timeout: PROBE_TIMEOUT_MS,
+        });
+        return { code: p.exitCode, stderr: p.stderr.toString() };
+      } catch (err) {
+        return { code: null, stderr: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    which: (name) => Bun.which(name),
+    query: (cmd) => {
+      try {
+        const p = Bun.spawnSync({
+          cmd: [...cmd],
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: PROBE_TIMEOUT_MS,
+        });
+        return { code: p.exitCode, stdout: p.stdout.toString(), stderr: p.stderr.toString() };
+      } catch (err) {
+        return { code: null, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    hasInteractiveDisplay: () =>
+      (process.env["DISPLAY"] ?? "") !== "" || (process.env["WAYLAND_DISPLAY"] ?? "") !== "",
+  };
+}
+
+export function assertLinuxSecretToolAvailable(
+  exec: LinuxVaultProbeExec = createDefaultProbeExec(),
+): void {
+  const probe = probeLinuxVault(exec);
+  if (isFatalLinuxVaultState(probe.state, exec.hasInteractiveDisplay())) {
+    throw new PlatformInitError(describeLinuxVaultState(probe.state, probe.detail));
+  }
+  if (probe.state !== "ok") {
+    // Runs before the gateway logger exists (this is a preflight for
+    // assemblePlatformServices), so stderr is the only channel available.
+    process.stderr.write(`[gateway] ${describeLinuxVaultState(probe.state, probe.detail)}\n`);
   }
 }
 


### PR DESCRIPTION
Closes #925 (gateway + doctor half).

`doctor-core.ts:81` did `Bun.which("secret-tool") === null` and then printed
`[ok] Vault: secret-tool is on PATH.` — a PATH check reported as a health check.
`platform/linux.ts:12/17` had the same shape. On a headless box with
`libsecret-tools` installed but no D-Bus session, both said fine and then every
Vault operation failed.

libsecret is only a *client*. It reaches a Secret Service provider over the
D-Bus session bus, and that provider must expose an unlocked default collection
before one credential can be stored.

## Reproduced first, on real Linux

Docker daemon was down; started Docker Desktop and used `ubuntu:24.04` as the
issue prescribes. Verbatim measurements:

| state | `secret-tool lookup <absent>` | `secret-tool search --all` | `ReadAlias("default")` | `Collection.Locked` | `store` |
|---|---|---|---|---|---|
| **A** no session bus | rc 1, `Cannot autolaunch D-Bus without X11 $DISPLAY` | same | — | — | fails |
| **C2** bus, no provider | rc 1, `The name org.freedesktop.secrets was not provided by any .service files` | rc 1, same | `ServiceUnknown` | `ServiceUnknown` | fails |
| **C** provider, no default collection | **rc 1, empty stderr** | **rc 0** | `o "/"` | `Object does not exist` | fails |
| **D** collection exists, locked | **rc 1, empty stderr** | **rc 0** | `o "/…/login"` | `b true` | fails (`Cannot create an item in a locked collection`) |
| **B** working | **rc 1, empty stderr** | **rc 0** | `o "/…/login"` | `b false` | succeeds |

**The load-bearing result:** rows C, D and B are *indistinguishable* by
`secret-tool lookup` or `search` — identical exit code, identical empty stderr.
A lookup-only probe would have been exactly as lenient as the PATH check it
replaced, just harder to notice. Only the Secret Service itself separates them,
so the probe reads `ReadAlias("default")` and then `Collection.Locked`. Those
are spec-defined (`org.freedesktop.Secret.Service`), so the probe is not
gnome-keyring-specific — KWallet and KeePassXC answer the same calls.

`$DBUS_SESSION_BUS_ADDRESS` and a bare `NameHasOwner` check were also tested and
rejected: `NameHasOwner` returns `true` in state C as well, because D-Bus
*activates* gnome-keyring on demand.

## The probe is read-only — verified, not assumed

It runs one `secret-tool lookup` plus at most two D-Bus property reads. The
lookup uses `application=nimbus-vault-probe`, deliberately **not** the
`application=nimbus` that `LinuxSecretToolVault` writes, so it is structurally
guaranteed to miss and can never read back a real credential. stdout is
`"ignore"`, never `"pipe"` — a matched secret has nowhere to leak. After running
the real probe in every state, `secret-tool search --all application
nimbus-vault-probe` returns empty (asserted in CI by a Linux-only test, and
observed in the end-to-end run below).

## Result — real code, real headless Linux

| state | `probeLinuxVault()` | gateway startup | `nimbus doctor` |
|---|---|---|---|
| A no session bus | `no-session-bus` | **aborts** | `[fail]`, exit 2 |
| C2 no provider | `no-secret-service` | **aborts** | `[fail]`, exit 2 |
| C no collection | `no-collection` | **aborts** | `[fail]`, exit 2 |
| B working | `ok` | continues | `[ok]`, exit 0 |

Before this change every one of those rows printed `[ok] Vault: secret-tool is
on PATH.` and the gateway started.

The startup error now names the actual cause and the remedy:

```
A Secret Service provider is running but exposes no default keyring collection,
so every Vault write fails.
Nimbus keeps credentials in the OS keyring through libsecret, which needs BOTH a
D-Bus session bus AND an unlocked Secret Service keyring — installing secret-tool
alone is not enough. On a headless machine, start Nimbus inside a session:
  dbus-run-session -- bash -c 'echo "" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'
Diagnostic: org.freedesktop.secrets has no default collection
```

The distinct "not installed" case keeps its original message and does **not**
get the D-Bus remedy — a test asserts the two never blur.

## Red-proved

Both guards were broken on purpose and watched fail before being restored:

- gateway: degenerating `probeLinuxVault` to `return {state:"ok"}` right after
  resolution → **15 failures**, including all 5 tests in
  *"the probe must not degenerate back into a PATH check"*.
- CLI: the same sabotage → **12 failures**, including all 4 rows of
  *"doctor must not report a PATH check as a health check"*.

Every fixture in those tests is verbatim Docker output, so a probe that only
handles invented message shapes cannot pass.

## Notes for review

- **Fatality is deliberately asymmetric for one state.** `locked` (collection
  exists but `Locked=true`) aborts the gateway only when `$DISPLAY` /
  `$WAYLAND_DISPLAY` are unset. With a display libsecret raises an unlock prompt
  and the write succeeds, so aborting would regress desktop users who start the
  gateway before unlocking. `nimbus doctor` reports it `[fail]` unconditionally —
  a diagnostic being stricter than production is the safe direction.
- **`unverified` warns, never oks.** If neither `busctl` (systemd) nor
  `dbus-send` (dbus) is installed, collection state cannot be read; doctor emits
  `[warn]` and the gateway logs but continues. Reachable only when a session bus
  exists without either tool, which is close to impossible in practice.
- CI is unaffected: `scripts/linux/linux-dbus-tests.sh` (`dbus-run-session` +
  `echo "" | gnome-keyring-daemon --unlock`) produces `ReadAlias → /…/login`,
  `Locked → b false` → `ok`. Verified by running the real suite in the container
  under that exact wrapper: 1584 tests, 0 failures.
- The probe logic is duplicated across `packages/gateway` and `packages/cli`
  because `cli` may not import gateway source. jscpd reports no clone between
  the two files.
- `doctor` resolves `secret-tool` with `Bun.which` only, while the gateway also
  falls back to `/usr/bin/secret-tool`. Unchanged from before, and stricter
  rather than more lenient, so left as is.

## Open question for the owner — not built here

Issue #925 asks whether a headless Linux vault backend should exist at all. My
read: **yes, eventually, but not as part of this fix.** The ICP is on-call and
platform engineers, so a large share of target machines have no desktop session,
and the current answer — "wrap your gateway in `dbus-run-session` plus
`gnome-keyring-daemon --unlock`" — is a real barrier at install time. But a
file-backed keyring is a credential-storage design decision: it touches
non-negotiable #3 (no plaintext credentials), needs a key-derivation and
at-rest-encryption story, and deserves its own review rather than being smuggled
in behind a diagnostics fix. This PR only makes the existing failure honest and
actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
