### PR TITLE
fix(ci): repair the coverage-gate count assertion broken by #936

### DIFF
--- a/scripts/structure-audit/check-coverage-gate-pal.test.ts
+++ b/scripts/structure-audit/check-coverage-gate-pal.test.ts
@@ -455,13 +455,31 @@ describe("auditCoverageGatePal", () => {
     expect(result.ok).toBe(true);
   });
 
-  test("the real workflow carries all 24 gates, 9 PAL and 15 Linux-only", () => {
-    const gates = parseCoverageGateMatrix(
-      readFileSync(join(REPO_ROOT, ".github/workflows/_test-suite.yml"), "utf8"),
-    );
-    expect(gates).toHaveLength(24);
+  test("the real workflow carries 9 PAL gates and 3 Linux batches covering all 15 Linux scripts", () => {
+    const yaml = readFileSync(join(REPO_ROOT, ".github/workflows/_test-suite.yml"), "utf8");
+    const gates = parseCoverageGateMatrix(yaml);
+
+    // #936 batched `coverage-gates-linux` from 15 one-gate jobs into 3, to hand
+    // 12 job slots back to a saturated concurrency pool. Matrix ENTRIES are
+    // therefore 12, not 24.
+    expect(gates).toHaveLength(12);
     expect(gates.filter((g) => g.pal === true)).toHaveLength(9);
-    expect(gates.filter((g) => g.pal === false)).toHaveLength(15);
+    expect(gates.filter((g) => g.pal === false)).toHaveLength(3);
+
+    // The count above is about scheduling. THIS is the property that matters and
+    // the one the old `toHaveLength(15)` was really protecting: batching changed
+    // how many jobs run, not how much is covered. A batch that silently dropped
+    // a script would keep the entry count at 3 and go unnoticed otherwise.
+    const batched = [...yaml.matchAll(/^ {12}scripts: "([^"]+)"$/gm)].flatMap((m) =>
+      (m[1] ?? "").split(" ").filter((s) => s !== ""),
+    );
+    expect(new Set(batched).size, "a Linux coverage script was dropped or duplicated").toBe(15);
+    expect(batched).toHaveLength(15);
+    for (const script of batched) {
+      expect(script, "batched entries must name `test:coverage:*` scripts").toMatch(
+        /^test:coverage:[a-z-]+$/,
+      );
+    }
   });
 
   test("the untouched fixture passes — so every red below is caused by its own edit", () => {


### PR DESCRIPTION
## main is red

```
(fail) auditCoverageGatePal > the real workflow carries all 24 gates, 9 PAL and 15 Linux-only
Expected length: 24
Received length: 12
```

#936 batched `coverage-gates-linux` from 15 one-gate jobs into 3. The audit's own test file hard-coded 24/9/15.

**My miss, and a specific one.** Before merging #936 I ran the audit *script* (`bun run audit:coverage-gate-pal` → OK) and treated that green as proof the audit was satisfied. I never ran the audit's own *test file*, where the hard-coded counts lived. A passing script is not a passing suite — and I even red-proved the script against a bad `pal:` value, which made the green feel more thorough than it was.

## The fix is stronger than a number change

Counts corrected to 12/9/3. But the useful half is what replaces `toHaveLength(15)`.

That number was really protecting coverage **breadth**, which the entry count no longer expresses: batching changed how many jobs run, not how much is covered. A batch that silently dropped a script would keep the entry count at 3 and sail straight through.

The test now parses the `scripts:` lists and asserts all **15 distinct `test:coverage:*` scripts appear exactly once**.

**Red-proved:** deleting `test:coverage:lan` from a batch reds the test. The old assertion could not have caught that either — it counted matrix entries, never scripts — so this is strictly stronger than what #936 broke.

## Blast radius

I checked for other fallout rather than assuming this was the only breakage: **404 structure-audit tests, this was the single failure.** The `Sync scheduler` / `Rate limiter` references in `nimbus-testing.md` and `architecture.md` are coverage *thresholds* per subsystem, not job names — unchanged and still accurate, since all 15 scripts still run at the same thresholds.

This unblocks #926, #939 and #940, which are all based on the red main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)