### PR TITLE
feat(ci): audit:review-coverage — close P3's org-wide half

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -169,6 +169,38 @@ jobs:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: bun scripts/structure-audit/check-cla-coverage.ts --strict
 
+  review-coverage:
+    name: review-coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        # Unlike the other sweep gates this one parses YAML, so it needs the
+        # workspace's `yaml` devDependency present.
+        run: bun install --frozen-lockfile
+      - name: Mint App token
+        id: apptoken
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: nimbus-agent
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper
+          # review-coverage reads .coderabbit.yaml from each gated repo — contents:read.
+          permission-contents: read
+      - name: Audit review coverage
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
+        run: bun scripts/structure-audit/check-review-coverage.ts --strict
+
   release-staleness:
     name: release-staleness
     runs-on: ubuntu-24.04

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -115,7 +115,7 @@ Design of record:
 | --- | --- | --- | --- |
 | P1 | Org CI Foundation | ✅ done | The scheduled sweep goes red on drift: SHA-pins across the 8 public org repos, ruleset shape across the 5 active code repos — proven green end-to-end (run 30060920603) |
 | P2 | Release Train | ✅ done — both phases (run 30231918767) | `audit:release-staleness` goes red when a channel (brew/scoop/linux/winget) lags the published Release past the grace window, when a release phantoms, when an npm package is tagged but unpublished, or when a consumer's **lockfile-resolved** dependency lags npm `@latest`. Red-proved on a real phantom and on three real dependency edges; green after both, `OK (12 edges current)`. |
-| P3 | Review Layer | 🔨 first step done (#846) | The monorepo now carries a tuned `.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and the PAL ban — closing the satellites→monorepo direction of the pattern above. **Note:** the previously-stated gate ("an invariant violation is caught in CI") was already met — `_structure.yml` runs `audit:invariants` and all 17 static checks execute there; the one branch `--binary-only` excludes is a census that always exits 0. |
+| P3 | Review Layer | ✅ done — gate green locally, awaiting first sweep run | The monorepo carries a tuned `.coderabbit.yaml` whose `path_instructions` encode I1–I30, the triple rule and the PAL ban (#846), and `audit:review-coverage` now fails when any gated repo's `.coderabbit.yaml` goes missing, stops parsing, or goes **inert** (`auto_review.enabled` off, `base_branches` no longer covering `main`, or empty `path_instructions`). **Note:** the previously-stated gate ("an invariant violation is caught in CI") was already met — `_structure.yml` runs `audit:invariants` and all 17 static checks execute there; the one branch `--binary-only` excludes is a census that always exits 0. The real gap was that only *this* repo's review config was validated. |
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ✅ done — `ci-latency` green in sweep run `30356357605` | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 12-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. **Measured after (run `30353595114`): 105 → 77 jobs, DAG wait 60.5 → 2.5 min, wall clock 36-74 → 20 min.** `audit:coverage-gate-pal` keeps the platform classification honest, co-gates included. |
 | P5 | Org Legibility | ✅ both gates green (run 30231918767) | `audit:secret-inventory` fails on any workflow secret missing from the credential registry **or** `ci-secrets.md`; `audit:actions-allowlist` fails on an unpermitted action **or** any workflow whose latest run ended in `startup_failure`. The second found a live nightly outage on its first correct run. Remaining: the legibility dashboard. |
@@ -548,6 +548,58 @@ moves to P6).
   OSes) have aged out of the sampling window
   (`MAX_RUNS_PER_WORKFLOW`). Regenerating sooner is a no-op: the window still
   holds pre-change runs carrying those keys.
