### PR TITLE
ci(install-smoke): run the shipped embedding config; refresh the Gate 1 runbook

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -179,19 +179,19 @@ jobs:
       - name: Quickstart smoke — init + why (Unix)
         if: runner.os != 'Windows'
         shell: bash
-        env:
-          # The Gateway does not bind its socket until the embedding runtime
-          # finishes initializing, and on a cold machine that means fetching
-          # MiniLM from HuggingFace (init timeout defaults to 600 s). The
-          # macOS runner sat at "starting embedding runtime" for a full 300 s
-          # without binding, so this is a real first-run cost, not slowness —
-          # tracked as a launch blocker; see the Gate 1 runbook.
-          #
-          # Skip it here: what this job exists to prove is the init → sync →
-          # why path, and neither `index.demoSymbol` (reads indexed symbols)
-          # nor `nimbus why` (blame + graph lanes) touches a vector table.
-          # Leaving it on would couple every run to a third-party CDN.
-          NIMBUS_SKIP_EMBEDDING_RUNTIME: "1"
+        # No `NIMBUS_SKIP_EMBEDDING_RUNTIME` here — deliberately. This job used
+        # to set it because the gateway would not bind its socket until the
+        # embedding runtime finished, which on a cold machine meant fetching
+        # MiniLM from a third-party CDN; the macOS runner sat at "starting
+        # embedding runtime" for 300 s without binding. #928 removed that
+        # coupling (bind-first: the runtime constructs in the background and a
+        # failed fetch settles to `unavailable` while the gateway keeps
+        # serving), so the skip now hides the very configuration real users run.
+        #
+        # Green is still NOT coupled to that CDN: nothing asserted below needs a
+        # vector — `index.demoSymbol` reads indexed symbols and `nimbus why`
+        # uses blame + graph lanes. The embedding assertion after the quickstart
+        # checks that embeddings are ENABLED, never that the model finished.
         run: |
           set -euo pipefail
           export HOME="$RUNNER_TEMP/fake-home"
@@ -301,6 +301,38 @@ jobs:
             echo "::error::nimbus why produced no Authorship section"; exit 1; }
           grep -q "Smoke Test" "$RUNNER_TEMP/why.log" || {
             echo "::error::nimbus why did not resolve the commit author"; exit 1; }
