### PR TITLE
chore(deps): @nimbus-dev/client 0.13.0 → 0.14.0 in packages/cli

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "@nimbus-dev/client": "^0.13.0",
+        "@nimbus-dev/client": "^0.14.0",
         "@nimbus-dev/sdk": "^1.8.1",
         "ink": "^7.1.1",
         "ink-text-input": "^6.0.0",
@@ -1814,7 +1814,7 @@
 
     "@nimbus-dev/admin-console": ["@nimbus-dev/admin-console@workspace:packages/admin-console"],
 
-    "@nimbus-dev/client": ["@nimbus-dev/client@0.13.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-Pwi/V9CLeliNshspQgJj9hS/kCcqkKfw5vz/OChmIVaky28V4eNTXvf9UNH3c817+ndHKuhdoVUw3R5PnwQtQA=="],
+    "@nimbus-dev/client": ["@nimbus-dev/client@0.14.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-s4tNoOHq8JCjMuoNEDRVWmQ4afWHU6FMyBwRSjeqAAjsOrswjDiz8mlQycu/gejCyNp+VabqXcJ6nbuJZeTBcg=="],
 
     "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.8.1", "", {}, "sha512-FzTiXa5GzG4Bdlw+gA1kg/cIFmvyH1FvLlQowGHZAhGbjX1BJB/ncFXQZijH9MO+mIDLkd/jMEwVfuiB7BNHkA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@nimbus-dev/client": "^0.13.0",
+    "@nimbus-dev/client": "^0.14.0",
     "@nimbus-dev/sdk": "^1.8.1",
     "ink": "^7.1.1",
     "ink-text-input": "^6.0.0",


### PR DESCRIPTION
Keeps the release-train `client:Nimbus` edge current.

## Why now

`@nimbus-dev/client@0.14.0` published **2026-07-29T20:22Z**. At the time of writing it sits inside `audit:release-staleness`'s 6-hour grace window, so the gate reports `OK (12 edges current)` — but the grace is measured from the npm version's own publish time, so this edge goes red on the next sweep without the bump. A `0.x` caret pins the minor, so `^0.13.0` cannot reach `0.14.0` via `bun install` alone; this needs the manifest edit.

## What 0.14.0 contains

[nimbus-client#44](https://github.com/nimbus-agent/nimbus-client/issues/44) — *preserve JSON-RPC code and data on rejection*, the upstream fix for the long-standing "client drops RPC error codes" gap. Purely additive: it adds `isJsonRpcError`, `JsonRpcError`, `jsonRpcErrorCode` and `jsonRpcErrorData` and leaves the existing thrown shape intact.

## Call-site review

**Nothing under `packages/cli/src` references the client's error types** (`IpcResponseError`, `JsonRpcError`, `jsonRpcError*`) — verified by grep. So this is a resolution bump, not an API adoption. Actually consuming the new error surface in the CLI (surfacing RPC codes instead of message-matching) is separate, deliberate work and is **not** in this PR.

## Verification

- `bun run typecheck` — green
- `bunx biome check packages scripts .github docs` — 3007 files, no fixes
- `bun run audit:release-staleness` — `OK (12 edges current)`
- `bun test packages/cli/src` — **1847 pass, 2 fail**, both in the `App state machine` TUI suite

### On those 2 failures — pre-existing flake, not this change

`packages/cli/src/tui/App.test.tsx` is flaky on `main` independently of the client version. Same file, three consecutive runs, no changes:

| tree | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| `main` (client 0.13.0) | 3 fail | 1 fail | 3 fail |
| this branch (client 0.14.0) | 1 fail | 1 fail | 2 fail |

Both trees sit in the same 1–3 range and the failing test varies between runs, so the bump does not cause it. Worth its own issue; not fixed here.

> Note: `bun run preflight:fast` reports `lint (biome)` failed in a `.claude/worktrees/` checkout with `paths were provided but ignored: .` — the known worktree false-fail. Validated with explicit paths instead (green, above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