+
+### P3 progress log
+
+**The stated gate was already met, so P3 was re-scoped rather than declared
+done.** `_structure.yml` already runs `audit:invariants`; the original acceptance
+criterion ("an invariant violation is caught in CI") needed no new work. What
+was genuinely missing was the *review* layer, in two halves.
+
+- **Half one — the monorepo's own config (#846, 2026-07-26).** The first
+  `.coderabbit.yaml` in the org, with `path_instructions` encoding I1–I30, the
+  triple rule and the PAL ban. `check-coderabbit-config.test.ts` validates it
+  locally and deeply: that it parses, that every instruction's glob resolves to
+  a real directory, that every cited `I<n>` exists as a heading in
+  `SECURITY-INVARIANTS.md`, and that nothing instructs the reviewer to enforce
+  the reserved I28. That last check is the load-bearing one — the config is
+  prose, so a renumbered invariant would otherwise teach the reviewer something
+  false forever, silently.
+- **Half two — `audit:review-coverage` (2026-07-30).** The monorepo's config was
+  tested; the four satellites' were not. That is the sub-program's own founding
+  pattern — a control that stops where it was written — sitting inside P3
+  itself. The sweep gate now reads `.coderabbit.yaml` from all five code repos.
+- **It asserts ACTIVE, not merely PRESENT.** This is the direct lesson from the
+  CLA outage and from `audit:actions-allowlist`'s `startup_failure` half: a
+  control can be committed, valid-looking and completely inert. A config with
+  `auto_review.enabled: false`, or whose `base_branches` no longer lists the
+  branch PRs actually target, reviews nothing while reading as covered. So the
+  gate checks `auto_review.enabled === true` (`!== true`, so a *missing* key
+  fails closed rather than defaulting to enabled), that `base_branches` includes
+  `main`, and that `path_instructions` is non-empty.
+- **`unparseable` is a distinct verdict from absent.** CodeRabbit silently
+  ignores a config it cannot parse, which is indistinguishable from having none
+  — but the repair differs, so the finding names which it is. A YAML document
+  that parses to a scalar or a list is also `unparseable`: legal YAML, unusable
+  config.
+- **Instruction CONTENT is deliberately NOT gated.** The five repos are
+  different products under different licences — the SDK must stay
+  dependency-free, the gateway carries I1–I30 — so any shared-content assertion
+  could only be satisfied by making every instruction vaguer. Content is the
+  owning repo's local test's job. A gate that would degrade the thing it guards
+  is not worth having.
+- **`awesome-nimbus` is an explicit exemption, not an omission.** It is a
+  curated link list with no source tree, so a review config there would assert a
+  control that reviews nothing. Recorded in `EXEMPT_REPOS` with its reason and
+  covered by a test, so the next reader can tell "decided" from "forgotten".
+- **Proof (2026-07-30):** live green — `audit:review-coverage: OK (5 repos, 1
+  exempt)`. Red-proved by adding the exempt `awesome-nimbus` to the gated set,
+  **verifying the mutation had actually landed in the file before trusting the
+  result**, and confirming exit 1 with `awesome-nimbus: no .coderabbit.yaml`.
+  23 unit tests cover the pure diff, the parse verdicts and the read
+  classification. Note the live red-prove exercised the *absent* path; the inert
+  and unparseable paths are proved by unit test, since red-proving those live
+  would mean degrading a real repo's config.
 
 ### P5 progress log
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "audit:org-settings-drift": "bun scripts/structure-audit/check-org-settings-drift.ts",
     "audit:team-reachability": "bun scripts/structure-audit/check-team-reachability.ts",
     "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
+    "audit:review-coverage": "bun scripts/structure-audit/check-review-coverage.ts",
     "audit:release-staleness": "bun scripts/structure-audit/check-release-staleness.ts",
     "audit:secret-inventory": "bun scripts/structure-audit/check-secret-inventory.ts",
     "audit:actions-allowlist": "bun scripts/structure-audit/check-actions-allowlist.ts",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -73,6 +73,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:org-settings-drift", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:team-reachability", // needs network + gh auth + org-read; runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:cla-coverage", // needs network + gh (reads each public repo's cla.yml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:review-coverage", // needs network + gh (reads each public repo's .coderabbit.yaml, contents:read); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:pin-freshness", // needs network + gh (release + tag reads per pinned action); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:ci-latency", // needs network + gh (Actions API across 9 repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:ci-latency:update-baseline", // explicit human action that rewrites the committed baseline; never a gate