+
+          # The gateway logs `[gateway] embeddings: <state>` at bind time (#928).
+          # Assert embeddings are genuinely ON in this run — the guard against
+          # someone quietly restoring NIMBUS_SKIP_EMBEDDING_RUNTIME and turning
+          # this job back into a test of a configuration nobody ships.
+          #
+          # `disabled` is the ONLY failing state. `warming` and `unavailable`
+          # both pass on purpose: the first means the fetch is still running,
+          # the second that it failed — and bind-first says neither may stop the
+          # gateway serving. Requiring `ready` would couple green CI to a
+          # third-party CDN, which is exactly what made this job flaky before.
+          embed_line=""
+          for d in "$HOME/.local/share/nimbus/logs" \
+                   "$HOME/Library/Application Support/Nimbus/logs"; do
+            [ -d "$d" ] || continue
+            for f in "$d"/*.log; do
+              [ -f "$f" ] || continue
+              line=$(grep -h "\[gateway\] embeddings:" "$f" | tail -1 || true)
+              [ -n "$line" ] && embed_line="$line"
+            done
+          done
+          if [ -z "$embed_line" ]; then
+            echo "::error::gateway never logged its embedding readiness — expected '[gateway] embeddings: <state>'"
+            exit 1
+          fi
+          echo "observed: $embed_line"
+          case "$embed_line" in
+            *"embeddings: disabled"*)
+              echo "::error::embeddings are DISABLED — the skip flag is back, so this job no longer covers the shipped first-run configuration"
+              exit 1
+              ;;
+          esac
 
           nimbus stop || true
 
@@ -481,6 +513,27 @@ jobs:
           }
           if ($why -notmatch "Smoke Test") {
             Write-Error "nimbus why did not resolve the commit author"; exit 1
+          }
+
+          # Same guard as the Unix leg: prove embeddings are ENABLED, never that
+          # the model finished. Windows never set NIMBUS_SKIP_EMBEDDING_RUNTIME,
+          # so this leg has always exercised the shipped configuration — the
+          # assertion keeps it that way.
+          $logDir = Join-Path $env:LOCALAPPDATA "Nimbus\data\logs"
+          $embedLine = $null
+          if (Test-Path $logDir) {
+            $embedLine = Get-ChildItem -Path $logDir -Filter *.log -ErrorAction SilentlyContinue |
+              ForEach-Object { Select-String -Path $_.FullName -Pattern '\[gateway\] embeddings:' } |
+              Select-Object -Last 1
+          }
+          if ($null -eq $embedLine) {
+            Write-Error "gateway never logged its embedding readiness — expected '[gateway] embeddings: <state>'"
+            exit 1
+          }
+          Write-Host "observed: $($embedLine.Line)"
+          if ($embedLine.Line -match 'embeddings: disabled') {
+            Write-Error "embeddings are DISABLED — this job no longer covers the shipped first-run configuration"
+            exit 1
           }
 
           nimbus stop

--- a/docs/superpowers/plans/2026-07-28-launch-execution.md
+++ b/docs/superpowers/plans/2026-07-28-launch-execution.md
@@ -717,9 +717,12 @@ The three gates in the spec are human process. They are checklists, not tasks �
 
 ### Gate 1 runbook — foreign-machine proof
 
-**Two Gate 1 blockers are already known — CI found them before a human did.**
-Task 1's assertions caught both on their first real run; `nimbus --help` had
-been passing on machines where `nimbus init` cannot work at all.
+**Three Gate 1 blockers were found by CI before a human did — all now RESOLVED
+(2026-07-30). Gate 1 is unblocked.** Task 1's assertions caught them on their
+first real runs; `nimbus --help` had been passing on machines where
+`nimbus init` cannot work at all. Kept here because the runbook exists to
+re-check exactly these failure classes on a real foreign machine — a closed
+issue is evidence the fix landed, not evidence the machine works.
 
 - **[#925](https://github.com/nimbus-agent/Nimbus/issues/925) — Linux `init`
   fails on any headless machine.** Installing `secret-tool` is necessary but
@@ -727,23 +730,33 @@ been passing on machines where `nimbus init` cannot work at all.
   with no session bus and no unlocked keyring every Vault operation fails and
   the Gateway aborts. That is the state of any server, container, SSH session,
   or WSL install — a large share of the ICP's machines. The README quickstart
-  never named the prerequisite; that half is fixed. Note `nimbus doctor` shares
-  the blind spot: it reports `[ok] Vault: secret-tool is on PATH` from a
-  `Bun.which` check alone, so it says OK where the Vault cannot work.
+  never named the prerequisite. **CLOSED:** the README states the prerequisite,
+  and `nimbus doctor` no longer shares the blind spot — it probed nothing but
+  `Bun.which("secret-tool")` and so reported `[ok]` where the Vault could not
+  work; `doctor-core.ts` now probes the session bus and collection state.
 - **[#928](https://github.com/nimbus-agent/Nimbus/issues/928) — first run
-  blocks on a HuggingFace fetch.** The Gateway does not bind its socket until
-  the embedding runtime initializes, which on a cold machine means downloading
+  blocks on a HuggingFace fetch.** The Gateway did not bind its socket until
+  the embedding runtime initialized, which on a cold machine means downloading
   MiniLM (`DEFAULT_EMBEDDING_INIT_TIMEOUT_MS = 600_000`). The macOS runner sat
   at "starting embedding runtime" for a full 300 s without binding. For the
   first command a new user ever runs, this is indistinguishable from a hang.
+  **CLOSED:** bind-first — the runtime constructs in the background and a failed
+  fetch settles to `unavailable` while the gateway keeps serving.
+- **[#932](https://github.com/nimbus-agent/Nimbus/issues/932) — macOS `init`
+  hung forever on a locked keychain.** Found only after #928 was fixed: the boot
+  log still stopped, for a different reason. A first-run Vault write escalated
+  to a GUI authorization dialog no background service can answer, and because
+  `bun:ffi` calls are synchronous the block froze the event loop — so no timeout
+  could ever fire. **CLOSED (PR #946):** keychain user interaction is refused
+  process-wide, so a locked keychain fails immediately with a runnable remedy.
 
-Both are product-behaviour changes, deliberately **not** made under this plan's
-freeze. Gate 1 cannot pass while either stands: they are exactly the
-"works only on the author's machine" failures this gate exists to catch.
+All three were product-behaviour changes, deliberately **not** made under this
+plan's original freeze; the freeze was lifted for them once they proved to be
+Gate 1 blockers rather than polish.
 
-- [ ] Linux: clean `ubuntu:24.04` container, no Bun preinstalled. Run the README quickstart verbatim against a **cloned third-party repo**, not Nimbus. **Blocked by [#925](https://github.com/nimbus-agent/Nimbus/issues/925).**
-- [ ] Windows: fresh local user account or a VM (Win 11 Home has neither Hyper-V nor Windows Sandbox). Same quickstart, same foreign repo.
-- [ ] macOS: covered by Task 1's `macos-14` job, or defer to a Gate 2 tester with a Mac and label it unverified. **Caveat:** that job now sets `NIMBUS_SKIP_EMBEDDING_RUNTIME=1`, so it does **not** cover the cold first-run model fetch ([#928](https://github.com/nimbus-agent/Nimbus/issues/928)) — a human still has to run one genuinely cold macOS first-run.
+- [ ] Linux: clean `ubuntu:24.04` container, no Bun preinstalled. Run the README quickstart verbatim against a **cloned third-party repo**, not Nimbus. (#925 is fixed, but a headless container is precisely where it bit — verify the documented prerequisite is sufficient in practice.)
+- [ ] Windows: fresh local user account or a VM (Win 11 Home has neither Hyper-V nor Windows Sandbox). Same quickstart, same foreign repo. **Least-covered platform:** no first-run defect was ever found here, which is weaker evidence than it looks — the macOS and Linux failures were only found because CI ran them.
+- [ ] macOS: partly covered by Task 1's `macos-14` job, which no longer sets `NIMBUS_SKIP_EMBEDDING_RUNTIME` and now asserts embeddings are not `disabled`. **Remaining gap:** it accepts `warming` and `unavailable`, so it proves the shipped configuration boots — **not** that the MiniLM download completes. A human still has to do one genuinely cold macOS first-run and confirm semantic search actually works afterwards.
 - [ ] Every break gets a fix **and** a regression test at the real-gateway layer. A unit test with an injected fake does not count.
 - [ ] **Exit:** Linux and Windows complete with zero manual intervention.
 


### PR DESCRIPTION
Now that #925, #928 and #932 are all closed, two related cleanups.

## 1. Stop skipping the embedding runtime

`NIMBUS_SKIP_EMBEDDING_RUNTIME=1` existed because the gateway wouldn't bind its socket until the embedding runtime finished, so a cold machine waited on a third-party CDN. **#928 removed that coupling** — bind-first: the runtime constructs in the background, a failed fetch settles to `unavailable`, and the gateway keeps serving.

So the skip no longer buys anything. It just hid the exact configuration every real user runs.

**This is less of a leap than it looks.** The flag was only ever set on the *Unix* step — the **Windows leg has been running with embeddings enabled all along and passing**. This brings Unix in line with what Windows already demonstrates.

**Green stays decoupled from the CDN.** Nothing asserted needs a vector, and I verified rather than assumed: `index.demoSymbol` is a synchronous DB read, and the `why` agent has zero embedding references.

## 2. Make the change verifiable

The gateway logs `[gateway] embeddings: <state>` at bind time (#928). Both legs now assert on it:

| State | Result | Why |
| --- | --- | --- |
| `ready` | pass | model loaded |
| `warming` | **pass** | fetch still running — bind-first says this must not block |
| `unavailable` | **pass** | fetch failed — same reason |
| `disabled` | **fail** | the skip is back |
| no line at all | **fail** | gateway never reported readiness |

Requiring `ready` would re-couple green CI to the CDN, which is what made this job painful in the first place. The assertion's real job is to fail if someone quietly restores the skip and turns this job back into a test of a configuration nobody ships.

Both variants were rehearsed locally against all five states in their real shells — bash for Unix, pwsh for Windows — and only the last two fail.

## 3. Refresh the Gate 1 runbook

It had gone stale enough to actively mislead: still said Linux was "**Blocked by #925**" and warned about a #928 caveat, both closed — and it predated #932 entirely. Someone picking it up would have skipped Linux and chased a resolved caveat.

Now records all three as resolved with what fixed them, while **keeping the checks**: a closed issue is evidence the fix landed, not evidence a foreign machine works. Also flags Windows as the least-covered platform (no first-run defect was ever found there, which is weaker evidence than it looks — the macOS and Linux failures were only found because CI ran them), and states the remaining macOS gap precisely.

**The macOS gap is narrowed, not closed.** The job now proves the shipped configuration *boots*; it does not prove the MiniLM download *completes*. A human cold macOS first-run is still required for that, and the runbook says so.

Also corrects the `nimbus doctor` note — it no longer PATH-checks `secret-tool`; `doctor-core.ts` probes the session bus and collection state.

## Verification

`audit:workflow-lint`, `audit:workflow-run-triggers`, `audit:action-sha-pins`, `lint:markdown`, `audit:doc-refs`, `audit:status-drift`, biome, and lychee at CI's exact scope (0 errors).

The real proof is this PR's own install-smoke run: it touches `.github/workflows/install-smoke.yml`, so the full 3-OS matrix executes with embeddings enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)