### PR TITLE
fix(quality): clear all 171 SonarCloud issues from the 2026-07-29 profile bump

### DIFF
--- a/packages/cli/src/commands/audit.test.ts
+++ b/packages/cli/src/commands/audit.test.ts
@@ -211,14 +211,19 @@ describe("runAudit (dispatcher)", () => {
     expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit: 50 } });
   });
 
-  it("respects --limit in the bare list path", async () => {
+  // A usable --limit is passed through; anything non-finite or non-positive falls back to 50.
+  it.each([
+    ["a valid value is respected", "7", 7],
+    ["an invalid (non-finite) value falls back to 50", "abc", 50],
+    ["zero falls back to 50", "0", 50],
+  ])("--limit in the bare list path: %s", async (_label, raw, limit) => {
     const ipc = createMockIpcClient([[]]);
     setFixture({
       gatewayState: { socketPath: FAKE_SOCKET_PATH },
       ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
     });
-    await runAudit(["--limit", "7"]);
-    expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit: 7 } });
+    await runAudit(["--limit", raw]);
+    expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit } });
   });
 
   it("throws the gateway-not-running error from the verify branch", async () => {
@@ -275,25 +280,5 @@ describe("runAudit (dispatcher)", () => {
     expect(ipc.calls[0]).toEqual({ method: "audit.exportAll", params: {} });
     expect(writes[0]?.path).toBe(outPath);
     expect(out.stdout).toContain(`wrote 1 audit rows to ${outPath}`);
-  });
-
-  it("falls back to limit 50 when --limit is given an invalid (non-finite) value", async () => {
-    const ipc = createMockIpcClient([[]]);
-    setFixture({
-      gatewayState: { socketPath: FAKE_SOCKET_PATH },
-      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
-    });
-    await runAudit(["--limit", "abc"]);
-    expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit: 50 } });
-  });
-
-  it("falls back to limit 50 when --limit is zero", async () => {
-    const ipc = createMockIpcClient([[]]);
-    setFixture({
-      gatewayState: { socketPath: FAKE_SOCKET_PATH },
-      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
-    });
-    await runAudit(["--limit", "0"]);
-    expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit: 50 } });
   });
 });

--- a/packages/cli/src/commands/doctor-core.ts
+++ b/packages/cli/src/commands/doctor-core.ts
@@ -192,7 +192,7 @@ function collectionState(exec: DoctorVaultExec): { state: DoctorVaultState; deta
     return { state: "no-collection", detail: `${SECRETS_NAME} has no default collection` };
   }
   const locked = askSecretService(exec, "locked", path);
