### PR TITLE
ci: cut PR fan-out from ~34 jobs to ~11

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -916,54 +916,41 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # BATCHED, not one-gate-per-job. These 15 gates each ran 0.6-1.3 min but
+    # QUEUED 11-20 min behind a saturated concurrent-job cap, and ~0.5 min of
+    # every leg was runner start + checkout + `bun install` — the matrix spent
+    # far more wall time on setup and queueing than on the thresholds it
+    # enforces. Three batches pay that setup 3x instead of 15x and hand 12 job
+    # slots back to the account-wide pool that every other PR is waiting on.
+    #
+    # The trade is honest: this branch of the DAG gets SLOWER in isolation
+    # (~1 min of parallel legs becomes ~3-5 min of serial ones). It wins because
+    # queueing, not execution, is the dominant term — and it stops being the
+    # right call if that ever ceases to be true.
+    #
+    # Every entry still carries an explicit `pal: false`: `audit:coverage-gate-pal`
+    # rule 4 requires the field on every entry, and rule 5 requires every entry in
+    # THIS job to be false. That audit parses only `- name:` and `pal:`, so the
+    # `scripts:` (plural) key below is invisible to it.
+    #
+    # Batches group by subsystem so a red check names a coherent area, and the
+    # run step below executes every script in a batch even after one fails —
+    # preserving the failure locality the 15-way `fail-fast: false` matrix gave.
     strategy:
       fail-fast: false
       matrix:
         gate:
-          - name: Engine
-            script: "test:coverage:engine"
+          - name: Engine & agents
+            flag: engine-agents
+            scripts: "test:coverage:engine test:coverage:agents test:coverage:workflow test:coverage:mcp test:coverage:preflight"
             pal: false
-          - name: Agents
-            script: "test:coverage:agents"
+          - name: Runtime services
+            flag: runtime-services
+            scripts: "test:coverage:sync test:coverage:rate-limiter test:coverage:watcher test:coverage:health test:coverage:metrics"
             pal: false
-          - name: Sync scheduler
-            script: "test:coverage:sync"
-            pal: false
-          - name: Rate limiter
-            script: "test:coverage:rate-limiter"
-            pal: false
-          - name: People
-            script: "test:coverage:people"
-            pal: false
-          - name: Workflow
-            script: "test:coverage:workflow"
-            pal: false
-          - name: Watcher
-            script: "test:coverage:watcher"
-            pal: false
-          - name: Config
-            script: "test:coverage:config"
-            pal: false
-          - name: TUI
-            script: "test:coverage:tui"
-            pal: false
-          - name: Deployment
-            script: "test:coverage:deployment"
-            pal: false
-          - name: Health
-            script: "test:coverage:health"
-            pal: false
-          - name: Metrics
-            script: "test:coverage:metrics"
-            pal: false
-          - name: Preflight
-            script: "test:coverage:preflight"
-            pal: false
-          - name: MCP
-            script: "test:coverage:mcp"
-            pal: false
-          - name: LAN
-            script: "test:coverage:lan"
+          - name: Interfaces & data
+            flag: interfaces-data
+            scripts: "test:coverage:people test:coverage:config test:coverage:tui test:coverage:deployment test:coverage:lan"
             pal: false
     steps:
       - name: Harden Runner
@@ -979,42 +966,32 @@ jobs:
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-nimbus-ci
 
-      - name: Linux — libsecret + D-Bus (vault tests)
-        if: runner.os == 'Linux' && matrix.gate.name == 'Vault'
-        shell: bash
-        run: sudo bash scripts/linux/install-vault-deps.sh
+      # The Vault and Sandbox prep steps that used to sit here were dead: this
+      # job's matrix has never contained a `Vault` or `Sandbox` entry (both are
+      # `pal: true` and live in `coverage-gates-pal`), so every one of their
+      # `matrix.gate.name == '…'` conditions was permanently false. The live
+      # copies remain in `coverage-gates-pal`, which is where those gates run.
 