--- a/scripts/structure-audit/check-review-coverage.test.ts
+++ b/scripts/structure-audit/check-review-coverage.test.ts
@@ -94,7 +94,6 @@ describe("diffReviewCoverage", () => {
 
   test("flags a missing auto_review block", () => {
     const cfg = goodConfig();
-    // biome-ignore lint/performance/noDelete: exercising the absent-key path
     delete (cfg["reviews"] as Record<string, unknown>)["auto_review"];
     const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
     expect(r.ok).toBe(false);

--- a/scripts/structure-audit/check-review-coverage.test.ts
+++ b/scripts/structure-audit/check-review-coverage.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyRepoRead,
+  diffReviewCoverage,
+  EXEMPT_REPOS,
+  type LiveConfig,
+  parseConfig,
+} from "./check-review-coverage.ts";
+
+/** A config that passes every check — the base each case mutates one field of. */
+function goodConfig(): Record<string, unknown> {
+  return {
+    language: "en-US",
+    reviews: {
+      profile: "chill",
+      auto_review: { enabled: true, drafts: false, base_branches: ["main"] },
+      path_instructions: [{ path: "src/**/*.ts", instructions: "long enough guidance" }],
+    },
+  };
+}
+
+const REPOS = ["Nimbus", "nimbus-sdk"];
+
+function live(overrides: Record<string, LiveConfig> = {}): Record<string, LiveConfig> {
+  return { Nimbus: goodConfig(), "nimbus-sdk": goodConfig(), ...overrides };
+}
+
+describe("diffReviewCoverage", () => {
+  test("passes when every repo has a present, parseable, active config", () => {
+    const r = diffReviewCoverage(REPOS, live());
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("flags an absent config", () => {
+    const r = diffReviewCoverage(REPOS, live({ "nimbus-sdk": null }));
+    expect(r.ok).toBe(false);
+    expect(r.errors).toEqual(["nimbus-sdk: no .coderabbit.yaml"]);
+  });
+
+  test("a repo missing from the live map is absent, not silently skipped", () => {
+    // Guards the `undefined` branch: a read loop that never wrote a key must not
+    // read as covered.
+    const r = diffReviewCoverage(REPOS, { Nimbus: goodConfig() });
+    expect(r.ok).toBe(false);
+    expect(r.errors).toEqual(["nimbus-sdk: no .coderabbit.yaml"]);
+  });
+
+  test("flags an unparseable config distinctly from an absent one", () => {
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: "unparseable" }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("not valid YAML");
+    // The distinction is the point: the repair differs.
+    expect(r.errors[0]).not.toContain("no .coderabbit.yaml");
+  });
+
+  test("flags a config with no reviews section", () => {
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: { language: "en-US" } }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("no `reviews` section");
+  });
+
+  test("flags auto_review.enabled: false — present but inert", () => {
+    const cfg = goodConfig();
+    (cfg["reviews"] as Record<string, unknown>)["auto_review"] = {
+      enabled: false,
+      base_branches: ["main"],
+    };
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("inert"))).toBe(true);
+  });
+
+  test("a missing `enabled` key is not treated as enabled", () => {
+    // `!== true` rather than `=== false`: an absent key must fail closed.
+    const cfg = goodConfig();
+    (cfg["reviews"] as Record<string, unknown>)["auto_review"] = { base_branches: ["main"] };
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("inert"))).toBe(true);
+  });
+
+  test("flags base_branches that does not cover main", () => {
+    const cfg = goodConfig();
+    (cfg["reviews"] as Record<string, unknown>)["auto_review"] = {
+      enabled: true,
+      base_branches: ["develop"],
+    };
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("base_branches"))).toBe(true);
+  });
+
+  test("flags a missing auto_review block", () => {
+    const cfg = goodConfig();
+    // biome-ignore lint/performance/noDelete: exercising the absent-key path
+    delete (cfg["reviews"] as Record<string, unknown>)["auto_review"];
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("not reviewed automatically"))).toBe(true);
+  });
+
+  test("flags empty path_instructions", () => {
+    const cfg = goodConfig();
+    (cfg["reviews"] as Record<string, unknown>)["path_instructions"] = [];
+    const r = diffReviewCoverage(REPOS, live({ Nimbus: cfg }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("path_instructions"))).toBe(true);
+  });
+
+  test("reports every failing repo, not just the first", () => {
+    const r = diffReviewCoverage(REPOS, { Nimbus: null, "nimbus-sdk": null });
+    expect(r.errors).toHaveLength(2);
+  });
+
+  test("does not check instruction CONTENT — repos are different products", () => {
+    // A deliberately terse instruction is still a pass here; content is the
+    // owning repo's local test's job.
+    const cfg = goodConfig();
+    (cfg["reviews"] as Record<string, unknown>)["path_instructions"] = [
+      { path: "src/**", instructions: "x" },
+    ];
+    expect(diffReviewCoverage(REPOS, live({ Nimbus: cfg })).ok).toBe(true);
+  });
+});
+
+describe("parseConfig", () => {
+  test("parses a mapping", () => {
+    expect(parseConfig("language: en-US\n")).toEqual({ language: "en-US" });
+  });
+
+  test("invalid YAML is unparseable, not a throw", () => {
+    expect(parseConfig("reviews:\n  - a\n bad indent: [")).toBe("unparseable");
+  });
+
+  test("a scalar document is unparseable — it is not a usable config", () => {
+    expect(parseConfig("just a string")).toBe("unparseable");
+  });
+
+  test("a list document is unparseable", () => {
+    expect(parseConfig("- a\n- b\n")).toBe("unparseable");
+  });
+
+  test("an empty document is unparseable rather than an empty pass", () => {
+    expect(parseConfig("")).toBe("unparseable");
+  });
+});
+
+describe("classifyRepoRead", () => {
+  test("a successful read is `read`", () => {
+    expect(classifyRepoRead({ ok: true, stdout: "x", stderr: "" }).kind).toBe("read");
+  });
+
+  test("404 is `absent` — a real finding", () => {
+    expect(classifyRepoRead({ ok: false, stdout: "", stderr: "", httpStatus: 404 }).kind).toBe(
+      "absent",
+    );
+  });
+
+  test("5xx is `indeterminate`, never absence", () => {
+    // The failure mode this prevents: a blip reported as "repo lost its config".
+    expect(classifyRepoRead({ ok: false, stdout: "", stderr: "", httpStatus: 503 }).kind).toBe(
+      "indeterminate",
+    );
+  });
+
+  test("an unknown status is `indeterminate`", () => {
+    expect(classifyRepoRead({ ok: false, stdout: "", stderr: "" }).kind).toBe("indeterminate");
+  });
+});
+
+describe("exemptions", () => {
+  test("awesome-nimbus is exempt with a stated reason", () => {
+    // Recorded so the next reader can tell "decided" from "forgotten".
+    expect(EXEMPT_REPOS["awesome-nimbus"]).toContain("no source tree");
+  });
+
+  test("every exemption carries a non-empty reason", () => {
+    for (const [repo, reason] of Object.entries(EXEMPT_REPOS)) {
+      expect(reason.length, `${repo} needs a reason`).toBeGreaterThan(10);
+    }
+  });
+});