-  if (locked === null || locked.code !== 0) {
+  if (locked?.code !== 0) {
     return { state: "unverified", detail: locked?.stderr.trim() ?? "" };
   }
   const flag = BOOL_PATTERN.exec(locked.stdout)?.[1];
@@ -227,15 +227,23 @@ export function doctorVaultStatus(
   return toStatus(state, detail);
 }
 
+/**
+ * `(detail)` when the probe never ran (not-applicable carries the OS name), `[detail]` when a
+ * non-ok state has something to say, and nothing at all when the vault is simply healthy.
+ */
+function vaultLineSuffix(status: DoctorVaultStatus): string {
+  if (status.state === "not-applicable") {
+    return ` (${status.detail})`;
+  }
+  if (status.detail.length > 0 && status.state !== "ok") {
+    return ` [${status.detail}]`;
+  }
+  return "";
+}
+
 export function formatDoctorVaultLine(status: DoctorVaultStatus): string {
   const report = VAULT_REPORT[status.state];
-  const suffix =
-    status.state === "not-applicable"
-      ? ` (${status.detail})`
-      : status.detail.length > 0 && status.state !== "ok"
-        ? ` [${status.detail}]`
-        : "";
-  return `${report.mark} Vault: ${report.text}${suffix}`;
+  return `${report.mark} Vault: ${report.text}${vaultLineSuffix(status)}`;
 }
 
 export function doctorVaultLine(

--- a/packages/cli/src/commands/identity.test.ts
+++ b/packages/cli/src/commands/identity.test.ts
@@ -219,7 +219,7 @@ describe("awaitLogin — buffers events that race ahead of jobId", () => {
       // backlog buffer + replay path (the event would otherwise be dropped and the Promise hang).
       handlers.get("identity.loginDone")?.({ jobId });
     });
-    await awaitLogin(ipc);
+    await expect(awaitLogin(ipc)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/lan.test.ts
+++ b/packages/cli/src/commands/lan.test.ts
@@ -133,37 +133,17 @@ describe("runLan — dispatcher", () => {
     expect(out.stdout).toContain("no");
   });
 
-  it("grant <peerId> → lan.grantWrite + confirmation", async () => {
+  // Each per-peer subcommand maps to one IPC method and prints its own confirmation line.
+  it.each([
+    ["grant", "lan.grantWrite", "Write access granted to peer peer-1"],
+    ["revoke", "lan.revokeWrite", "Write access revoked for peer peer-1"],
+    ["remove", "lan.removePeer", "Peer peer-1 removed."],
+  ])("%s <peerId> → %s + confirmation", async (subcommand, method, confirmation) => {
     const mock = createMockIpcClient([{ ok: true }]);
     setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
-    await runLan(["grant", "peer-1"]);
-    expect(mock.calls[0]).toEqual({
-      method: "lan.grantWrite",
-      params: { peerId: "peer-1" },
-    });
-    expect(out.stdout).toContain("Write access granted to peer peer-1");
-  });
-
-  it("revoke <peerId> → lan.revokeWrite + confirmation", async () => {
-    const mock = createMockIpcClient([{ ok: true }]);
-    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
-    await runLan(["revoke", "peer-1"]);
-    expect(mock.calls[0]).toEqual({
-      method: "lan.revokeWrite",
-      params: { peerId: "peer-1" },
-    });
-    expect(out.stdout).toContain("Write access revoked for peer peer-1");
-  });
-
-  it("remove <peerId> → lan.removePeer + confirmation", async () => {
-    const mock = createMockIpcClient([{ ok: true }]);
-    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
-    await runLan(["remove", "peer-1"]);
-    expect(mock.calls[0]).toEqual({
-      method: "lan.removePeer",
-      params: { peerId: "peer-1" },
-    });
-    expect(out.stdout).toContain("Peer peer-1 removed.");
+    await runLan([subcommand, "peer-1"]);
+    expect(mock.calls[0]).toEqual({ method, params: { peerId: "peer-1" } });
+    expect(out.stdout).toContain(confirmation);
   });
 
   it("throws 'Gateway is not running' when state is undefined (parser passes, gateway absent)", async () => {

--- a/packages/cli/src/commands/team-federation.test.ts
+++ b/packages/cli/src/commands/team-federation.test.ts
@@ -221,13 +221,14 @@ describe("runTeamFederationRpc", () => {
 
   it("audit (no entries array) takes the empty branch without throwing", async () => {
     const { client } = fakeClient({}); // r.entries undefined → Array.isArray false → []
-    await runTeamFederationRpc(client, {
-      kind: "audit",
-      namespace: "ns",
-      purpose: "why",
-      sinceMs: 5,
-    });
-    // no throw == pass
+    await expect(
+      runTeamFederationRpc(client, {
+        kind: "audit",
+        namespace: "ns",
+        purpose: "why",
+        sinceMs: 5,
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/src/mcp/adapter.test.ts
+++ b/packages/cli/src/mcp/adapter.test.ts
@@ -440,19 +440,9 @@ describe("projectRankedItem — missing/wrong field branches", () => {
     expect(out["url"]).toBeUndefined();
   });
 
-  it("omits score when score is absent", () => {
+  it.each(["score", "modifiedAt", "semanticSnippet"])("omits %s when absent", (field) => {
     const out = projectRankedItem({ name: "x" });
-    expect(out["score"]).toBeUndefined();
-  });
-
-  it("omits modifiedAt when absent", () => {
-    const out = projectRankedItem({ name: "x" });
-    expect(out["modifiedAt"]).toBeUndefined();
-  });
-
-  it("omits semanticSnippet when absent", () => {
-    const out = projectRankedItem({ name: "x" });
-    expect(out["semanticSnippet"]).toBeUndefined();
+    expect(out[field]).toBeUndefined();
   });
 
   it("omits meta when rawMeta is null", () => {

--- a/packages/cli/src/tui/ConnectorHealth.test.tsx
+++ b/packages/cli/src/tui/ConnectorHealth.test.tsx
@@ -44,9 +44,14 @@ describe("ConnectorHealth", () => {
     unmount();
   });
 
-  test("prefixes degraded statuses (backoff/error) with ⚠", async () => {
+  // A single connector in each status, and the glyph its row must carry.
+  test.each([
+    ["error is prefixed with the degraded marker", "slack", "error", "⚠"],
+    ["syncing maps to the half-circle glyph (in-flight)", "github", "syncing", "◐"],
+    ["backoff maps to the empty-circle glyph (failure)", "slack", "backoff", "○"],
+  ])("%s", async (_label, serviceId, status, glyph) => {
     const stub = new StubIpcClient({
-      results: { "connector.listStatus": [{ serviceId: "slack", status: "error" }] },
+      results: { "connector.listStatus": [{ serviceId, status }] },
     });
     const { lastFrame, unmount } = render(
       <IpcContext.Provider value={ctx(stub)}>
@@ -54,7 +59,7 @@ describe("ConnectorHealth", () => {
       </IpcContext.Provider>,
     );
     await new Promise((r) => setTimeout(r, 20));
-    expect(lastFrame() ?? "").toContain("⚠");
+    expect(lastFrame() ?? "").toContain(glyph);
     unmount();
   });
 
@@ -92,34 +97,6 @@ describe("ConnectorHealth", () => {
     const frame = lastFrame() ?? "";
     expect(frame).toContain("No connectors registered");
     expect(frame).not.toContain("(none)");
-    unmount();
-  });
-
-  test("syncing maps to the half-circle glyph (in-flight)", async () => {
-    const stub = new StubIpcClient({
-      results: { "connector.listStatus": [{ serviceId: "github", status: "syncing" }] },
-    });
-    const { lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <ConnectorHealth mode="idle" />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
-    expect(lastFrame() ?? "").toContain("◐");
-    unmount();
-  });
-
-  test("backoff maps to the empty-circle glyph (failure)", async () => {
-    const stub = new StubIpcClient({
-      results: { "connector.listStatus": [{ serviceId: "slack", status: "backoff" }] },
-    });
-    const { lastFrame, unmount } = render(
-      <IpcContext.Provider value={ctx(stub)}>
-        <ConnectorHealth mode="idle" />
-      </IpcContext.Provider>,
-    );
-    await new Promise((r) => setTimeout(r, 20));
-    expect(lastFrame() ?? "").toContain("○");
     unmount();
   });
 });

--- a/packages/gateway/src/automation/watcher-store.test.ts
+++ b/packages/gateway/src/automation/watcher-store.test.ts
@@ -39,7 +39,7 @@ describe("watcher-store", () => {
 
   test("deleteWatcher no-op when schema below v8", () => {
     const db = new Database(":memory:");
-    deleteWatcher(db, "any-id");
+    expect(() => deleteWatcher(db, "any-id")).not.toThrow();
   });
 
   test("setWatcherEnabled returns false when schema below v8", () => {

--- a/packages/gateway/src/chatops/chatops-boot.test.ts
+++ b/packages/gateway/src/chatops/chatops-boot.test.ts
@@ -517,6 +517,7 @@ describe("buildChatopsBoot — full production graph", () => {
     h.socket.emit(mention("C0", "U_BOB", "@nimbus who is on call?", "35"));
     // Non-JSON → raw string → not an object → emailless → unmapped → refusal under refuse mode.
     await until(() => h.audits.some((a) => a.actionType === "chatops.refusal"));
+    expect(h.audits.map((a) => a.actionType)).toContain("chatops.refusal");
     await h.boot.service.stop();
   });
 

--- a/packages/gateway/src/clips/clip-token-store.test.ts
+++ b/packages/gateway/src/clips/clip-token-store.test.ts
@@ -90,45 +90,18 @@ describe("clip-token-store", () => {
     expect(a).not.toBe(b);
   });
 
-  test("corrupt JSON in vault → empty map (fail-safe, no throw)", async () => {
+  // Every non-conforming vault payload is fail-safe: an empty map, never a throw.
+  test.each([
+    ["corrupt JSON", "{not json"],
+    ["empty object (isStringMap vacuous-true)", "{}"],
+    ["non-object JSON (number)", "42"],
+    ["JSON array (Array rejected)", '["a","b"]'],
+    ["null JSON", "null"],
+    ["object with a non-string value (every→false)", '{"chrome":5}'],
+    ["empty string", ""],
+  ])("stored %s → empty map", async (_label, stored) => {
     const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, "{not json");
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("stored empty object → empty map (isStringMap vacuous-true)", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, "{}");
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("stored non-object JSON (number) → empty map", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, "42");
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("stored JSON array → empty map (Array rejected)", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, '["a","b"]');
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("stored null JSON → empty map", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, "null");
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("object with a non-string value → empty map (every→false)", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, '{"chrome":5}');
-    expect(await loadClipTokens(v)).toEqual({});
-  });
-
-  test("empty-string vault value → empty map", async () => {
-    const v = fakeVault();
-    await v.set(CLIP_TOKENS_VAULT_KEY, "");
+    await v.set(CLIP_TOKENS_VAULT_KEY, stored);
     expect(await loadClipTokens(v)).toEqual({});
   });
 });

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -115,23 +115,13 @@ describe("env-var parsers", () => {
       expect(m.size).toBe(0);
     });
 
-    test("whitespace-only env returns empty map", () => {
-      process.env["NIMBUS_SEARCH_PRIORITY_JSON"] = "   ";
-      expect(parseSearchPriorityJson().size).toBe(0);
-    });
-
-    test("invalid JSON returns empty map", () => {
-      process.env["NIMBUS_SEARCH_PRIORITY_JSON"] = "{not json";
-      expect(parseSearchPriorityJson().size).toBe(0);
-    });
-
-    test("non-object JSON (array) returns empty map", () => {
-      process.env["NIMBUS_SEARCH_PRIORITY_JSON"] = "[1,2,3]";
-      expect(parseSearchPriorityJson().size).toBe(0);
-    });
-
-    test("null JSON returns empty map", () => {
-      process.env["NIMBUS_SEARCH_PRIORITY_JSON"] = "null";
+    test.each([
+      ["whitespace-only", "   "],
+      ["invalid JSON", "{not json"],
+      ["non-object JSON (array)", "[1,2,3]"],
+      ["null JSON", "null"],
+    ])("%s env returns empty map", (_label, raw) => {
+      process.env["NIMBUS_SEARCH_PRIORITY_JSON"] = raw;
       expect(parseSearchPriorityJson().size).toBe(0);
     });
 
@@ -157,28 +147,18 @@ describe("env-var parsers", () => {
       expect(parseEngineContextWindowItems()).toBe(20);
     });
 
-    test("empty string returns default 20", () => {
-      process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = "";
-      expect(parseEngineContextWindowItems()).toBe(20);
-    });
-
     test("in-range value (1..200) is accepted", () => {
       process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = "42";
       expect(parseEngineContextWindowItems()).toBe(42);
     });
 
-    test("out-of-range value (<1) falls back to 20", () => {
-      process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = "0";
-      expect(parseEngineContextWindowItems()).toBe(20);
-    });
-
-    test("out-of-range value (>200) falls back to 20", () => {
-      process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = "300";
-      expect(parseEngineContextWindowItems()).toBe(20);
-    });
-
-    test("non-numeric value falls back to 20", () => {
-      process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = "abc";
+    test.each([
+      ["empty string", ""],
+      ["out-of-range (<1)", "0"],
+      ["out-of-range (>200)", "300"],
+      ["non-numeric", "abc"],
+    ])("%s falls back to 20", (_label, raw) => {
+      process.env["NIMBUS_ENGINE_CONTEXT_WINDOW_ITEMS"] = raw;
       expect(parseEngineContextWindowItems()).toBe(20);
     });
   });
@@ -188,23 +168,17 @@ describe("env-var parsers", () => {
       expect(parseConversationalAgentMaxSteps()).toBe(20);
     });
 
-    test("empty string returns default 20", () => {
-      process.env["NIMBUS_ASK_MAX_STEPS"] = "";
-      expect(parseConversationalAgentMaxSteps()).toBe(20);
-    });
-
     test("in-range (1..64) is accepted", () => {
       process.env["NIMBUS_ASK_MAX_STEPS"] = "8";
       expect(parseConversationalAgentMaxSteps()).toBe(8);
     });
 
-    test("out-of-range (>64) falls back to 20", () => {
-      process.env["NIMBUS_ASK_MAX_STEPS"] = "1000";
-      expect(parseConversationalAgentMaxSteps()).toBe(20);
-    });
-
-    test("non-numeric falls back to 20", () => {
-      process.env["NIMBUS_ASK_MAX_STEPS"] = "nope";
+    test.each([
+      ["empty string", ""],
+      ["out-of-range (>64)", "1000"],
+      ["non-numeric", "nope"],
+    ])("%s falls back to 20", (_label, raw) => {
+      process.env["NIMBUS_ASK_MAX_STEPS"] = raw;
       expect(parseConversationalAgentMaxSteps()).toBe(20);
     });
   });
@@ -214,28 +188,18 @@ describe("env-var parsers", () => {
       expect(parseMaxAgentDepth()).toBe(3);
     });
 
-    test("empty string returns default 3", () => {
-      process.env["NIMBUS_MAX_AGENT_DEPTH"] = "";
-      expect(parseMaxAgentDepth()).toBe(3);
-    });
-
     test("in-range (1..10) is accepted", () => {
       process.env["NIMBUS_MAX_AGENT_DEPTH"] = "5";
       expect(parseMaxAgentDepth()).toBe(5);
     });
 
-    test("out-of-range (<1) falls back to 3", () => {
-      process.env["NIMBUS_MAX_AGENT_DEPTH"] = "0";
-      expect(parseMaxAgentDepth()).toBe(3);
-    });
-
-    test("out-of-range (>10) falls back to 3", () => {
-      process.env["NIMBUS_MAX_AGENT_DEPTH"] = "99";
-      expect(parseMaxAgentDepth()).toBe(3);
-    });
-
-    test("non-numeric falls back to 3", () => {
-      process.env["NIMBUS_MAX_AGENT_DEPTH"] = "deep";
+    test.each([
+      ["empty string", ""],
+      ["out-of-range (<1)", "0"],
+      ["out-of-range (>10)", "99"],
+      ["non-numeric", "deep"],
+    ])("%s falls back to 3", (_label, raw) => {
+      process.env["NIMBUS_MAX_AGENT_DEPTH"] = raw;
       expect(parseMaxAgentDepth()).toBe(3);
     });
   });
@@ -245,23 +209,17 @@ describe("env-var parsers", () => {
       expect(parseMaxToolCallsPerSession()).toBe(20);
     });
 
-    test("empty string returns default 20", () => {
-      process.env["NIMBUS_MAX_TOOL_CALLS_PER_SESSION"] = "";
-      expect(parseMaxToolCallsPerSession()).toBe(20);
-    });
-
     test("in-range (1..200) is accepted", () => {
       process.env["NIMBUS_MAX_TOOL_CALLS_PER_SESSION"] = "150";
       expect(parseMaxToolCallsPerSession()).toBe(150);
     });
 
-    test("out-of-range (>200) falls back to 20", () => {
-      process.env["NIMBUS_MAX_TOOL_CALLS_PER_SESSION"] = "500";
-      expect(parseMaxToolCallsPerSession()).toBe(20);
-    });
-
-    test("non-numeric falls back to 20", () => {
-      process.env["NIMBUS_MAX_TOOL_CALLS_PER_SESSION"] = "many";
+    test.each([
+      ["empty string", ""],
+      ["out-of-range (>200)", "500"],
+      ["non-numeric", "many"],
+    ])("%s falls back to 20", (_label, raw) => {
+      process.env["NIMBUS_MAX_TOOL_CALLS_PER_SESSION"] = raw;
       expect(parseMaxToolCallsPerSession()).toBe(20);
     });
   });

--- a/packages/gateway/src/config/nimbus-toml-quorum.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-quorum.test.ts
@@ -16,20 +16,12 @@ describe("[hitl.quorum] config", () => {
     expect(parseQuorumConfig("").size).toBe(0);
   });
 
-  it("ignores malformed rows — non-numeric approvers", () => {
-    const raw = ['[hitl.quorum."x.y"]', "approvers = bad", "window_seconds = 300"].join("\n");
-    const cfg = parseQuorumConfig(raw);
-    expect(cfg.has("x.y")).toBe(false);
-  });
-
-  it("ignores malformed rows — approvers < 1", () => {
-    const raw = ['[hitl.quorum."x.y"]', "approvers = 0", "window_seconds = 300"].join("\n");
-    const cfg = parseQuorumConfig(raw);
-    expect(cfg.has("x.y")).toBe(false);
-  });
-
-  it("ignores malformed rows — window_seconds <= 0", () => {
-    const raw = ['[hitl.quorum."x.y"]', "approvers = 2", "window_seconds = 0"].join("\n");
+  it.each([
+    ["non-numeric approvers", "approvers = bad", "window_seconds = 300"],
+    ["approvers < 1", "approvers = 0", "window_seconds = 300"],
+    ["window_seconds <= 0", "approvers = 2", "window_seconds = 0"],
+  ])("ignores malformed rows — %s", (_label, approvers, windowSeconds) => {
+    const raw = ['[hitl.quorum."x.y"]', approvers, windowSeconds].join("\n");
     const cfg = parseQuorumConfig(raw);
     expect(cfg.has("x.y")).toBe(false);
   });

--- a/packages/gateway/src/config/nimbus-toml.test.ts
+++ b/packages/gateway/src/config/nimbus-toml.test.ts
@@ -354,13 +354,15 @@ describe("resolveNimbusTomlForProfile", () => {
     expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.toml"));
   });
 
-  test("returns nimbus.toml when NIMBUS_PROFILE is empty string", () => {
-    process.env["NIMBUS_PROFILE"] = "";
-    expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.toml"));
-  });
-
-  test("returns nimbus.toml when NIMBUS_PROFILE is 'default'", () => {
-    process.env["NIMBUS_PROFILE"] = "default";
+  // Anything that isn't a non-default profile name resolves to the plain nimbus.toml — including
+  // "staging", whose alt file is deliberately never created (fall-back path).
+  test.each([
+    ["an empty string", ""],
+    ["'default'", "default"],
+    ["'default' padded with whitespace", "  default  "],
+    ["a profile whose alt file does not exist", "staging"],
+  ])("returns nimbus.toml when NIMBUS_PROFILE is %s", (_label, profile) => {
+    process.env["NIMBUS_PROFILE"] = profile;
     expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.toml"));
   });
 
@@ -369,17 +371,6 @@ describe("resolveNimbusTomlForProfile", () => {
     // create the alt file
     writeToml(dir, "", "nimbus.work.toml");
     expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.work.toml"));
-  });
-
-  test("falls back to nimbus.toml when NIMBUS_PROFILE is set but alt file does not exist", () => {
-    process.env["NIMBUS_PROFILE"] = "staging";
-    // do NOT create nimbus.staging.toml
-    expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.toml"));
-  });
-
-  test("trims whitespace from NIMBUS_PROFILE", () => {
-    process.env["NIMBUS_PROFILE"] = "  default  ";
-    expect(resolveNimbusTomlForProfile(dir)).toBe(join(dir, "nimbus.toml"));
   });
 });
 

--- a/packages/gateway/src/config/session-toml.test.ts
+++ b/packages/gateway/src/config/session-toml.test.ts
@@ -16,62 +16,33 @@ describe("parseNimbusTomlSessionSection", () => {
     expect(out).toEqual({});
   });
 
-  test("[session] block with memory_ttl_hours = 12 applies the value", () => {
-    const src = "[session]\nmemory_ttl_hours = 12\n";
-    const out = parseNimbusTomlSessionSection(src);
-    expect(out.memoryTtlHours).toBe(12);
+  test.each([
+    ["a plain in-range value", "[session]\nmemory_ttl_hours = 12\n", 12],
+    ["an inline comment stripped after the value", "[session]\nmemory_ttl_hours = 8 # eight\n", 8],
+    [
+      "the [session] key winning over an earlier foreign section",
+      "[other]\nmemory_ttl_hours = 99\n\n[session]\nmemory_ttl_hours = 5\n",
+      5,
+    ],
+    [
+      "a later section switching the parser back off",
+      "[session]\nmemory_ttl_hours = 5\n[other]\nmemory_ttl_hours = 99\n",
+      5,
+    ],
+    ["CRLF line endings", "[session]\r\nmemory_ttl_hours = 6\r\n", 6],
+  ])("applies memory_ttl_hours from %s", (_label, src, expected) => {
+    expect(parseNimbusTomlSessionSection(src).memoryTtlHours).toBe(expected);
   });
 
-  test("memory_ttl_hours = 0 is rejected (must be > 0)", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours = 0\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("absurd out-of-range value (100000) is rejected", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours = 100000\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("negative value is rejected", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours = -5\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("non-numeric value is rejected (parseInt -> NaN)", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours = abc\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("inline comment after value is stripped before parsing", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours = 8 # eight hours\n");
-    expect(out.memoryTtlHours).toBe(8);
-  });
-
-  test("keys outside [session] are ignored", () => {
-    const src = "[other]\nmemory_ttl_hours = 99\n\n[session]\nmemory_ttl_hours = 5\n";
-    const out = parseNimbusTomlSessionSection(src);
-    expect(out.memoryTtlHours).toBe(5);
-  });
-
-  test("after [session], a new section switches the parser off", () => {
-    const src = "[session]\nmemory_ttl_hours = 5\n[other]\nmemory_ttl_hours = 99\n";
-    const out = parseNimbusTomlSessionSection(src);
-    expect(out.memoryTtlHours).toBe(5);
-  });
-
-  test("unknown key inside [session] is ignored", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nunknown_key = 99\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("line with no '=' is skipped (eq <= 0 guard)", () => {
-    const out = parseNimbusTomlSessionSection("[session]\nmemory_ttl_hours\n");
-    expect(out.memoryTtlHours).toBeUndefined();
-  });
-
-  test("CRLF line endings are handled", () => {
-    const out = parseNimbusTomlSessionSection("[session]\r\nmemory_ttl_hours = 6\r\n");
-    expect(out.memoryTtlHours).toBe(6);
+  test.each([
+    ["0 (must be > 0)", "[session]\nmemory_ttl_hours = 0\n"],
+    ["an absurd out-of-range value (100000)", "[session]\nmemory_ttl_hours = 100000\n"],
+    ["a negative value", "[session]\nmemory_ttl_hours = -5\n"],
+    ["a non-numeric value (parseInt -> NaN)", "[session]\nmemory_ttl_hours = abc\n"],
+    ["an unknown key inside [session]", "[session]\nunknown_key = 99\n"],
+    ["a line with no '=' (eq <= 0 guard)", "[session]\nmemory_ttl_hours\n"],
+  ])("leaves memoryTtlHours unset for %s", (_label, src) => {
+    expect(parseNimbusTomlSessionSection(src).memoryTtlHours).toBeUndefined();
   });
 });
 

--- a/packages/gateway/src/config/telemetry-toml.test.ts
+++ b/packages/gateway/src/config/telemetry-toml.test.ts
@@ -235,33 +235,14 @@ describe("applyTelemetryEnvOverrides (via loadNimbusTelemetryFromPath)", () => {
     return loadNimbusTelemetryFromPath(join(dir, "no-such-file.toml"));
   }
 
-  test("NIMBUS_TELEMETRY_ENABLED=1 forces enabled=true", () => {
-    process.env[ENV_ENABLED] = "1";
+  // Truthy/falsy spellings are matched case-insensitively.
+  test.each(["1", "true", "TRUE"])("NIMBUS_TELEMETRY_ENABLED=%s forces enabled=true", (raw) => {
+    process.env[ENV_ENABLED] = raw;
     expect(loadDefaults().enabled).toBe(true);
   });
 
-  test("NIMBUS_TELEMETRY_ENABLED=true forces enabled=true", () => {
-    process.env[ENV_ENABLED] = "true";
-    expect(loadDefaults().enabled).toBe(true);
-  });
-
-  test("NIMBUS_TELEMETRY_ENABLED=TRUE forces enabled=true (case-insensitive)", () => {
-    process.env[ENV_ENABLED] = "TRUE";
-    expect(loadDefaults().enabled).toBe(true);
-  });
-
-  test("NIMBUS_TELEMETRY_ENABLED=0 forces enabled=false", () => {
-    process.env[ENV_ENABLED] = "0";
-    expect(loadDefaults().enabled).toBe(false);
-  });
-
-  test("NIMBUS_TELEMETRY_ENABLED=false forces enabled=false", () => {
-    process.env[ENV_ENABLED] = "false";
-    expect(loadDefaults().enabled).toBe(false);
-  });
-
-  test("NIMBUS_TELEMETRY_ENABLED=FALSE forces enabled=false (case-insensitive)", () => {
-    process.env[ENV_ENABLED] = "FALSE";
+  test.each(["0", "false", "FALSE"])("NIMBUS_TELEMETRY_ENABLED=%s forces enabled=false", (raw) => {
+    process.env[ENV_ENABLED] = raw;
     expect(loadDefaults().enabled).toBe(false);
   });
 
@@ -300,29 +281,15 @@ describe("applyTelemetryEnvOverrides (via loadNimbusTelemetryFromPath)", () => {
     expect(loadDefaults().flushIntervalSeconds).toBe(86_400);
   });
 
-  test("NIMBUS_TELEMETRY_FLUSH_SECONDS = 0 is rejected (must be > 0)", () => {
-    process.env[ENV_FLUSH] = "0";
-    expect(loadDefaults().flushIntervalSeconds).toBe(
-      DEFAULT_NIMBUS_TELEMETRY_TOML.flushIntervalSeconds,
-    );
-  });
-
-  test("NIMBUS_TELEMETRY_FLUSH_SECONDS negative is rejected", () => {
-    process.env[ENV_FLUSH] = "-100";
-    expect(loadDefaults().flushIntervalSeconds).toBe(
-      DEFAULT_NIMBUS_TELEMETRY_TOML.flushIntervalSeconds,
-    );
-  });
-
-  test("NIMBUS_TELEMETRY_FLUSH_SECONDS non-numeric is rejected", () => {
-    process.env[ENV_FLUSH] = "not-a-number";
-    expect(loadDefaults().flushIntervalSeconds).toBe(
-      DEFAULT_NIMBUS_TELEMETRY_TOML.flushIntervalSeconds,
-    );
-  });
-
-  test("NIMBUS_TELEMETRY_FLUSH_SECONDS empty string leaves default", () => {
-    process.env[ENV_FLUSH] = "";
+  // A value that is not a positive number at all leaves the default untouched — unlike an
+  // out-of-range positive number, which clamps.
+  test.each([
+    ["0 (must be > 0)", "0"],
+    ["negative", "-100"],
+    ["non-numeric", "not-a-number"],
+    ["empty string", ""],
+  ])("NIMBUS_TELEMETRY_FLUSH_SECONDS %s leaves the default", (_label, raw) => {
+    process.env[ENV_FLUSH] = raw;
     expect(loadDefaults().flushIntervalSeconds).toBe(
       DEFAULT_NIMBUS_TELEMETRY_TOML.flushIntervalSeconds,
     );

--- a/packages/gateway/src/connectors/_lib/teams/api.test.ts
+++ b/packages/gateway/src/connectors/_lib/teams/api.test.ts
@@ -270,18 +270,27 @@ describe("nextMessageCursorFromDeltaPage", () => {
     expect(result.stored).not.toBeNull();
   });
 
-  test("deltaLink present, pairIdx still < pairs.length: hasMore=true (L165 branch)", () => {
-    const state = makeBaseState({ pairIdx: 0 });
-    const page = { "@odata.deltaLink": "https://delta.link" };
+  // pairs.length is 2 in the base state, so pairIdx 1 is the last pair (hasMore=false); an empty
+  // deltaLink is not a deltaLink at all and falls through to the last branch (L165).
+  test.each([
+    [
+      "deltaLink present, pairIdx still < pairs.length (L165 branch)",
+      0,
+      "https://delta.link",
+      true,
+    ],
+    [
+      "deltaLink present, pairIdx reaches pairs.length → pairIdx resets to 0 (L168 branch)",
+      1,
+      "https://delta.link",
+      false,
+    ],
+    ["deltaLink empty string → falls through to the last branch (L165)", 0, "", true],
+  ])("%s: hasMore=%s", (_label, pairIdx, deltaLink, expected) => {
+    const state = makeBaseState({ pairIdx });
+    const page = { "@odata.deltaLink": deltaLink };
     const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
-    expect(result.hasMore).toBe(true);
-  });
-
-  test("deltaLink present, pairIdx reaches pairs.length: pairIdx resets to 0, hasMore=false (L168 branch)", () => {
-    const state = makeBaseState({ pairIdx: 1 }); // pairIdx+1 = 2 >= pairs.length (2)
-    const page = { "@odata.deltaLink": "https://delta.link" };
-    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
-    expect(result.hasMore).toBe(false);
+    expect(result.hasMore).toBe(expected);
   });
 
   test("neither nextLink nor deltaLink: falls through to last branch (L179)", () => {
@@ -310,13 +319,6 @@ describe("nextMessageCursorFromDeltaPage", () => {
       encodeTeamsSyncCursor,
     );
     // No nextLink, no deltaLink → last branch, pairIdx 0→1 < 2, hasMore=true
-    expect(result.hasMore).toBe(true);
-  });
-
-  test("deltaLink empty string: falls through to last branch (L165 branch: empty string)", () => {
-    const state = makeBaseState({ pairIdx: 0 });
-    const page = { "@odata.deltaLink": "" };
-    const result = nextMessageCursorFromDeltaPage(page, state, "t1|c1", encodeTeamsSyncCursor);
     expect(result.hasMore).toBe(true);
   });
 

--- a/packages/gateway/src/connectors/confluence-sync.test.ts
+++ b/packages/gateway/src/connectors/confluence-sync.test.ts
@@ -181,36 +181,18 @@ describeWithFetchRestore("confluence-sync", () => {
   });
 
   // -------------------------------------------------------------------------
-  // HTTP 429 rate-limited response (lines 181-183)
+  // Failure responses: rate-limit (lines 181-183), non-OK (185-186), unparseable body (193)
   // -------------------------------------------------------------------------
-  test("throws on 429 rate-limit response", async () => {
+  test.each([
+    ["429 rate-limit response", 429, "rate limited", "rate limited"],
+    ["non-ok HTTP response", 500, "internal server error", "Confluence sync HTTP 500"],
+    ["invalid JSON body", 200, "not json {{{{", "invalid JSON"],
+  ])("throws on %s", async (_label, status, body, expectedMessage) => {
     const ctx = makeCtx();
-    globalThis.fetch = makeFetch(429, "rate limited") as typeof fetch;
+    globalThis.fetch = makeFetch(status, body) as typeof fetch;
 
     const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
-  });
-
-  // -------------------------------------------------------------------------
-  // HTTP non-OK (e.g. 500) response (lines 185-186)
-  // -------------------------------------------------------------------------
-  test("throws on non-ok HTTP response", async () => {
-    const ctx = makeCtx();
-    globalThis.fetch = makeFetch(500, "internal server error") as typeof fetch;
-
-    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("Confluence sync HTTP 500");
-  });
-
-  // -------------------------------------------------------------------------
-  // Invalid JSON body (line 193)
-  // -------------------------------------------------------------------------
-  test("throws on invalid JSON body", async () => {
-    const ctx = makeCtx();
-    globalThis.fetch = makeFetch(200, "not json {{{{") as typeof fetch;
-
-    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+    await expect(sync.sync(ctx, null)).rejects.toThrow(expectedMessage);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/gateway/src/connectors/data-profile-sync.test.ts
+++ b/packages/gateway/src/connectors/data-profile-sync.test.ts
@@ -191,39 +191,16 @@ describe("data-profile-sync — JSONL happy path", () => {
     expectServiceItemCount(db, "dataprofile", 1);
   });
 
-  test("indexes a .ndjson file (same as jsonl)", async () => {
+  // The file is upserted either way: a .ndjson extension is treated as jsonl, and a first line
+  // that isn't a JSON object just yields empty columns rather than failing the sync.
+  test.each([
+    ["a .ndjson file (same as jsonl)", "records.ndjson", '{"a":1}\n{"b":2}\n'],
+    ["JSONL with an invalid first line", "bad.jsonl", 'not-json\n{"a":1}\n'],
+    ["JSONL with a non-object first line (array)", "arr.jsonl", '[1,2,3]\n{"a":1}\n'],
+  ])("indexes %s", async (_label, name, body) => {
     const { dir, cleanup: c } = await makeTempDir();
     cleanup = c;
-    await writeFile(join(dir, "records.ndjson"), '{"a":1}\n{"b":2}\n');
-
-    const db = createMemoryIndexDb();
-    const sync = createDataProfileSyncable(makeOptions());
-    const r = await sync.sync(
-      syncTestContext(db, createStubVault({ "dataprofile.dir": dir })),
-      null,
-    );
-    expect(r.itemsUpserted).toBe(1);
-  });
-
-  test("JSONL with invalid first line → empty columns but still upserted", async () => {
-    const { dir, cleanup: c } = await makeTempDir();
-    cleanup = c;
-    // First line is not valid JSON
-    await writeFile(join(dir, "bad.jsonl"), 'not-json\n{"a":1}\n');
-
-    const db = createMemoryIndexDb();
-    const sync = createDataProfileSyncable(makeOptions());
-    const r = await sync.sync(
-      syncTestContext(db, createStubVault({ "dataprofile.dir": dir })),
-      null,
-    );
-    expect(r.itemsUpserted).toBe(1);
-  });
-
-  test("JSONL with non-object first line (array) → empty columns", async () => {
-    const { dir, cleanup: c } = await makeTempDir();
-    cleanup = c;
-    await writeFile(join(dir, "arr.jsonl"), '[1,2,3]\n{"a":1}\n');
+    await writeFile(join(dir, name), body);
 
     const db = createMemoryIndexDb();
     const sync = createDataProfileSyncable(makeOptions());

--- a/packages/gateway/src/connectors/jira-sync.test.ts
+++ b/packages/gateway/src/connectors/jira-sync.test.ts
@@ -82,29 +82,16 @@ describeWithFetchRestore("jira-sync", () => {
 
   // ── no-op when only some credentials are provided ──────────────────────────
 
-  test("no-op when email is empty", async () => {
+  // Any one blank credential is enough to make the whole sync a no-op. `"///"` is included here
+  // because a base_url of only slashes normalizes to "".
+  test.each([
+    ["email is empty", "jira.email", ""],
+    ["api_token is empty", "jira.api_token", ""],
+    ["base_url normalizes to empty", "jira.base_url", "///"],
+  ])("no-op when %s", async (_label, key, value) => {
     const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
     const db = createMemoryIndexDb();
-    const ctx = { db, vault: credVault({ "jira.email": "" }), ...silentSyncContextExtras() };
-    const r = await sync.sync(ctx, null);
-    expect(r.itemsUpserted).toBe(0);
-    expect(r.cursor).toBeNull();
-  });
-
-  test("no-op when api_token is empty", async () => {
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    const db = createMemoryIndexDb();
-    const ctx = { db, vault: credVault({ "jira.api_token": "" }), ...silentSyncContextExtras() };
-    const r = await sync.sync(ctx, null);
-    expect(r.itemsUpserted).toBe(0);
-    expect(r.cursor).toBeNull();
-  });
-
-  test("no-op when base_url normalizes to empty", async () => {
-    // A base_url of only slashes normalizes to "" → noop
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    const db = createMemoryIndexDb();
-    const ctx = { db, vault: credVault({ "jira.base_url": "///" }), ...silentSyncContextExtras() };
+    const ctx = { db, vault: credVault({ [key]: value }), ...silentSyncContextExtras() };
     const r = await sync.sync(ctx, null);
     expect(r.itemsUpserted).toBe(0);
     expect(r.cursor).toBeNull();
@@ -365,46 +352,21 @@ describeWithFetchRestore("jira-sync", () => {
     await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
   });
 
-  test("throws UnauthenticatedError on HTTP 401", async () => {
+  // 401/403 surface as UnauthenticatedError, other non-ok statuses as a generic error, and a
+  // 200 with an unparseable body as a JSON error — in each case the message names the cause.
+  test.each([
+    ["UnauthenticatedError on HTTP 401", 401, "Unauthorized", "401"],
+    ["UnauthenticatedError on HTTP 403", 403, "Forbidden", "403"],
+    ["a generic error on non-ok HTTP status (500)", 500, "Server Error", "500"],
+    ["an error on an invalid JSON response", 200, "not-json{{{", "invalid JSON"],
+  ])("throws %s", async (_label, status, body, expectedMessage) => {
     const { ctx } = credCtx();
     globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("Unauthorized", { status: 401 });
+      return new Response(body, { status });
     }) as unknown as typeof fetch;
 
     const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("401");
-  });
-
-  test("throws UnauthenticatedError on HTTP 403", async () => {
-    const { ctx } = credCtx();
-    globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("Forbidden", { status: 403 });
-    }) as unknown as typeof fetch;
-
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("403");
-  });
-
-  test("throws generic error on non-ok HTTP status (500)", async () => {
-    const { ctx } = credCtx();
-    globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("Server Error", { status: 500 });
-    }) as unknown as typeof fetch;
-
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("500");
-  });
-
-  // ── JSON parse errors ──────────────────────────────────────────────────────
-
-  test("throws error on invalid JSON response", async () => {
-    const { ctx } = credCtx();
-    globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("not-json{{{", { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+    await expect(sync.sync(ctx, null)).rejects.toThrow(expectedMessage);
   });
 
   test("throws error when issues field is missing from response", async () => {

--- a/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh-args-json.test.ts
@@ -88,8 +88,8 @@ describe("LazyConnectorMesh — args_json failure (S8-F9)", () => {
         },
       ],
     });
-    await mesh.ensureUserMcpRunning("broken-svc");
-    await mesh.disconnect();
+    await expect(mesh.ensureUserMcpRunning("broken-svc")).resolves.toBeUndefined();
+    await expect(mesh.disconnect()).resolves.toBeUndefined();
   });
 });
 

--- a/packages/gateway/src/connectors/lazy-mesh/mesh.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/mesh.test.ts
@@ -78,64 +78,40 @@ describe("createLazyConnectorMesh", () => {
   });
 });
 
+/**
+ * Every `ensure<Service>Running` delegator resolves to a no-op when the vault holds no key
+ * for that service. Table-driven because the assertion is identical for all 18 — the only
+ * thing under test is that the delegator exists and short-circuits.
+ */
+const ENSURE_DELEGATORS: ReadonlyArray<readonly [string, (m: LazyConnectorMesh) => Promise<void>]> =
+  [
+    ["ensurePhase3BundleRunning", (m) => m.ensurePhase3BundleRunning()],
+    ["ensureGoogleDriveRunning", (m) => m.ensureGoogleDriveRunning()],
+    ["ensureGithubRunning", (m) => m.ensureGithubRunning()],
+    ["ensureGitlabRunning", (m) => m.ensureGitlabRunning()],
+    ["ensureBitbucketRunning", (m) => m.ensureBitbucketRunning()],
+    ["ensureSlackRunning", (m) => m.ensureSlackRunning()],
+    ["ensureLinearRunning", (m) => m.ensureLinearRunning()],
+    ["ensureJiraRunning", (m) => m.ensureJiraRunning()],
+    ["ensureNotionRunning", (m) => m.ensureNotionRunning()],
+    ["ensureMendeleyRunning", (m) => m.ensureMendeleyRunning()],
+    ["ensureAppleRunning", (m) => m.ensureAppleRunning()],
+    ["ensureObsidianRunning", (m) => m.ensureObsidianRunning()],
+    ["ensureConfluenceRunning", (m) => m.ensureConfluenceRunning()],
+    ["ensureDiscordRunning", (m) => m.ensureDiscordRunning()],
+    ["ensureJenkinsRunning", (m) => m.ensureJenkinsRunning()],
+    ["ensureCircleciRunning", (m) => m.ensureCircleciRunning()],
+    ["ensurePagerdutyRunning", (m) => m.ensurePagerdutyRunning()],
+    ["ensureKubernetesRunning", (m) => m.ensureKubernetesRunning()],
+  ];
+
 describe("ensure<Service>Running delegators (no vault keys → all no-op)", () => {
   beforeEach(() => {
     mesh = new LazyConnectorMesh(makePaths(), createMockVault());
   });
 
-  test("ensurePhase3BundleRunning is a no-op without vault keys", async () => {
-    await mesh!.ensurePhase3BundleRunning();
-  });
-  test("ensureGoogleDriveRunning", async () => {
-    await mesh!.ensureGoogleDriveRunning();
-  });
-  test("ensureGithubRunning", async () => {
-    await mesh!.ensureGithubRunning();
-  });
-  test("ensureGitlabRunning", async () => {
-    await mesh!.ensureGitlabRunning();
-  });
-  test("ensureBitbucketRunning", async () => {
-    await mesh!.ensureBitbucketRunning();
-  });
-  test("ensureSlackRunning", async () => {
-    await mesh!.ensureSlackRunning();
-  });
-  test("ensureLinearRunning", async () => {
-    await mesh!.ensureLinearRunning();
-  });
-  test("ensureJiraRunning", async () => {
-    await mesh!.ensureJiraRunning();
-  });
-  test("ensureNotionRunning", async () => {
-    await mesh!.ensureNotionRunning();
-  });
-  test("ensureMendeleyRunning", async () => {
-    await mesh!.ensureMendeleyRunning();
-  });
-  test("ensureAppleRunning", async () => {
-    await mesh!.ensureAppleRunning();
-  });
-  test("ensureObsidianRunning", async () => {
-    await mesh!.ensureObsidianRunning();
-  });
-  test("ensureConfluenceRunning", async () => {
-    await mesh!.ensureConfluenceRunning();
-  });
-  test("ensureDiscordRunning", async () => {
-    await mesh!.ensureDiscordRunning();
-  });
-  test("ensureJenkinsRunning", async () => {
-    await mesh!.ensureJenkinsRunning();
-  });
-  test("ensureCircleciRunning", async () => {
-    await mesh!.ensureCircleciRunning();
-  });
-  test("ensurePagerdutyRunning", async () => {
-    await mesh!.ensurePagerdutyRunning();
-  });
-  test("ensureKubernetesRunning", async () => {
-    await mesh!.ensureKubernetesRunning();
+  test.each(ENSURE_DELEGATORS)("%s is a no-op without vault keys", async (_name, run) => {
+    await expect(run(mesh!)).resolves.toBeUndefined();
   });
 });
 
@@ -144,20 +120,21 @@ describe("user-mcp + extension lifecycle (no rows)", () => {
     mesh = new LazyConnectorMesh(makePaths(), createMockVault(), {
       listUserMcpConnectors: () => [],
     });
-    await mesh.ensureUserMcpRunning("nonexistent");
+    await expect(mesh.ensureUserMcpRunning("nonexistent")).resolves.toBeUndefined();
   });
 
   test("stopExtensionClient on unknown id is a no-op", async () => {
     mesh = new LazyConnectorMesh(makePaths(), createMockVault());
-    await mesh.stopExtensionClient("unknown.ext");
+    await expect(mesh.stopExtensionClient("unknown.ext")).resolves.toBeUndefined();
   });
 });
 
 describe("disconnect with no active slots", () => {
   test("disconnect after construction tears down filesystem MCP cleanly", async () => {
     mesh = new LazyConnectorMesh(makePaths(), createMockVault());
-    await mesh.disconnect();
-    await mesh.disconnect();
+    await expect(mesh.disconnect()).resolves.toBeUndefined();
+    // Idempotent: a second disconnect on an already-torn-down mesh must also be a no-op.
+    await expect(mesh.disconnect()).resolves.toBeUndefined();
     mesh = undefined;
   });
 });

--- a/packages/gateway/src/connectors/lazy-mesh/phase3-config.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/phase3-config.test.ts
@@ -868,10 +868,16 @@ describe("phase3AddSnowflakeMcp", () => {
     expect(servers["snowflake"]).toBeUndefined();
   });
 
-  test("no-op when both are whitespace-only", async () => {
+  // Blank credentials and an account that would be unsafe to hand to a spawn (leading dash =
+  // looks like a flag; control character) all leave the server unregistered.
+  test.each([
+    ["both are whitespace-only", "   ", "   "],
+    ["account has a leading dash (unsafe)", "-bad-account", "tok"],
+    ["account contains a control character (unsafe)", "acme\x01xy", "tok"],
+  ])("no-op when %s", async (_label, account, token) => {
     const vault = createMockVault();
-    await vault.set("snowflake.account", "   ");
-    await vault.set("snowflake.oauth_token", "   ");
+    await vault.set("snowflake.account", account);
+    await vault.set("snowflake.oauth_token", token);
     const servers: Record<string, ServerSpec> = {};
     await phase3AddSnowflakeMcp(vault, servers, SANDBOX_CWD);
     expect(servers["snowflake"]).toBeUndefined();
@@ -914,24 +920,6 @@ describe("phase3AddSnowflakeMcp", () => {
     expect(spec).toBeDefined();
     if (spec === undefined) return;
     expect(spec.env?.["SNOWFLAKE_TOKEN"]).toBe("jwt-only");
-  });
-
-  test("no-op when account has a leading dash (unsafe)", async () => {
-    const vault = createMockVault();
-    await vault.set("snowflake.account", "-bad-account");
-    await vault.set("snowflake.oauth_token", "tok");
-    const servers: Record<string, ServerSpec> = {};
-    await phase3AddSnowflakeMcp(vault, servers, SANDBOX_CWD);
-    expect(servers["snowflake"]).toBeUndefined();
-  });
-
-  test("no-op when account contains a control character (unsafe)", async () => {
-    const vault = createMockVault();
-    await vault.set("snowflake.account", "acme\x01xy");
-    await vault.set("snowflake.oauth_token", "tok");
-    const servers: Record<string, ServerSpec> = {};
-    await phase3AddSnowflakeMcp(vault, servers, SANDBOX_CWD);
-    expect(servers["snowflake"]).toBeUndefined();
   });
 
   test("no-op when account exceeds 253 characters (unsafe)", async () => {
@@ -1101,31 +1089,22 @@ describe("phase3AddPowerBiMcp", () => {
     expect(servers["powerbi"]).toBeUndefined();
   });
 
-  test("no-op when credentials are whitespace-only", async () => {
+  // Same shape as the Snowflake no-op table: blank credentials, or a tenant_id that would be
+  // unsafe to hand to a spawn, both leave powerbi unregistered.
+  test.each([
+    ["credentials are whitespace-only", "   ", "   ", "   "],
+    ["tenant_id has a leading dash (unsafe)", "-bad-tenant", "my-client-id", "my-client-secret"],
+    [
+      "tenant_id contains a control character (unsafe)",
+      "acme\x01tenant",
+      "my-client-id",
+      "my-client-secret",
+    ],
+  ])("no-op when %s", async (_label, tenantId, clientId, clientSecret) => {
     const vault = createMockVault();
-    await vault.set("powerbi.tenant_id", "   ");
-    await vault.set("powerbi.client_id", "   ");
-    await vault.set("powerbi.client_secret", "   ");
-    const servers: Record<string, ServerSpec> = {};
-    await phase3AddPowerBiMcp(vault, servers, SANDBOX_CWD);
-    expect(servers["powerbi"]).toBeUndefined();
-  });
-
-  test("no-op when tenant_id has a leading dash (unsafe)", async () => {
-    const vault = createMockVault();
-    await vault.set("powerbi.tenant_id", "-bad-tenant");
-    await vault.set("powerbi.client_id", "my-client-id");
-    await vault.set("powerbi.client_secret", "my-client-secret");
-    const servers: Record<string, ServerSpec> = {};
-    await phase3AddPowerBiMcp(vault, servers, SANDBOX_CWD);
-    expect(servers["powerbi"]).toBeUndefined();
-  });
-
-  test("no-op when tenant_id contains a control character (unsafe)", async () => {
-    const vault = createMockVault();
-    await vault.set("powerbi.tenant_id", "acme\x01tenant");
-    await vault.set("powerbi.client_id", "my-client-id");
-    await vault.set("powerbi.client_secret", "my-client-secret");
+    await vault.set("powerbi.tenant_id", tenantId);
+    await vault.set("powerbi.client_id", clientId);
+    await vault.set("powerbi.client_secret", clientSecret);
     const servers: Record<string, ServerSpec> = {};
     await phase3AddPowerBiMcp(vault, servers, SANDBOX_CWD);
     expect(servers["powerbi"]).toBeUndefined();

--- a/packages/gateway/src/connectors/looker-content-mapping.test.ts
+++ b/packages/gateway/src/connectors/looker-content-mapping.test.ts
@@ -48,7 +48,7 @@ test("returns null when title is empty string", () => {
   expect(mapLookerDashboardToItem({ id: "1", title: "" }, { syncedAt: 1 })).toBeNull();
 });
 
-test("returns null for non-record input", () => {
+test("returns null for non-record dashboard input", () => {
   expect(mapLookerDashboardToItem(null, { syncedAt: 1 })).toBeNull();
   expect(mapLookerDashboardToItem("string", { syncedAt: 1 })).toBeNull();
   expect(mapLookerDashboardToItem(42, { syncedAt: 1 })).toBeNull();
@@ -115,7 +115,7 @@ test("returns null when name is empty string", () => {
   ).toBeNull();
 });
 
-test("returns null for non-record input", () => {
+test("returns null for non-record view input", () => {
   expect(mapLookerViewToItem(null, { syncedAt: 1 })).toBeNull();
   expect(mapLookerViewToItem("string", { syncedAt: 1 })).toBeNull();
 });

--- a/packages/gateway/src/connectors/microsoft-graph-sync-shared.test.ts
+++ b/packages/gateway/src/connectors/microsoft-graph-sync-shared.test.ts
@@ -36,22 +36,14 @@ describe("decodeMicrosoftGraphDeltaCursor", () => {
     expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toEqual(cursor);
   });
 
-  // L19 true branch: decodeNimbusJsonCursorPayload returns null (payload decodes to JSON null)
-  test("returns undefined when payload is JSON null (o === null)", () => {
-    // encodeNimbusJsonCursor with null payload → base64url of "null"
-    const enc = PREFIX + Buffer.from("null", "utf8").toString("base64url");
-    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
-  });
-
-  // L19 true branch: decodeNimbusJsonCursorPayload returns an array
-  test("returns undefined when payload is a JSON array (Array.isArray branch)", () => {
-    const enc = PREFIX + Buffer.from("[1,2,3]", "utf8").toString("base64url");
-    expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
-  });
-
-  // L19 true branch: decodeNimbusJsonCursorPayload returns a non-object primitive
-  test("returns undefined when payload is a JSON string (typeof !== object)", () => {
-    const enc = PREFIX + Buffer.from('"hello"', "utf8").toString("base64url");
+  // L19 true branch — every payload that decodes to something other than a plain object is
+  // rejected: JSON null (o === null), an array (Array.isArray), and a primitive (typeof !== object).
+  test.each([
+    ["JSON null (o === null)", "null"],
+    ["a JSON array (Array.isArray branch)", "[1,2,3]"],
+    ["a JSON string (typeof !== object)", '"hello"'],
+  ])("returns undefined when payload is %s", (_label, json) => {
+    const enc = PREFIX + Buffer.from(json, "utf8").toString("base64url");
     expect(decodeMicrosoftGraphDeltaCursor(enc, PREFIX)).toBeUndefined();
   });
 

--- a/packages/gateway/src/connectors/notion-sync.test.ts
+++ b/packages/gateway/src/connectors/notion-sync.test.ts
@@ -134,10 +134,14 @@ describeWithFetchRestore("notion-sync", () => {
     expect(row?.author_id).not.toBeNull();
   });
 
-  // ── covers lines 109–111: HTTP 429 → throws "rate limited" ──
-  test("throws on HTTP 429 rate-limited response", async () => {
+  // ── covers lines 109–111 (429), 113–114 (non-ok status) and 117–121 (unparseable body) ──
+  test.each([
+    ["HTTP 429 rate-limited response", 429, "", "rate limited"],
+    ["non-ok HTTP response", 500, "Internal Server Error", "Notion sync HTTP 500"],
+    ["invalid JSON response body", 200, "not json at all!!!", "invalid JSON"],
+  ])("throws on %s", async (_label, status, body, expectedMessage) => {
     globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("", { status: 429 });
+      return new Response(body, { status });
     }) as unknown as typeof fetch;
 
     const db = createMemoryIndexDb();
@@ -147,39 +151,7 @@ describeWithFetchRestore("notion-sync", () => {
       db,
       ...silentSyncContextExtras(),
     };
-    await expect(sync.sync(ctx, null)).rejects.toThrow("rate limited");
-  });
-
-  // ── covers lines 113–114: non-ok HTTP (e.g. 500) → throws with status ──
-  test("throws on non-ok HTTP response", async () => {
-    globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("Internal Server Error", { status: 500 });
-    }) as unknown as typeof fetch;
-
-    const db = createMemoryIndexDb();
-    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
-    const ctx = {
-      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
-      db,
-      ...silentSyncContextExtras(),
-    };
-    await expect(sync.sync(ctx, null)).rejects.toThrow("Notion sync HTTP 500");
-  });
-
-  // ── covers lines 117–121: invalid JSON response body ──
-  test("throws on invalid JSON response body", async () => {
-    globalThis.fetch = (async (): Promise<Response> => {
-      return new Response("not json at all!!!", { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const db = createMemoryIndexDb();
-    const sync = createNotionSyncable({ ensureNotionMcpRunning: async () => {} });
-    const ctx = {
-      vault: createStubVault({ "notion.oauth": makeOauthPayload() }),
-      db,
-      ...silentSyncContextExtras(),
-    };
-    await expect(sync.sync(ctx, null)).rejects.toThrow("invalid JSON");
+    await expect(sync.sync(ctx, null)).rejects.toThrow(expectedMessage);
   });
 
   // ── covers lines 122–124: valid JSON but not a record (e.g. array) ──

--- a/packages/gateway/src/engine/agent.test.ts
+++ b/packages/gateway/src/engine/agent.test.ts
@@ -183,19 +183,13 @@ describe("toMastraModelId (via agentModel)", () => {
     ).not.toThrow();
   });
 
-  test("bare gpt id is accepted", () => {
+  test.each([
+    ["a bare gpt id", "gpt-4o-mini"],
+    ["a bare o3 id", "o3-mini"],
+    ["an unknown family (passed through unmodified)", "llama-3"],
+  ])("accepts %s", (_label, agentModel) => {
     const { localIndex } = freshIndex();
-    expect(() => createNimbusEngineAgent({ localIndex, agentModel: "gpt-4o-mini" })).not.toThrow();
-  });
-
-  test("bare o3 id is accepted", () => {
-    const { localIndex } = freshIndex();
-    expect(() => createNimbusEngineAgent({ localIndex, agentModel: "o3-mini" })).not.toThrow();
-  });
-
-  test("unknown family passes through unmodified", () => {
-    const { localIndex } = freshIndex();
-    expect(() => createNimbusEngineAgent({ localIndex, agentModel: "llama-3" })).not.toThrow();
+    expect(() => createNimbusEngineAgent({ localIndex, agentModel })).not.toThrow();
   });
 });
 

--- a/packages/gateway/src/engine/router.test.ts
+++ b/packages/gateway/src/engine/router.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { AgentUnavailableReason } from "./gateway-agent-error.ts";
 import { GatewayAgentUnavailableError } from "./gateway-agent-error.ts";
 import { classifyIntent } from "./router.ts";
+
+/** Status → reason mapping, identical for every provider. */
+const HTTP_STATUS_REASONS: ReadonlyArray<readonly [number, string, AgentUnavailableReason]> = [
+  [429, "Too Many Requests", "rate_limited"],
+  [404, "Not Found", "model_not_found"],
+  [500, "Internal Server Error", "provider_error"],
+];
 
 const BUN_NATIVE_FETCH = globalThis.fetch;
 const ORIGINAL_ANTHROPIC = process.env["ANTHROPIC_API_KEY"];
@@ -372,9 +380,9 @@ describe("classifyIntent — Anthropic error paths", () => {
     expect((caught as GatewayAgentUnavailableError).provider).toBe("anthropic");
   });
 
-  test("HTTP 429 → rate_limited", async () => {
+  test.each(HTTP_STATUS_REASONS)("HTTP %s → %s", async (status, body, reason) => {
     useAnthropicOnly();
-    stubFetch(async () => textResponse("Too Many Requests", 429));
+    stubFetch(async () => textResponse(body, status));
 
     let caught: unknown;
     try {
@@ -383,35 +391,7 @@ describe("classifyIntent — Anthropic error paths", () => {
       caught = e;
     }
     expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("rate_limited");
-  });
-
-  test("HTTP 404 → model_not_found", async () => {
-    useAnthropicOnly();
-    stubFetch(async () => textResponse("Not Found", 404));
-
-    let caught: unknown;
-    try {
-      await classifyIntent("hi");
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("model_not_found");
-  });
-
-  test("HTTP 500 → provider_error", async () => {
-    useAnthropicOnly();
-    stubFetch(async () => textResponse("Internal Server Error", 500));
-
-    let caught: unknown;
-    try {
-      await classifyIntent("hi");
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("provider_error");
+    expect((caught as GatewayAgentUnavailableError).reason).toBe(reason);
   });
 
   test("fetch throws (network exception) → network_error", async () => {
@@ -588,9 +568,9 @@ describe("classifyIntent — OpenAI error paths", () => {
     expect((caught as GatewayAgentUnavailableError).provider).toBe("openai");
   });
 
-  test("HTTP 429 → rate_limited", async () => {
+  test.each(HTTP_STATUS_REASONS)("HTTP %s → %s", async (status, body, reason) => {
     useOpenAiOnly();
-    stubFetch(async () => textResponse("Too Many Requests", 429));
+    stubFetch(async () => textResponse(body, status));
 
     let caught: unknown;
     try {
@@ -599,35 +579,7 @@ describe("classifyIntent — OpenAI error paths", () => {
       caught = e;
     }
     expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("rate_limited");
-  });
-
-  test("HTTP 404 → model_not_found", async () => {
-    useOpenAiOnly();
-    stubFetch(async () => textResponse("Not Found", 404));
-
-    let caught: unknown;
-    try {
-      await classifyIntent("hi");
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("model_not_found");
-  });
-
-  test("HTTP 500 → provider_error", async () => {
-    useOpenAiOnly();
-    stubFetch(async () => textResponse("Internal Server Error", 500));
-
-    let caught: unknown;
-    try {
-      await classifyIntent("hi");
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
-    expect((caught as GatewayAgentUnavailableError).reason).toBe("provider_error");
+    expect((caught as GatewayAgentUnavailableError).reason).toBe(reason);
   });
 
   test("fetch throws → network_error with openai provider", async () => {

--- a/packages/gateway/src/extensions/auto-update-rpc.test.ts
+++ b/packages/gateway/src/extensions/auto-update-rpc.test.ts
@@ -335,90 +335,29 @@ describe("dispatchAutoUpdateRpc extension.update", () => {
     expect(audits[0]?.payload["message"]).toBe("boom string, not an Error");
   });
 
-  // lines 222-229 extractPhase: each branch via distinct Error messages
-  it("records phase=signature_failed when error message contains 'signature_failed'", async () => {
+  // lines 222-229 extractPhase: one row per branch, keyed off a keyword in the Error message —
+  // plus the fall-through row whose message matches no known keyword.
+  it.each([
+    ["signature_failed verification", "signature_failed"],
+    ["swap_failed on disk", "swap_failed"],
+    ["download timeout exceeded", "download_failed"],
+    ["extract tarball failed", "extract_failed"],
+    ["something completely unexpected", "internal_error"],
+  ])("an error reading '%s' records phase=%s", async (message, phase) => {
     const deps = baseDeps();
     const audits: Array<{ type: string; payload: Record<string, unknown> }> = [];
     deps.appendAudit = async (type, payload) => {
       audits.push({ type, payload });
     };
     deps.performUpgrade = async () => {
-      throw new Error("signature_failed verification");
+      throw new Error(message);
     };
     await dispatchAutoUpdateRpc(
       "extension.update",
       { id: "com.example.a", toVersion: "1.1.0" },
       deps,
     );
-    expect(audits[0]?.payload["phase"]).toBe("signature_failed");
-  });
-
-  it("records phase=swap_failed when error message contains 'swap_failed'", async () => {
-    const deps = baseDeps();
-    const audits: Array<{ type: string; payload: Record<string, unknown> }> = [];
-    deps.appendAudit = async (type, payload) => {
-      audits.push({ type, payload });
-    };
-    deps.performUpgrade = async () => {
-      throw new Error("swap_failed on disk");
-    };
-    await dispatchAutoUpdateRpc(
-      "extension.update",
-      { id: "com.example.a", toVersion: "1.1.0" },
-      deps,
-    );
-    expect(audits[0]?.payload["phase"]).toBe("swap_failed");
-  });
-
-  it("records phase=download_failed when error message contains 'download'", async () => {
-    const deps = baseDeps();
-    const audits: Array<{ type: string; payload: Record<string, unknown> }> = [];
-    deps.appendAudit = async (type, payload) => {
-      audits.push({ type, payload });
-    };
-    deps.performUpgrade = async () => {
-      throw new Error("download timeout exceeded");
-    };
-    await dispatchAutoUpdateRpc(
-      "extension.update",
-      { id: "com.example.a", toVersion: "1.1.0" },
-      deps,
-    );
-    expect(audits[0]?.payload["phase"]).toBe("download_failed");
-  });
-
-  it("records phase=extract_failed when error message contains 'extract'", async () => {
-    const deps = baseDeps();
-    const audits: Array<{ type: string; payload: Record<string, unknown> }> = [];
-    deps.appendAudit = async (type, payload) => {
-      audits.push({ type, payload });
-    };
-    deps.performUpgrade = async () => {
-      throw new Error("extract tarball failed");
-    };
-    await dispatchAutoUpdateRpc(
-      "extension.update",
-      { id: "com.example.a", toVersion: "1.1.0" },
-      deps,
-    );
-    expect(audits[0]?.payload["phase"]).toBe("extract_failed");
-  });
-
-  it("records phase=internal_error when error message matches no known phase keyword", async () => {
-    const deps = baseDeps();
-    const audits: Array<{ type: string; payload: Record<string, unknown> }> = [];
-    deps.appendAudit = async (type, payload) => {
-      audits.push({ type, payload });
-    };
-    deps.performUpgrade = async () => {
-      throw new Error("something completely unexpected");
-    };
-    await dispatchAutoUpdateRpc(
-      "extension.update",
-      { id: "com.example.a", toVersion: "1.1.0" },
-      deps,
-    );
-    expect(audits[0]?.payload["phase"]).toBe("internal_error");
+    expect(audits[0]?.payload["phase"]).toBe(phase);
   });
 
   // Happy path audit: upgrade applied emits extension.autoUpdate.applied

--- a/packages/gateway/src/extensions/verify-extensions.test.ts
+++ b/packages/gateway/src/extensions/verify-extensions.test.ts
@@ -1024,8 +1024,10 @@ describe("verifyExtensionsBestEffort — orphan sweep branch coverage", () => {
     const fakeRoot = join(extensionsDir, "not-a-dir-file");
     writeFileSync(fakeRoot, "blocking", "utf8");
     try {
-      await verifyExtensionsBestEffort(db, logger, undefined, undefined, fakeRoot);
-      // No crash — just a silent catch
+      // No crash — the readdirSync ENOTDIR is swallowed by the best-effort sweep's catch.
+      await expect(
+        verifyExtensionsBestEffort(db, logger, undefined, undefined, fakeRoot),
+      ).resolves.toBeUndefined();
     } finally {
       try {
         dbRun(db, "DELETE FROM extension WHERE 1=1");

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -169,15 +169,22 @@ async function main(): Promise<void> {
   logEmbeddingStateAtBind(platform.embeddingReadiness());
 }
 
+/**
+ * The clause that follows the state name: a reassurance while the model is still warming,
+ * otherwise the reason the state is what it is (when there is one).
+ */
+function embeddingBindDetail(readiness: EmbeddingReadiness): string {
+  if (readiness.state === "warming") {
+    return " — semantic search activates when it finishes; everything else is available now";
+  }
+  return readiness.reason === null ? "" : ` (${readiness.reason})`;
+}
+
 /** One line, at bind time, naming the embedding state the gateway started serving in. */
 function logEmbeddingStateAtBind(readiness: EmbeddingReadiness): void {
-  const detail =
-    readiness.state === "warming"
-      ? " — semantic search activates when it finishes; everything else is available now"
-      : readiness.reason === null
-        ? ""
-        : ` (${readiness.reason})`;
-  process.stdout.write(`[gateway] embeddings: ${readiness.state}${detail}\n`);
+  process.stdout.write(
+    `[gateway] embeddings: ${readiness.state}${embeddingBindDetail(readiness)}\n`,
+  );
 }
 
 try {

--- a/packages/gateway/src/index/drift-hints.test.ts
+++ b/packages/gateway/src/index/drift-hints.test.ts
@@ -147,49 +147,19 @@ describe("driftHintsFromIndex", () => {
     expect(lines.some((l) => l.includes("differs"))).toBe(false);
   });
 
-  // Branch: metadata is null literal → skips inner snap block
-  test("skips lambda snapshot block when metadata is JSON null", () => {
+  // One row per guard on the way to the lambda-snapshot block. In every case the heartbeat
+  // timestamp line still renders — only the snapshot line is suppressed.
+  test.each([
+    ["metadata is JSON null (skips the inner snap block)", "null"],
+    ["metadata is a JSON array (!Array.isArray guard fires)", "[1, 2, 3]"],
+    ["awsLambdaIndexedCount is a string (typeof-false arm)", '{"awsLambdaIndexedCount":"many"}'],
+    // JSON.parse("1e309") yields Infinity — a value that passes `typeof === "number"` but fails
+    // `Number.isFinite`, so this row is what covers the isFinite-false arm specifically.
+    ["awsLambdaIndexedCount is non-finite (isFinite-false arm)", '{"awsLambdaIndexedCount":1e309}'],
+  ])("skips the lambda snapshot lines when %s", (_label, metadata) => {
     const db = new Database(":memory:");
     LocalIndex.ensureSchema(db);
-    const t = Date.now();
-    insertHeartbeat(db, "null", t);
-    const lines = driftHintsFromIndex(db);
-    // Should have the heartbeat timestamp line but no "indexed Lambda count" line
-    expect(lines.some((l) => l.startsWith("IaC heartbeat last updated:"))).toBe(true);
-    expect(lines.some((l) => l.includes("indexed Lambda count was"))).toBe(false);
-  });
-
-  // Branch: metadata is a JSON array → !Array.isArray guard fires
-  test("skips lambda snapshot block when metadata is a JSON array", () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const t = Date.now();
-    insertHeartbeat(db, "[1, 2, 3]", t);
-    const lines = driftHintsFromIndex(db);
-    expect(lines.some((l) => l.startsWith("IaC heartbeat last updated:"))).toBe(true);
-    expect(lines.some((l) => l.includes("indexed Lambda count was"))).toBe(false);
-  });
-
-  // Branch: metadata is a valid object but awsLambdaIndexedCount is not a number
-  test("skips lambda snapshot lines when awsLambdaIndexedCount is a string", () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const t = Date.now();
-    insertHeartbeat(db, JSON.stringify({ awsLambdaIndexedCount: "many" }), t);
-    const lines = driftHintsFromIndex(db);
-    expect(lines.some((l) => l.startsWith("IaC heartbeat last updated:"))).toBe(true);
-    expect(lines.some((l) => l.includes("indexed Lambda count was"))).toBe(false);
-  });
-
-  // Branch: awsLambdaIndexedCount is a number but non-finite (Number.isFinite() false arm).
-  test("skips lambda snapshot lines when awsLambdaIndexedCount is non-finite", () => {
-    const db = new Database(":memory:");
-    LocalIndex.ensureSchema(db);
-    const t = Date.now();
-    // JSON.parse("1e309") yields Infinity — a value that passes `typeof === "number"`
-    // but fails `Number.isFinite`, exercising the isFinite-false arm specifically (the
-    // typeof-false arm is covered by the "non-numeric" test above).
-    insertHeartbeat(db, '{"awsLambdaIndexedCount":1e309}', t);
+    insertHeartbeat(db, metadata, Date.now());
     const lines = driftHintsFromIndex(db);
     expect(lines.some((l) => l.startsWith("IaC heartbeat last updated:"))).toBe(true);
     expect(lines.some((l) => l.includes("indexed Lambda count was"))).toBe(false);

--- a/packages/gateway/src/ipc/_lib/long-running.test.ts
+++ b/packages/gateway/src/ipc/_lib/long-running.test.ts
@@ -148,8 +148,9 @@ describe("LongRunningJobRegistry", () => {
       emit,
       run: async () => undefined,
     });
-    await registry.awaitJob(jobId);
-    await registry.awaitJob(jobId);
-    await registry.awaitJob("never-existed");
+    await expect(registry.awaitJob(jobId)).resolves.toBeUndefined();
+    // Already-settled job: awaiting a second time must still resolve, not hang.
+    await expect(registry.awaitJob(jobId)).resolves.toBeUndefined();
+    await expect(registry.awaitJob("never-existed")).resolves.toBeUndefined();
   });
 });

--- a/packages/gateway/src/ipc/automation-rpc.test.ts
+++ b/packages/gateway/src/ipc/automation-rpc.test.ts
@@ -590,11 +590,17 @@ describe("extension.info", () => {
 });
 
 describe("extension.enable / disable / remove", () => {
-  test("enable returns ok:true for an existing extension", async () => {
+  // None of the three needs a mesh, and `remove` reports ok even when install_path is missing
+  // from disk — its cleanup is best-effort.
+  test.each([
+    ["enable an existing extension", "extension.enable", "/p/a"],
+    ["disable an existing extension", "extension.disable", "/p/a"],
+    ["remove with a non-existent install_path", "extension.remove", "/definitely/not/a/real/path"],
+  ])("%s returns ok:true", async (_label, method, installPath) => {
     const db = seededDb();
-    seedExtensionRow(db, "com.example.a", "/p/a");
+    seedExtensionRow(db, "com.example.a", installPath);
     const out = await dispatchAutomationRpc({
-      method: "extension.enable",
+      method,
       params: { id: "com.example.a" },
       db,
     });
@@ -609,17 +615,6 @@ describe("extension.enable / disable / remove", () => {
       db,
     });
     expect((out as { value: { ok: boolean } }).value.ok).toBe(false);
-  });
-
-  test("disable returns ok:true and does not require a mesh", async () => {
-    const db = seededDb();
-    seedExtensionRow(db, "com.example.a", "/p/a");
-    const out = await dispatchAutomationRpc({
-      method: "extension.disable",
-      params: { id: "com.example.a" },
-      db,
-    });
-    expect((out as { value: { ok: boolean } }).value.ok).toBe(true);
   });
 
   test("disable invokes mesh.stopExtensionClient when mesh is provided", async () => {
@@ -685,17 +680,6 @@ describe("extension.enable / disable / remove", () => {
         db,
       }),
     ).rejects.toThrow(/not found/i);
-  });
-
-  test("remove tolerates a non-existent install_path on disk (best-effort cleanup)", async () => {
-    const db = seededDb();
-    seedExtensionRow(db, "com.example.a", "/definitely/not/a/real/path-xyz-12345");
-    const out = await dispatchAutomationRpc({
-      method: "extension.remove",
-      params: { id: "com.example.a" },
-      db,
-    });
-    expect((out as { value: { ok: boolean } }).value.ok).toBe(true);
   });
 
   test("remove refuses when reverseDeps is non-empty and --force not set", async () => {

--- a/packages/gateway/src/ipc/connector-rpc-handlers/status.test.ts
+++ b/packages/gateway/src/ipc/connector-rpc-handlers/status.test.ts
@@ -177,36 +177,19 @@ describe("handleConnectorHealthHistory", () => {
     expect(typeof list[0]?.occurredAtMs).toBe("number");
   });
 
-  test("custom limit is honored", () => {
+  // `seeded` is how many history rows exist; `returned` is how many the clamped limit yields —
+  // so the 99_999 row proves the 500 ceiling by returning everything seeded, not the raw limit.
+  test.each([
+    ["custom limit is honored", 5, 2, 2],
+    ["limit < 1 is clamped to 1", 3, 0, 1],
+    ["limit > 500 is clamped to 500", 2, 99_999, 2],
+    ["limit float is floored", 4, 2.9, 2],
+  ])("%s", (_label, seeded, limit, returned) => {
     registerConnector("github");
-    seedHistory("github", 5);
-    const r = handleConnectorHealthHistory(buildCtx({ service: "github", limit: 2 }));
+    seedHistory("github", seeded);
+    const r = handleConnectorHealthHistory(buildCtx({ service: "github", limit }));
     expect(r.kind).toBe("hit");
-    expect(r.value as unknown[]).toHaveLength(2);
-  });
-
-  test("limit < 1 is clamped to 1", () => {
-    registerConnector("github");
-    seedHistory("github", 3);
-    const r = handleConnectorHealthHistory(buildCtx({ service: "github", limit: 0 }));
-    expect(r.kind).toBe("hit");
-    expect(r.value as unknown[]).toHaveLength(1);
-  });
-
-  test("limit > 500 is clamped to 500", () => {
-    registerConnector("github");
-    seedHistory("github", 2);
-    const r = handleConnectorHealthHistory(buildCtx({ service: "github", limit: 99_999 }));
-    expect(r.kind).toBe("hit");
-    expect(r.value as unknown[]).toHaveLength(2);
-  });
-
-  test("limit float is floored", () => {
-    registerConnector("github");
-    seedHistory("github", 4);
-    const r = handleConnectorHealthHistory(buildCtx({ service: "github", limit: 2.9 }));
-    expect(r.kind).toBe("hit");
-    expect(r.value as unknown[]).toHaveLength(2);
+    expect(r.value as unknown[]).toHaveLength(returned);
   });
 
   test("non-finite limit is ignored (default 100)", () => {

--- a/packages/gateway/src/ipc/lan-server.test.ts
+++ b/packages/gateway/src/ipc/lan-server.test.ts
@@ -40,7 +40,7 @@ describe("LanServer boot/stop", () => {
   test("stop cleanly releases the port", async () => {
     server = makeServer();
     await server.start();
-    await server.stop();
+    await expect(server.stop()).resolves.toBeUndefined();
     server = undefined;
   });
 });

--- a/packages/gateway/src/ipc/policy-rpc.test.ts
+++ b/packages/gateway/src/ipc/policy-rpc.test.ts
@@ -21,12 +21,9 @@ function ctx(): PolicyRpcCtx {
 }
 
 describe("dispatchPolicyRpc", () => {
-  test("policy.show returns the current state (hit)", async () => {
-    const out = await dispatchPolicyRpc("policy.show", {}, ctx());
-    expect(out.kind).toBe("hit");
-  });
-  test("policy.verify returns the current state (hit)", async () => {
-    const out = await dispatchPolicyRpc("policy.verify", {}, ctx());
+  // The param-free reads need no anchor role and no arguments — they just report current state.
+  test.each(["policy.show", "policy.verify", "policy.refetch"])("%s returns a hit", async (m) => {
+    const out = await dispatchPolicyRpc(m, {}, ctx());
     expect(out.kind).toBe("hit");
   });
   test("policy.sign on a non-anchor fails closed", async () => {
@@ -52,10 +49,6 @@ describe("dispatchPolicyRpc", () => {
     await expect(
       dispatchPolicyRpc("policy.trust", { pubkey: "x" }, { ...ctx(), isAnchor: false }),
     ).rejects.toThrow();
-  });
-  test("policy.refetch returns the refresh outcome (hit)", async () => {
-    const out = await dispatchPolicyRpc("policy.refetch", {}, ctx());
-    expect(out.kind).toBe("hit");
   });
   test("unknown method => miss", async () => {
     expect((await dispatchPolicyRpc("policy.nope", {}, ctx())).kind).toBe("miss");

--- a/packages/gateway/src/ipc/server/dispatchers-happy-paths.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers-happy-paths.test.ts
@@ -9,7 +9,7 @@ import { LocalIndex } from "../../index/local-index.ts";
 import { createMockVault } from "../../vault/mock.ts";
 import { ConsentCoordinatorImpl } from "../consent.ts";
 import { createStreamRegistry } from "../engine-ask-stream.ts";
-import { phase4RpcSkipped, type ServerCtx } from "./context.ts";
+import { diagnosticsRpcSkipped, phase4RpcSkipped, type ServerCtx } from "./context.ts";
 import {
   tryDispatchAgentsRpc,
   tryDispatchAuditRpc,
@@ -69,11 +69,12 @@ function trackDb(): Database {
 describe("assertDiagnosticsRpcAccess fall-through (the `return;` after each guard)", () => {
   test("config.* with configDir present falls through to dispatch", async () => {
     const ctx = makeCtx({ configDir: tmpDir });
-    try {
-      await tryDispatchDiagnosticsRpc(ctx, "config.validate", null);
-    } catch {
-      /* expected — handler reports errors */
-    }
+    // The handler itself may report a typed error; what's under test is that the access guard
+    // fell THROUGH rather than returning the `skipped` sentinel.
+    const outcome = await tryDispatchDiagnosticsRpc(ctx, "config.validate", null).catch(
+      (e: unknown) => e,
+    );
+    expect(outcome).not.toBe(diagnosticsRpcSkipped);
   });
 
   test("telemetry.* (non-preview) with dataDir present falls through", async () => {

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -392,12 +392,12 @@ describe("tryDispatchIndexReembedRpc", () => {
     const localIndex = new LocalIndex(db);
     const tmp = mkdtempSync(join(tmpdir(), "nimbus-reembed-"));
     const { ctx } = makeCtx({ localIndex, dataDir: tmp });
-    try {
-      await tryDispatchIndexReembedRpc(ctx, "index.reembedCancel", { jobId: "missing" });
-    } catch {
-      // typed error from dispatcher is acceptable; we only want the
-      // delegation code path covered.
-    }
+    // A typed error from the dispatcher is acceptable; what's under test is that the method was
+    // delegated rather than skipped.
+    const outcome = await tryDispatchIndexReembedRpc(ctx, "index.reembedCancel", {
+      jobId: "missing",
+    }).catch((e: unknown) => e);
+    expect(outcome).not.toBe(phase4RpcSkipped);
   });
 });
 
@@ -667,11 +667,12 @@ describe("tryDispatchConnectorRpc", () => {
       localIndex,
       openUrl: async () => {},
     });
-    try {
-      await tryDispatchConnectorRpc(ctx, "connector.auth", {}, "c1");
-    } catch {
-      // typed error acceptable
-    }
+    // A typed error is acceptable; what's under test is that the inner branch ran rather than
+    // the dispatcher returning the `skipped` sentinel.
+    const outcome = await tryDispatchConnectorRpc(ctx, "connector.auth", {}, "c1").catch(
+      (e: unknown) => e,
+    );
+    expect(outcome).not.toBe(connectorRpcSkipped);
   });
 });
 

--- a/packages/gateway/src/ipc/session-rpc.test.ts
+++ b/packages/gateway/src/ipc/session-rpc.test.ts
@@ -257,34 +257,18 @@ describe("session.recall", () => {
     expect(stub.recallCalls[0]?.topK).toBe(8);
   });
 
-  test("clamps topK to upper bound 32", async () => {
+  test.each([
+    ["clamps topK to upper bound 32", 999, 32],
+    ["clamps topK to lower bound 1", 0, 1],
+    ["floors fractional topK", 5.9, 5],
+  ])("%s", async (_label, topK, expected) => {
     const stub = makeStubStore();
     await dispatchSessionRpc({
       method: "session.recall",
-      params: { sessionId: "s", query: "q", topK: 999 },
+      params: { sessionId: "s", query: "q", topK },
       store: stub.store,
     });
-    expect(stub.recallCalls[0]?.topK).toBe(32);
-  });
-
-  test("clamps topK to lower bound 1", async () => {
-    const stub = makeStubStore();
-    await dispatchSessionRpc({
-      method: "session.recall",
-      params: { sessionId: "s", query: "q", topK: 0 },
-      store: stub.store,
-    });
-    expect(stub.recallCalls[0]?.topK).toBe(1);
-  });
-
-  test("floors fractional topK", async () => {
-    const stub = makeStubStore();
-    await dispatchSessionRpc({
-      method: "session.recall",
-      params: { sessionId: "s", query: "q", topK: 5.9 },
-      store: stub.store,
-    });
-    expect(stub.recallCalls[0]?.topK).toBe(5);
+    expect(stub.recallCalls[0]?.topK).toBe(expected);
   });
 
   test("non-finite topK (NaN, Infinity) falls back to default 8", async () => {

--- a/packages/gateway/src/ipc/session.test.ts
+++ b/packages/gateway/src/ipc/session.test.ts
@@ -113,7 +113,9 @@ describe("ClientSession.push — reader parse error (sendParseFailure)", () => {
   // lineLimitCtor and parseJsonRpcLine only ever throws JsonRpcParseError, so no production
   // input can deliver a non-JsonRpcParseError to that catch. Reaching it would require a DI seam
   // on the reader/parser ctor — deferred to Sub-project D. The other 16/18 arms clear the 80% floor.
-  test.skip("non-JsonRpcParseError from reader falls back to 'Parse error' (branch=1) — D candidate", () => {});
+  // KNOWN GAP (D candidate): a non-JsonRpcParseError thrown by the reader should fall back to
+  // the generic 'Parse error' response (branch=1). Left uncovered rather than stubbed — the
+  // reader cannot be driven into that state through the public session surface.
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/people/parse-from-header.test.ts
+++ b/packages/gateway/src/people/parse-from-header.test.ts
@@ -32,9 +32,23 @@ test("parseFromHeaderForPerson: multiple comma-separated addresses (last named p
   expect(r.email).toBe("second@example.com");
 });
 
-test("parseFromHeaderForPerson: angle-bracket-only (no display name)", () => {
-  const r = parseFromHeaderForPerson("<addr@host.com>");
-  expect(r.email).toBe("addr@host.com");
+// All three yield an email with no display name, but each reaches it by a different internal
+// route — see the per-row notes.
+test.each([
+  ["angle-bracket-only", "<addr@host.com>", "addr@host.com"],
+  // Inner of the first pair is "<addr@host.com", which contains "<", so
+  // extractFirstAngleBracketEmail skips it; searchFrom advances to 1 and the inner pair parses.
+  ["nested angle brackets (skips to the valid inner pair)", "<<addr@host.com>>", "addr@host.com"],
+  // open === 0 → tryParseNamedAngleMailbox returns null (no display name to its left), so
+  // extractFirstAngleBracketEmail is what ends up finding the address.
+  [
+    "a '<' at index 0 (tryParseNamedAngleMailbox open <= 0 bail-out)",
+    "<email@example.com>",
+    "email@example.com",
+  ],
+])("parseFromHeaderForPerson: %s → email, no display name", (_label, header, email) => {
+  const r = parseFromHeaderForPerson(header);
+  expect(r.email).toBe(email);
   expect(r.displayName).toBeUndefined();
 });
 
@@ -147,15 +161,6 @@ test("parseFromHeaderForPerson: angle bracket with bad email inside → skips, n
   expect(parseFromHeaderForPerson("<notanemail>")).toEqual({});
 });
 
-test("parseFromHeaderForPerson: nested angle brackets — outer inner has <, skips; inner pair is valid", () => {
-  // extractFirstAngleBracketEmail: inner.includes("<") branch causes searchFrom to advance
-  // <<addr@host.com>> — inner of first pair is "<addr@host.com" which contains "<", so skip
-  // searchFrom advances to 1; next < is at 1, next > at 15; inner = "addr@host.com" which is valid
-  const r = parseFromHeaderForPerson("<<addr@host.com>>");
-  expect(r.email).toBe("addr@host.com");
-  expect(r.displayName).toBeUndefined();
-});
-
 test("parseFromHeaderForPerson: angle with > inside inner — inner.includes(>) branch", () => {
   // inner contains ">" which causes isBareMailboxShape to fail (has ">")
   // "<a>b@c.com>" — open=0 close=2, inner="a" which has no @, searchFrom=1
@@ -164,15 +169,6 @@ test("parseFromHeaderForPerson: angle with > inside inner — inner.includes(>) 
   // The character ">" causes isBareMailboxShape to return false
   // Use a string that has no second valid pair
   expect(parseFromHeaderForPerson("<no-at-sign>")).toEqual({});
-});
-
-test("parseFromHeaderForPerson: tryParseNamedAngleMailbox open <= 0 when < is at index 0", () => {
-  // open === 0 means open <= 0 → returns null; falls through to extractFirstAngleBracketEmail
-  // "<email@example.com>" — open is at 0, so tryParseNamedAngle returns null (no displayName)
-  // extractFirstAngleBracketEmail then finds it
-  const r = parseFromHeaderForPerson("<email@example.com>");
-  expect(r.email).toBe("email@example.com");
-  expect(r.displayName).toBeUndefined();
 });
 
 test("parseFromHeaderForPerson: tryParseNamedAngleMailbox with bad inner email → null, extract also fails → empty", () => {

--- a/packages/gateway/src/people/person-id.test.ts
+++ b/packages/gateway/src/people/person-id.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { NIMBUS_PERSON_NAMESPACE_UUID, uuidV5 } from "./person-id.ts";
 
+/** 36 chars, lowercase hex, 8-4-4-4-12. */
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 // ---------------------------------------------------------------------------
 // NIMBUS_PERSON_NAMESPACE_UUID — value contract
 // ---------------------------------------------------------------------------
@@ -14,10 +17,13 @@ test("NIMBUS_PERSON_NAMESPACE_UUID has the expected value", () => {
 // version nibble 0x8 — intentionally NOT RFC 4122 v5; see person-id.ts).
 // ---------------------------------------------------------------------------
 describe("uuidV5 — happy path", () => {
-  test("returns a lowercase hyphenated UUID string", () => {
-    const result = uuidV5("alice@example.com", NIMBUS_PERSON_NAMESPACE_UUID);
-    // Must be 36 chars: 8-4-4-4-12
-    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  test.each([
+    ["a plain email", "alice@example.com"],
+    ["an empty string", ""],
+    ["unicode characters", "Ålice Ångström <alice@example.se>"],
+    ["a 10k-character name", "a".repeat(10_000)],
+  ])("returns a lowercase hyphenated UUID string for %s", (_label, name) => {
+    expect(uuidV5(name, NIMBUS_PERSON_NAMESPACE_UUID)).toMatch(UUID_SHAPE);
   });
 
   test("is deterministic — same name+namespace → same UUID", () => {
@@ -40,14 +46,9 @@ describe("uuidV5 — happy path", () => {
     expect(a).not.toBe(b);
   });
 
-  test("empty string name does not throw and returns a UUID", () => {
-    const result = uuidV5("", NIMBUS_PERSON_NAMESPACE_UUID);
-    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-  });
-
   test("whitespace-only name produces a valid UUID (whitespace is preserved, not stripped)", () => {
     const result = uuidV5("   ", NIMBUS_PERSON_NAMESPACE_UUID);
-    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(result).toMatch(UUID_SHAPE);
     // Confirm whitespace-only produces a different UUID than empty string
     const empty = uuidV5("", NIMBUS_PERSON_NAMESPACE_UUID);
     expect(result).not.toBe(empty);
@@ -57,17 +58,6 @@ describe("uuidV5 — happy path", () => {
     const lower = uuidV5("alice@example.com", NIMBUS_PERSON_NAMESPACE_UUID);
     const upper = uuidV5("ALICE@EXAMPLE.COM", NIMBUS_PERSON_NAMESPACE_UUID);
     expect(lower).not.toBe(upper);
-  });
-
-  test("name with unicode characters produces a valid UUID", () => {
-    const result = uuidV5("Ålice Ångström <alice@example.se>", NIMBUS_PERSON_NAMESPACE_UUID);
-    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-  });
-
-  test("long name does not throw", () => {
-    const long = "a".repeat(10_000);
-    const result = uuidV5(long, NIMBUS_PERSON_NAMESPACE_UUID);
-    expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 });
 

--- a/packages/gateway/src/platform/gateway-log-file.test.ts
+++ b/packages/gateway/src/platform/gateway-log-file.test.ts
@@ -90,46 +90,20 @@ describe("scrubRedactedValuePatterns", () => {
     expect(scrubRedactedValuePatterns("hello world")).toBe("hello world");
   });
 
-  test("redacts Bearer token", () => {
-    const result = scrubRedactedValuePatterns("Authorization: Bearer abc123def456ghi789jkl");
+  // One row per credential shape the scrubber knows: the line it appears on, and the exact
+  // substring that must not survive.
+  test.each([
+    ["Bearer token", "Authorization: Bearer ", "abc123def456ghi789jkl"],
+    ["sk- style key (OpenAI pattern)", "key=", "sk-abcdefghijklmnopqrstuvwxyz01234567890"],
+    ["sk-ant- anthropic key", "key=", "sk-ant-abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["ghp_ github token", "token=", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"],
+    ["gho_ github oauth token", "token=", "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"],
+    ["xoxb- Slack bot token", "slack=", "xoxb-12345678-abcdefgh"],
+    ["AKIA AWS access key", "aws=", "AKIAIOSFODNN7EXAMPLE"],
+  ])("redacts %s", (_label, prefix, secret) => {
+    const result = scrubRedactedValuePatterns(`${prefix}${secret}`);
     expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("abc123def456ghi789jkl");
-  });
-
-  test("redacts sk- style key (OpenAI pattern)", () => {
-    const result = scrubRedactedValuePatterns("key=sk-abcdefghijklmnopqrstuvwxyz01234567890");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("sk-abcdefghijklmnopqrstuvwxyz01234567890");
-  });
-
-  test("redacts sk-ant- anthropic key", () => {
-    const result = scrubRedactedValuePatterns("key=sk-ant-abcdefghijklmnopqrstuvwxyz0123456789");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("sk-ant-abcdefghijklmnopqrstuvwxyz0123456789");
-  });
-
-  test("redacts ghp_ github token", () => {
-    const result = scrubRedactedValuePatterns("token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567");
-  });
-
-  test("redacts gho_ github oauth token", () => {
-    const result = scrubRedactedValuePatterns("token=gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567");
-  });
-
-  test("redacts xoxb- Slack bot token", () => {
-    const result = scrubRedactedValuePatterns("slack=xoxb-12345678-abcdefgh");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("xoxb-12345678-abcdefgh");
-  });
-
-  test("redacts AKIA AWS access key", () => {
-    const result = scrubRedactedValuePatterns("aws=AKIAIOSFODNN7EXAMPLE");
-    expect(result).toContain("[REDACTED]");
-    expect(result).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(result).not.toContain(secret);
   });
 
   test("redacts JWT token (eyJ...)", () => {
@@ -169,85 +143,40 @@ describe("resolveLogLevel (via createGatewayPinoLogger)", () => {
     }
   });
 
-  test("defaults to warn when NIMBUS_LOG_LEVEL is unset", () => {
-    delete process.env["NIMBUS_LOG_LEVEL"];
+  /**
+   * Build a logger in a throwaway dir with NIMBUS_LOG_LEVEL set (or deleted, for `undefined`)
+   * and stdout forced non-TTY — the simpler of the two branches — and report the level it chose.
+   */
+  function resolvedLevel(raw: string | undefined): string {
+    if (raw === undefined) {
+      delete process.env["NIMBUS_LOG_LEVEL"];
+    } else {
+      process.env["NIMBUS_LOG_LEVEL"] = raw;
+    }
     const dir = mkdtempSync(join(tmpdir(), "nimbus-gw-log-level-"));
     try {
-      // isTTY=false so we get the simpler path
       const restore = forceIsTty(false);
       try {
-        const log = createGatewayPinoLogger(dir);
-        expect(log.level).toBe("warn");
+        return createGatewayPinoLogger(dir).level;
       } finally {
         restore();
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }
 
-  test("defaults to warn when NIMBUS_LOG_LEVEL is empty string", () => {
-    process.env["NIMBUS_LOG_LEVEL"] = "";
-    const dir = mkdtempSync(join(tmpdir(), "nimbus-gw-log-level-"));
-    try {
-      const restore = forceIsTty(false);
-      try {
-        const log = createGatewayPinoLogger(dir);
-        expect(log.level).toBe("warn");
-      } finally {
-        restore();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+  // Unset, blank and unrecognised levels all fall back to warn; a recognised level is honoured.
+  const LEVEL_CASES: ReadonlyArray<readonly [string | undefined, string]> = [
+    [undefined, "warn"],
+    ["", "warn"],
+    ["verbose", "warn"],
+    ["debug", "debug"],
+    ["silent", "silent"],
+  ];
 
-  test("defaults to warn when NIMBUS_LOG_LEVEL is an unknown level", () => {
-    process.env["NIMBUS_LOG_LEVEL"] = "verbose";
-    const dir = mkdtempSync(join(tmpdir(), "nimbus-gw-log-level-"));
-    try {
-      const restore = forceIsTty(false);
-      try {
-        const log = createGatewayPinoLogger(dir);
-        expect(log.level).toBe("warn");
-      } finally {
-        restore();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("uses NIMBUS_LOG_LEVEL=debug when valid", () => {
-    process.env["NIMBUS_LOG_LEVEL"] = "debug";
-    const dir = mkdtempSync(join(tmpdir(), "nimbus-gw-log-level-"));
-    try {
-      const restore = forceIsTty(false);
-      try {
-        const log = createGatewayPinoLogger(dir);
-        expect(log.level).toBe("debug");
-      } finally {
-        restore();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("uses NIMBUS_LOG_LEVEL=silent when valid", () => {
-    process.env["NIMBUS_LOG_LEVEL"] = "silent";
-    const dir = mkdtempSync(join(tmpdir(), "nimbus-gw-log-level-"));
-    try {
-      const restore = forceIsTty(false);
-      try {
-        const log = createGatewayPinoLogger(dir);
-        expect(log.level).toBe("silent");
-      } finally {
-        restore();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+  test.each(LEVEL_CASES)("NIMBUS_LOG_LEVEL=%s resolves to level %s", (raw, expected) => {
+    expect(resolvedLevel(raw)).toBe(expected);
   });
 });
 

--- a/packages/gateway/src/platform/linux.ts
+++ b/packages/gateway/src/platform/linux.ts
@@ -212,7 +212,7 @@ export function probeLinuxVault(
   }
 
   const locked = runFirstAvailable(exec, collectionLockedCommands(collection));
-  if (locked === null || locked.code !== 0) {
+  if (locked?.code !== 0) {
     return { state: "unverified", detail: locked?.stderr.trim() ?? "" };
   }
   const flag = BOOLEAN_RE.exec(locked.stdout);

--- a/packages/gateway/src/preflight/preflight.test.ts
+++ b/packages/gateway/src/preflight/preflight.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { ServiceConfig } from "../metrics/dora-config.ts";
+import type { DoraProvider, ServiceConfig } from "../metrics/dora-config.ts";
 import { computeDeployPreflight } from "./preflight.ts";
 
 // ---------------------------------------------------------------------------
@@ -543,45 +543,27 @@ describe("failing_ci_runs gaps", () => {
     expect(result.checks.failing_ci_runs.count).toBe(1);
   });
 
-  test("gitlab repo uses gitlab service column", () => {
-    const cfg = baseConfig({ repos: [{ provider: "gitlab", providerId: "group/proj" }] });
-    insertItem(db, "gitlab", "ci_run", "Pipeline", NOW - ONE_HOUR, {
-      branch: "main",
-      conclusion: "failure",
-    });
-    const result = computeDeployPreflight(db, cfg, "main", NOW, 5);
-    expect(result.checks.failing_ci_runs.count).toBe(1);
-  });
+  // Every non-github provider reads its failing ci_run rows from its own service column, so a
+  // single failure row seeded under that column must be counted.
+  const OWN_COLUMN_PROVIDERS: ReadonlyArray<readonly [DoraProvider, string, string]> = [
+    ["gitlab", "group/proj", "Pipeline"],
+    ["bitbucket", "org/bb-repo", "Pipeline"],
+    ["jenkins", "deploy-job", "Build"],
+    ["circleci", "org/repo", "Pipeline"],
+  ];
 
-  test("bitbucket repo uses bitbucket service column", () => {
-    const cfg = baseConfig({ repos: [{ provider: "bitbucket", providerId: "org/bb-repo" }] });
-    insertItem(db, "bitbucket", "ci_run", "Pipeline", NOW - ONE_HOUR, {
-      branch: "main",
-      conclusion: "failure",
-    });
-    const result = computeDeployPreflight(db, cfg, "main", NOW, 5);
-    expect(result.checks.failing_ci_runs.count).toBe(1);
-  });
-
-  test("jenkins repo uses jenkins service column", () => {
-    const cfg = baseConfig({ repos: [{ provider: "jenkins", providerId: "deploy-job" }] });
-    insertItem(db, "jenkins", "ci_run", "Build", NOW - ONE_HOUR, {
-      branch: "main",
-      conclusion: "failure",
-    });
-    const result = computeDeployPreflight(db, cfg, "main", NOW, 5);
-    expect(result.checks.failing_ci_runs.count).toBe(1);
-  });
-
-  test("circleci repo uses circleci service column", () => {
-    const cfg = baseConfig({ repos: [{ provider: "circleci", providerId: "org/repo" }] });
-    insertItem(db, "circleci", "ci_run", "Pipeline", NOW - ONE_HOUR, {
-      branch: "main",
-      conclusion: "failure",
-    });
-    const result = computeDeployPreflight(db, cfg, "main", NOW, 5);
-    expect(result.checks.failing_ci_runs.count).toBe(1);
-  });
+  test.each(OWN_COLUMN_PROVIDERS)(
+    "%s repo uses its own service column",
+    (provider, providerId, runTitle) => {
+      const cfg = baseConfig({ repos: [{ provider, providerId }] });
+      insertItem(db, provider, "ci_run", runTitle, NOW - ONE_HOUR, {
+        branch: "main",
+        conclusion: "failure",
+      });
+      const result = computeDeployPreflight(db, cfg, "main", NOW, 5);
+      expect(result.checks.failing_ci_runs.count).toBe(1);
+    },
+  );
 
   test("multiple repos deduplicates service columns", () => {
     // Two github repos → only one 'github_actions' column entry

--- a/packages/gateway/src/search/hybrid-internal.test.ts
+++ b/packages/gateway/src/search/hybrid-internal.test.ts
@@ -352,42 +352,16 @@ describe("loadBm25Hits", () => {
 // ---------------------------------------------------------------------------
 
 describe("runVectorSearch", () => {
-  test("returns [] when semantic=false", () => {
+  // No opts here ever carry a queryEmbedding / queryEmbedding1536, so the third row is the
+  // "semantic on, non-empty query, but nothing to search with" case.
+  test.each([
+    ["semantic=false", "test", false],
+    ["nameQ is empty string", "", true],
+    ["no embedding vectors provided", "hello", true],
+  ])("returns [] when %s", (_label, query, semantic) => {
     const db = freshDb();
-    const opts: HybridSearchOptions = {
-      query: "test",
-      limit: 10,
-      embeddingModel: "m1",
-      semantic: false,
-    };
-    const result = runVectorSearch(db, opts, 10, undefined, "test");
-    expect(result).toEqual([]);
-    db.close();
-  });
-
-  test("returns [] when nameQ is empty string", () => {
-    const db = freshDb();
-    const opts: HybridSearchOptions = {
-      query: "",
-      limit: 10,
-      embeddingModel: "m1",
-      semantic: true,
-    };
-    const result = runVectorSearch(db, opts, 10, undefined, "");
-    expect(result).toEqual([]);
-    db.close();
-  });
-
-  test("returns [] when no embedding vectors provided", () => {
-    const db = freshDb();
-    const opts: HybridSearchOptions = {
-      query: "hello",
-      limit: 10,
-      embeddingModel: "m1",
-      semantic: true,
-      // no queryEmbedding or queryEmbedding1536
-    };
-    const result = runVectorSearch(db, opts, 10, undefined, "hello");
+    const opts: HybridSearchOptions = { query, limit: 10, embeddingModel: "m1", semantic };
+    const result = runVectorSearch(db, opts, 10, undefined, query);
     expect(result).toEqual([]);
     db.close();
   });

--- a/packages/gateway/src/security/secret-patterns.test.ts
+++ b/packages/gateway/src/security/secret-patterns.test.ts
@@ -54,32 +54,21 @@ describe("redactSecret", () => {
 });
 
 describe("buildContextSnippet", () => {
-  test("includes ±40 chars around the match, secret middle = [REDACTED]", () => {
-    const body =
-      "// before block of harmless content here\nconst KEY = 'AKIAIOSFODNN7EXAMPLE';\n// trailing content also fine";
-    const offset = body.indexOf("AKIA");
-    const length = "AKIAIOSFODNN7EXAMPLE".length;
-    const snippet = buildContextSnippet(body, offset, length);
+  // Whatever the ±40-char window has to clamp against — plenty of room, a body shorter than the
+  // 80-char window, or a secret flush against the end — the secret never survives into the
+  // snippet.
+  test.each([
+    [
+      "±40 chars of room on both sides",
+      "// before block of harmless content here\nconst KEY = 'AKIAIOSFODNN7EXAMPLE';\n// trailing content also fine",
+    ],
+    ["a body shorter than 80 chars", "k='AKIAIOSFODNN7EXAMPLE';"],
+    ["the secret at end-of-body (no overrun)", "trailing AKIAIOSFODNN7EXAMPLE"],
+  ])("redacts the secret with %s", (_label, body) => {
+    const secret = "AKIAIOSFODNN7EXAMPLE";
+    const snippet = buildContextSnippet(body, body.indexOf(secret), secret.length);
     expect(snippet).toContain("[REDACTED]");
-    expect(snippet).not.toContain("AKIAIOSFODNN7EXAMPLE");
-  });
-
-  test("snippet for body shorter than 80 chars contains [REDACTED] and no secret", () => {
-    const body = "k='AKIAIOSFODNN7EXAMPLE';";
-    const offset = body.indexOf("AKIA");
-    const length = "AKIAIOSFODNN7EXAMPLE".length;
-    const snippet = buildContextSnippet(body, offset, length);
-    expect(snippet).toContain("[REDACTED]");
-    expect(snippet).not.toContain("AKIAIOSFODNN7EXAMPLE");
-  });
-
-  test("snippet at end-of-body works without overrun", () => {
-    const body = "trailing AKIAIOSFODNN7EXAMPLE";
-    const offset = body.indexOf("AKIA");
-    const length = "AKIAIOSFODNN7EXAMPLE".length;
-    const snippet = buildContextSnippet(body, offset, length);
-    expect(snippet).toContain("[REDACTED]");
-    expect(snippet).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(snippet).not.toContain(secret);
   });
 });
 

--- a/packages/gateway/src/sync/rate-limiter.test.ts
+++ b/packages/gateway/src/sync/rate-limiter.test.ts
@@ -127,7 +127,7 @@ describe("ProviderRateLimiter – deterministic (clock-injected)", () => {
       github: { requestsPerMinute: 999, burstSize: base.burstSize },
     });
     // Acquire burstSize tokens — if burstSize were 0 this would throw
-    await limiter.acquire("github", base.burstSize);
+    await expect(limiter.acquire("github", base.burstSize)).resolves.toBeUndefined();
   });
 
   test("quota override merges partial fields: only burstSize overridden", async () => {

--- a/packages/gateway/src/tribal/tribal-watcher.test.ts
+++ b/packages/gateway/src/tribal/tribal-watcher.test.ts
@@ -120,15 +120,17 @@ test("ingest never throws even if embed fails", async () => {
       },
     }),
   );
-  await w.ingest({
-    platform: "slack",
-    channelId: "C1",
-    userId: "U",
-    text: "how do I deploy?",
-    ts: "1",
-    addressedToBot: false,
-  });
-  // no throw = pass
+  // A failing embed must be swallowed: ingest resolves rather than propagating "worker down".
+  await expect(
+    w.ingest({
+      platform: "slack",
+      channelId: "C1",
+      userId: "U",
+      text: "how do I deploy?",
+      ts: "1",
+      addressedToBot: false,
+    }),
+  ).resolves.toBeUndefined();
 });
 
 test("an Error thrown during ingest is logged via the optional log seam (err.message branch)", async () => {

--- a/packages/gateway/src/voice/stt.test.ts
+++ b/packages/gateway/src/voice/stt.test.ts
@@ -99,14 +99,6 @@ describe("WhisperSttProvider", () => {
     expect(await provider.isAvailable()).toBe(true);
   });
 
-  test("isAvailable returns false when binary not found", async () => {
-    const provider = new WhisperSttProvider({
-      whisperBin: "whisper-cli",
-      which: (_name) => null,
-    });
-    expect(await provider.isAvailable()).toBe(false);
-  });
-
   test("isAvailable with absolute forward-slash path checks file existence (file exists)", async () => {
     // import.meta.path is an absolute path that exists
     const provider = new WhisperSttProvider({
@@ -116,20 +108,14 @@ describe("WhisperSttProvider", () => {
     expect(await provider.isAvailable()).toBe(true);
   });
 
-  test("isAvailable with absolute forward-slash path checks file existence (file missing)", async () => {
-    const provider = new WhisperSttProvider({
-      whisperBin: "/absolutely/nonexistent/whisper",
-      which: (_name) => null,
-    });
-    expect(await provider.isAvailable()).toBe(false);
-  });
-
-  test("isAvailable with backslash path checks file existence", async () => {
-    // A path with backslash that doesn't exist → false
-    const provider = new WhisperSttProvider({
-      whisperBin: "C:\\nonexistent\\whisper.exe", // cross-platform-ok: intentional Windows backslash to exercise the `includes("\\")` branch
-      which: (_name) => null,
-    });
+  // With `which` stubbed to null, availability rests entirely on the path itself: a bare name has
+  // nowhere left to resolve, and an absolute path (either separator) must exist on disk.
+  test.each([
+    ["a bare binary name not found on PATH", "whisper-cli"],
+    ["an absolute forward-slash path that does not exist", "/absolutely/nonexistent/whisper"],
+    ["a backslash path that does not exist", "C:\\nonexistent\\whisper.exe"], // cross-platform-ok: intentional Windows backslash to exercise the `includes("\\")` branch
+  ])("isAvailable returns false for %s", async (_label, whisperBin) => {
+    const provider = new WhisperSttProvider({ whisperBin, which: (_name) => null });
     expect(await provider.isAvailable()).toBe(false);
   });
 

--- a/packages/gateway/test/integration/slice7-lineage.test.ts
+++ b/packages/gateway/test/integration/slice7-lineage.test.ts
@@ -119,6 +119,6 @@ test("Slice-7: mappers return null for incomplete raw inputs (no network needed)
   ).toBeNull();
 });
 
-test.skip("FULL 6-hop chain Tableau→Looker→dbt→Snowflake→Airflow→PR (needs dbt+Airflow graph participation — review F2)", () => {
-  // Unskip once the dbt + Airflow connectors become graph-participating.
-});
+// KNOWN GAP (review F2): the FULL 6-hop chain Tableau→Looker→dbt→Snowflake→Airflow→PR is not
+// asserted yet — it needs the dbt + Airflow connectors to become graph-participating first. Add
+// the test then rather than carrying a permanently-skipped stub here.

--- a/packages/gateway/test/unit/connectors/circleci-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/circleci-sync.test.ts
@@ -362,22 +362,13 @@ describe("circleci-sync — with shared fixture", () => {
   });
 
   describe("project slug derivation", () => {
-    test("owner-only (no `/`) → skipped via githubRepoToCircleProjectSlug returning null", async () => {
-      seedGithubRepo(fixture.createSyncContext(), "no-slash-here");
-      const res = await createCircleciSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
-      expect(fixture.fetchMock.calls).toHaveLength(0);
-      expect(res.itemsUpserted).toBe(0);
-    });
-
-    test("trailing slash (`acme/`) → skipped", async () => {
-      seedGithubRepo(fixture.createSyncContext(), "acme/");
-      const res = await createCircleciSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
-      expect(fixture.fetchMock.calls).toHaveLength(0);
-      expect(res.itemsUpserted).toBe(0);
-    });
-
-    test("leading slash (`/repo-a`) → skipped", async () => {
-      seedGithubRepo(fixture.createSyncContext(), "/repo-a");
+    // Anything githubRepoToCircleProjectSlug maps to null is skipped before any HTTP call.
+    test.each([
+      ["owner-only (no `/`)", "no-slash-here"],
+      ["trailing slash", "acme/"],
+      ["leading slash", "/repo-a"],
+    ])("%s → skipped, no fetch", async (_label, repo) => {
+      seedGithubRepo(fixture.createSyncContext(), repo);
       const res = await createCircleciSyncable(ENSURE_MCP).sync(fixture.createSyncContext(), null);
       expect(fixture.fetchMock.calls).toHaveLength(0);
       expect(res.itemsUpserted).toBe(0);

--- a/packages/gateway/test/unit/db/repair.test.ts
+++ b/packages/gateway/test/unit/db/repair.test.ts
@@ -79,13 +79,10 @@ describe("repairIndex — orphaned sync tokens", () => {
   });
 });
 
-describe("repairIndex — FTS5 rebuild", () => {
-  test.skip("FTS5 rebuild — unreachable from :memory: (would need real FTS5 corruption to trigger fts5_consistency = fail)", () => {
-    // repairFts5 only runs when verifyIndex flags fts5_consistency = "fail",
-    // which requires actual FTS5 shadow-table corruption. Bun's :memory: SQLite
-    // cannot induce that state without lower-level manipulation outside the API.
-  });
-});
+// KNOWN GAP — repairIndex's FTS5 rebuild is unreachable from this suite: repairFts5 only runs
+// when verifyIndex flags fts5_consistency = "fail", which requires actual FTS5 shadow-table
+// corruption. Bun's :memory: SQLite cannot induce that state without lower-level manipulation
+// outside the public API, so no stub test is carried here.
 
 describe("repairIndex — audit log entry", () => {
   test("writes audit_log entry when repairs are applied", () => {

--- a/packages/gateway/test/unit/db/snapshot.test.ts
+++ b/packages/gateway/test/unit/db/snapshot.test.ts
@@ -322,25 +322,10 @@ describe("db/snapshot", () => {
       }
     });
 
-    it("includes a FILENAME header line", () => {
+    it.each(["FILENAME", "TIMESTAMP", "SIZE"])("includes a %s column header", (header) => {
       takeSnapshot(db, dataDir);
       const entries = listSnapshots(dataDir);
-      const output = formatSnapshotList(entries);
-      expect(output).toContain("FILENAME");
-    });
-
-    it("includes a TIMESTAMP column", () => {
-      takeSnapshot(db, dataDir);
-      const entries = listSnapshots(dataDir);
-      const output = formatSnapshotList(entries);
-      expect(output).toContain("TIMESTAMP");
-    });
-
-    it("includes a SIZE column", () => {
-      takeSnapshot(db, dataDir);
-      const entries = listSnapshots(dataDir);
-      const output = formatSnapshotList(entries);
-      expect(output).toContain("SIZE");
+      expect(formatSnapshotList(entries)).toContain(header);
     });
 
     it("formats multiple entries as separate lines", async () => {

--- a/packages/gateway/test/unit/ipc/connector-rpc-handlers/auth.test.ts
+++ b/packages/gateway/test/unit/ipc/connector-rpc-handlers/auth.test.ts
@@ -1602,23 +1602,14 @@ describe("handleConnectorAuth — OAuth dispatch (error paths)", () => {
     });
   }
 
-  test("onedrive: missing NIMBUS_OAUTH_MICROSOFT_CLIENT_ID throws -32602", async () => {
-    const ctx = makeOAuthCtx({ service: "onedrive" }, vault, localIndex);
-    await expect(handleConnectorAuth(ctx)).rejects.toMatchObject({ rpcCode: -32602 });
-  });
-
-  test("outlook: missing NIMBUS_OAUTH_MICROSOFT_CLIENT_ID throws -32602", async () => {
-    const ctx = makeOAuthCtx({ service: "outlook" }, vault, localIndex);
-    await expect(handleConnectorAuth(ctx)).rejects.toMatchObject({ rpcCode: -32602 });
-  });
-
-  test("slack: missing NIMBUS_OAUTH_SLACK_CLIENT_ID throws -32602", async () => {
-    const ctx = makeOAuthCtx({ service: "slack" }, vault, localIndex);
-    await expect(handleConnectorAuth(ctx)).rejects.toMatchObject({ rpcCode: -32602 });
-  });
-
-  test("notion: missing NIMBUS_OAUTH_NOTION_CLIENT_ID throws -32602", async () => {
-    const ctx = makeOAuthCtx({ service: "notion" }, vault, localIndex);
+  // Each service needs its provider's client-id env var; absent it, auth is a -32602.
+  test.each([
+    ["onedrive", "NIMBUS_OAUTH_MICROSOFT_CLIENT_ID"],
+    ["outlook", "NIMBUS_OAUTH_MICROSOFT_CLIENT_ID"],
+    ["slack", "NIMBUS_OAUTH_SLACK_CLIENT_ID"],
+    ["notion", "NIMBUS_OAUTH_NOTION_CLIENT_ID"],
+  ])("%s: missing %s throws -32602", async (service) => {
+    const ctx = makeOAuthCtx({ service }, vault, localIndex);
     await expect(handleConnectorAuth(ctx)).rejects.toMatchObject({ rpcCode: -32602 });
   });
 });

--- a/packages/mcp-connectors/airflow/test/sandbox.test.ts
+++ b/packages/mcp-connectors/airflow/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/argocd/test/sandbox.test.ts
+++ b/packages/mcp-connectors/argocd/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/athena/test/sandbox.test.ts
+++ b/packages/mcp-connectors/athena/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/aws/test/sandbox.test.ts
+++ b/packages/mcp-connectors/aws/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/azure/test/sandbox.test.ts
+++ b/packages/mcp-connectors/azure/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/bigquery/test/sandbox.test.ts
+++ b/packages/mcp-connectors/bigquery/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/bitbucket/test/sandbox.test.ts
+++ b/packages/mcp-connectors/bitbucket/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/canva/test/sandbox.test.ts
+++ b/packages/mcp-connectors/canva/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/circleci/test/sandbox.test.ts
+++ b/packages/mcp-connectors/circleci/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/codemagic/test/sandbox.test.ts
+++ b/packages/mcp-connectors/codemagic/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/confluence/test/sandbox.test.ts
+++ b/packages/mcp-connectors/confluence/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/dagster/test/sandbox.test.ts
+++ b/packages/mcp-connectors/dagster/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/databricks/test/sandbox.test.ts
+++ b/packages/mcp-connectors/databricks/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/datadog/test/sandbox.test.ts
+++ b/packages/mcp-connectors/datadog/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/dataprofile/test/sandbox.test.ts
+++ b/packages/mcp-connectors/dataprofile/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/dbt/test/sandbox.test.ts
+++ b/packages/mcp-connectors/dbt/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/dependencytrack/test/sandbox.test.ts
+++ b/packages/mcp-connectors/dependencytrack/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/discord/test/sandbox.test.ts
+++ b/packages/mcp-connectors/discord/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/elasticsearch/test/sandbox.test.ts
+++ b/packages/mcp-connectors/elasticsearch/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/fastmail/test/sandbox.test.ts
+++ b/packages/mcp-connectors/fastmail/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/figma/test/sandbox.test.ts
+++ b/packages/mcp-connectors/figma/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/firebase/test/sandbox.test.ts
+++ b/packages/mcp-connectors/firebase/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/flagsmith/test/sandbox.test.ts
+++ b/packages/mcp-connectors/flagsmith/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/flux/test/sandbox.test.ts
+++ b/packages/mcp-connectors/flux/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/gcp/test/sandbox.test.ts
+++ b/packages/mcp-connectors/gcp/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/github-actions/test/sandbox.test.ts
+++ b/packages/mcp-connectors/github-actions/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/github/test/sandbox.test.ts
+++ b/packages/mcp-connectors/github/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/gitlab/test/sandbox.test.ts
+++ b/packages/mcp-connectors/gitlab/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/gmail/test/sandbox.test.ts
+++ b/packages/mcp-connectors/gmail/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/google-drive/test/sandbox.test.ts
+++ b/packages/mcp-connectors/google-drive/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/google-meet/test/sandbox.test.ts
+++ b/packages/mcp-connectors/google-meet/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/google-photos/test/sandbox.test.ts
+++ b/packages/mcp-connectors/google-photos/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/grafana/test/sandbox.test.ts
+++ b/packages/mcp-connectors/grafana/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/greenhouse/test/sandbox.test.ts
+++ b/packages/mcp-connectors/greenhouse/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/hubspot/test/sandbox.test.ts
+++ b/packages/mcp-connectors/hubspot/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/iac/test/sandbox.test.ts
+++ b/packages/mcp-connectors/iac/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/imap/test/sandbox.test.ts
+++ b/packages/mcp-connectors/imap/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/intercom/test/sandbox.test.ts
+++ b/packages/mcp-connectors/intercom/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/jenkins/test/sandbox.test.ts
+++ b/packages/mcp-connectors/jenkins/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/jira/test/sandbox.test.ts
+++ b/packages/mcp-connectors/jira/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/kubernetes/test/sandbox.test.ts
+++ b/packages/mcp-connectors/kubernetes/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/launchdarkly/test/sandbox.test.ts
+++ b/packages/mcp-connectors/launchdarkly/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/lever/test/sandbox.test.ts
+++ b/packages/mcp-connectors/lever/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/linear/test/sandbox.test.ts
+++ b/packages/mcp-connectors/linear/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/localdb/test/sandbox.test.ts
+++ b/packages/mcp-connectors/localdb/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/mendeley/test/sandbox.test.ts
+++ b/packages/mcp-connectors/mendeley/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/mercury/test/sandbox.test.ts
+++ b/packages/mcp-connectors/mercury/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/miro/test/sandbox.test.ts
+++ b/packages/mcp-connectors/miro/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/mlflow/test/sandbox.test.ts
+++ b/packages/mcp-connectors/mlflow/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/netlify/test/sandbox.test.ts
+++ b/packages/mcp-connectors/netlify/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/newrelic/test/sandbox.test.ts
+++ b/packages/mcp-connectors/newrelic/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/notion/test/sandbox.test.ts
+++ b/packages/mcp-connectors/notion/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/obsidian/test/sandbox.test.ts
+++ b/packages/mcp-connectors/obsidian/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/onedrive/test/sandbox.test.ts
+++ b/packages/mcp-connectors/onedrive/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/outlook/test/sandbox.test.ts
+++ b/packages/mcp-connectors/outlook/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/pagerduty/test/sandbox.test.ts
+++ b/packages/mcp-connectors/pagerduty/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/pipedrive/test/sandbox.test.ts
+++ b/packages/mcp-connectors/pipedrive/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/prefect/test/sandbox.test.ts
+++ b/packages/mcp-connectors/prefect/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/protonmail/test/sandbox.test.ts
+++ b/packages/mcp-connectors/protonmail/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/raindrop/test/sandbox.test.ts
+++ b/packages/mcp-connectors/raindrop/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/ramp/test/sandbox.test.ts
+++ b/packages/mcp-connectors/ramp/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/ramp/test/search-filter.test.ts
+++ b/packages/mcp-connectors/ramp/test/search-filter.test.ts
@@ -65,34 +65,22 @@ describe("filterRampTransactions", () => {
     expect(filterRampTransactions(many, { query: "amazon", limit: 3 })).toHaveLength(3);
   });
 
-  test("card_holder present but first_name missing — filter still matches on last_name and department", () => {
-    // Exercises the (p !== "") false arm in the .filter() for first_name = ""
-    const row = txn();
-    const holder = row["card_holder"] as Record<string, unknown>;
-    delete holder["first_name"];
-    // last_name + department_name remain, so "Lovelace" still matches
-    expect(filterRampTransactions([row], { query: "Lovelace" })).toHaveLength(1);
-    // first_name is gone — searching for "Ada" yields nothing
-    expect(filterRampTransactions([row], { query: "Ada" })).toHaveLength(0);
-  });
-
-  test("card_holder present but last_name missing — filter still matches on first_name and department", () => {
-    // Exercises the (p !== "") false arm in the .filter() for last_name = ""
-    const row = txn();
-    const holder = row["card_holder"] as Record<string, unknown>;
-    delete holder["last_name"];
-    expect(filterRampTransactions([row], { query: "Ada" })).toHaveLength(1);
-    expect(filterRampTransactions([row], { query: "Lovelace" })).toHaveLength(0);
-  });
-
-  test("card_holder present but department_name missing — filter still matches on first_name", () => {
-    // Exercises the (p !== "") false arm in the .filter() for department_name = ""
-    const row = txn();
-    const holder = row["card_holder"] as Record<string, unknown>;
-    delete holder["department_name"];
-    expect(filterRampTransactions([row], { query: "Ada" })).toHaveLength(1);
-    expect(filterRampTransactions([row], { query: "Engineering" })).toHaveLength(0);
-  });
+  // One row per card_holder field, each exercising the (p !== "") false arm in the .filter() for
+  // that field: the surviving fields still match, and the deleted one no longer does.
+  test.each([
+    ["first_name", "Lovelace", "Ada"],
+    ["last_name", "Ada", "Lovelace"],
+    ["department_name", "Ada", "Engineering"],
+  ])(
+    "card_holder present but %s missing — still matches the remaining fields",
+    (field, stillMatches, noLongerMatches) => {
+      const row = txn();
+      const holder = row["card_holder"] as Record<string, unknown>;
+      delete holder[field];
+      expect(filterRampTransactions([row], { query: stillMatches })).toHaveLength(1);
+      expect(filterRampTransactions([row], { query: noLongerMatches })).toHaveLength(0);
+    },
+  );
 
   test("card_holder present with all name fields missing — cardHolderName returns empty string", () => {
     // All three filter(p !== "") arms produce false; cardHolderName contributes "" to the haystack

--- a/packages/mcp-connectors/readwise/test/sandbox.test.ts
+++ b/packages/mcp-connectors/readwise/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/salesforce/test/sandbox.test.ts
+++ b/packages/mcp-connectors/salesforce/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/semgrep/test/sandbox.test.ts
+++ b/packages/mcp-connectors/semgrep/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/sentry/test/sandbox.test.ts
+++ b/packages/mcp-connectors/sentry/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/shared/imap-tool-kit.test.ts
+++ b/packages/mcp-connectors/shared/imap-tool-kit.test.ts
@@ -208,39 +208,17 @@ describe("envInt", () => {
     expect(envInt("__TEST_IMAP_PORT", 993)).toBe(993);
   });
 
-  test("returns fallback for empty string", () => {
-    process.env["__TEST_IMAP_PORT"] = "";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(993);
-    delete process.env["__TEST_IMAP_PORT"];
-  });
-
-  test("parses a valid port", () => {
-    process.env["__TEST_IMAP_PORT"] = "587";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(587);
-    delete process.env["__TEST_IMAP_PORT"];
-  });
-
-  test("returns fallback for non-numeric value", () => {
-    process.env["__TEST_IMAP_PORT"] = "notanumber";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(993);
-    delete process.env["__TEST_IMAP_PORT"];
-  });
-
-  test("returns fallback for 0 (below range)", () => {
-    process.env["__TEST_IMAP_PORT"] = "0";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(993);
-    delete process.env["__TEST_IMAP_PORT"];
-  });
-
-  test("returns fallback for 65536 (above range)", () => {
-    process.env["__TEST_IMAP_PORT"] = "65536";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(993);
-    delete process.env["__TEST_IMAP_PORT"];
-  });
-
-  test("accepts 65535 (boundary)", () => {
-    process.env["__TEST_IMAP_PORT"] = "65535";
-    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(65535);
+  // fallback 993 throughout, so the expected value doubles as "was the raw value accepted?"
+  test.each([
+    ["empty string", "", 993],
+    ["a valid port", "587", 587],
+    ["a non-numeric value", "notanumber", 993],
+    ["0 (below range)", "0", 993],
+    ["65536 (above range)", "65536", 993],
+    ["65535 (upper boundary)", "65535", 65535],
+  ])("%s → %s", (_label, raw, expected) => {
+    process.env["__TEST_IMAP_PORT"] = raw;
+    expect(envInt("__TEST_IMAP_PORT", 993)).toBe(expected);
     delete process.env["__TEST_IMAP_PORT"];
   });
 

--- a/packages/mcp-connectors/slack/test/sandbox.test.ts
+++ b/packages/mcp-connectors/slack/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/snyk/test/sandbox.test.ts
+++ b/packages/mcp-connectors/snyk/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/sonarqube/test/sandbox.test.ts
+++ b/packages/mcp-connectors/sonarqube/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/stackoverflow/test/sandbox.test.ts
+++ b/packages/mcp-connectors/stackoverflow/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/storybook/test/sandbox.test.ts
+++ b/packages/mcp-connectors/storybook/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/stripe/test/sandbox.test.ts
+++ b/packages/mcp-connectors/stripe/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/teams/test/sandbox.test.ts
+++ b/packages/mcp-connectors/teams/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/testflight/test/sandbox.test.ts
+++ b/packages/mcp-connectors/testflight/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/vercel/test/sandbox.test.ts
+++ b/packages/mcp-connectors/vercel/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/vertex-ai/test/sandbox.test.ts
+++ b/packages/mcp-connectors/vertex-ai/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/wiz/test/sandbox.test.ts
+++ b/packages/mcp-connectors/wiz/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/zendesk/test/sandbox.test.ts
+++ b/packages/mcp-connectors/zendesk/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/zoom/test/sandbox.test.ts
+++ b/packages/mcp-connectors/zoom/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp-connectors/zotero/test/sandbox.test.ts
+++ b/packages/mcp-connectors/zotero/test/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSandboxContractTests } from "@nimbus-dev/sdk/testing";
@@ -7,6 +7,6 @@ const manifestPath = resolve(fileURLToPath(import.meta.url), "../../nimbus.exten
 
 describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])("sandbox contract", () => {
   it("respects declared permissions", async () => {
-    await runSandboxContractTests(manifestPath);
+    await expect(runSandboxContractTests(manifestPath)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why the board jumped 10 → 171

Not new debt. The **`Sonar way` TypeScript quality profile was updated 2026-07-29**, activating two test-file rules. Sonar backdates issues from newly-activated rules to each line's last commit date, so the count jumped while the **quality gate stayed green** — nothing landed in the new-code period. All 171 are pre-existing code.

| Rule | Count | Fix |
| --- | --- | --- |
| `S2699` tests should include assertions | 118 (BLOCKER) | see below |
| `S5976` similar tests → parameterized | 48 (MAJOR) | `test.each` / `it.each` across 37 files |
| `S3358` nested ternary | 2 | extracted `embeddingBindDetail`, `vaultLineSuffix` |
| `S6582` prefer optional chain | 2 | `locked === null \|\| locked.code !== 0` → `locked?.code !== 0` |
| `S8754` duplicate test title | 1 | qualified both Looker mapper titles |

**Zero suppressions, zero rule exclusions.** Every issue fixed in code, test files held to production standard, per `docs/structure-audit/sonarqube-rule-tuning.md`.

## S2699 (118)

- **79× `mcp-connectors/*/test/sandbox.test.ts`** — byte-identical files whose assertions live inside the SDK's `runSandboxContractTests`, which Sonar can't see through. Now assert the contract the test actually makes: `await expect(runSandboxContractTests(m)).resolves.toBeUndefined()`.
- **21× `lazy-mesh/mesh.test.ts`** — the 18 `ensure<Service>Running` no-op tests became one table-driven test (which also pre-empts an `S5976` hit); the rest assert `resolves.toBeUndefined()`.
- **15 scattered** — asserted the outcome each test already relied on: `not.toThrow()`, `resolves.toBeUndefined()`, or for the dispatcher fall-through tests `expect(outcome).not.toBe(<namespace>RpcSkipped)`, matching the existing `"skips other methods"` convention in those files.
- **3 permanently-skipped empty placeholders** (`session`, `slice7-lineage`, `repair`) → `KNOWN GAP` comments.

## Three judgment calls worth reviewer attention

1. **`S5976` groups came from the API, not from reading the file.** The rule reports on the *first test of a group*, and that group is often not the visually adjacent block — in `person-id.test.ts` the flagged trio was lines 17/43/62, not 17/23/29. Group membership was read from each issue's secondary locations (`Related test` flows). Where a neighbouring test was semantically identical but escaped the group on an AST difference, it was folded in too, so nothing regroups on the next scan.
2. **`test.todo` was rejected, not overlooked.** bun-types requires a callback, which leaves an empty body `S2699` still flags. A skipped stub that can never run documents a gap no better than a comment, so the three placeholders became comments.
3. **The sandbox assertion was red-proved before being applied to 79 files** — confirmed a rejecting promise *fails* the test rather than passing silently.

## Verification

- `typecheck` 0 · `biome` 3024 files clean (`--error-on-warnings`)
- Tests: gateway 8993 + 2630 · cli 1899 · mcp-connectors 948 — all pass
- `check-nimbus-invariants` 0 · `audit:cross-platform` clean
- **`coverage-floor` ok against Docker-Linux lcov.** Run authoritatively rather than assumed: an optional-chain refactor trims a file's branch count, which has previously tipped a borderline file under the per-file floor.

## Pre-existing, NOT touched

`packages/gateway/test/integration/updater/wiring.test.ts:78` fails identically on a clean `origin/main` worktree (`_platformOverride: "linux-x86_64"` → factory returns `undefined`). Separate defect on main, outside this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation for CLI, gateway, connector, search, configuration, authentication, logging, and sandbox behaviors.
  * Added clearer assertions for successful asynchronous operations, error handling, limits, fallbacks, credential safety, and status rendering.
  * Improved coverage of malformed, invalid, missing, and boundary-value inputs across integrations.

* **Refactor**
  * Consolidated repetitive test scenarios into data-driven test suites, making coverage easier to maintain without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->