-      - name: Linux — bubblewrap + libcap-dev + strace + cppcheck (sandbox tests)
-        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
+      - name: Run coverage gates
         shell: bash
         run: |
-          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
-          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
-          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
-          sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
-
-      - name: Build sandbox helper (Linux only, sandbox gate)
-        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
-        shell: bash
-        run: bun run build:sandbox-helper
-
-      - name: Static-analyse sandbox helper with cppcheck (Linux only, sandbox gate)
-        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
-        shell: bash
-        run: cppcheck --enable=all --error-exitcode=1 --suppress=missingIncludeSystem packages/gateway/src-native/sandbox-helper/main.c
-
-      - name: Setcap on sandbox helper (Linux only, sandbox gate)
-        if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
-        shell: bash
-        run: sudo setcap cap_net_admin+ep packages/gateway/src-native/sandbox-helper/nimbus-sandbox-helper
-
-      - name: Run coverage gate
-        shell: bash
-        run: |
-          if [[ "${{ matrix.gate.name }}" == "Vault" && "${{ runner.os }}" == "Linux" ]]; then
-            bash scripts/ci/run-with-optional-dbus.sh bun run ${{ matrix.gate.script }}
-          else
-            bun run ${{ matrix.gate.script }}
+          # Run every gate in the batch even after one fails, so a red check
+          # reports ALL failing gates rather than only the first — the failure
+          # locality the old 15-way `fail-fast: false` matrix gave, preserved.
+          failed=()
+          for script in ${{ matrix.gate.scripts }}; do
+            echo "::group::${script}"
+            if bun run "${script}"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::coverage gate failed: ${script}"
+              failed+=("${script}")
+            fi
+          done
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "Failing coverage gates in this batch: ${failed[*]}"
+            exit 1
           fi
         env:
           CI: "true"
@@ -1030,4 +1007,4 @@ jobs:
         with:
           # No `token:` — same reason as the upload step above (Nimbus#782).
           use_oidc: true
