### PR TITLE
fix(cli): handle the embedding warm-up error in `nimbus search`

### DIFF
--- a/packages/cli/src/commands/search.test.ts
+++ b/packages/cli/src/commands/search.test.ts
@@ -142,3 +142,113 @@ describe("runSearch — dispatcher", () => {
     expect(out.stdout).toContain('"title": "Bar"');
   });
 });
+
+// #928 made the gateway bind BEFORE the embedding model loads, so a semantic
+// search on a cold machine gets JSON-RPC -32021 instead of results. The CLI had
+// no handler, so `nimbus search` on a first run printed a raw JSON-RPC error —
+// the exact first-run papercut #928 set out to remove.
+describe("runSearch — embedding warm-up", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  const warmingError = (): Error =>
+    new Error(
+      "index.searchRanked: the embedding runtime is still warming up (Xenova/all-MiniLM-L6-v2, 4s). " +
+        "Semantic results are not available yet; retry shortly, or re-run without semantic search " +
+        "to get keyword-only matches.",
+    );
+
+  it("falls back to keyword-only results when the runtime is warming", async () => {
+    const mock = createMockIpcClient([
+      warmingError(),
+      { embedding: { state: "warming" } },
+      [{ id: "github:pr_1", title: "My PR" }],
+    ]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await runSearch(["hello"]);
+
+    expect(mock.calls.map((c) => c.method)).toEqual([
+      "index.searchRanked",
+      "gateway.ping",
+      "index.searchRanked",
+    ]);
+    // The retry must actually drop semantic, or the gateway just throws again.
+    expect(mock.calls[2]?.params).toMatchObject({ name: "hello", semantic: false });
+    expect(out.stdout).toContain("My PR");
+  });
+
+  it("puts the warm-up notice on stderr so stdout stays valid JSON", async () => {
+    const mock = createMockIpcClient([
+      warmingError(),
+      { embedding: { state: "warming" } },
+      [{ id: "a", title: "T" }],
+    ]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await runSearch(["hello"]);
+
+    expect(out.stderr).toMatch(/warming up/);
+    expect(out.stdout).not.toMatch(/warming up/);
+    // The whole point of stderr: `nimbus search ... | jq` must still parse.
+    expect(() => JSON.parse(out.stdout) as unknown).not.toThrow();
+  });
+
+  it("rethrows the ORIGINAL error when the runtime is not warming", async () => {
+    const mock = createMockIpcClient([
+      new Error("index.searchRanked: database is locked"),
+      { embedding: { state: "ready" } },
+    ]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await expect(runSearch(["hello"])).rejects.toThrow(/database is locked/);
+  });
+
+  it("rethrows the original error when the ping itself fails", async () => {
+    // The ping is a diagnostic. Its failure must never replace the real error.
+    const mock = createMockIpcClient([
+      new Error("index.searchRanked: database is locked"),
+      new Error("socket closed"),
+    ]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await expect(runSearch(["hello"])).rejects.toThrow(/database is locked/);
+  });
+
+  it("does not ping at all for a keyword-only search", async () => {
+    // --no-semantic can never trip the warming gate, so there is nothing to recover.
+    const mock = createMockIpcClient([new Error("index.searchRanked: boom")]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await expect(runSearch(["hello", "--no-semantic"])).rejects.toThrow(/boom/);
+    expect(mock.calls.map((c) => c.method)).toEqual(["index.searchRanked"]);
+  });
+
+  it("rethrows when ping omits the embedding block entirely", async () => {
+    // `gateway.ping` builds its embedding fields from an OPTIONAL
+    // `getEmbeddingStatus` hook (inline-handlers.ts: `?.() ?? {}`), so a gateway
+    // with embeddings unwired answers with no `embedding` key at all. That must
+    // read as "not warming", not crash on the optional chain.
+    const mock = createMockIpcClient([
+      new Error("index.searchRanked: database is locked"),
+      { version: "1.5.0", uptime: 42 },
+    ]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await expect(runSearch(["hello"])).rejects.toThrow(/database is locked/);
+  });
+
+  it("adds no extra round-trip on the happy path", async () => {
+    const mock = createMockIpcClient([[{ id: "x", title: "Y" }]]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+
+    await runSearch(["hello"]);
+
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]?.method).toBe("index.searchRanked");
+  });
+});

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -110,9 +110,67 @@ export async function runSearch(args: string[]): Promise<void> {
     if (itemType !== undefined) {
       params["itemType"] = itemType;
     }
-    const rows = await client.call<unknown[]>("index.searchRanked", params);
+    const rows = await searchWithWarmingFallback(client, params, semantic);
     console.log(JSON.stringify(rows, null, 2));
   } finally {
     await client.disconnect().catch(() => {});
+  }
+}
+
+/**
+ * Since #928 the gateway binds its IPC socket BEFORE the embedding model finishes
+ * loading, so a semantic search on a cold machine can arrive while there are no
+ * vectors yet. The gateway answers with JSON-RPC `-32021`
+ * (`EMBEDDING_WARMING_RPC_CODE`) rather than silently degrading to BM25 — which is
+ * the right call, but the CLI had no handler, so `nimbus search` on a first run
+ * printed a raw JSON-RPC error.
+ *
+ * Recovery is LAZY — try the search, and only on failure ask `gateway.ping` what
+ * the embedding runtime is doing — for two reasons. It keeps the happy path at a
+ * single round-trip, and it avoids branching on the error's shape: the
+ * `@nimbus-dev/client` transport rejects with a plain `Error` carrying only
+ * `error.message`, discarding the JSON-RPC `code` and `data`, so `-32021` is not
+ * visible to us here. Matching the message text would be brittle; asking the
+ * gateway for structured state is not.
+ *
+ * (The durable fix is for the client to preserve `code`/`data` on rejection, which
+ * would let this — and every other typed gateway error — be matched directly.)
+ *
+ * No race: readiness moves warming -> ready monotonically. It never returns to
+ * `warming`, so a retry cannot land in the state that produced the error.
+ */
+async function searchWithWarmingFallback(
+  client: IPCClient,
+  params: Record<string, unknown>,
+  semantic: boolean,
+): Promise<unknown[]> {
+  try {
+    return await client.call<unknown[]>("index.searchRanked", params);
+  } catch (err) {
+    // A keyword-only search can never trip the warming gate, so nothing to recover.
+    if (!semantic) {
+      throw err;
+    }
+    if (!(await isEmbeddingWarming(client))) {
+      throw err;
+    }
+    // stderr, not stdout: stdout carries the JSON result and must stay parseable
+    // by anything piping this command into `jq`.
+    console.error(
+      "note: semantic search is still warming up; showing keyword-only results. Retry shortly for semantic ranking.",
+    );
+    return await client.call<unknown[]>("index.searchRanked", { ...params, semantic: false });
+  }
+}
+
+/** Asks the gateway whether the embedding runtime is warming. Any doubt answers false. */
+async function isEmbeddingWarming(client: IPCClient): Promise<boolean> {
+  try {
+    const ping = await client.call<{ embedding?: { state?: unknown } }>("gateway.ping", {});
+    return ping.embedding?.state === "warming";
+  } catch {
+    // The ping is a diagnostic, not the operation. If it fails, the caller must
+    // still see the ORIGINAL search error rather than one about pinging.
+    return false;
   }
 }


### PR DESCRIPTION
## The gap

#928 made the gateway bind its IPC socket **before** the embedding model loads, and correctly answers a semantic query that arrives too early with JSON-RPC `-32021` rather than silently degrading to BM25.

Nothing on the CLI side handled it. So on a genuinely cold machine — the exact first-run path #928 existed to fix — `nimbus search` printed a raw JSON-RPC error.

It now degrades the way the first-run design memo (#931 §2b) specified: **a one-line notice, keyword results, never fatal.**

## Why it asks a second question instead of reading the first answer

Recovery is **lazy**: run the search, and only on failure ask `gateway.ping` what the embedding runtime is doing.

1. **The happy path keeps its single round-trip.** A ping-first design would add one to every search — and would break every existing test in this file, since the mock client answers from a positional queue.
2. **It avoids branching on the error's shape.** `@nimbus-dev/client`'s transport rejects with `new Error(jsonRpcErrorMessage(err))` — only `error.message` survives; the JSON-RPC `code` and `data` are **discarded**. `-32021` is therefore invisible to the CLI. Matching the message text would be brittle; asking the gateway for structured state is not.

**No race:** readiness moves `warming → ready` monotonically and never returns to `warming`, so the retry cannot land in the state that produced the error.

The notice goes to **stderr**, so `nimbus search … | jq` still parses.

## Tests

Seven, each red-proved by sabotaging the implementation and watching the right one fail:

| sabotage | tests that fail |
|---|---|
| remove the fallback (pre-fix behaviour) | 2 |
| move the notice to stdout | 1 |
| retry without dropping `semantic` | 1 |

Covered: the fallback; stderr placement (with a real `JSON.parse` of stdout); a non-warming error rethrowing the **original** error; a failing ping rethrowing the original error (the ping is a diagnostic and must never replace the real failure); `--no-semantic` never pinging at all; a ping whose `embedding` block is absent entirely — `getEmbeddingStatus` is optional on the gateway (`?.() ?? {}`), so that shape is real; and the happy path adding no round-trip.

Full `bun test packages/cli/src`: **1875 pass, 0 fail.**

## Follow-up this PR deliberately does not do

The durable fix is for **`@nimbus-dev/client` to preserve `code`/`data` on rejection**. Today every typed gateway error arrives at every consumer as a bare message string — this one, and any future `-32xxx`. That is a change in the `nimbus-client` repo plus a version bump, so it is out of scope here, but it is the reason this PR has to ask a second question at all. The VS Code extension consumes the same client and would hit the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)