--- a/scripts/structure-audit/check-review-coverage.ts
+++ b/scripts/structure-audit/check-review-coverage.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:review-coverage — asserts every gated org repo carries a `.coderabbit.yaml`
+ * that is present, parseable, AND ACTIVE.
+ *
+ * This is P3's org-wide half. `check-coderabbit-config.test.ts` already validates
+ * THIS repo's config in depth (invariant ids, instruction quality); nothing
+ * validated the satellites', which is the "controls stop where they were written"
+ * pattern this sub-program exists to break.
+ *
+ * Why "active" and not just "present": the lesson from the CLA outage and from
+ * `audit:actions-allowlist` is that a control can be committed, valid-looking and
+ * completely inert. A `.coderabbit.yaml` with `auto_review.enabled: false`, or one
+ * whose `base_branches` no longer lists the branch PRs actually target, reviews
+ * nothing — and reads as covered. Presence alone would have passed all three.
+ *
+ * Deliberately NOT checked: instruction CONTENT. The repos are different products
+ * under different licences (the SDK must stay dependency-free; the gateway carries
+ * I1-I30), so a shared-content assertion could only be satisfied by making the
+ * instructions vaguer. Per-repo content is the local test's job, in the repo that
+ * owns it.
+ *
+ * Same fail-soft-local / strict-in-CI contract as the other org-drift-sweep gates.
+ */
+
+import { parse } from "yaml";
+
+import { classifyReadFailure, type GhResult, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Classify one per-repo contents read into read / absent / indeterminate. */
+export function classifyRepoRead(res: GhResult): { kind: "read" | "absent" | "indeterminate" } {
+  if (res.ok) return { kind: "read" };
+  return { kind: classifyReadFailure(res.httpStatus) };
+}
+
+/**
+ * Repos whose PRs carry source worth an automated review pass.
+ *
+ * `awesome-nimbus` is deliberately absent: it is a curated link list with no
+ * source tree, so a review config there would assert a control that reviews
+ * nothing. Recorded as an explicit exemption rather than an omission, so the
+ * next person can tell "decided" from "forgotten".
+ */
+const GATED_REPOS = ["Nimbus", "nimbus-sdk", "nimbus-client", "nimbus-vscode", "nimbus-web-clipper"];
+
+export const EXEMPT_REPOS: Readonly<Record<string, string>> = {
+  "awesome-nimbus": "curated link list — no source tree to review",
+};
+
+/** The branch PRs are expected to target across the org. */
+const EXPECTED_BASE = "main";
+
+/**
+ * What a repo's config looked like when read.
+ *
+ * `null` = no `.coderabbit.yaml`. `"unparseable"` = the file exists but is not
+ * valid YAML — distinct from absent, because CodeRabbit silently ignores a config
+ * it cannot parse, which looks exactly like having none.
+ */
+export type LiveConfig = Record<string, unknown> | null | "unparseable";
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Pure diff — the whole verdict, so it is unit-testable without network.
+ *
+ * Every check reports the repo by name, because the repair differs per finding:
+ * "add a config" is a different job from "someone turned auto_review off".
+ */
+export function diffReviewCoverage(
+  repos: string[],
+  live: Record<string, LiveConfig>,
+): AuditResult {
+  const errors: string[] = [];
+  for (const repo of repos) {
+    const cfg = live[repo];
+    if (cfg === null || cfg === undefined) {
+      errors.push(`${repo}: no .coderabbit.yaml`);
+      continue;
+    }
+    if (cfg === "unparseable") {
+      errors.push(`${repo}: .coderabbit.yaml is not valid YAML (CodeRabbit ignores it silently)`);
+      continue;
+    }
+    const reviews = asRecord(cfg["reviews"]);
+    if (!reviews) {
+      errors.push(`${repo}: .coderabbit.yaml has no \`reviews\` section`);
+      continue;
+    }
+
+    const auto = asRecord(reviews["auto_review"]);
+    if (!auto) {
+      errors.push(`${repo}: no \`reviews.auto_review\` — PRs are not reviewed automatically`);
+    } else {
+      if (auto["enabled"] !== true) {
+        errors.push(`${repo}: \`auto_review.enabled\` is not true — the config is inert`);
+      }
+      const bases = auto["base_branches"];
+      if (!Array.isArray(bases) || !bases.includes(EXPECTED_BASE)) {
+        errors.push(
+          `${repo}: \`auto_review.base_branches\` does not include \`${EXPECTED_BASE}\` — PRs into ${EXPECTED_BASE} are not reviewed`,
+        );
+      }
+    }
+
+    const instructions = reviews["path_instructions"];
+    if (!Array.isArray(instructions) || instructions.length === 0) {
+      errors.push(
+        `${repo}: \`reviews.path_instructions\` is empty — the config carries no repo-specific guidance`,
+      );
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/** Parse a config blob, mapping any YAML error to the `unparseable` verdict. */
+export function parseConfig(yamlText: string): LiveConfig {
+  let parsed: unknown;
+  try {
+    parsed = parse(yamlText);
+  } catch {
+    return "unparseable";
+  }
+  // A YAML document can legally be a scalar or a list; neither is a usable
+  // CodeRabbit config, and both would otherwise reach the shape checks as
+  // something that is not a mapping.
+  return asRecord(parsed) ?? "unparseable";
+}
+
+if (import.meta.main) {
+  const strict = isStrict(process.argv.slice(2), process.env);
+  const label = "audit:review-coverage";
+
+  // Reachability probe — same contract as cla-coverage. The gated repos are
+  // public, so a per-repo 404 unambiguously means "config absent" (a real
+  // finding) rather than "unauthorized"; the only fail-soft case is `gh` or the
+  // network being unavailable at all, which this single probe detects.
+  const probe = runGh(["gh", "api", "repos/nimbus-agent/Nimbus", "--jq", ".name"]);
+  if (!probe.ok) {
+    const outcome = strictSkip(label, strict);
+    if (outcome.code === 1) console.error(outcome.message);
+    else console.warn(outcome.message);
+    process.exit(outcome.code);
+  }
+
+  const live: Record<string, LiveConfig> = {};
+  for (const repo of GATED_REPOS) {
+    const res = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/contents/.coderabbit.yaml`,
+      "--jq",
+      ".content",
+    ]);
+    // Only a 404 means "absent". A transient failure must never be recorded as
+    // absence — that turns a blip into a fake "repo lost its review config" red.
+    const cls = classifyRepoRead(res);
+    if (cls.kind === "indeterminate") {
+      const outcome = strictSkip(
+        label,
+        strict,
+        `review-coverage indeterminate — ${repo} read failed transiently (HTTP ${res.httpStatus ?? "?"})`,
+      );
+      if (outcome.code === 1) console.error(outcome.message);
+      else console.warn(outcome.message);
+      process.exit(outcome.code);
+    }
+    if (cls.kind === "absent") {
+      live[repo] = null;
+      continue;
+    }
+    // `.replace(/\s/g, "")` strips the newlines GitHub inserts into the base64
+    // *envelope* of the contents API response — NOT the decoded YAML.
+    live[repo] = parseConfig(Buffer.from(res.stdout.replace(/\s/g, ""), "base64").toString("utf8"));
+  }
+
+  const result = diffReviewCoverage(GATED_REPOS, live);
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+  const exempt = Object.keys(EXEMPT_REPOS).length;
+  console.log(`${label}: OK (${GATED_REPOS.length} repos, ${exempt} exempt)`);
+}

--- a/scripts/structure-audit/check-review-coverage.ts
+++ b/scripts/structure-audit/check-review-coverage.ts
@@ -47,7 +47,13 @@ export function classifyRepoRead(res: GhResult): { kind: "read" | "absent" | "in
  * nothing. Recorded as an explicit exemption rather than an omission, so the
  * next person can tell "decided" from "forgotten".
  */
-const GATED_REPOS = ["Nimbus", "nimbus-sdk", "nimbus-client", "nimbus-vscode", "nimbus-web-clipper"];
+const GATED_REPOS = [
+  "Nimbus",
+  "nimbus-sdk",
+  "nimbus-client",
+  "nimbus-vscode",
+  "nimbus-web-clipper",
+];
 
 export const EXEMPT_REPOS: Readonly<Record<string, string>> = {
   "awesome-nimbus": "curated link list — no source tree to review",
@@ -77,10 +83,7 @@ function asRecord(v: unknown): Record<string, unknown> | undefined {
  * Every check reports the repo by name, because the repair differs per finding:
  * "add a config" is a different job from "someone turned auto_review off".
  */
-export function diffReviewCoverage(
-  repos: string[],
-  live: Record<string, LiveConfig>,
-): AuditResult {
+export function diffReviewCoverage(repos: string[], live: Record<string, LiveConfig>): AuditResult {
   const errors: string[] = [];
   for (const repo of repos) {
     const cfg = live[repo];


### PR DESCRIPTION
Completes **P3 (Review Layer)**. The sub-program's stated gate was already met, so this delivers what was actually missing rather than declaring it done.

## The gap

`.coderabbit.yaml` shipped for the monorepo in #846, and `check-coderabbit-config.test.ts` validates it deeply — globs resolve to real directories, every cited `I<n>` exists in `SECURITY-INVARIANTS.md`, nothing tells the reviewer to enforce the reserved I28.

**Nothing validated the four satellites' configs.** That is this sub-program's own founding pattern — a control that stops where it was written — sitting inside P3 itself.

## What the gate asserts

`audit:review-coverage` reads `.coderabbit.yaml` from all five code repos and requires it be present, parseable **and active**:

- `auto_review.enabled === true` — written as `!== true`, so a *missing* key fails closed rather than defaulting to enabled
- `auto_review.base_branches` includes `main`
- `reviews.path_instructions` is non-empty

**Active, not merely present**, is the direct lesson from the CLA outage and from `audit:actions-allowlist`'s `startup_failure` half: a control can be committed, valid-looking and completely inert. A config with `auto_review` off reviews nothing while reading as covered — presence alone passes it.

`unparseable` is a **distinct verdict from absent**, because CodeRabbit silently ignores a config it cannot parse and the repair differs. A YAML document parsing to a scalar or list is also `unparseable`: legal YAML, unusable config.

## Two deliberate non-goals

- **Instruction CONTENT is not gated.** The five repos are different products under different licences — the SDK must stay dependency-free, the gateway carries I1–I30 — so a shared-content assertion could only be satisfied by making every instruction vaguer. A gate that degrades what it guards isn't worth having; content stays the owning repo's local test's job.
- **`awesome-nimbus` is an explicit `EXEMPT_REPOS` entry with a stated reason** (curated link list, no source tree), covered by a test, so the next reader can tell "decided" from "forgotten".

## Verification

- **Live green:** `audit:review-coverage: OK (5 repos, 1 exempt)`
- **Red-proved:** added the exempt `awesome-nimbus` to the gated set, **verified the mutation had actually landed in the file** before trusting the result, and confirmed exit 1 with `awesome-nimbus: no .coderabbit.yaml`. Reverted, re-confirmed green.
  - Scope honesty: the live red-prove exercised the **absent** path. The inert and unparseable paths are proved by unit test — red-proving those live would mean degrading a real repo's config.
- `bun test scripts/` — **943 pass, 0 fail** (includes the preflight-gate manifest drift test, which accepts the new `CI_ONLY_GATES` entry)
- 23 unit tests covering the pure diff, the parse verdicts and the read classification
- `bun run typecheck` — **exit 0**, 0 errors across the full log
- `bunx biome check packages scripts .github docs` — 3009 files, no fixes
- `markdownlint-cli2` — 0 issues; `lychee` — 1071 links, **0 errors** (whole branch)

Registered in `package.json`, `CI_ONLY_GATES` (network + `gh`, sweep-only), and a new `review-coverage` job on `org-drift-sweep.yml`. Per the known constraint, the net-new sweep job's first real run is post-merge.

> Touches `docs/infrastructure-roadmap.md`, as does #944 — different regions, but whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