-          flags: ${{ matrix.gate.name }}
+          flags: ${{ matrix.gate.flag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,15 +100,38 @@ jobs:
           echo "gateway-touched=$GW" >> "$GITHUB_OUTPUT"
           echo "cli-touched=$CLI" >> "$GITHUB_OUTPUT"
 
-          # Cross-platform matrix: always emit all 4 entries. Branch
-          # protection rulesets require the expanded check names
-          # (`PR quality — Cross-platform (cli, macos-15)` etc.); a
-          # per-package skip would post the un-expanded template name and
-          # leave the 4 required checks "Expected — Waiting for status to
-          # be reported" forever. The `code-changed` gate already
-          # short-circuits docs-only PRs, so per-package gating saves
-          # nothing here.
-          MATRIX='[{"os":"macos-15","pkg":"gateway"},{"os":"windows-2025","pkg":"gateway"},{"os":"macos-15","pkg":"cli"},{"os":"windows-2025","pkg":"cli"}]'
+          # Cross-platform matrix: emit only the packages this PR can affect.
+          #
+          # This used to always emit all 4 entries, on the stated grounds that
+          # branch-protection rulesets require the expanded check names. That is
+          # no longer true — the General ruleset (14784377) requires exactly:
+          # "PR quality — required gates", the six Security contexts, the two
+          # CodeQL "Analyze (…)" contexts and "cla". No expanded Cross-platform
+          # name appears in any ruleset, so narrowing the matrix removes no
+          # required context. `pr-quality-required` still `needs:` this job, so
+          # the gate keeps its dependency either way.
+          #
+          # gateway-touched / cli-touched are exclude-logic (true unless every
+          # changed file is provably irrelevant to that package) and both fall
+          # back to true on an empty diff, so the failure mode is running MORE
+          # than needed, never less. A PR touching only packages/cli/ drops the
+          # two gateway legs — macOS especially, where the account-wide cap is
+          # just 5 concurrent jobs.
+          ENTRIES=()
+          if [[ "$GW" == "true" ]]; then
+            ENTRIES+=('{"os":"macos-15","pkg":"gateway"}' '{"os":"windows-2025","pkg":"gateway"}')
+          fi
+          if [[ "$CLI" == "true" ]]; then
+            ENTRIES+=('{"os":"macos-15","pkg":"cli"}' '{"os":"windows-2025","pkg":"cli"}')
+          fi
+          # An empty matrix makes GitHub fail the job rather than skip it, which
+          # would red every docs-only PR through `pr-quality-required`. Neither
+          # flag can be false on an empty diff, but belt-and-braces: fall back to
+          # the cli pair, the cheaper of the two.
+          if [[ ${#ENTRIES[@]} -eq 0 ]]; then
+            ENTRIES+=('{"os":"macos-15","pkg":"cli"}' '{"os":"windows-2025","pkg":"cli"}')
+          fi
+          MATRIX="[$(IFS=,; echo "${ENTRIES[*]}")]"
           echo "cross-platform-matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
           # Fail-safe: an empty diff (e.g. base resolution glitch) is treated as
@@ -202,14 +225,16 @@ jobs:
   # restore that isolation by construction.
   pr-quality-cross-platform:
     name: PR quality — Cross-platform (${{ matrix.pkg }}, ${{ matrix.os }})
-    # The filter always emits the full 4-entry matrix on `pull_request`
-    # events (see ci.yml#Detect-changed-paths). Branch-protection rulesets
-    # require the expanded check names (`PR quality — Cross-platform
-    # (cli, macos-15)` etc.), so this job must RUN on every PR — even
-    # docs-only ones — or those 4 required checks never post and sit
-    # "Expected — Waiting for status to be reported" forever. The expensive
-    # steps below are individually gated on `code-changed`, so a docs-only PR
-    # spins up the 4 matrix legs but does no test work (they report success).
+    # The filter emits only the packages this PR can affect (see
+    # ci.yml#Detect-changed-paths). No expanded Cross-platform check name is a
+    # required context in any ruleset — verified against the live General
+    # ruleset — so a narrowed matrix leaves nothing "Expected — Waiting for
+    # status to be reported". `pr-quality-required` needs: this job, which is
+    # what actually gates.
+    #
+    # The job still RUNS on every PR: the expensive steps below are individually
+    # gated on `code-changed`, so a docs-only PR spins up the remaining legs and
+    # reports success without doing test work.
     if: github.event_name == 'pull_request'
     needs: filter
     strategy:

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -87,10 +87,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lychee --config lychee.toml --no-progress 'docs/**/*.md' '*.md'
 
-  markdownlint:
-    name: markdownlint-cli2
+  # SEVEN jobs collapsed into one. Each of markdownlint / OG card / SVG audit /
+  # README CLI tripwire / package READMEs / cast tripwire / Starlight build was
+  # a separate runner paying its own Harden Runner + checkout + `bun install`
+  # — roughly 30s of identical setup each — to run one `bun run` that finishes
+  # in seconds. Seven runners for well under a minute of actual work.
+  #
+  # None of these seven names is a required status check (the General ruleset
+  # requires only "PR quality — required gates", the six security contexts, the
+  # two CodeQL contexts and "cla"), so collapsing them changes no merge gate.
+  # `link-check` stays its own job: it is the slow one and it fetches the
+  # network, so it should not serialise behind the fast static checks.
+  #
+  # The cost, stated plainly: fail-fast becomes fail-first. A markdownlint
+  # failure now stops the steps after it, so a contributor sees one failure per
+  # push instead of all of them at once. Acceptable here because these checks
+  # are near-instant to re-run locally and rarely fail together.
+  docs-checks:
+    name: Docs checks
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -111,26 +127,14 @@ jobs:
       - name: Run markdownlint-cli2
         run: bun run lint:markdown
 
-  og-card-render:
-    name: OG card render
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
+      - name: Run SVG asset audit
+        run: bun run audit:svg-assets
 
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
+      - name: Run README CLI-command tripwire
+        run: bun run audit:readme-cli
 
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
+      - name: Run package READMEs audit
+        run: bun run audit:package-readmes
 
       - name: Render OG card
         run: bun run render:og-card
@@ -142,130 +146,17 @@ jobs:
             exit 1
           fi
 
-  svg-audit:
-    name: SVG asset audit
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
-
-      - name: Run SVG asset audit
-        run: bun run audit:svg-assets
-
-  readme-cli-tripwire:
-    name: README CLI-command tripwire
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
-
-      - name: Run README CLI-command tripwire
-        run: bun run audit:readme-cli
-
-  package-readmes:
-    name: Package READMEs audit
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
-
-      - name: Run package READMEs audit
-        run: bun run audit:package-readmes
-
-  cast-tripwire:
-    name: Cast transcript tripwire
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
+      - name: Run build
+        run: bun --cwd packages/docs run build
 
       - name: Run cast tripwire
+        id: cast
         run: bun run record-casts --check --artifacts-dir=cast-artifacts
 
       - name: Upload drift artifacts
-        if: failure()
+        if: failure() && steps.cast.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cast-drift
           path: cast-artifacts/
           retention-days: 7
-
-  docs-build:
-    name: Starlight build test
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Nimbus CI
-        uses: ./.github/actions/setup-nimbus-ci
-
-      - name: Run build
-        run: bun --cwd packages/docs run build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,6 +59,25 @@ jobs:
       - name: Accepted-advisory registry
         run: bun run audit:advisories
 
+      # Folded in from the former standalone `js-licenses` job, which paid a
+      # whole runner (harden + checkout + `bun install`, ~30s) to run this one
+      # command against the same tree this job already has checked out.
+      #
+      # Consequence worth knowing: a license-allowlist violation now fails the
+      # REQUIRED "Dependency audit" check rather than the advisory "JS license
+      # compliance" one, so it blocks merge where it previously did not. That is
+      # the correct direction — docs/license-policy.md describes it as policy,
+      # not advice — but it is a behaviour change, not a pure refactor.
+      #
+      # JS-side mirror of cargo-deny's license check on the Tauri Rust tree. The
+      # allowlist is the intersection of licenses safe to redistribute under both
+      # halves of our dual-license model: AGPL-3.0 (gateway/cli/connectors,
+      # shipped as compiled binaries) and MIT (sdk/client, published as-is to
+      # npm). See docs/license-policy.md for the full policy and the procedure
+      # for adding to the allowlist or PACKAGE_OVERRIDES.
+      - name: License compliance (workspace-wide)
+        run: bun run audit:js-licenses
+
   trivy-scan:
     name: Trivy vulnerability scan
     runs-on: ubuntu-24.04
@@ -169,6 +188,16 @@ jobs:
           CI: "true"
 
   cargo-audit:
+    # Skipped on PRs that touch no Rust. This name is a literal with no `${{ }}`
+    # in it, so a skipped job still posts this exact required context with
+    # conclusion `skipped`, which GitHub counts as passing — the trap that once
+    # blocked docs-only PRs fires only on names carrying an unexpanded expression.
+    #
+    # `!cancelled()` rather than `success()` on the needs: a red gitleaks (it
+    # scans FULL history, so it can go red on a commit outside this diff) must not
+    # silently turn this required scan into a passing `skipped`.
+    needs: gitleaks
+    if: ${{ !cancelled() && needs.gitleaks.outputs.rust != 'false' }}
     name: Cargo audit (Tauri)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -209,6 +238,16 @@ jobs:
         run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
 
   cargo-deny:
+    # Skipped on PRs that touch no Rust. This name is a literal with no `${{ }}`
+    # in it, so a skipped job still posts this exact required context with
+    # conclusion `skipped`, which GitHub counts as passing — the trap that once
+    # blocked docs-only PRs fires only on names carrying an unexpanded expression.
+    #
+    # `!cancelled()` rather than `success()` on the needs: a red gitleaks (it
+    # scans FULL history, so it can go red on a commit outside this diff) must not
+    # silently turn this required scan into a passing `skipped`.
+    needs: gitleaks
+    if: ${{ !cancelled() && needs.gitleaks.outputs.rust != 'false' }}
     name: Cargo deny (licenses + advisories + bans)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -244,39 +283,6 @@ jobs:
           command: check all
           command-arguments: --hide-inclusion-graph
 
-  js-licenses:
-    name: JS license compliance
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Bun and install dependencies
-        uses: ./.github/actions/setup-nimbus-ci
-        with:
-          verify-lock: "false"
-
-      - name: License compliance (workspace-wide)
-        # JS-side mirror of cargo-deny's license check on the Tauri Rust
-        # tree. The allowlist is the intersection of licenses safe to
-        # redistribute under both halves of our dual-license model:
-        # AGPL-3.0 (gateway/cli/connectors, shipped as compiled binaries)
-        # and MIT (sdk/client, published as-is to npm). See
-        # docs/license-policy.md for the full policy and the procedure
-        # for adding to the allowlist or PACKAGE_OVERRIDES.
-        run: bun run audit:js-licenses
-
   gitleaks:
     name: Gitleaks secret scan
     runs-on: ubuntu-24.04
@@ -285,6 +291,12 @@ jobs:
       contents: read
       # PR comments + status check from gitleaks.
       pull-requests: write
+    # Hosts the Rust change detection for cargo-audit / cargo-deny. It lives
+    # here rather than in a new job because a dedicated `changes` job would
+    # itself cost a runner slot, cancelling half the saving — and this job
+    # already checks out full history, which is what the diff needs.
+    outputs:
+      rust: ${{ steps.rust-changed.outputs.rust }}
 
     steps:
       - name: Harden Runner
@@ -298,6 +310,34 @@ jobs:
           # Full history so gitleaks can diff against base.
           fetch-depth: 0
           persist-credentials: false
+
+      # Does this PR touch the Rust surface at all? cargo-audit and cargo-deny
+      # scan `packages/ui/src-tauri` (where Cargo.lock and deny.toml live); on
+      # the overwhelming majority of PRs, which touch no Rust, they spend two
+      # runner slots re-proving an unchanged lockfile.
+      #
+      # Deliberately `!= 'false'` downstream, never `== 'true'`: if this step
+      # fails, the base SHA cannot be resolved, or the event is not a PR, the
+      # output is empty and BOTH scans run. The gate fails OPEN for the security
+      # check — the only thing it fails closed on is skipping work.
+      - name: Detect Rust changes
+        id: rust-changed
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -uo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          if [[ -z "${base}" ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "base sha unavailable — running the Rust scans"
+            echo "rust=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if git diff --name-only "${base}" HEAD \
+            | grep -qE '^(packages/ui/src-tauri/|rust-toolchain\.toml$|\.github/workflows/security\.yml$)'; then
+            echo "rust=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "rust=false" >> "${GITHUB_OUTPUT}"
+          fi
 
       # Direct binary invocation rather than `gitleaks/gitleaks-action`
       # because that JS action still ships `runs.using: node20`, which

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,38 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   silent-degrade site is greppable. Also: the lazy runtime now warms eagerly (nothing has to call
   `embedQuery` to start the load), a terminated worker bridge stops claiming `warming`, and the
   600 s worker init window is unchanged but no longer sits on the bind path.
+- **2026-07-29 — CI fan-out cut from ~34 jobs per PR to ~11; the queue was arithmetic, not misconfiguration.**
+  PRs were taking hours, all of them queued. Measured rather than guessed: 18-19
+  jobs running against GitHub Free's 20-concurrent-job account cap, macOS pinned
+  at exactly 5/5 (its own sub-cap) on two consecutive samples, and 85-133 jobs
+  waiting — of which 85 were cheap ubuntu ones. One PR push fanned out to ~34
+  jobs across 9 workflows, against ~10 branches in flight. The org moved to Team
+  (20 -> 60 concurrent, verified live: a later sample showed 36 running), and
+  this change removes the fan-out that made the cap bind in the first place.
+  **`coverage-gates-linux`: 15 one-gate jobs -> 3 batched jobs (-12).** Each leg
+  ran 0.6-1.3 min but queued 11-20 min, and ~0.5 min of every leg was runner
+  start + checkout + `bun install` — the matrix spent more wall time on setup and
+  queueing than on the thresholds it enforced. The batch step runs every script
+  even after one fails, preserving the failure locality `fail-fast: false` gave.
+  Five `Vault`/`Sandbox` prep steps were deleted from that job as provably dead:
+  its matrix has never held either gate, so every `matrix.gate.name == '…'`
+  condition was permanently false. **docs-quality: 8 jobs -> 2 (-6)** — seven
+  runners each paying ~30s of identical setup for one near-instant `bun run`;
+  `link-check` stays separate because it is the slow, network-touching one.
+  **`js-licenses` folded into `Dependency audit` (-1)**, which moves a license
+  violation onto a required check — a behaviour change, recorded as such.
+  **`cargo-audit`/`cargo-deny` skipped on PRs touching no Rust (-2)** and
+  **the cross-platform matrix narrowed to the packages a PR can affect (-2)**.
+  Both touch required-check semantics and both were verified against the LIVE
+  ruleset rather than the comments describing it: the `ci.yml` comment asserting
+  that rulesets require the expanded `Cross-platform (pkg, os)` names is stale —
+  the General ruleset requires only `PR quality — required gates`, the six
+  Security contexts, two CodeQL contexts and `cla`. The cargo gate is written
+  `!= 'false'` and `!cancelled()`, so a failed detector, an unresolvable base
+  SHA, or a red gitleaks all run the scans rather than posting a passing
+  `skipped`. The `audit:coverage-gate-pal` guard was red-proved against the new
+  batch entries before trusting it. Eight dead `ci-latency-baseline.json` rows
+  pruned (seven deleted jobs plus a `Bencher Report` entry that named no job).
 
 - **2026-07-29 — The last two `bun audit` advisories closed: one fixed, one written down.**
   `bun audit` reported 2 (1 moderate, 1 low). Neither blocked CI — the gate is

--- a/docs/structure-audit/ci-latency-baseline.json
+++ b/docs/structure-audit/ci-latency-baseline.json
@@ -398,41 +398,9 @@
       "execMedian": 1.83,
       "execSpread": 0.04
     },
-    "Nimbus :: Docs Quality :: Bencher Report": {
-      "execMedian": 0,
-      "execSpread": 0
-    },
-    "Nimbus :: Docs Quality :: Cast transcript tripwire": {
-      "execMedian": 0.7,
-      "execSpread": 0.05
-    },
-    "Nimbus :: Docs Quality :: OG card render": {
-      "execMedian": 0.65,
-      "execSpread": 0.05
-    },
-    "Nimbus :: Docs Quality :: Package READMEs audit": {
-      "execMedian": 0.64,
-      "execSpread": 0.08
-    },
-    "Nimbus :: Docs Quality :: README CLI-command tripwire": {
-      "execMedian": 0.64,
-      "execSpread": 0.08
-    },
-    "Nimbus :: Docs Quality :: SVG asset audit": {
-      "execMedian": 0.68,
-      "execSpread": 0.11
-    },
-    "Nimbus :: Docs Quality :: Starlight build test": {
-      "execMedian": 0.63,
-      "execSpread": 0.1
-    },
     "Nimbus :: Docs Quality :: lychee link check": {
       "execMedian": 0.66,
       "execSpread": 0.18
-    },
-    "Nimbus :: Docs Quality :: markdownlint-cli2": {
-      "execMedian": 0.61,
-      "execSpread": 0.12
     },
     "Nimbus :: Performance Benchmarks :: Bench (macos-15)": {
       "execMedian": 32.58,


### PR DESCRIPTION
## Why

PRs were taking hours, all queued. Measured before changing anything:

| runner | queued | running | cap |
|---|---|---|---|
| ubuntu | 85 | 6 | — |
| macOS | 3 | 5 | **5 (saturated)** |
| windows | 0 | 7 | — |
| **total** | **89** | **18** | **20 (saturated)** |

Two consecutive samples showed macOS at exactly 5/5 and the total at 18 then 19 — the account-wide cap was the binding constraint, not any misconfiguration. One push fanned out to ~34 jobs across 9 workflows, against ~10 branches in flight.

The org has since moved to Team (20 → 60 concurrent; verified live — a later sample showed **36** running, above the old ceiling). This PR removes the fan-out that made the cap bind in the first place.

## What

| change | jobs |
|---|---|
| `coverage-gates-linux`: 15 one-gate jobs → 3 batched | **−12** |
| `docs-quality`: 8 jobs → 2 | **−6** |
| `cargo-audit`/`cargo-deny` skipped on non-Rust PRs | −2 |
| cross-platform matrix narrowed to affected packages | −2 |
| `js-licenses` folded into `Dependency audit` | −1 |

Each of the 15 coverage legs ran 0.6–1.3 min but **queued 11–20 min**, and ~0.5 min of every leg was runner start + checkout + `bun install` — the matrix spent more wall time on setup and queueing than on the thresholds it enforced. Five `Vault`/`Sandbox` prep steps in that job were deleted as provably dead: its matrix has never contained either gate, so every `matrix.gate.name == '…'` condition was permanently false.

## Ruleset safety

Two changes touch **required** contexts, so both were verified against the live ruleset rather than the comments describing it:

- The `ci.yml` comment asserting that rulesets require the expanded `Cross-platform (pkg, os)` names is **stale**. The General ruleset requires only `PR quality — required gates`, the six Security contexts, the two CodeQL contexts, and `cla`.
- Every `name:` in `security.yml` is a literal with no `${{ }}`. The trap that once blocked docs-only PRs fires only on names carrying an unexpanded expression, so a skipped job posts its exact required context and counts as passing.

Fail-open by construction: the Rust gate reads `!= 'false'` (not `== 'true'`) and carries `!cancelled()`, so a failed detector, an unresolvable base SHA, a non-PR event, or a red gitleaks all **run** the scans rather than posting a passing `skipped`. The cross-platform matrix can never be emitted empty — verified across all four GW/CLI combinations — since an empty matrix fails a job rather than skipping it, which would red every docs-only PR.

`audit:coverage-gate-pal` was **red-proved** against the new batch entries: flipping one `pal:` makes it name "Runtime services" explicitly, so its green means it parsed them rather than skipped them.

## Deliberately not taken

- **`_perf.yml` `pull_request` trigger** — saves 1 job but removes the only perf regression gate PRs have.
- **Merging `integration` into `e2e-gateway`** — saves 1 job at the cost of sharing a process lifetime and temp-dir namespace between two suites that currently cannot contaminate each other.

## Trade-off

The coverage branch of the DAG gets **slower in isolation** (~1 min of parallel legs → ~3–5 min of serial ones). It wins because queueing, not execution, is the dominant term — and it stops being the right call if that ceases to be true.

## Also

- Pruned 8 dead `ci-latency-baseline.json` rows (7 deleted jobs + a `Bencher Report` entry naming no job). `check.ts` fails only on regressions, so these were inert, but they were drift.
- **Separate finding, not fixed here:** `Validate PR title` is not in the ruleset's required contexts, and `.github/BRANCH_PROTECTION.md` is stale against the live ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)