### PR TITLE
feat(p6): gate ruleset bypass actors — owner-run audit + credential-free attestation

### DIFF
--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -1,12 +1,13 @@
 {
-  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs `shared` against each repo in `repos`. P6 flips the contributor-two switches in `shared.pull_request`. NOT diffed: `required_status_checks`/`code_quality` (per-repo CI shape) and `bypass_actors` (the CI App token cannot read org-level bypass actors — see the P1 progress log). Intended bypass, for the future higher-privilege check: OrganizationAdmin on Nimbus/nimbus-vscode/nimbus-web-clipper; none on nimbus-client/nimbus-sdk.",
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs `shared` against each repo in `repos`. NOT diffed there: `required_status_checks`/`code_quality` (per-repo CI shape) and `bypass_actors` (the CI App installation token cannot read org-level bypass actors — see the P1 progress log). Bypass actors are instead gated by the owner-run `audit:bypass-actors`, whose attestation the sweep's `audit:bypass-attestation` checks; both read the `bypass` block below.",
   "$contributor_two": {
-    "note": "Solo-mode switches to flip when a second maintainer gains write access — one reviewed diff. Three live in shared.pull_request below and are already drift-gated; the bypass switch is not (the CI App token cannot read bypass_actors — see the roadmap).",
+    "note": "Solo-mode switches to flip when a second maintainer gains write access — one reviewed diff. All four are now drift-gated: three by audit:ruleset-drift (shared.pull_request) and two by audit:bypass-actors (the bypass block).",
     "switches": {
       "shared.pull_request.required_approving_review_count": { "solo": 0, "team": 1 },
       "shared.pull_request.require_code_owner_review": { "solo": false, "team": true },
       "shared.pull_request.require_last_push_approval": { "solo": false, "team": true },
-      "bypass_actors.OrganizationAdmin.bypass_mode": { "solo": "always", "team": "pull_request" }
+      "bypass.by_repo[*].bypass_mode": { "solo": "always", "team": "pull_request" },
+      "bypass.attestation_grace_days": { "solo": 90, "team": 30 }
     }
   },
   "shared": {
@@ -23,6 +24,16 @@
       "require_code_owner_review": false,
       "require_last_push_approval": false,
       "required_approving_review_count": 0
+    }
+  },
+  "bypass": {
+    "attestation_grace_days": 90,
+    "by_repo": {
+      "Nimbus": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+      "nimbus-client": [],
+      "nimbus-sdk": [],
+      "nimbus-vscode": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+      "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }]
     }
   },
   "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"]

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -201,6 +201,25 @@ jobs:
           GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: bun scripts/structure-audit/check-review-coverage.ts --strict
 
+  bypass-attestation:
+    name: bypass-attestation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: this gate reads only the committed attestation + declared
+      # config. Reading bypass_actors needs Administration:write, which is the
+      # whole reason the attestation indirection exists.
+      - name: Audit the bypass-actor attestation
+        run: bun scripts/structure-audit/check-bypass-attestation.ts --strict
+
   release-staleness:
     name: release-staleness
     runs-on: ubuntu-24.04

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -119,7 +119,7 @@ Design of record:
 | P4a | Main-CI concurrency | ✅ shipped | Every commit on `main` has a completed CI run |
 | P4b | Latency | ✅ done — `ci-latency` green in sweep run `30356357605` | `audit:ci-latency` tracks per-job execution, runner queue and DAG wait across the 9 org repos and fails when a job's execution regresses beyond its own measured noise band. Tuning followed the measurement, not the design of record's hunch: a push run demanded ~105 job slots against a pool granting 12-17, so the fix was cutting the fan-out (coverage gates 72 → 42 jobs, Linux-only except the 9 PAL-touching ones) and narrowing E2E's dependency edge — not the proposed cache tuning or sharding, which would have added jobs to the constrained pool. **Measured after, re-measured at n>1 on 2026-07-30: 105 → 77 jobs (4/4 runs), DAG wait 60.5 → 3.0 min median (n=15, and all 45 sampled E2E legs now gated by `ci-rust` — the edge the slice rewrote), non-macOS wall 23-89 → 16-38 min.** Wall clock measured as *last job in the run* did not improve (45 → 67 min median over 20+20 runs); instrumented, that tail is entirely the nine macOS PAL coverage gates queuing for scarce macOS runners, and it is unchanged at like congestion — see the progress log. `audit:coverage-gate-pal` keeps the platform classification honest, co-gates included. |
 | P5 | Org Legibility | ✅ both gates green (run 30231918767) | `audit:secret-inventory` fails on any workflow secret missing from the credential registry **or** `ci-secrets.md`; `audit:actions-allowlist` fails on an unpermitted action **or** any workflow whose latest run ended in `startup_failure`. The second found a live nightly outage on its first correct run. Remaining: the legibility dashboard. |
-| P6 | Access & Contribution Model | 🔨 P6a + CLA done | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos. Remaining: bypass-actor audit |
+| P6 | Access & Contribution Model | ✅ done — bypass gates wired; sweep proof pending (run id TBD — backfill after the post-merge `org-drift-sweep` dispatch) | Every repo reachable through a team + org settings gated (both in the sweep); contributor-two switches recorded in checked-in config; CLA live and **actually executing** on all 6 repos; bypass actors gated by the owner-run `audit:bypass-actors` + the sweep's `audit:bypass-attestation` |
 
 **Sequence:** P1 → P6 → P2 → P5 → P3 → P4b. Three items ignore the sequence and
 land immediately: P4a, `nimbus-client` rulesets, and the contribution-licensing
@@ -228,9 +228,25 @@ moves to P6).
   (`first_time_contributors`) so a loosening is caught; tightening it to
   `all_external_contributors` remains a separate, deliberate change to this file
   and the org setting together.
-- **Deferred:** the CLA (own spec) and a higher-privilege **bypass-actor audit**
-  (the CI App token cannot read `bypass_actors`; a future owner-`gh`-run check,
-  no PAT). Private-repo ruleset protection stays **blocked-on-Team** (Free plan).
+- **Bypass-actor audit — CLOSED (2026-07-30).** The last P6 item. `audit:ruleset-drift`
+  still cannot read `bypass_actors` (its App token gets an empty array; reading the
+  field needs `Administration: write`, which a read-only gate must not hold), so the
+  field is gated by a pair instead: the owner-run `audit:bypass-actors` diffs live
+  state against a new machine-readable `bypass` block and writes a committed
+  attestation, and the credential-free `audit:bypass-attestation` runs in the sweep
+  checking freshness (90d, flipping to 30 at contributor-two), repo coverage, and
+  that the snapshot still agrees with declared intent.
+- **What the design review caught before any code existed.** `--attest` originally
+  keyed off the diff alone. But `decideExit` returns exit 0 for a partial read with
+  no drift — correct for a reporting gate, wrong for an attesting one — so a 4-of-5
+  read would have written an attestation claiming five repos, which the sweep gate
+  then accepts as full coverage for the whole grace window. `--attest` now requires
+  a complete read, and the written `repos` field derives from what was observed.
+- **Honest limit.** The attestation is a committed file and can be hand-edited, so
+  the gate proves *a green attestation was committed recently and still agrees with
+  declared intent*, not *the org is clean now*. The control is that the file is
+  PR-visible and diff-reviewed. Residual exposure is bounded by the grace window.
+- **Deferred:** private-repo ruleset protection stays **blocked-on-Team** (Free plan).
 
 ### CLA progress log
 

--- a/docs/structure-audit/bypass-actors-attestation.json
+++ b/docs/structure-audit/bypass-actors-attestation.json
@@ -1,0 +1,37 @@
+{
+  "attested_at": "2026-07-30T07:39:28.479Z",
+  "attested_by": "asafgolombek",
+  "grace_days": 90,
+  "repos": [
+    "Nimbus",
+    "nimbus-client",
+    "nimbus-sdk",
+    "nimbus-vscode",
+    "nimbus-web-clipper"
+  ],
+  "observed": {
+    "Nimbus": [
+      {
+        "actor_id": null,
+        "actor_type": "OrganizationAdmin",
+        "bypass_mode": "always"
+      }
+    ],
+    "nimbus-client": [],
+    "nimbus-sdk": [],
+    "nimbus-vscode": [
+      {
+        "actor_id": null,
+        "actor_type": "OrganizationAdmin",
+        "bypass_mode": "always"
+      }
+    ],
+    "nimbus-web-clipper": [
+      {
+        "actor_id": null,
+        "actor_type": "OrganizationAdmin",
+        "bypass_mode": "always"
+      }
+    ]
+  }
+}

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit-review.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit-review.md
@@ -1,0 +1,46 @@
+# Design Review: P6 Bypass-actor Audit Implementation Plan
+
+This document contains a design review of the [2026-07-30-p6-bypass-actor-audit.md](./2026-07-30-p6-bypass-actor-audit.md) implementation plan, detailing open questions, suggestions, and potential improvements.
+
+---
+
+## 1. Open Questions
+
+### 1.1. Uncaught JSON Parsing Errors in Loaders
+
+In Task 1 (Step 4), `loadDeclaredBypass` reads `general-branch.json` and immediately parses it:
+
+```ts
+export function loadDeclaredBypass(repoRoot: string): DeclaredBypassFile {
+  const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
+  return JSON.parse(raw) as DeclaredBypassFile;
+}
+```
+
+* **The Question**: If `general-branch.json` contains a syntax error (e.g., a trailing comma or a merge conflict marker), this will throw a raw `SyntaxError` and crash the process with a stack trace. Is this intentional, or should we handle JSON parsing failure gracefully with a structured error message?
+* **Suggestion**: Wrap the `JSON.parse` in a try-catch block and return/print a clean, descriptive error message indicating that `general-branch.json` has invalid JSON syntax, mirroring the parsing safety implemented for the attestation file.
+
+### 1.2. CLI Help/Usage Information
+
+The CLIs in Task 3 and Task 4 check `argv` directly but do not provide help information:
+
+* **The Question**: If the user runs `bun run audit:bypass-actors --help` or passes invalid/unexpected arguments, how should the tools respond?
+* **Suggestion**: Add a simple argument check. If the CLI receives `--help` or `-h`, it should print a brief description of the tool, its flags (e.g., `--attest`, `--strict`), and exit.
+
+---
+
+## 2. Improvements & Suggestions
+
+### 2.1. Robustness of the `attested_by` login resolution
+
+In Task 3 (Step 5), Gate 1's CLI queries the authenticated user:
+
+```ts
+const who = runGh(["gh", "api", "user", "--jq", ".login"]);
+```
+
+* **Improvement**: If this API query fails (e.g., due to rate limiting or restricted token scopes), `who.ok` is `false`, and it defaults to `"unknown"`. We should also strip any trailing whitespace/newlines from `who.stdout` if `who.ok` is `true` (which the plan currently does via `.trim()`). However, to make local offline testing of the `--attest` flag easier, we can also check if a fallback environment variable (like `USER`, `USERNAME`, or `GITHUB_ACTOR`) is set before falling back to `"unknown"`.
+
+### 2.2. Standardize Grace Window Extraction
+
+* **Improvement**: In `check-bypass-attestation.ts`, `graceDays` is passed into `evaluateAttestation` from the loaded config. To make the test setup in `check-bypass-attestation.test.ts` more robust, ensure that the schema check for `attestation_grace_days` (such as checking if it is an integer > 0) is also enforced when initializing the input, or verify that the validator `validateDeclaredBypass` is called prior to checking the attestation in the CLI entry point.

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
@@ -1,0 +1,1477 @@
+# P6 Bypass-actor Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the `bypass_actors` field of every active org repo's `General` ruleset, which `audit:ruleset-drift` structurally cannot read, by pairing an owner-run audit with a credential-free attestation-freshness check in the weekly sweep.
+
+**Architecture:** Two CLI gates share one pure diff function. `audit:bypass-actors` runs on the owner's machine (their `gh` token has `admin:org`, which *does* return `bypass_actors`), diffs live state against declared intent in `.github/rulesets/general-branch.json`, and on a green **and complete** read writes a committed attestation snapshot. `audit:bypass-attestation` runs in `org-drift-sweep` with no credential at all, re-running the same diff offline against that snapshot plus checking its freshness and repo coverage.
+
+**Tech Stack:** Bun + TypeScript (strict), `bun:test`, `gh` CLI via the existing `_gh-audit.ts` helpers, Biome.
+
+**Spec:** [`../specs/2026-07-30-p6-bypass-actor-audit-design.md`](../specs/2026-07-30-p6-bypass-actor-audit-design.md)
+**Review response:** [`../specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md`](../specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md)
+
+## Global Constraints
+
+- **No `any`.** Use `unknown` for external data and narrow it. TypeScript strict mode is non-negotiable.
+- **Branch:** work on `dev/asafgolombek/p6-bypass-actor-audit`. Never commit on `main`.
+- **Prefer dependency injection over `mock.module`.** The clock is injected as `nowMs`; there is no `Date.now()` inside any pure function.
+- **Every gate mirrors `check-ruleset-drift.ts`'s contract:** fail-soft when `gh` is unavailable, `--strict` in CI, a transient read failure degrades to `indeterminate` and is never recorded as a finding.
+- **Both new `audit:*` scripts MUST be added to `CI_ONLY_GATES` in `scripts/lib/preflight-gates.ts`.** A `package.json` script that is neither in `PREFLIGHT_GATES` nor in that list fails the manifest drift test.
+- **All fenced code blocks in any markdown you write need a language tag** (`audit:lint:markdown` enforces MD040).
+- **Verification per task:** `bunx biome check packages scripts` (NOT `bun run lint` — it reports 0 files inside `.claude/worktrees/`), plus `bun test scripts/structure-audit/<file>.test.ts`.
+- Run `bun install --frozen-lockfile` once in the worktree before starting; a fresh worktree has no `node_modules` and every gate fake-fails without it.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `.github/rulesets/general-branch.json` | Declared intent: the `bypass` block + the fourth `$contributor_two` switch. Data only. |
+| `scripts/structure-audit/check-bypass-actors.ts` | Types, config load + validation, the pure `diffBypassActors`, and Gate 1's CLI. |
+| `scripts/structure-audit/_bypass-attestation.ts` | Attestation shape, parse, read, write. Shared by both gates; no network, no `gh`. |
+| `scripts/structure-audit/check-bypass-attestation.ts` | Gate 2's pure `evaluateAttestation` + its CLI. Imports the diff from Gate 1's module. |
+| `docs/structure-audit/bypass-actors-attestation.json` | The committed snapshot. Generated, never hand-edited. |
+| `.github/workflows/org-drift-sweep.yml` | The `bypass-attestation` job. No token mint. |
+| `scripts/lib/preflight-gates.ts` | `CI_ONLY_GATES` entries for both scripts. |
+| `package.json` | The two `audit:*` script entries. |
+
+`check-bypass-attestation.ts` importing from `check-bypass-actors.ts` is safe: the CLI body is guarded by `if (import.meta.main)`, which is false on import.
+
+---
+
+### Task 1: Declared bypass config + validation
+
+**Files:**
+
+- Modify: `.github/rulesets/general-branch.json`
+- Create: `scripts/structure-audit/check-bypass-actors.ts`
+- Test: `scripts/structure-audit/check-bypass-actors.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `BypassActor`, `DeclaredBypassFile`, `AuditResult`, `VALID_BYPASS_MODES`, `NULL_ID_ACTOR_TYPES`, `KNOWN_ACTOR_TYPES`, `loadDeclaredBypass(repoRoot: string): DeclaredBypassFile`, `validateDeclaredBypass(file: DeclaredBypassFile): string[]`.
+
+- [ ] **Step 1: Update the declared config**
+
+Replace `.github/rulesets/general-branch.json` in full. Three things change: the `$comment` and `$contributor_two.note` no longer claim bypass actors are ungated, a fourth switch is documented, and the new `bypass` block carries the machine-readable intent.
+
+```json
+{
+  "$comment": "Desired shape of the 'General' branch ruleset on every active org repo. audit:ruleset-drift diffs `shared` against each repo in `repos`. NOT diffed there: `required_status_checks`/`code_quality` (per-repo CI shape) and `bypass_actors` (the CI App installation token cannot read org-level bypass actors — see the P1 progress log). Bypass actors are instead gated by the owner-run `audit:bypass-actors`, whose attestation the sweep's `audit:bypass-attestation` checks; both read the `bypass` block below.",
+  "$contributor_two": {
+    "note": "Solo-mode switches to flip when a second maintainer gains write access — one reviewed diff. All four are now drift-gated: three by audit:ruleset-drift (shared.pull_request) and two by audit:bypass-actors (the bypass block).",
+    "switches": {
+      "shared.pull_request.required_approving_review_count": { "solo": 0, "team": 1 },
+      "shared.pull_request.require_code_owner_review": { "solo": false, "team": true },
+      "shared.pull_request.require_last_push_approval": { "solo": false, "team": true },
+      "bypass.by_repo[*].bypass_mode": { "solo": "always", "team": "pull_request" },
+      "bypass.attestation_grace_days": { "solo": 90, "team": 30 }
+    }
+  },
+  "shared": {
+    "name": "General",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions_ref_include": ["refs/heads/main"],
+    "conditions_ref_exclude": [],
+    "required_rule_types": ["deletion", "non_fast_forward", "pull_request"],
+    "pull_request": {
+      "allowed_merge_methods": ["squash"],
+      "dismiss_stale_reviews_on_push": true,
+      "required_review_thread_resolution": true,
+      "require_code_owner_review": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    }
+  },
+  "bypass": {
+    "attestation_grace_days": 90,
+    "by_repo": {
+      "Nimbus": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+      "nimbus-client": [],
+      "nimbus-sdk": [],
+      "nimbus-vscode": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+      "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }]
+    }
+  },
+  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `scripts/structure-audit/check-bypass-actors.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import {
+  type DeclaredBypassFile,
+  loadDeclaredBypass,
+  validateDeclaredBypass,
+} from "./check-bypass-actors.ts";
+
+/** A declared file that passes validation — the base each case mutates one field of. */
+function goodFile(): DeclaredBypassFile {
+  return {
+    repos: ["Nimbus", "nimbus-sdk"],
+    bypass: {
+      attestation_grace_days: 90,
+      by_repo: {
+        Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+        "nimbus-sdk": [],
+      },
+    },
+  };
+}
+
+describe("validateDeclaredBypass", () => {
+  test("accepts a well-formed file", () => {
+    expect(validateDeclaredBypass(goodFile())).toEqual([]);
+  });
+
+  test("rejects a by_repo key set that does not match repos", () => {
+    const f = goodFile();
+    f.repos = ["Nimbus", "nimbus-sdk", "nimbus-client"];
+    const errors = validateDeclaredBypass(f);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("do not match repos");
+  });
+
+  test("rejects an invalid bypass_mode by name, pointing at the config not the org", () => {
+    const f = goodFile();
+    f.bypass.by_repo["Nimbus"] = [{ actor_type: "OrganizationAdmin", bypass_mode: "alway" }];
+    const errors = validateDeclaredBypass(f);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('invalid bypass_mode "alway"');
+    expect(errors[0]).toContain("bypass.by_repo.Nimbus");
+    expect(errors[0]).toContain("always|pull_request");
+  });
+
+  test("rejects a known-but-unsupported actor type distinctly from an unknown one", () => {
+    const known = goodFile();
+    known.bypass.by_repo["Nimbus"] = [{ actor_type: "Team", actor_id: 42, bypass_mode: "always" }];
+    expect(validateDeclaredBypass(known)[0]).toContain("unsupported actor_type");
+
+    const unknown = goodFile();
+    unknown.bypass.by_repo["Nimbus"] = [{ actor_type: "Wizard", bypass_mode: "always" }];
+    expect(validateDeclaredBypass(unknown)[0]).toContain("unknown actor_type");
+  });
+
+  test("rejects a non-positive or non-integer grace window", () => {
+    for (const bad of [0, -1, 1.5]) {
+      const f = goodFile();
+      f.bypass.attestation_grace_days = bad;
+      expect(validateDeclaredBypass(f)[0]).toContain("attestation_grace_days");
+    }
+  });
+});
+
+describe("loadDeclaredBypass", () => {
+  test("the checked-in config is valid and covers all five active repos", () => {
+    const file = loadDeclaredBypass(process.cwd());
+    expect(validateDeclaredBypass(file)).toEqual([]);
+    expect(file.repos.length).toBe(5);
+    expect(Object.keys(file.bypass.by_repo).sort()).toEqual([...file.repos].sort());
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+bun test scripts/structure-audit/check-bypass-actors.test.ts
+```
+
+Expected: FAIL — `Cannot find module './check-bypass-actors.ts'`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Create `scripts/structure-audit/check-bypass-actors.ts`. This step adds only the types, loader and validator; the diff and CLI arrive in Tasks 2 and 3.
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * audit:bypass-actors — asserts each active org repo's `General` ruleset carries
+ * exactly the bypass actors declared in `.github/rulesets/general-branch.json`.
+ *
+ * Why this is a SEPARATE gate from audit:ruleset-drift: that gate's credential is
+ * a repo-scoped App installation token with `Administration: read`, and GitHub
+ * returns an EMPTY `bypass_actors` to it for org-level actors. Proven live that
+ * `organization-administration: read` does not restore the field, and reading it
+ * otherwise needs `Administration: write` — which a read-only audit gate must not
+ * hold. So this one runs from the OWNER's machine (an `admin:org` token does
+ * return the field) and leaves a committed attestation the sweep can check
+ * without any credential at all. See docs/infrastructure-roadmap.md, P6.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** One entry of a ruleset's `bypass_actors` array. */
+export interface BypassActor {
+  actor_type: string;
+  /** `null` for org-level actors; a numeric id for Team/Integration/RepositoryRole. */
+  actor_id?: number | null;
+  bypass_mode: string;
+}
+
+export interface DeclaredBypassFile {
+  repos: string[];
+  bypass: {
+    attestation_grace_days: number;
+    by_repo: Record<string, BypassActor[]>;
+  };
+}
+
+export const VALID_BYPASS_MODES: readonly string[] = ["always", "pull_request"];
+
+/**
+ * The only actor types this gate supports — those whose `actor_id` is null.
+ *
+ * Not a portability concern (there is no staging org; every sweep gate hard-codes
+ * `nimbus-agent`) but a REVIEWABILITY one: the entire control here is that the
+ * config and attestation are PR-visible and diff-reviewed, and `"actor_id":
+ * 4382579` is not something a human reviewer can check. Supporting a numeric-id
+ * actor requires resolving ids to names first — see the design's 1.1 response.
+ */
+export const NULL_ID_ACTOR_TYPES: readonly string[] = ["OrganizationAdmin"];
+
+/** Every actor type GitHub can return, used only to sharpen the validation error. */
+export const KNOWN_ACTOR_TYPES: readonly string[] = [
+  "OrganizationAdmin",
+  "Team",
+  "Integration",
+  "RepositoryRole",
+  "DeployKey",
+];
+
+export function loadDeclaredBypass(repoRoot: string): DeclaredBypassFile {
+  const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
+  return JSON.parse(raw) as DeclaredBypassFile;
+}
+
+/**
+ * Validates the DECLARED config before any diffing.
+ *
+ * A typo like `"alway"` would already red the gate by mismatching live
+ * `"always"` — but as `bypass_mode: expected alway, got always`, which points the
+ * reader at the ORG when the defect is in the CONFIG. Validating first turns that
+ * into a finding that names the file. Same red, correct target.
+ */
+export function validateDeclaredBypass(file: DeclaredBypassFile): string[] {
+  const errors: string[] = [];
+
+  const declaredRepos = Object.keys(file.bypass.by_repo).sort();
+  const repos = [...file.repos].sort();
+  if (JSON.stringify(declaredRepos) !== JSON.stringify(repos)) {
+    errors.push(
+      `bypass.by_repo keys ${JSON.stringify(declaredRepos)} do not match repos ${JSON.stringify(repos)}`,
+    );
+  }
+
+  for (const [repo, actors] of Object.entries(file.bypass.by_repo)) {
+    for (const actor of actors) {
+      if (!VALID_BYPASS_MODES.includes(actor.bypass_mode)) {
+        errors.push(
+          `invalid bypass_mode "${actor.bypass_mode}" in bypass.by_repo.${repo} (expected ${VALID_BYPASS_MODES.join("|")})`,
+        );
+      }
+      if (!NULL_ID_ACTOR_TYPES.includes(actor.actor_type)) {
+        errors.push(
+          KNOWN_ACTOR_TYPES.includes(actor.actor_type)
+            ? `unsupported actor_type "${actor.actor_type}" in bypass.by_repo.${repo} — only null-id org-level actors (${NULL_ID_ACTOR_TYPES.join("|")}) are supported`
+            : `unknown actor_type "${actor.actor_type}" in bypass.by_repo.${repo}`,
+        );
+      }
+    }
+  }
+
+  const grace = file.bypass.attestation_grace_days;
+  if (!Number.isInteger(grace) || grace <= 0) {
+    errors.push(`bypass.attestation_grace_days must be a positive integer, got ${String(grace)}`);
+  }
+
+  return errors;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+bun test scripts/structure-audit/check-bypass-actors.test.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+bunx biome check packages scripts
+git add .github/rulesets/general-branch.json scripts/structure-audit/check-bypass-actors.ts scripts/structure-audit/check-bypass-actors.test.ts
+git commit -m "feat(p6): declare machine-readable bypass intent + validate it
+
+The intended bypass shape has lived in a JSON \$comment STRING since P1.
+Prose in a comment is not a gate. Moves it into a real \`bypass\` block and
+validates actor_type/bypass_mode/grace before any diffing, so a config typo
+names the config rather than reading as org drift."
+```
+
+---
+
+### Task 2: The pure diff
+
+**Files:**
+
+- Modify: `scripts/structure-audit/check-bypass-actors.ts`
+- Test: `scripts/structure-audit/check-bypass-actors.test.ts`
+
+**Interfaces:**
+
+- Consumes: `BypassActor`, `AuditResult`, `NULL_ID_ACTOR_TYPES` from Task 1.
+- Produces: `actorKey(a: BypassActor): string`, `diffBypassActors(repos: string[], declared: Record<string, BypassActor[]>, observed: Record<string, BypassActor[]>): AuditResult`. Task 4 calls `diffBypassActors` with the attested snapshot as `observed`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/structure-audit/check-bypass-actors.test.ts`:
+
+```ts
+import { actorKey, type BypassActor, diffBypassActors } from "./check-bypass-actors.ts";
+
+const REPOS = ["Nimbus", "nimbus-sdk"];
+const ADMIN: BypassActor = { actor_type: "OrganizationAdmin", bypass_mode: "always" };
+
+function declared(): Record<string, BypassActor[]> {
+  return { Nimbus: [ADMIN], "nimbus-sdk": [] };
+}
+
+/** Live shape: GitHub always includes actor_id, null for org-level actors. */
+function observed(): Record<string, BypassActor[]> {
+  return {
+    Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+    "nimbus-sdk": [],
+  };
+}
+
+describe("diffBypassActors", () => {
+  test("passes when live matches declared, with actor_id null vs omitted", () => {
+    const r = diffBypassActors(REPOS, declared(), observed());
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("flags an unexpected bypass actor", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("nimbus-sdk: unexpected bypass actor");
+  });
+
+  test("flags a missing declared bypass actor", () => {
+    const live = observed();
+    live["Nimbus"] = [];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("Nimbus: missing declared bypass actor");
+  });
+
+  test("reports a widened bypass_mode as a mode change, not as add+remove", () => {
+    const live = observed();
+    live["Nimbus"] = [
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+    ];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]).toContain("bypass_mode: expected always, got pull_request");
+  });
+
+  test("treats a non-null-id actor type as a hard error, never normalizing it away", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [{ actor_type: "Team", actor_id: 42, bypass_mode: "always" }];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("unsupported bypass actor type Team (id 42)");
+  });
+
+  test("flags a repo that is not declared at all", () => {
+    const r = diffBypassActors([...REPOS, "nimbus-new"], declared(), observed());
+    expect(r.errors[0]).toContain("nimbus-new: not declared in bypass.by_repo");
+  });
+
+  test("flags a declared repo with no observation", () => {
+    const live = observed();
+    delete live["nimbus-sdk"];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.errors[0]).toContain("nimbus-sdk: no observed bypass_actors");
+  });
+
+  test("is order-independent across the actor set", () => {
+    const twoDeclared: Record<string, BypassActor[]> = {
+      Nimbus: [
+        { actor_type: "OrganizationAdmin", bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+      ],
+      "nimbus-sdk": [],
+    };
+    const twoLive: Record<string, BypassActor[]> = {
+      Nimbus: [
+        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+      ],
+      "nimbus-sdk": [],
+    };
+    expect(diffBypassActors(REPOS, twoDeclared, twoLive).ok).toBe(true);
+  });
+});
+
+describe("actorKey", () => {
+  test("normalizes an omitted actor_id to the same key as an explicit null", () => {
+    expect(actorKey({ actor_type: "OrganizationAdmin", bypass_mode: "always" })).toBe(
+      actorKey({ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun test scripts/structure-audit/check-bypass-actors.test.ts
+```
+
+Expected: FAIL — `actorKey` / `diffBypassActors` are not exported.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `scripts/structure-audit/check-bypass-actors.ts`:
+
+```ts
+/** Stable identity of an actor INCLUDING its mode — an omitted id equals an explicit null. */
+export function actorKey(actor: BypassActor): string {
+  return `${actor.actor_type}:${actor.actor_id ?? "null"}:${actor.bypass_mode}`;
+}
+
+/** Identity WITHOUT the mode, so a mode change reports as a change, not add+remove. */
+function actorIdentity(actor: BypassActor): string {
+  return `${actor.actor_type}:${actor.actor_id ?? "null"}`;
+}
+
+/**
+ * Pure diff — the whole verdict, so both gates share it and neither needs network.
+ * Gate 1 passes live `gh` data as `observed`; Gate 2 passes the attested snapshot.
+ *
+ * Findings are directional because the repairs differ: "someone added an override"
+ * is a different job from "an intended override was removed".
+ */
+export function diffBypassActors(
+  repos: string[],
+  declared: Record<string, BypassActor[]>,
+  observed: Record<string, BypassActor[]>,
+): AuditResult {
+  const errors: string[] = [];
+
+  for (const repo of repos) {
+    const want = declared[repo];
+    if (want === undefined) {
+      errors.push(`${repo}: not declared in bypass.by_repo`);
+      continue;
+    }
+    const got = observed[repo];
+    if (got === undefined) {
+      errors.push(`${repo}: no observed bypass_actors`);
+      continue;
+    }
+
+    // An actor type we cannot render human-checkably is a hard error, never
+    // silently normalized — otherwise a Team bypass added in the UI reads green.
+    const unsupported = got.filter((a) => !NULL_ID_ACTOR_TYPES.includes(a.actor_type));
+    if (unsupported.length > 0) {
+      for (const actor of unsupported) {
+        errors.push(
+          `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
+        );
+      }
+      continue;
+    }
+
+    const wantById = new Map(want.map((a) => [actorIdentity(a), a]));
+    const gotById = new Map(got.map((a) => [actorIdentity(a), a]));
+
+    for (const [identity, actor] of gotById) {
+      const expected = wantById.get(identity);
+      if (expected === undefined) {
+        errors.push(`${repo}: unexpected bypass actor: ${actorKey(actor)}`);
+        continue;
+      }
+      if (expected.bypass_mode !== actor.bypass_mode) {
+        errors.push(
+          `${repo}: ${identity} bypass_mode: expected ${expected.bypass_mode}, got ${actor.bypass_mode}`,
+        );
+      }
+    }
+    for (const [identity, actor] of wantById) {
+      if (!gotById.has(identity)) {
+        errors.push(`${repo}: missing declared bypass actor: ${actorKey(actor)}`);
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bun test scripts/structure-audit/check-bypass-actors.test.ts
+```
+
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+bunx biome check packages scripts
+git add scripts/structure-audit/check-bypass-actors.ts scripts/structure-audit/check-bypass-actors.test.ts
+git commit -m "feat(p6): add the pure bypass-actor diff
+
+Shared by both gates: Gate 1 feeds it live gh data, Gate 2 the attested
+snapshot. A non-null-id actor type is a hard error rather than normalized
+away, so a Team bypass added in the UI cannot read as green."
+```
+
+---
+
+### Task 3: Attestation module + Gate 1 CLI
+
+**Files:**
+
+- Create: `scripts/structure-audit/_bypass-attestation.ts`
+- Create: `scripts/structure-audit/_bypass-attestation.test.ts`
+- Modify: `scripts/structure-audit/check-bypass-actors.ts` (append the CLI)
+
+**Interfaces:**
+
+- Consumes: `BypassActor`, `AuditResult`, `diffBypassActors`, `loadDeclaredBypass`, `validateDeclaredBypass` from Tasks 1–2; `isStrict`, `runGh`, `strictSkip`, `classifyReadFailure`, `isRecord` from `./_gh-audit.ts`.
+- Produces: `Attestation`, `ATTESTATION_PATH`, `parseAttestation(raw: string): Attestation | "unparseable"`, `readAttestation(repoRoot: string): string | null`, `writeAttestation(repoRoot: string, a: Attestation): void`, and `decideAttestWrite(input): { write: boolean; reason?: string }`. Task 4 consumes `Attestation`, `parseAttestation`, `readAttestation`, `ATTESTATION_PATH`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/structure-audit/_bypass-attestation.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import { decideAttestWrite, parseAttestation } from "./_bypass-attestation.ts";
+
+describe("parseAttestation", () => {
+  test("parses a well-formed attestation", () => {
+    const raw = JSON.stringify({
+      attested_at: "2026-07-30T06:15:00.000Z",
+      attested_by: "asafgolombek",
+      grace_days: 90,
+      repos: ["Nimbus"],
+      observed: { Nimbus: [] },
+    });
+    const parsed = parseAttestation(raw);
+    expect(parsed).not.toBe("unparseable");
+    if (parsed === "unparseable") throw new Error("unreachable");
+    expect(parsed.attested_by).toBe("asafgolombek");
+  });
+
+  test("reports invalid JSON as unparseable", () => {
+    expect(parseAttestation("{not json")).toBe("unparseable");
+  });
+
+  test("reports legal JSON that is not an object as unparseable", () => {
+    expect(parseAttestation("[]")).toBe("unparseable");
+    expect(parseAttestation('"a string"')).toBe("unparseable");
+    expect(parseAttestation("null")).toBe("unparseable");
+  });
+});
+
+describe("decideAttestWrite", () => {
+  test("writes on a green, complete read", () => {
+    expect(decideAttestWrite({ ok: true, queried: 5, total: 5, unreachable: [] }).write).toBe(true);
+  });
+
+  test("refuses on drift", () => {
+    const d = decideAttestWrite({ ok: false, queried: 5, total: 5, unreachable: [] });
+    expect(d.write).toBe(false);
+    expect(d.reason).toContain("drift");
+  });
+
+  // The hole the design review caught: decideExit returns exit 0 for a partial
+  // read with no drift, so keying --attest off the exit code alone would write an
+  // attestation claiming 5 repos on 4 repos' evidence.
+  test("refuses on a PARTIAL read even with zero drift", () => {
+    const d = decideAttestWrite({
+      ok: true,
+      queried: 4,
+      total: 5,
+      unreachable: ["nimbus-sdk"],
+    });
+    expect(d.write).toBe(false);
+    expect(d.reason).toContain("nimbus-sdk");
+    expect(d.reason).toContain("read 4 of 5");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun test scripts/structure-audit/_bypass-attestation.test.ts
+```
+
+Expected: FAIL — `Cannot find module './_bypass-attestation.ts'`.
+
+- [ ] **Step 3: Write the attestation module**
+
+Create `scripts/structure-audit/_bypass-attestation.ts`:
+
+```ts
+/**
+ * The committed bypass-actor attestation: shape, parse, read, write.
+ *
+ * Shared by the owner-run gate (which writes it) and the sweep gate (which reads
+ * it). No network and no `gh` — deliberately, since the sweep job must run with
+ * no credential at all.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { BypassActor } from "./check-bypass-actors.ts";
+import { isRecord } from "./_gh-audit.ts";
+
+export const ATTESTATION_PATH = "docs/structure-audit/bypass-actors-attestation.json";
+
+export interface Attestation {
+  /** ISO-8601 UTC, from `new Date().toISOString()`. */
+  attested_at: string;
+  /** `gh api user` login, or "unknown" — diagnostic only, never a gating input. */
+  attested_by: string;
+  /** Denormalized for diagnostics ONLY; the gate reads grace from the config. */
+  grace_days: number;
+  /** Derived from the repos actually observed, never copied from config. */
+  repos: string[];
+  observed: Record<string, BypassActor[]>;
+}
+
+/** Parse a raw attestation blob. Anything that is not a JSON object is `unparseable`. */
+export function parseAttestation(raw: string): Attestation | "unparseable" {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "unparseable";
+  }
+  // Legal JSON can be a scalar, null or an array; none is a usable attestation.
+  return isRecord(parsed) ? (parsed as unknown as Attestation) : "unparseable";
+}
+
+/** Read the attestation file, or `null` when it does not exist. */
+export function readAttestation(repoRoot: string): string | null {
+  try {
+    return readFileSync(join(repoRoot, ATTESTATION_PATH), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function writeAttestation(repoRoot: string, attestation: Attestation): void {
+  writeFileSync(join(repoRoot, ATTESTATION_PATH), `${JSON.stringify(attestation, null, 2)}\n`);
+}
+
+export interface AttestWriteInput {
+  /** Whether the diff was clean. */
+  ok: boolean;
+  /** How many repos were read successfully. */
+  queried: number;
+  /** How many repos were declared. */
+  total: number;
+  unreachable: string[];
+}
+
+/**
+ * Whether `--attest` may write.
+ *
+ * TWO conditions, and the second is not redundant: `decideExit` returns exit 0
+ * for a partial read with no drift (correct for a reporting gate, wrong for an
+ * attesting one). Writing there would produce an attestation whose `repos` field
+ * claims full coverage on partial evidence, which the sweep gate would then
+ * accept for the whole grace window. Attesting is interactive and re-runnable,
+ * so refusing costs nothing.
+ */
+export function decideAttestWrite(input: AttestWriteInput): { write: boolean; reason?: string } {
+  if (!input.ok) {
+    return { write: false, reason: "refusing to attest: bypass-actor drift was found" };
+  }
+  if (input.unreachable.length > 0 || input.queried !== input.total) {
+    return {
+      write: false,
+      reason: `cannot attest: ${input.unreachable.join(", ")} unreachable (read ${input.queried} of ${input.total})`,
+    };
+  }
+  return { write: true };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bun test scripts/structure-audit/_bypass-attestation.test.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Append Gate 1's CLI**
+
+Append to `scripts/structure-audit/check-bypass-actors.ts`:
+
+```ts
+/**
+ * Exit decision for the per-repo loop.
+ *
+ * INVARIANT, mirroring check-ruleset-drift: real drift on a reachable repo is
+ * never discarded because a DIFFERENT repo's read failed. `queried === 0` is the
+ * only skip-green case.
+ */
+export function decideExit(input: {
+  queried: number;
+  errors: string[];
+  unreachable: string[];
+  strict?: boolean;
+}): { code: 0 | 1; message: string } {
+  const { queried, errors, unreachable, strict = false } = input;
+
+  if (queried === 0) return strictSkip("audit:bypass-actors", strict);
+
+  if (errors.length > 0) {
+    const lines = errors.map((err) => `audit:bypass-actors: ${err}`);
+    if (unreachable.length > 0) {
+      lines.push(`audit:bypass-actors: WARNING — could not query: ${unreachable.join(", ")}`);
+    }
+    return { code: 1, message: lines.join("\n") };
+  }
+
+  if (unreachable.length > 0) {
+    return {
+      code: 0,
+      message: `audit:bypass-actors: OK (${queried} repos) — WARNING: could not query ${unreachable.join(", ")}`,
+    };
+  }
+
+  return { code: 0, message: `audit:bypass-actors: OK (${queried} repos)` };
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const strict = isStrict(argv, process.env);
+  const attest = argv.includes("--attest");
+  const label = "audit:bypass-actors";
+  const file = loadDeclaredBypass(process.cwd());
+
+  const configErrors = validateDeclaredBypass(file);
+  if (configErrors.length > 0) {
+    for (const err of configErrors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+
+  const observed: Record<string, BypassActor[]> = {};
+  const unreachable: string[] = [];
+  let queried = 0;
+
+  for (const repo of file.repos) {
+    const listResult = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/rulesets`,
+      "--jq",
+      '.[] | select(.name=="General") | .id',
+    ]);
+    if (!listResult.ok) {
+      unreachable.push(repo);
+      continue;
+    }
+    const id = listResult.stdout.trim();
+    if (id === "") {
+      // gh succeeded and simply found no matching ruleset — real drift, not a skip.
+      queried += 1;
+      observed[repo] = [];
+      continue;
+    }
+
+    const detail = runGh(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    if (!detail.ok) {
+      unreachable.push(repo);
+      continue;
+    }
+
+    queried += 1;
+    const live: unknown = JSON.parse(detail.stdout);
+    const actors = isRecord(live) && Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
+    observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
+  }
+
+  const result = diffBypassActors(file.repos, file.bypass.by_repo, observed);
+  const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
+
+  if (attest) {
+    const decision = decideAttestWrite({
+      ok: result.ok,
+      queried,
+      total: file.repos.length,
+      unreachable,
+    });
+    if (!decision.write) {
+      if (outcome.code === 1) console.error(outcome.message);
+      console.error(`${label}: ${decision.reason ?? "refusing to attest"}`);
+      process.exit(1);
+    }
+    const who = runGh(["gh", "api", "user", "--jq", ".login"]);
+    writeAttestation(process.cwd(), {
+      attested_at: new Date().toISOString(),
+      attested_by: who.ok ? who.stdout.trim() : "unknown",
+      grace_days: file.bypass.attestation_grace_days,
+      repos: Object.keys(observed).sort(),
+      observed,
+    });
+    console.log(`${label}: OK (${queried} repos) — wrote ${ATTESTATION_PATH}`);
+    process.exit(0);
+  }
+
+  if (outcome.code === 1) console.error(outcome.message);
+  else if (outcome.message.includes("skipped")) console.warn(outcome.message);
+  else console.log(outcome.message);
+  process.exit(outcome.code);
+}
+```
+
+Add these imports at the top of `check-bypass-actors.ts`, beneath the existing `node:` imports:
+
+```ts
+import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import {
+  ATTESTATION_PATH,
+  decideAttestWrite,
+  writeAttestation,
+} from "./_bypass-attestation.ts";
+```
+
+- [ ] **Step 6: Add a decideExit test**
+
+Append to `scripts/structure-audit/check-bypass-actors.test.ts`:
+
+```ts
+import { decideExit } from "./check-bypass-actors.ts";
+
+describe("decideExit", () => {
+  test("skips green when nothing was readable and not strict", () => {
+    expect(decideExit({ queried: 0, errors: [], unreachable: ["Nimbus"] }).code).toBe(0);
+  });
+
+  test("fails when nothing was readable under --strict", () => {
+    expect(decideExit({ queried: 0, errors: [], unreachable: ["Nimbus"], strict: true }).code).toBe(1);
+  });
+
+  test("keeps drift found on a reachable repo despite another repo failing", () => {
+    const out = decideExit({ queried: 1, errors: ["Nimbus: unexpected"], unreachable: ["nimbus-sdk"] });
+    expect(out.code).toBe(1);
+    expect(out.message).toContain("Nimbus: unexpected");
+    expect(out.message).toContain("could not query: nimbus-sdk");
+  });
+
+  test("passes with a warning on a partial read with no drift", () => {
+    const out = decideExit({ queried: 4, errors: [], unreachable: ["nimbus-sdk"] });
+    expect(out.code).toBe(0);
+    expect(out.message).toContain("WARNING");
+  });
+});
+```
+
+- [ ] **Step 7: Run all tests and lint**
+
+```bash
+bun test scripts/structure-audit/check-bypass-actors.test.ts scripts/structure-audit/_bypass-attestation.test.ts
+bunx biome check packages scripts
+```
+
+Expected: PASS, 25 tests total.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/structure-audit/_bypass-attestation.ts scripts/structure-audit/_bypass-attestation.test.ts scripts/structure-audit/check-bypass-actors.ts scripts/structure-audit/check-bypass-actors.test.ts
+git commit -m "feat(p6): add the owner-run bypass-actor gate + --attest
+
+--attest requires BOTH a green diff and a complete read. The second guard is
+not redundant: decideExit returns exit 0 for a partial read with no drift, so
+keying the write off the exit code would attest full coverage on partial
+evidence. The written repos field also derives from what was observed."
+```
+
+---
+
+### Task 4: Gate 2 — the sweep's attestation check
+
+**Files:**
+
+- Create: `scripts/structure-audit/check-bypass-attestation.ts`
+- Test: `scripts/structure-audit/check-bypass-attestation.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Attestation`, `parseAttestation`, `readAttestation`, `ATTESTATION_PATH` from Task 3; `BypassActor`, `AuditResult`, `diffBypassActors`, `loadDeclaredBypass` from Tasks 1–2.
+- Produces: `evaluateAttestation(input: AttestationCheckInput): AuditResult`, `FUTURE_TOLERANCE_MS`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/structure-audit/check-bypass-attestation.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import type { BypassActor } from "./check-bypass-actors.ts";
+import { type AttestationCheckInput, evaluateAttestation } from "./check-bypass-attestation.ts";
+
+const NOW = Date.parse("2026-07-30T12:00:00.000Z");
+const DAY = 86_400_000;
+
+const DECLARED: Record<string, BypassActor[]> = {
+  Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+  "nimbus-sdk": [],
+};
+
+function attestation(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    attested_at: new Date(NOW - 3 * DAY).toISOString(),
+    attested_by: "asafgolombek",
+    grace_days: 90,
+    repos: ["Nimbus", "nimbus-sdk"],
+    observed: {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+      "nimbus-sdk": [],
+    },
+    ...overrides,
+  });
+}
+
+function input(overrides: Partial<AttestationCheckInput> = {}): AttestationCheckInput {
+  return {
+    raw: attestation(),
+    declaredRepos: ["Nimbus", "nimbus-sdk"],
+    declaredBypass: DECLARED,
+    graceDays: 90,
+    nowMs: NOW,
+    ...overrides,
+  };
+}
+
+describe("evaluateAttestation", () => {
+  test("passes on a fresh, complete, agreeing attestation", () => {
+    const r = evaluateAttestation(input());
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("reports an absent file distinctly from an unparseable one", () => {
+    expect(evaluateAttestation(input({ raw: null })).errors[0]).toContain("no attestation file");
+    expect(evaluateAttestation(input({ raw: "{oops" })).errors[0]).toContain("not valid JSON");
+  });
+
+  test("reports legal JSON that is not an object as unparseable", () => {
+    expect(evaluateAttestation(input({ raw: "[]" })).errors[0]).toContain("not valid JSON");
+  });
+
+  test("fails one day past the grace window", () => {
+    const raw = attestation({ attested_at: new Date(NOW - 91 * DAY).toISOString() });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("91d old (grace 90d)");
+  });
+
+  test("reads grace from config, not from the attestation's own grace_days", () => {
+    const raw = attestation({ attested_at: new Date(NOW - 45 * DAY).toISOString(), grace_days: 90 });
+    expect(evaluateAttestation(input({ raw, graceDays: 90 })).ok).toBe(true);
+    // A hand-edited grace_days:90 cannot widen a config that says 30.
+    expect(evaluateAttestation(input({ raw, graceDays: 30 })).ok).toBe(false);
+  });
+
+  // NaN comparisons are ALL false, so a naive `elapsed > grace` check PASSES.
+  test("treats an unparseable attested_at as a finding, never as fresh", () => {
+    const raw = attestation({ attested_at: "not-a-date" });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("not a parseable timestamp");
+  });
+
+  test("rejects a future-dated attestation beyond the skew tolerance", () => {
+    const raw = attestation({ attested_at: new Date(NOW + 2 * 3_600_000).toISOString() });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("in the future");
+  });
+
+  test("tolerates small forward clock skew", () => {
+    const raw = attestation({ attested_at: new Date(NOW + 10 * 60_000).toISOString() });
+    expect(evaluateAttestation(input({ raw })).ok).toBe(true);
+  });
+
+  test("fails when a newly declared repo is not covered by the attestation", () => {
+    const r = evaluateAttestation(
+      input({
+        declaredRepos: ["Nimbus", "nimbus-sdk", "nimbus-new"],
+        declaredBypass: { ...DECLARED, "nimbus-new": [] },
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("do not match declared repos"))).toBe(true);
+  });
+
+  test("fails when the attested snapshot no longer agrees with declared intent", () => {
+    const r = evaluateAttestation(
+      input({ declaredBypass: { ...DECLARED, Nimbus: [] } }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("drifts from declared intent");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bun test scripts/structure-audit/check-bypass-attestation.test.ts
+```
+
+Expected: FAIL — `Cannot find module './check-bypass-attestation.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/structure-audit/check-bypass-attestation.ts`:
+
+```ts
+#!/usr/bin/env bun
+
+/**
+ * audit:bypass-attestation — the sweep's half of the P6 bypass-actor gate.
+ *
+ * Runs with NO credential: it re-runs the same pure diff offline against the
+ * committed attestation, and checks that the attestation is fresh, covers every
+ * declared repo, and still agrees with declared intent.
+ *
+ * The gated property is NOT "the org is clean" — it is "a green attestation was
+ * committed recently and still agrees with declared intent". The attestation is a
+ * committed file and can be hand-edited; the real control is that it is PR-visible
+ * and diff-reviewed. See the design's "What this does not prove".
+ *
+ * Deliberately sweep-only, never the preflight FAST tier: its red depends on the
+ * OWNER's re-attestation cadence, so a stale attestation must never block an
+ * external contributor's unrelated PR.
+ */
+
+import type { AuditResult, BypassActor } from "./check-bypass-actors.ts";
+import { diffBypassActors, loadDeclaredBypass } from "./check-bypass-actors.ts";
+import { ATTESTATION_PATH, parseAttestation, readAttestation } from "./_bypass-attestation.ts";
+
+/** Forward clock skew we absorb rather than treat as a hand edit. */
+export const FUTURE_TOLERANCE_MS = 60 * 60 * 1000;
+
+const DAY_MS = 86_400_000;
+
+export interface AttestationCheckInput {
+  /** Raw file contents, or `null` when the file is absent. */
+  raw: string | null;
+  declaredRepos: string[];
+  declaredBypass: Record<string, BypassActor[]>;
+  /** From `bypass.attestation_grace_days` — NEVER the attestation's own field. */
+  graceDays: number;
+  /** Injected so freshness is testable without touching the system clock. */
+  nowMs: number;
+}
+
+export function evaluateAttestation(input: AttestationCheckInput): AuditResult {
+  const { raw, declaredRepos, declaredBypass, graceDays, nowMs } = input;
+
+  if (raw === null) {
+    return {
+      ok: false,
+      errors: [
+        `no attestation file at ${ATTESTATION_PATH} — run \`bun run audit:bypass-actors --attest\``,
+      ],
+    };
+  }
+
+  const parsed = parseAttestation(raw);
+  if (parsed === "unparseable") {
+    return { ok: false, errors: [`${ATTESTATION_PATH} is not valid JSON (or is not an object)`] };
+  }
+
+  const errors: string[] = [];
+
+  const attestedAtMs = Date.parse(parsed.attested_at);
+  if (Number.isNaN(attestedAtMs)) {
+    // Every comparison with NaN is false, so a naive staleness check would PASS.
+    errors.push(`attested_at "${parsed.attested_at}" is not a parseable timestamp`);
+  } else {
+    const elapsed = nowMs - attestedAtMs;
+    if (elapsed < -FUTURE_TOLERANCE_MS) {
+      errors.push(
+        `attested_at is ${Math.round(-elapsed / 60_000)} minutes in the future — clock skew or a hand-edited file`,
+      );
+    } else if (elapsed > graceDays * DAY_MS) {
+      errors.push(
+        `attestation is ${Math.floor(elapsed / DAY_MS)}d old (grace ${graceDays}d) — re-run \`bun run audit:bypass-actors --attest\``,
+      );
+    }
+  }
+
+  const attestedRepos = [...parsed.repos].sort();
+  const declared = [...declaredRepos].sort();
+  if (JSON.stringify(attestedRepos) !== JSON.stringify(declared)) {
+    errors.push(
+      `attested repos ${JSON.stringify(attestedRepos)} do not match declared repos ${JSON.stringify(declared)} — re-attest to cover the change`,
+    );
+  }
+
+  const diff = diffBypassActors(declaredRepos, declaredBypass, parsed.observed);
+  for (const err of diff.errors) {
+    errors.push(`attested snapshot drifts from declared intent — ${err}`);
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+if (import.meta.main) {
+  const label = "audit:bypass-attestation";
+  const file = loadDeclaredBypass(process.cwd());
+
+  const result = evaluateAttestation({
+    raw: readAttestation(process.cwd()),
+    declaredRepos: file.repos,
+    declaredBypass: file.bypass.by_repo,
+    graceDays: file.bypass.attestation_grace_days,
+    nowMs: Date.now(),
+  });
+
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`${label}: ${err}`);
+    // This gate takes no `--strict` branch, unlike every other sweep gate. Those
+    // fail SOFT locally because they need `gh` auth an external contributor lacks.
+    // This one reads two committed files and nothing else, so there is no
+    // environment where it cannot run — an unreadable, stale or disagreeing
+    // attestation is always a real finding. The workflow still passes `--strict`
+    // for consistency; it is simply a no-op here.
+    process.exit(1);
+  }
+
+  console.log(`${label}: OK (${file.repos.length} repos, grace ${file.bypass.attestation_grace_days}d)`);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bun test scripts/structure-audit/check-bypass-attestation.test.ts
+```
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+bun test scripts/structure-audit/check-bypass-attestation.test.ts
+bunx biome check packages scripts
+git add scripts/structure-audit/check-bypass-attestation.ts scripts/structure-audit/check-bypass-attestation.test.ts
+git commit -m "feat(p6): add the credential-free attestation gate
+
+Checks freshness, repo coverage, and that the attested snapshot still agrees
+with declared intent — the last catching a config edit without a re-attest.
+Two fail-opens are handled explicitly: an unparseable attested_at yields NaN
+(every comparison false, so a naive staleness check passes) and a future date
+stays fresh until real time catches up."
+```
+
+---
+
+### Task 5: Wiring — scripts, gate manifest, sweep job, stale comments
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `scripts/lib/preflight-gates.ts:71-95` (`CI_ONLY_GATES`)
+- Modify: `.github/workflows/org-drift-sweep.yml`
+- Modify: `scripts/structure-audit/check-ruleset-drift.ts:115-123` and its `DesiredRulesetFile` docstring
+
+**Interfaces:**
+
+- Consumes: the two CLIs from Tasks 3–4.
+- Produces: `audit:bypass-actors` and `audit:bypass-attestation` as runnable `bun run` scripts.
+
+- [ ] **Step 1: Add the package.json scripts**
+
+Beside the other sweep gates (after `"audit:review-coverage"`):
+
+```json
+    "audit:bypass-actors": "bun scripts/structure-audit/check-bypass-actors.ts",
+    "audit:bypass-attestation": "bun scripts/structure-audit/check-bypass-attestation.ts",
+```
+
+- [ ] **Step 2: Add both to CI_ONLY_GATES**
+
+In `scripts/lib/preflight-gates.ts`, append inside `CI_ONLY_GATES`:
+
+```ts
+  "audit:bypass-actors", // needs an OWNER gh token (admin:org) — the CI App token cannot read bypass_actors; an explicit human action, never a gate
+  "audit:bypass-attestation", // local + deterministic, but its red depends on the OWNER's re-attestation cadence; sweep-only so a stale attestation never blocks a contributor's PR
+```
+
+- [ ] **Step 3: Verify the manifest drift test still passes**
+
+```bash
+bun test scripts/lib/
+```
+
+Expected: PASS. If it fails with "gate not in manifest", the names in Step 2 do not match `package.json` exactly.
+
+- [ ] **Step 4: Add the sweep job**
+
+In `.github/workflows/org-drift-sweep.yml`, after the `review-coverage` job. Note there is **no token mint and no `bun install`** — the gate reads a committed JSON file and uses no external dependency.
+
+```yaml
+  bypass-attestation:
+    name: bypass-attestation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      # No App token: this gate reads only the committed attestation + declared
+      # config. Reading bypass_actors needs Administration:write, which is the
+      # whole reason the attestation indirection exists.
+      - name: Audit the bypass-actor attestation
+        run: bun scripts/structure-audit/check-bypass-attestation.ts --strict
+```
+
+- [ ] **Step 5: Correct the stale comments in check-ruleset-drift.ts**
+
+Replace the comment block at lines 115-123 (beginning `// Bypass actors are intentionally NOT diffed.`) with:
+
+```ts
+  // Bypass actors are intentionally NOT diffed HERE. This gate's credential is a
+  // repo-scoped App installation token with `Administration: read`, which returns
+  // an EMPTY `bypass_actors` for org-level actors (OrganizationAdmin) — proven
+  // live that adding `organization-administration: read` does not restore it, and
+  // reading them would need `Administration: write`, which a read-only audit gate
+  // must not hold. The field IS gated, by the owner-run `audit:bypass-actors`
+  // plus the sweep's `audit:bypass-attestation`, both reading the `bypass` block
+  // of .github/rulesets/general-branch.json. See docs/infrastructure-roadmap.md, P6.
+```
+
+Then update the `DesiredRulesetFile` docstring (around line 39-44), replacing the sentence "There are no per-repo overrides — bypass actors are intentionally not diffed (see `diffRuleset` / the P1 progress log), and everything else is uniform." with:
+
+```ts
+ * `shared` is uniform across repos; per-repo bypass intent lives in the sibling
+ * `bypass` block and is consumed by check-bypass-actors.ts, not by this gate.
+```
+
+- [ ] **Step 6: Verify both scripts run**
+
+```bash
+bun run audit:bypass-actors
+bun run audit:bypass-attestation
+```
+
+Expected: `audit:bypass-actors: OK (5 repos)`. `audit:bypass-attestation` will FAIL with "no attestation file" — correct, the file arrives in Task 6.
+
+- [ ] **Step 7: Lint, workflow-lint and commit**
+
+```bash
+bunx biome check packages scripts
+bun run audit:workflow-lint
+bun run audit:action-sha-pins
+git add package.json scripts/lib/preflight-gates.ts .github/workflows/org-drift-sweep.yml scripts/structure-audit/check-ruleset-drift.ts
+git commit -m "feat(p6): wire both bypass gates; correct the now-stale ruleset-drift comments
+
+Four places asserted bypass actors were ungated. ruleset-drift still does not
+diff them — its credential cannot — but its comment now points at the gate that
+does, rather than describing a follow-up."
+```
+
+---
+
+### Task 6: Red-prove, attest, and close P6
+
+**Files:**
+
+- Create: `docs/structure-audit/bypass-actors-attestation.json` (generated)
+- Modify: `docs/infrastructure-roadmap.md`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1–5.
+- Produces: a green `bypass-attestation` job in the sweep.
+
+- [ ] **Step 1: Live red-prove the diff**
+
+The gate ships green by construction (live state already matches declared), so this is the one live red-prove available. It mutates only the working tree — **no org setting is changed**.
+
+```bash
+bun -e 'const p=".github/rulesets/general-branch.json";const f=require("fs");const s=f.readFileSync(p,"utf8");f.writeFileSync(p,s.replace(/"bypass_mode": "always"/,"\"bypass_mode\": \"pull_request\""));'
+grep -c 'pull_request"' .github/rulesets/general-branch.json
+```
+
+**Verify the mutation actually landed before trusting the result** — the `review-coverage` red-prove taught this. The `grep -c` must show the edit is present.
+
+```bash
+bun run audit:bypass-actors; echo "EXIT=$?"
+```
+
+Expected: `EXIT=1` with `Nimbus: OrganizationAdmin:null bypass_mode: expected pull_request, got always`.
+
+- [ ] **Step 2: Revert the red-prove**
+
+```bash
+git checkout -- .github/rulesets/general-branch.json
+bun run audit:bypass-actors; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`, `audit:bypass-actors: OK (5 repos)`.
+
+- [ ] **Step 3: Red-prove the partial-read refusal**
+
+Temporarily add a non-existent repo to `repos` and `bypass.by_repo` in `.github/rulesets/general-branch.json`:
+
+```json
+      "nimbus-does-not-exist": []
+```
+
+(add to both `repos` and `bypass.by_repo`), then:
+
+```bash
+bun run audit:bypass-actors --attest; echo "EXIT=$?"
+git checkout -- .github/rulesets/general-branch.json
+```
+
+Expected: `EXIT=1` with `cannot attest: nimbus-does-not-exist unreachable (read 5 of 6)`, and **no attestation file written**. Confirm with `git status --short` showing no new file.
+
+- [ ] **Step 4: Generate the real attestation**
+
+```bash
+bun run audit:bypass-actors --attest
+cat docs/structure-audit/bypass-actors-attestation.json
+```
+
+Expected: `OK (5 repos) — wrote docs/structure-audit/bypass-actors-attestation.json`, and the file lists all five repos with `OrganizationAdmin`/`always` on Nimbus, nimbus-vscode and nimbus-web-clipper, `[]` on nimbus-client and nimbus-sdk.
+
+- [ ] **Step 5: Verify Gate 2 now passes**
+
+```bash
+bun run audit:bypass-attestation; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`, `audit:bypass-attestation: OK (5 repos, grace 90d)`.
+
+- [ ] **Step 6: Red-prove Gate 2's staleness path**
+
+```bash
+bun -e 'const p="docs/structure-audit/bypass-actors-attestation.json";const f=require("fs");const a=JSON.parse(f.readFileSync(p,"utf8"));a.attested_at=new Date(Date.now()-91*86400000).toISOString();f.writeFileSync(p,JSON.stringify(a,null,2)+"\n");'
+bun run audit:bypass-attestation; echo "EXIT=$?"
+git checkout -- docs/structure-audit/bypass-actors-attestation.json 2>/dev/null || bun run audit:bypass-actors --attest
+```
+
+Expected: `EXIT=1` with `attestation is 91d old (grace 90d)`. The final command restores a fresh attestation (the file is untracked until Step 8, so `git checkout` may fail — the `--attest` fallback handles it).
+
+- [ ] **Step 7: Update the roadmap**
+
+In `docs/infrastructure-roadmap.md`, change the P6 row's Status cell from `🔨 P6a + CLA done` to `✅ done — bypass-attestation green in sweep run <RUN_ID>` (fill in after Step 9), and change the Gate cell's trailing `Remaining: bypass-actor audit` to `bypass actors gated by the owner-run audit:bypass-actors + the sweep's audit:bypass-attestation`.
+
+Add to the P6a progress log, replacing the `**Deferred:**` bullet's bypass-actor clause:
+
+```markdown
+- **Bypass-actor audit — CLOSED (2026-07-30).** The last P6 item. `audit:ruleset-drift`
+  still cannot read `bypass_actors` (its App token gets an empty array; reading the
+  field needs `Administration: write`, which a read-only gate must not hold), so the
+  field is gated by a pair instead: the owner-run `audit:bypass-actors` diffs live
+  state against a new machine-readable `bypass` block and writes a committed
+  attestation, and the credential-free `audit:bypass-attestation` runs in the sweep
+  checking freshness (90d, flipping to 30 at contributor-two), repo coverage, and
+  that the snapshot still agrees with declared intent.
+- **What the design review caught before any code existed.** `--attest` originally
+  keyed off the diff alone. But `decideExit` returns exit 0 for a partial read with
+  no drift — correct for a reporting gate, wrong for an attesting one — so a 4-of-5
+  read would have written an attestation claiming five repos, which the sweep gate
+  then accepts as full coverage for the whole grace window. `--attest` now requires
+  a complete read, and the written `repos` field derives from what was observed.
+- **Honest limit.** The attestation is a committed file and can be hand-edited, so
+  the gate proves *a green attestation was committed recently and still agrees with
+  declared intent*, not *the org is clean now*. The control is that the file is
+  PR-visible and diff-reviewed. Residual exposure is bounded by the grace window.
+```
+
+Keep the remaining deferred items (private-repo ruleset protection stays blocked-on-Team).
+
+- [ ] **Step 8: Full local verification**
+
+```bash
+bun test scripts/structure-audit/
+bunx biome check packages scripts
+bun run lint:markdown
+bun run audit:doc-refs
+bun run audit:status-drift
+```
+
+All must pass. Then commit:
+
+```bash
+git add docs/structure-audit/bypass-actors-attestation.json docs/infrastructure-roadmap.md
+git commit -m "feat(p6): attest the live bypass state and close P6
+
+Red-proved three ways before attesting: a flipped declared bypass_mode reds the
+diff, an unreachable repo refuses to attest, and a backdated attestation reds
+the sweep gate. Live state matches declared intent on all five repos."
+```
+
+- [ ] **Step 9: Push, PR, and prove it in the sweep**
+
+```bash
+git push -u origin dev/asafgolombek/p6-bypass-actor-audit
+gh pr create --fill
+```
+
+After merge, dispatch the sweep and confirm the new job is green — **this is P6's actual bar, not the merge**:
+
+```bash
+gh workflow run org-drift-sweep.yml --ref main
+gh run list --workflow=org-drift-sweep.yml --limit 1
+```
+
+Verify `bypass-attestation` is `success`, then backfill the run id into the roadmap row from Step 7 and commit that one-line change.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Gate 1 → Tasks 1-3. Gate 2 → Task 4. Config block + grace switch → Task 1. Stale-comment corrections (all four sites) → Task 1 (the two in `general-branch.json`) and Task 5 (the two in `check-ruleset-drift.ts`). Attestation shape → Task 3. Sweep placement + `CI_ONLY_GATES` → Task 5. Red-prove → Task 6 Steps 1-3 and 6. Definition of done items 1-6 → Task 6 Steps 4-9.
+
+**Review-response coverage.** 1.2 partial-read guard → Task 3 (`decideAttestWrite` + its test) and Task 6 Step 3. 1.1 unsupported-actor hard error → Task 2. 1.3 NaN and future-date → Task 4. 2.1 `attested_by` → "unknown" → Task 3 Step 5. 2.3 enum validation → Task 1. 2.2 was declined, so no task — correct.
+
+**Type consistency.** `AuditResult` is defined once in `check-bypass-actors.ts` and imported by Gate 2. `BypassActor` likewise. `diffBypassActors(repos, declared, observed)` keeps that argument order at all three call sites (Task 2 tests, Task 3 CLI, Task 4 `evaluateAttestation`). `ATTESTATION_PATH` is defined in `_bypass-attestation.ts` and used in Tasks 3 and 4.
+
+**One asymmetry worth flagging to the implementer:** Gate 2 is the only sweep gate with no `--strict` branch. Every other one fails soft locally because it needs `gh` auth that an external contributor lacks; Gate 2 reads two committed files and nothing else, so there is no environment in which it cannot run. The workflow still passes `--strict` for consistency with its siblings, where it is a no-op. This is explained in a comment at the exit site rather than left for a reader to infer.

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
@@ -836,7 +836,11 @@ if (import.meta.main) {
     observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
   }
 
-  const result = diffBypassActors(file.repos, file.bypass.by_repo, observed);
+  const result = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
+  // Diff only the repos actually observed — unreachable repos are already
+  // reported by decideExit's "could not query" warning, so feeding them into
+  // the diff too would manufacture a bogus "no observed bypass_actors"
+  // finding and make a partial read misreport as a drift finding.
   const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
 
   if (attest) {

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
@@ -1240,7 +1240,7 @@ if (import.meta.main) {
 bun test scripts/structure-audit/check-bypass-attestation.test.ts
 ```
 
-Expected: PASS, 13 tests.
+Expected: PASS, 12 tests.
 
 - [ ] **Step 5: Lint and commit**
 

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
@@ -11,6 +11,45 @@
 **Spec:** [`../specs/2026-07-30-p6-bypass-actor-audit-design.md`](../specs/2026-07-30-p6-bypass-actor-audit-design.md)
 **Review response:** [`../specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md`](../specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md)
 
+> **2026-07-30 fix wave (whole-branch review, after this plan shipped).** Three
+> Important findings landed against the code blocks below, since corrected in
+> `check-bypass-actors.ts` (this document's embedded code and tests are updated
+> to match, so it never contradicts the shipped code):
+>
+> 1. **Duplicate actor identities silently collapsed.** `diffBypassActors` built
+>    `wantById`/`gotById` via `new Map(array.map(...))` keyed on identity
+>    (type + id, mode excluded) — `Map` keeps only the LAST entry for a repeated
+>    key, discarding a duplicate (e.g. the same actor listed as both `always` and
+>    `pull_request`) with no signal, and the outcome depended on array order.
+>    Fixed by `duplicateIdentities`, checked on both `want` and `got` before
+>    either becomes a Map.
+> 2. **The null-id rule checked the type name only, never `actor_id`.** A
+>    null-id-eligible type (`OrganizationAdmin`) carrying a numeric `actor_id`
+>    sailed through in both `diffBypassActors` and `validateDeclaredBypass`,
+>    directly defeating the reviewability rationale documented at
+>    `NULL_ID_ACTOR_TYPES`. Fixed by `isSupportedActor` (diff side) and the
+>    parallel `else if` branch (validator side) — both now require
+>    `actor_type` in `NULL_ID_ACTOR_TYPES` **and** `(actor_id ?? null) === null`.
+>    This also required rewriting the original "is order-independent across the
+>    actor set" test, which used a numeric-id `OrganizationAdmin` and asserted
+>    the diff PASSED — under the corrected rule that is a hard error, so the old
+>    test locked in the defect. See the rewritten test below plus the new
+>    "...on the error path" test for order-independence of the error case.
+> 3. **A 404 was laundered into "unreachable" instead of a finding.** Gate 1's CLI
+>    treated every `runGh` failure identically. A 404 on the repo itself (renamed
+>    or deleted) means the repo is genuinely absent — a real finding — not an
+>    indeterminate/transient failure. Fixed by classifying with
+>    `classifyReadFailure` (from `_gh-audit.ts`, already used by the sibling
+>    `check-cla-coverage.ts`): `"absent"` becomes a hard error folded into
+>    `result.errors`; anything else stays `unreachable` as before. `decideExit`'s
+>    `queried === 0` skip-green guard was also narrowed to
+>    `queried === 0 && errors.length === 0`, so a confirmed-absent repo can never
+>    be swallowed by the soft skip even in the edge case where every declared
+>    repo turns out to be absent.
+>
+> Full writeup + red-proof output: `task-6-report.md` in this branch's
+> `.superpowers/sdd/2026-07-30-p6-bypass-actor-audit/` folder.
+
 ## Global Constraints
 
 - **No `any`.** Use `unknown` for external data and narrow it. TypeScript strict mode is non-negotiable.
@@ -303,6 +342,14 @@ export function validateDeclaredBypass(file: DeclaredBypassFile): string[] {
             ? `unsupported actor_type "${actor.actor_type}" in bypass.by_repo.${repo} — only null-id org-level actors (${NULL_ID_ACTOR_TYPES.join("|")}) are supported`
             : `unknown actor_type "${actor.actor_type}" in bypass.by_repo.${repo}`,
         );
+      } else if ((actor.actor_id ?? null) !== null) {
+        // The type is null-id-eligible, but THIS entry carries a numeric id — the
+        // exact shape the reviewability rationale (see NULL_ID_ACTOR_TYPES above)
+        // exists to reject. Distinct message from "unsupported actor_type" above:
+        // the type is fine, the numeric id is the defect.
+        errors.push(
+          `bypass.by_repo.${repo} declares "${actor.actor_type}" with a numeric actor_id (${actor.actor_id}) — unsupported: a numeric id is not human-reviewable in a PR diff`,
+        );
       }
     }
   }
@@ -427,21 +474,102 @@ describe("diffBypassActors", () => {
   });
 
   test("is order-independent across the actor set", () => {
-    const twoDeclared: Record<string, BypassActor[]> = {
+    // A legitimately-passing single-repo set, reordered relative to
+    // `declared()`/`observed()`. NOTE (2026-07-30 fix wave): the original version
+    // of this test used a SECOND actor per repo — `{ actor_type:
+    // "OrganizationAdmin", actor_id: 7, bypass_mode: "always" }` — and asserted
+    // the diff PASSED. Under the corrected rule (an actor is supported only when
+    // its type is null-id-eligible AND its actor_id is actually null — see the
+    // Task 2 implementation note below) that numeric-id actor is a hard error, so
+    // the old assertion locked in exactly the defect the correction closes. See
+    // "is order-independent on the error path" for order-independence of the
+    // error case instead.
+    const oneDeclared: Record<string, BypassActor[]> = {
+      "nimbus-sdk": [],
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+    };
+    const oneLive: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+      "nimbus-sdk": [],
+    };
+    expect(diffBypassActors(REPOS, oneDeclared, oneLive).ok).toBe(true);
+  });
+
+  test("is order-independent on the error path: same findings regardless of input order", () => {
+    const declaredTwoRepos: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+      "nimbus-sdk": [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+    };
+    const liveTwoRepos: Record<string, BypassActor[]> = {
+      // Nimbus: a numeric-id OrganizationAdmin — unsupported (Finding 2).
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" }],
+      // nimbus-sdk: a duplicated identity — Finding 1.
+      "nimbus-sdk": [
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+      ],
+    };
+    const forward = diffBypassActors(["Nimbus", "nimbus-sdk"], declaredTwoRepos, liveTwoRepos);
+    const reversed = diffBypassActors(["nimbus-sdk", "Nimbus"], declaredTwoRepos, liveTwoRepos);
+    expect(forward.ok).toBe(false);
+    expect(reversed.ok).toBe(false);
+    expect([...forward.errors].sort()).toEqual([...reversed.errors].sort());
+  });
+
+  test("Finding 1: a duplicate OBSERVED identity is a hard error, never normalized to the last entry", () => {
+    // Proven failure: declared has a single pull_request-mode actor; observed
+    // repeats the same identity as `always` then `pull_request`. Map-based
+    // dedup on actorIdentity would keep only the LAST entry (pull_request),
+    // matching declared and returning a false green — silently discarding the
+    // more permissive `always` bypass, which is exactly what this gate exists
+    // to catch.
+    const declaredOne: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "pull_request" }],
+    };
+    const dupedActors: BypassActor[] = [
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+    ];
+    const r = diffBypassActors(["Nimbus"], declaredOne, { Nimbus: dupedActors });
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain(
+      "duplicate observed bypass actor identity OrganizationAdmin:null",
+    );
+
+    // Order-dependence proof: swapping the two observed entries must NOT change
+    // the verdict (both must be errors — this was the reported symptom).
+    const rSwapped = diffBypassActors(["Nimbus"], declaredOne, {
+      Nimbus: [...dupedActors].reverse(),
+    });
+    expect(rSwapped.ok).toBe(false);
+  });
+
+  test("Finding 1: a duplicate DECLARED identity is also a hard error", () => {
+    const declaredDuped: Record<string, BypassActor[]> = {
       Nimbus: [
         { actor_type: "OrganizationAdmin", bypass_mode: "always" },
-        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", bypass_mode: "pull_request" },
       ],
-      "nimbus-sdk": [],
     };
-    const twoLive: Record<string, BypassActor[]> = {
-      Nimbus: [
-        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
-        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
-      ],
-      "nimbus-sdk": [],
+    const live: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
     };
-    expect(diffBypassActors(REPOS, twoDeclared, twoLive).ok).toBe(true);
+    const r = diffBypassActors(["Nimbus"], declaredDuped, live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain(
+      "duplicate declared bypass actor identity OrganizationAdmin:null",
+    );
+  });
+
+  test("Finding 2: a numeric-id OrganizationAdmin is a hard error on the diff side, not merely 'unknown type'", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [{ actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" }];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("unsupported bypass actor type OrganizationAdmin");
+    expect(r.errors[0]).toContain("numeric actor_id (7)");
+    expect(r.errors[0]).toContain("not human-reviewable");
+    expect(r.errors[0]).not.toContain("unknown actor_type");
   });
 });
 
@@ -478,6 +606,35 @@ function actorIdentity(actor: BypassActor): string {
 }
 
 /**
+ * True only for an actor this gate can render human-checkably: a type in
+ * `NULL_ID_ACTOR_TYPES` carrying an actually-null `actor_id`. Checking the type
+ * name alone is not enough — a null-id type can still show up with a numeric id
+ * (e.g. a GitHub API quirk or a hand-edited config), and that is exactly the
+ * shape the reviewability rationale (see `NULL_ID_ACTOR_TYPES`) exists to reject.
+ */
+function isSupportedActor(actor: BypassActor): boolean {
+  return NULL_ID_ACTOR_TYPES.includes(actor.actor_type) && (actor.actor_id ?? null) === null;
+}
+
+/**
+ * Identity keys that occur more than once in an actor array.
+ *
+ * `new Map(array.map(...))` silently keeps only the LAST entry for a repeated
+ * key — a duplicate identity (e.g. the same actor listed twice with different
+ * `bypass_mode`s) would otherwise be discarded with no signal, and which entry
+ * "wins" depends on array order. Both sides of the diff must be checked before
+ * either is turned into a Map.
+ */
+function duplicateIdentities(actors: BypassActor[]): string[] {
+  const counts = new Map<string, number>();
+  for (const actor of actors) {
+    const id = actorIdentity(actor);
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).map(([id]) => id);
+}
+
+/**
  * Pure diff — the whole verdict, so both gates share it and neither needs network.
  * Gate 1 passes live `gh` data as `observed`; Gate 2 passes the attested snapshot.
  *
@@ -503,13 +660,42 @@ export function diffBypassActors(
       continue;
     }
 
-    // An actor type we cannot render human-checkably is a hard error, never
-    // silently normalized — otherwise a Team bypass added in the UI reads green.
-    const unsupported = got.filter((a) => !NULL_ID_ACTOR_TYPES.includes(a.actor_type));
+    // A duplicate identity must never be silently resolved by `Map` keeping the
+    // last entry — that would discard the most permissive bypass_mode with no
+    // signal, and the surviving entry would depend on array order. Checked on
+    // BOTH sides before either is turned into a Map.
+    const wantDupes = duplicateIdentities(want);
+    if (wantDupes.length > 0) {
+      for (const id of wantDupes) {
+        errors.push(
+          `${repo}: duplicate declared bypass actor identity ${id} in bypass.by_repo.${repo}`,
+        );
+      }
+      continue;
+    }
+    const gotDupes = duplicateIdentities(got);
+    if (gotDupes.length > 0) {
+      for (const id of gotDupes) {
+        errors.push(
+          `${repo}: duplicate observed bypass actor identity ${id} — cannot safely diff against declared intent`,
+        );
+      }
+      continue;
+    }
+
+    // An actor we cannot render human-checkably is a hard error, never silently
+    // normalized — otherwise a Team bypass, or a null-id type carrying a numeric
+    // id, added in the UI reads green. The two cases get DISTINCT messages: an
+    // unknown/non-null-id type is a type problem, but a null-id type carrying a
+    // numeric actor_id is a reviewability problem, not a type problem — saying
+    // "unknown type" there would misdescribe the defect.
+    const unsupported = got.filter((a) => !isSupportedActor(a));
     if (unsupported.length > 0) {
       for (const actor of unsupported) {
         errors.push(
-          `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
+          NULL_ID_ACTOR_TYPES.includes(actor.actor_type)
+            ? `${repo}: unsupported bypass actor type ${actor.actor_type} with a numeric actor_id (${actor.actor_id}) — a numeric id is not human-reviewable in a PR diff`
+            : `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
         );
       }
       continue;
@@ -756,8 +942,12 @@ Append to `scripts/structure-audit/check-bypass-actors.ts`:
  * Exit decision for the per-repo loop.
  *
  * INVARIANT, mirroring check-ruleset-drift: real drift on a reachable repo is
- * never discarded because a DIFFERENT repo's read failed. `queried === 0` is the
- * only skip-green case.
+ * never discarded because a DIFFERENT repo's read failed. `queried === 0` is
+ * the skip-green case — but ONLY when there are also no errors. A confirmed
+ * 404 (repo absent) is folded into `errors` even when it drove `queried` to 0
+ * (e.g. every declared repo turned out to be renamed/deleted); that is real
+ * signal that `gh` worked, not "nothing was readable", so it must never be
+ * swallowed by the soft skip.
  */
 export function decideExit(input: {
   queried: number;
@@ -767,7 +957,7 @@ export function decideExit(input: {
 }): { code: 0 | 1; message: string } {
   const { queried, errors, unreachable, strict = false } = input;
 
-  if (queried === 0) return strictSkip("audit:bypass-actors", strict);
+  if (queried === 0 && errors.length === 0) return strictSkip("audit:bypass-actors", strict);
 
   if (errors.length > 0) {
     const lines = errors.map((err) => `audit:bypass-actors: ${err}`);
@@ -802,6 +992,13 @@ if (import.meta.main) {
 
   const observed: Record<string, BypassActor[]> = {};
   const unreachable: string[] = [];
+  // A confirmed 404 on the repo itself is NOT "unreachable" — that bucket is for
+  // transient/indeterminate failures (5xx, rate-limit, network) that must never
+  // be read as a finding. A 404 means the repo is genuinely absent (renamed or
+  // deleted), which is real drift: it must exit 1, never a soft "could not
+  // query" warning that leaves the gate green. Mirrors check-cla-coverage.ts's
+  // classifyReadFailure handling.
+  const absentErrors: string[] = [];
   let queried = 0;
 
   for (const repo of file.repos) {
@@ -813,7 +1010,13 @@ if (import.meta.main) {
       '.[] | select(.name=="General") | .id',
     ]);
     if (!listResult.ok) {
-      unreachable.push(repo);
+      if (classifyReadFailure(listResult.httpStatus) === "absent") {
+        absentErrors.push(
+          `${repo}: repository not found (HTTP 404 on rulesets) — likely renamed or deleted; update bypass.by_repo if intentional`,
+        );
+      } else {
+        unreachable.push(repo);
+      }
       continue;
     }
     const id = listResult.stdout.trim();
@@ -826,21 +1029,28 @@ if (import.meta.main) {
 
     const detail = runGh(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
     if (!detail.ok) {
-      unreachable.push(repo);
+      if (classifyReadFailure(detail.httpStatus) === "absent") {
+        absentErrors.push(
+          `${repo}: repository not found (HTTP 404 on rulesets/${id}) — likely renamed or deleted; update bypass.by_repo if intentional`,
+        );
+      } else {
+        unreachable.push(repo);
+      }
       continue;
     }
 
     queried += 1;
     const live: unknown = JSON.parse(detail.stdout);
-    const actors = isRecord(live) && Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
+    const actors =
+      isRecord(live) && Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
     observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
   }
 
-  const result = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
-  // Diff only the repos actually observed — unreachable repos are already
-  // reported by decideExit's "could not query" warning, so feeding them into
-  // the diff too would manufacture a bogus "no observed bypass_actors"
-  // finding and make a partial read misreport as a drift finding.
+  const diffResult = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
+  const result: AuditResult = {
+    ok: diffResult.ok && absentErrors.length === 0,
+    errors: [...absentErrors, ...diffResult.errors],
+  };
   const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
 
   if (attest) {
@@ -877,13 +1087,25 @@ if (import.meta.main) {
 Add these imports at the top of `check-bypass-actors.ts`, beneath the existing `node:` imports:
 
 ```ts
-import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
 import {
   ATTESTATION_PATH,
   decideAttestWrite,
   writeAttestation,
 } from "./_bypass-attestation.ts";
 ```
+
+> **2026-07-30 fix wave (post-review), Finding 3.** The version above (and shipped
+> in the original PR) treated every `runGh` failure identically, pushing the repo
+> onto `unreachable` regardless of cause — so a genuinely deleted/renamed repo
+> (both `gh api` calls 404) read as an "unreachable" WARNING and the gate still
+> exited 0. `_gh-audit.ts` exports exactly the primitive to fix this —
+> `classifyReadFailure(httpStatus)`, already consumed the same way by the sibling
+> `check-cla-coverage.ts` — so a confirmed 404 is now folded into `absentErrors`
+> (a hard error, exit 1) while any other failure (5xx, rate-limit, network) stays
+> `unreachable` as before. `decideExit`'s `queried === 0` guard was also narrowed
+> to `queried === 0 && errors.length === 0` so a fully-absent repo set can never
+> be swallowed by the soft skip. The code block above already reflects the fix.
 
 - [ ] **Step 6: Add a decideExit test**
 

--- a/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
+++ b/docs/superpowers/plans/2026-07-30-p6-bypass-actor-audit.md
@@ -253,9 +253,22 @@ export const KNOWN_ACTOR_TYPES: readonly string[] = [
   "DeployKey",
 ];
 
+const DECLARED_PATH = ".github/rulesets/general-branch.json";
+
 export function loadDeclaredBypass(repoRoot: string): DeclaredBypassFile {
-  const raw = readFileSync(join(repoRoot, ".github/rulesets/general-branch.json"), "utf8");
-  return JSON.parse(raw) as DeclaredBypassFile;
+  const raw = readFileSync(join(repoRoot, DECLARED_PATH), "utf8");
+  try {
+    return JSON.parse(raw) as DeclaredBypassFile;
+  } catch (err) {
+    // Deliberately NOT an "unparseable" verdict like the attestation's. That file
+    // is generated and could plausibly be corrupted; THIS one is hand-authored and
+    // already covered by `biome check .`, so a parse failure means a broken repo,
+    // not a runtime condition to degrade around. Rethrow with the path so the
+    // failure names the file instead of a bare character offset.
+    throw new Error(
+      `${DECLARED_PATH} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /**
@@ -1038,6 +1051,23 @@ describe("evaluateAttestation", () => {
     expect(r.errors.some((e) => e.includes("do not match declared repos"))).toBe(true);
   });
 
+  // The second NaN fail-open: `elapsed > NaN` is false, so an unguarded missing
+  // attestation_grace_days would report a 10-year-old attestation as fresh.
+  test("a non-numeric grace window is a finding, not a silently disabled check", () => {
+    const raw = attestation({ attested_at: new Date(NOW - 3650 * DAY).toISOString() });
+    const r = evaluateAttestation(input({ raw, graceDays: Number.NaN }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("attestation_grace_days"))).toBe(true);
+  });
+
+  test("a zero or negative grace window is a finding", () => {
+    for (const bad of [0, -30]) {
+      const r = evaluateAttestation(input({ graceDays: bad }));
+      expect(r.ok).toBe(false);
+      expect(r.errors.some((e) => e.includes("attestation_grace_days"))).toBe(true);
+    }
+  });
+
   test("fails when the attested snapshot no longer agrees with declared intent", () => {
     const r = evaluateAttestation(
       input({ declaredBypass: { ...DECLARED, Nimbus: [] } }),
@@ -1081,7 +1111,11 @@ Create `scripts/structure-audit/check-bypass-attestation.ts`:
  */
 
 import type { AuditResult, BypassActor } from "./check-bypass-actors.ts";
-import { diffBypassActors, loadDeclaredBypass } from "./check-bypass-actors.ts";
+import {
+  diffBypassActors,
+  loadDeclaredBypass,
+  validateDeclaredBypass,
+} from "./check-bypass-actors.ts";
 import { ATTESTATION_PATH, parseAttestation, readAttestation } from "./_bypass-attestation.ts";
 
 /** Forward clock skew we absorb rather than treat as a hand edit. */
@@ -1119,6 +1153,18 @@ export function evaluateAttestation(input: AttestationCheckInput): AuditResult {
 
   const errors: string[] = [];
 
+  // The SECOND NaN fail-open, one level up from `attested_at`. A missing
+  // `attestation_grace_days` makes `graceDays * DAY_MS` NaN, and `elapsed > NaN`
+  // is false — so deleting one config line would silently disable the freshness
+  // check while the gate stayed green. Guarded here as well as in the CLI, since
+  // this pure function is what the tests exercise.
+  const graceValid = Number.isFinite(graceDays) && graceDays > 0;
+  if (!graceValid) {
+    errors.push(
+      `grace window is not a positive number (${String(graceDays)}) — check bypass.attestation_grace_days`,
+    );
+  }
+
   const attestedAtMs = Date.parse(parsed.attested_at);
   if (Number.isNaN(attestedAtMs)) {
     // Every comparison with NaN is false, so a naive staleness check would PASS.
@@ -1129,7 +1175,7 @@ export function evaluateAttestation(input: AttestationCheckInput): AuditResult {
       errors.push(
         `attested_at is ${Math.round(-elapsed / 60_000)} minutes in the future — clock skew or a hand-edited file`,
       );
-    } else if (elapsed > graceDays * DAY_MS) {
+    } else if (graceValid && elapsed > graceDays * DAY_MS) {
       errors.push(
         `attestation is ${Math.floor(elapsed / DAY_MS)}d old (grace ${graceDays}d) — re-run \`bun run audit:bypass-actors --attest\``,
       );
@@ -1155,6 +1201,15 @@ export function evaluateAttestation(input: AttestationCheckInput): AuditResult {
 if (import.meta.main) {
   const label = "audit:bypass-attestation";
   const file = loadDeclaredBypass(process.cwd());
+
+  // Validate the declared config BEFORE consuming its grace window. Gate 1 does
+  // this too; skipping it here would let a missing `attestation_grace_days`
+  // reach the comparison as NaN and silently disable the freshness check.
+  const configErrors = validateDeclaredBypass(file);
+  if (configErrors.length > 0) {
+    for (const err of configErrors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
 
   const result = evaluateAttestation({
     raw: readAttestation(process.cwd()),
@@ -1185,7 +1240,7 @@ if (import.meta.main) {
 bun test scripts/structure-audit/check-bypass-attestation.test.ts
 ```
 
-Expected: PASS, 11 tests.
+Expected: PASS, 13 tests.
 
 - [ ] **Step 5: Lint and commit**
 
@@ -1473,5 +1528,39 @@ Verify `bypass-attestation` is `success`, then backfill the run id into the road
 **Review-response coverage.** 1.2 partial-read guard → Task 3 (`decideAttestWrite` + its test) and Task 6 Step 3. 1.1 unsupported-actor hard error → Task 2. 1.3 NaN and future-date → Task 4. 2.1 `attested_by` → "unknown" → Task 3 Step 5. 2.3 enum validation → Task 1. 2.2 was declined, so no task — correct.
 
 **Type consistency.** `AuditResult` is defined once in `check-bypass-actors.ts` and imported by Gate 2. `BypassActor` likewise. `diffBypassActors(repos, declared, observed)` keeps that argument order at all three call sites (Task 2 tests, Task 3 CLI, Task 4 `evaluateAttestation`). `ATTESTATION_PATH` is defined in `_bypass-attestation.ts` and used in Tasks 3 and 4.
+
+**Plan-review disposition (2026-07-30).** Reviewed in
+[`2026-07-30-p6-bypass-actor-audit-review.md`](./2026-07-30-p6-bypass-actor-audit-review.md);
+2 adopted, 2 declined.
+
+- **2.2 — adopted, and it found a second NaN fail-open.** Gate 2's CLI consumed
+  `attestation_grace_days` without validating it. A missing value makes
+  `graceDays * DAY_MS` NaN, and `elapsed > NaN` is false — verified: a
+  3650-day-old attestation evaluates as *fresh*. Deleting one config line would
+  have silently disabled the freshness check while the gate stayed green. Now
+  guarded in both `evaluateAttestation` (so tests cover it) and the CLI, with
+  two new tests. Same bug class as the `attested_at` NaN the design review
+  caught, one level up.
+- **1.1 — partially adopted.** `loadDeclaredBypass` now names the file on a parse
+  failure instead of throwing a bare offset. Deliberately *not* given an
+  `unparseable` verdict like the attestation's: that file is generated and could
+  plausibly be corrupted, while this one is hand-authored and already covered by
+  `biome check .`, so a parse failure is a broken repo rather than a runtime
+  condition. The existing `loadDesiredFile` in `check-ruleset-drift.ts` has the
+  identical bare `JSON.parse`; not touched here, as it is a working gate and out
+  of scope.
+- **1.2 (`--help`) — declined.** No gate in `scripts/structure-audit/` implements
+  it (verified by grep). These are `bun run audit:*` entry points invoked from
+  `package.json` and CI, not user-facing CLIs — `packages/cli` is the product's
+  CLI. Adding help text to 2 of ~20 gates would create inconsistency without a
+  consumer.
+- **2.1 (`attested_by` env fallback) — declined; already litigated.** This repeats
+  §2.1 of the design review response, where `git config`/`$USER` fallbacks were
+  rejected because they name the environment rather than the credential that
+  performed the read. The new motivation — easier offline `--attest` testing — is
+  impossible by construction: `--attest` requires five successful `gh` reads, so
+  offline it exits at `queried === 0` long before `attested_by` is resolved.
+  `GITHUB_ACTOR` would be actively worse, naming a CI principal for a gate that
+  is never meant to run in CI.
 
 **One asymmetry worth flagging to the implementer:** Gate 2 is the only sweep gate with no `--strict` branch. Every other one fails soft locally because it needs `gh` auth that an external contributor lacks; Gate 2 reads two committed files and nothing else, so there is no environment in which it cannot run. The workflow still passes `--strict` for consistency with its siblings, where it is a no-op. This is explained in a comment at the exit site rather than left for a reader to infer.

--- a/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md
+++ b/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design-review-response.md
@@ -1,0 +1,182 @@
+# Design Review Response: Bypass-actor audit
+
+Response to
+[2026-07-30-p6-bypass-actor-audit-design-review.md](./2026-07-30-p6-bypass-actor-audit-design-review.md),
+against
+[2026-07-30-p6-bypass-actor-audit-design.md](./2026-07-30-p6-bypass-actor-audit-design.md).
+
+**Disposition: 4 fixed, 1 partially fixed with the mechanism rejected, 1 declined
+on evidence.**
+
+| # | Item | Disposition |
+| --- | --- | --- |
+| 1.1 | Actor-id portability | **Fixed differently** — premise doesn't apply; real issue is reviewability. Wildcard suggestion rejected. |
+| 1.2 | Partial reads under `--attest` | **Fixed** — genuine hole, the most valuable finding in the review |
+| 1.3 | Clock skew / timezone | **Partially fixed** — UTC half already held; the future-date fail-open did not |
+| 2.1 | `attested_by` fallback | **Goal adopted, mechanism rejected** |
+| 2.2 | Directory autocreation | **Declined** — directory is git-tracked, cannot be absent |
+| 2.3 | `bypass_mode` enum validation | **Fixed**, with the rationale corrected |
+
+---
+
+## 1.2 — Partial reads under `--attest` — FIXED
+
+The strongest finding, and a real hole rather than a hardening suggestion.
+
+The draft said `--attest` writes "only when the diff is green" and stopped there.
+Checking `decideExit` in `check-ruleset-drift.ts` — which this gate mirrors —
+confirms the gap:
+
+```ts
+if (errors.length > 0) { ...code 1 }
+if (unreachable.length > 0) {
+  return { code: 0, message: `OK (${queried} repos) — WARNING: could not query ...` };
+}
+```
+
+A 4-of-5 read with no drift **exits 0**. That is correct for a reporting gate and
+wrong for an attesting one: `--attest` keyed off exit code would write an
+attestation whose `repos` field claims five repos on four repos' evidence. Gate
+2's check 3 compares that field against declared `repos`, sees five, and passes.
+The partial read launders itself into a green sweep for the whole grace window —
+in the sub-program whose entire premise is that controls silently stop covering
+things.
+
+**Fix.** `--attest` now requires two conditions: green diff **and**
+`queried === repos.length` with `unreachable` empty. Any unreachable repo exits 1
+and writes nothing. Additionally the written `repos` field is **derived from the
+observed set rather than copied from config**, so even a future refactor that
+loses the first guard cannot claim uncovered repos.
+
+Attesting is interactive and re-runnable, so refusing on partial data costs
+nothing.
+
+## 1.1 — Actor-id portability — FIXED DIFFERENTLY, suggestion rejected
+
+**The stated premise does not apply.** The review posits a fork or a
+"test/staging GitHub organization" where ids differ. Verified: `nimbus-agent` has
+19 repos and no staging or test org exists, and every gate in this sweep —
+`ruleset-drift`, `org-settings-drift`, `cla-coverage`, `review-coverage` —
+hard-codes `nimbus-agent` in its `gh api` paths. A fork could not run this gate
+regardless: it is sweep-only and needs org-owner credentials. There is no
+environment in which these ids vary.
+
+**But there is a real problem underneath, and it is not portability — it is
+reviewability.** Every bypass actor in the org today is `OrganizationAdmin` with
+`actor_id: null`. `Team`, `Integration` and `RepositoryRole` carry numeric ids,
+and the entire control in this design is that the config and attestation are
+PR-visible and diff-reviewed. `"actor_id": 4382579` is not something a human
+reviewer can check. A numeric id would quietly downgrade the gate to a
+shape-check while still reading as green.
+
+**The suggested fix would make this worse, so it is rejected.** Wildcard
+`actor_id` matching means *any* team's bypass satisfies a declared entry — which
+erases exactly the distinction the gate exists to detect. "A team has admin
+bypass here" and "*this specific* team has admin bypass here" are different
+security properties, and the wildcard collapses them.
+
+**What was done instead.** The design now states the supported scope explicitly —
+null-id org-level actors — and makes an undeclared actor type a **hard error**
+rather than a silent normalization, so a `Team` bypass added through the UI reds
+the gate. If such an actor is ever genuinely wanted, the recorded follow-up is to
+resolve ids to names at read time (`/orgs/{org}/teams/{id}`) and diff on the name,
+keeping the config human-checkable. Deferred until one exists (YAGNI); the hard
+error ensures it cannot be added unnoticed in the meantime.
+
+## 1.3 — Clock skew and timezone — PARTIALLY FIXED
+
+**The UTC half already held.** The suggestion is to "mandate ISO 8601 UTC strings
+and enforce UTC-only arithmetic (e.g. comparing millisecond timestamps relative
+to `Date.now()`)". That is what the design already produces: `toISOString()`
+returns UTC with a `Z` suffix by JS spec, and `Date.now() - Date.parse(...)` is
+epoch milliseconds on both sides. Epoch ms carry no offset, so there is no
+timezone normalization step to add — a machine in UTC+13 and one in UTC-8 compute
+the identical elapsed duration. No change needed here.
+
+**Two genuine fail-opens were missing, both of which the item gestures at.**
+
+1. **Unparseable `attested_at`** → `Date.parse` returns `NaN`, and every
+   comparison with `NaN` is false — so a naive `elapsed > grace` staleness check
+   *passes*. A corrupt timestamp read as fresh, indefinitely. Now handled as
+   check 1's `unparseable` verdict.
+2. **Future-dated `attested_at`** → negative elapsed time stays under any grace
+   window until real time catches up. Clock skew or a hand edit both produce it.
+   Now a hard error beyond a **1 hour** tolerance, which absorbs NTP drift without
+   absorbing a meaningful backdate.
+
+Both are the same failure shape the design already worries about elsewhere: the
+check passes not because the property holds, but because the comparison is
+vacuous.
+
+## 2.1 — `attested_by` fallback — GOAL ADOPTED, MECHANISM REJECTED
+
+The robustness goal is right: a diagnostic field must never sink an otherwise
+complete audit. Adopted — on failure the field is written `"unknown"` and the
+attestation still succeeds.
+
+**The proposed fallback sources are rejected on correctness.** `git config
+user.name`, `user.email` and `$USER` name whoever configured the checkout, not
+the credential that performed the read. In an audit artifact whose purpose is
+attributing an observation, asserting an identity the audit cannot support is
+worse than recording nothing — it manufactures false provenance precisely where
+provenance is the point.
+
+The stated failure mode is also close to unreachable in isolation: `gh api user`
+failing means `gh` auth is broken, in which case the five ruleset reads have
+already failed and no attestation is written at all. There is no realistic path
+where user-lookup fails alone.
+
+## 2.2 — Directory autocreation — DECLINED
+
+`docs/structure-audit/` is **git-tracked**: it contains a committed `.gitkeep`
+plus `ci-latency-baseline.json`, `coverage-baseline.json`, `any-baseline.json`,
+`baseline.md` and `sonarqube-rule-tuning.md`. It cannot be absent in any checkout
+where this script can run, since the script itself lives in the same repo.
+
+A recursive `mkdir` would be unreachable defensive code guarding an impossible
+state. Declined as YAGNI. If the attestation ever moves to an untracked location,
+this becomes correct and should be revisited then.
+
+## 2.3 — `bypass_mode` enum validation — FIXED, rationale corrected
+
+Adopted, but the stated impact is backwards and worth correcting so the reasoning
+survives in the record. The review says a typo such as `"alway"` would pass
+validation "but fail or drift at run time". It would not pass anything: declared
+`"alway"` versus live `"always"` is a mismatch, and the gate goes **red** — loudly
+and immediately.
+
+So this is not a correctness fix. It is a **diagnosis** fix, which is still worth
+having. Unvalidated, the finding reads:
+
+```text
+Nimbus: bypass_mode: expected alway, got always
+```
+
+which points the reader at the org setting when the defect is in the config file.
+Validated:
+
+```text
+invalid bypass_mode "alway" in bypass.by_repo.Nimbus (expected always|pull_request)
+```
+
+Same red, correct target. On a gate expected to fire a few times a year,
+misdiagnosis is the expensive failure — this is the same reasoning that made
+`absent` and `unparseable` distinct verdicts in `review-coverage`.
+
+`actor_type` is validated alongside it, which is also what enforces the 1.1 hard
+error.
+
+---
+
+## Net effect
+
+One real bug (1.2) and two real fail-opens (1.3) removed before any code was
+written — the case for reviewing a spec rather than a diff. The two items
+declined or redirected were declined on verified evidence, not preference: 2.2
+guards a state that git makes impossible, and 1.1's suggested wildcard would have
+weakened the exact property the gate protects.
+
+No change to the design's shape, credential model, or the
+[grace-window decision](./2026-07-30-p6-bypass-actor-audit-design.md). The
+*"What this does not prove"* section stands unchanged and remains the item most
+worth an explicit accept before implementation.

--- a/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design-review.md
+++ b/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design-review.md
@@ -1,0 +1,48 @@
+# Design Review: Bypass-actor audit
+
+This document contains a design review of the [2026-07-30-p6-bypass-actor-audit-design.md](./2026-07-30-p6-bypass-actor-audit-design.md) specification, detailing open questions, suggestions, and potential improvements.
+
+---
+
+## 1. Open Questions
+
+### 1.1. Portability of Actor IDs (Forks, Test Orgs)
+
+The normalization section details comparing an order-independent set of `${actor_type}:${actor_id ?? "null"}:${bypass_mode}` triples:
+> Comparison is therefore an order-independent set of `${actor_type}:${actor_id ?? "null"}:${bypass_mode}` triples.
+
+* **The Question**: If a team or user is added as a bypass actor, their `actor_id` (e.g., the team ID or user ID) is organization-specific. If the project/configuration is forked or audited in a test/staging GitHub organization, these IDs will differ from the production Nimbus org. How will the design handle environments where the IDs are different, or are we assuming only org-wide actors like `OrganizationAdmin` (which have no specific `actor_id`) will be used?
+* **Impact**: If a team bypass is ever declared, the audit will fail in any non-production environment/fork if the ID is hardcoded, or it will require environment-dependent config mappings.
+* **Suggestion**: If user or team actors are permitted, allow wildcard matching for `actor_id` in the declared config (e.g., comparing only `actor_type` and `bypass_mode` if `actor_id` is specified as `*` or omitted in the declared ruleset JSON), or specify that only org-level roles (like `OrganizationAdmin`, which have a null `actor_id` across all orgs) are supported.
+
+### 1.2. Handling of Reachability / Failures on Renamed or Archived Repositories
+
+* **The Question**: If a repository listed in `repos` is archived, renamed, or temporarily deleted, how does `audit:bypass-actors` (owner-run) handle the failure to resolve the ruleset?
+* **Impact**: If it exits with `indeterminate` (fail-soft), it shouldn't block the ability to generate a new attestation for the remaining healthy repositories, or conversely, it shouldn't allow bypass changes on the healthy repositories to go unnoticed.
+* **Suggestion**: Clarify how `decideExit` behaves under `--attest`. If one repo out of five is unreachable, `--attest` must not write a new attestation file, as it cannot verify the complete state. The tool should exit 1 (or indeterminate) and refuse to write the attestation.
+
+### 1.3. Timezone and Clock Skew in Attestation Grace Checks
+
+* **The Question**: When calculating if `attested_at` is within the grace window, how do we protect against local system timezone differences or clock skew?
+* **Impact**: If the attestation is done on a machine with a clock set in the future or a different local time offset, parsing and comparison might lead to false green or false red states.
+* **Suggestion**: Mandate ISO 8601 UTC strings (`YYYY-MM-DDTHH:mm:ss.sssZ`) for `attested_at` and enforce UTC-only arithmetic (e.g., comparing millisecond timestamps relative to `Date.now()`) to compute the elapsed duration.
+
+---
+
+## 2. Improvements & Suggestions
+
+### 2.1. Fallback for `attested_by` Capture
+
+The specification states:
+> `attested_by` comes from `gh api user --jq .login`
+
+* **The Risk**: If `gh` is authenticated using a token that lacks permission to query the current user endpoint, or if the API call temporarily fails or is rate-limited, the `--attest` command might fail to generate the attestation file entirely.
+* **Improvement**: If `gh api user` fails, fallback to extracting the operator's identity via `git config user.name` or `git config user.email`, or environment variables (e.g., `USER`, `USERNAME`), so the attestation can still be successfully generated.
+
+### 2.2. Directory Autocreation for Attestation File
+
+* **Improvement**: Ensure that the target directory `docs/structure-audit/` is automatically created (if it doesn't already exist) before attempting to write `docs/structure-audit/bypass-actors-attestation.json` when the `--attest` flag is run.
+
+### 2.3. Structural Schema Validation for Declared Bypass Intent
+
+* **Improvement**: In the unit tests or in the config validator, assert that `bypass_mode` only takes valid values allowed by GitHub Ruleset schemas (e.g., `"always"`, `"pull_request"`). This prevents typos in `general-branch.json` (such as `"alway"`) from passing validation but failing or drifting at run time.

--- a/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design.md
+++ b/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design.md
@@ -1,0 +1,307 @@
+# P6 — Bypass-actor audit design
+
+**Date:** 2026-07-30
+**Sub-program:** P6 (Access & Contribution Model), the last remaining item
+**Design of record:** `superpowers/specs/2026-07-23-org-infrastructure-program-design.md`
+**Roadmap:** [`docs/infrastructure-roadmap.md`](../../infrastructure-roadmap.md)
+
+---
+
+## Problem
+
+`audit:ruleset-drift` deliberately does **not** diff `bypass_actors`. The reason is
+recorded in the P1 progress log: the sweep's CI credential is a repo-scoped App
+installation token with `Administration: read`, and GitHub returns an **empty**
+`bypass_actors` array to it for org-level actors such as `OrganizationAdmin`. It
+was proven live that adding `organization-administration: read` does not restore
+the field, and reading it otherwise requires `Administration: write` — which a
+read-only audit gate must not hold. Diffing the field from the sweep therefore
+false-failed on every repo carrying an org-level bypass, and the field was
+dropped from the diff.
+
+The consequence is a real gap. A bypass actor is the single most powerful
+override in a ruleset: it exempts a principal from every rule the ruleset
+enforces, including the `pull_request` rule that is the whole point of the
+`General` ruleset. Nothing currently detects one being added, widened, or
+retargeted.
+
+The intended shape has been recorded in prose since P1 — `OrganizationAdmin` on
+`Nimbus`/`nimbus-vscode`/`nimbus-web-clipper`, none on
+`nimbus-client`/`nimbus-sdk` — inside a JSON `$comment` **string**. Prose in a
+comment is not a gate.
+
+## Verified premises
+
+Both checked before designing, rather than taken from the existing prose:
+
+1. **An owner-context `gh` token does return `bypass_actors`.** The local token
+   (scopes `admin:org`, `repo`) reads the field successfully on all five active
+   repos. The P1 limitation is specific to the App installation token, not to
+   `gh` generally.
+2. **Live state currently matches the declared intent exactly:**
+
+   | repo | live `bypass_actors` | declared intent |
+   | --- | --- | --- |
+   | `Nimbus` | `OrganizationAdmin` / `always` | `OrganizationAdmin` |
+   | `nimbus-vscode` | `OrganizationAdmin` / `always` | `OrganizationAdmin` |
+   | `nimbus-web-clipper` | `OrganizationAdmin` / `always` | `OrganizationAdmin` |
+   | `nimbus-client` | `[]` | none |
+   | `nimbus-sdk` | `[]` | none |
+
+   `bypass_mode: always` matches the `solo` side of the existing
+   `$contributor_two` switch.
+
+Premise 2 means the gate **ships green by construction**. Per the precedent set
+by `audit:ci-latency`, the red-proof is therefore a unit test, not the first live
+run — with one exception noted under *Red-prove* below.
+
+## Rejected approaches
+
+| Approach | Why rejected |
+| --- | --- |
+| Grant the sweep App `Administration: write` | Fully automated, but costs the read-only property the roadmap explicitly committed to. An audit credential that can rewrite every ruleset in the org is a worse trade than a slower cadence. |
+| A second narrow App with `Administration: write` | Isolates blast radius from the release bot, but still stores an org secret that can rewrite rulesets, and adds a credential to rotate and track in `credential-registry.ts`. |
+| Owner-run CLI only, no gate | Simplest, but by this program's own operating principle it is not done. A control nobody is reminded to run is precisely the "controls stop where they were written" pattern the program exists to break. |
+
+## Chosen approach: owner-run audit + attestation-freshness gate
+
+Two gates share **one pure diff function**. The owner-run gate feeds it live data
+from `gh`; the sweep gate feeds it the attested snapshot. No network in the
+sweep, no duplicated comparison logic.
+
+```text
+        diffBypassActors(declared, observed) → { ok, errors }
+                 ▲                                   ▲
+                 │ live, via gh (admin:org)          │ attested snapshot (offline)
+        audit:bypass-actors                   audit:bypass-attestation
+        [owner-run, --attest]                 [sweep job, no credential mint]
+```
+
+The gated property is not "the org is clean" — it is **"a green attestation was
+committed recently, and it still agrees with declared intent."** That is a
+property a machine can check with no privileged credential.
+
+### Gate 1 — `audit:bypass-actors` (owner-run)
+
+`scripts/structure-audit/check-bypass-actors.ts`
+
+Reads declared intent from `.github/rulesets/general-branch.json`, resolves each
+repo's `General` ruleset id, fetches the ruleset, and diffs `bypass_actors`.
+
+Mirrors `check-ruleset-drift.ts` throughout — same file, same helpers, same
+control flow:
+
+- `runGh`, `isRecord`, `isStrict`, `strictSkip` from `_gh-audit.ts`
+- `classifyReadFailure` so a 5xx/403 degrades to `indeterminate` and is never
+  recorded as a finding (the 2026-07-27 operating rule)
+- the `decideExit` invariant: **drift found on a reachable repo is never
+  discarded because a different repo's read failed**; `queried === 0` is the only
+  skip-green case
+- fail-soft when `gh` is absent or unauthenticated, so an external contributor is
+  never blocked
+
+**Normalization.** Live returns
+`{"actor_id": null, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}`.
+Declared entries omit `actor_id`. Comparison is therefore an order-independent
+set of `${actor_type}:${actor_id ?? "null"}:${bypass_mode}` triples. Set
+comparison, not array equality — actor order is not meaningful.
+
+**Findings are directional**, because the repairs differ:
+
+- `unexpected bypass actor: <triple>` — someone added an override
+- `missing declared bypass actor: <triple>` — an intended override was removed
+- `bypass_mode: expected <x>, got <y>` — an override was widened or narrowed
+- `<repo>: not declared in bypass.by_repo` — config gap, see check 3 below
+
+**`--attest`** writes `docs/structure-audit/bypass-actors-attestation.json`
+**only when the diff is green.** A fresh attestation can therefore never encode a
+known-bad state. On a red diff it exits 1 and writes nothing.
+
+### Gate 2 — `audit:bypass-attestation` (sweep)
+
+`scripts/structure-audit/check-bypass-attestation.ts`
+
+Four checks, all offline — no `gh`, no token mint, no network:
+
+1. **exists and parses.** `absent` and `unparseable` are distinct verdicts,
+   because the repair differs (the `review-coverage` lesson). A YAML/JSON
+   document that parses to a scalar or array is `unparseable`.
+2. **`attested_at` is within the grace window.** Grace is read from
+   `bypass.attestation_grace_days` in `general-branch.json` — currently **90
+   days**, to be flipped to **30** at contributor-two via the documented switch.
+   Rationale: in solo mode the repo owner is the only org
+   admin, so the audit is near-self-checking; its real value begins when a second
+   maintainer gains write access — exactly when the other three switches flip.
+   Encoding the window as a fourth switch keeps that reasoning in one place and
+   makes tightening it part of the same reviewed diff.
+3. **the attested `repos` set equals the declared `repos` set.** Load-bearing:
+   adding a sixth repo to `general-branch.json` must invalidate an attestation
+   that never covered it. Without this check a newly-added repo would be silently
+   unaudited behind a green gate — this program's founding failure mode.
+4. **the attested `observed` block still diffs clean against current declared
+   intent**, by re-running `diffBypassActors` offline. So editing
+   `general-branch.json` without re-attesting is caught, rather than sitting
+   green until the grace window expires.
+
+Check 4 is why the attestation stores observations rather than only a timestamp.
+
+**Placement: the sweep only, not the `preflight:fast` tier.** Gate 2 is local and
+deterministic, so it *could* run on every PR like `audit:secret-inventory`. It
+must not. Its red depends on the repo owner's re-attestation cadence, so a stale
+attestation would block an external contributor's unrelated PR — punishing the
+wrong person, and manufacturing exactly the always-red gate the 2026-07-27
+operating rule warns about.
+
+### Attestation file shape
+
+`docs/structure-audit/bypass-actors-attestation.json` — committed, sits beside
+`ci-latency-baseline.json`.
+
+```json
+{
+  "attested_at": "2026-07-30T06:15:00.000Z",
+  "attested_by": "asafgolombek",
+  "grace_days": 90,
+  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"],
+  "observed": {
+    "Nimbus": [{ "actor_type": "OrganizationAdmin", "actor_id": null, "bypass_mode": "always" }],
+    "nimbus-vscode": [{ "actor_type": "OrganizationAdmin", "actor_id": null, "bypass_mode": "always" }],
+    "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "actor_id": null, "bypass_mode": "always" }],
+    "nimbus-client": [],
+    "nimbus-sdk": []
+  }
+}
+```
+
+`attested_by` comes from `gh api user --jq .login`, so the commit records who
+attested as well as when. `grace_days` is denormalized into the file for
+diagnostics only; **check 2 reads
+`bypass.attestation_grace_days` from `general-branch.json`, never this field**,
+so a hand-edited `grace_days` cannot widen the window.
+
+### Config changes — `.github/rulesets/general-branch.json`
+
+A new top-level `bypass` block. This is the file's **first per-repo override**,
+because intent genuinely differs per repo:
+
+```json
+"bypass": {
+  "attestation_grace_days": 90,
+  "by_repo": {
+    "Nimbus":             [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+    "nimbus-vscode":      [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+    "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+    "nimbus-client":      [],
+    "nimbus-sdk":         []
+  }
+}
+```
+
+Chosen over converting `repos: string[]` to a map, which would churn
+`DesiredRulesetFile`, `loadDesiredFile` and the existing `ruleset-drift` tests
+for no gain.
+
+**`attestation_grace_days` holds the CURRENT value, following the file's existing
+convention** — exactly as `shared.pull_request.required_approving_review_count`
+is `0` (the live solo value) while `$contributor_two` documents the flip to `1`.
+There is no separate "which mode am I in" marker in this file, and adding one
+would create a second source of truth for the same fact. `$contributor_two.switches`
+therefore gains a documentation entry only:
+
+```json
+"bypass.attestation_grace_days": { "solo": 90, "team": 30 }
+```
+
+A unit test asserts `Object.keys(bypass.by_repo)` equals the `repos` set, so
+declaring a repo without its bypass intent fails locally rather than at sweep
+time.
+
+### Stale assertions this must correct
+
+Four places currently state that bypass actors are not audited. Leaving any is
+the doc-drift the triple rule exists to prevent:
+
+| location | current text |
+| --- | --- |
+| `general-branch.json` `$comment` | "NOT diffed … Intended bypass, for the future higher-privilege check" |
+| `general-branch.json` `$contributor_two.note` | "the bypass switch is not [drift-gated]" |
+| `check-ruleset-drift.ts` (the block at ~L115–123) | "a follow-up requiring a higher-privilege context" |
+| `DesiredRulesetFile` docstring | "There are no per-repo overrides" |
+
+`audit:ruleset-drift` itself keeps **not** diffing bypass actors — its credential
+still cannot read them. Its comment changes from describing a follow-up to
+pointing at `audit:bypass-actors` as the gate that now covers the field.
+
+## What this does not prove
+
+The attestation is a committed file, so it can be hand-edited. Gate 2 proves *a
+green attestation was committed recently and still agrees with declared intent* —
+not *the org is clean right now*. The real control is that the file is
+PR-visible and diff-reviewed: a forged or backdated attestation shows up as a
+reviewable diff.
+
+Signing the attestation was considered and rejected as theatre: the only
+plausible signer is the same person who could forge it.
+
+This limit is stated here deliberately. By this program's own standard — *"a gate
+that checks a control's presence cannot see that the control is structurally
+unable to execute"* — naming the limit is the difference between a real gate and
+a comforting one. The residual risk is bounded by the grace window: up to 90 days
+in solo mode, 30 once a second maintainer has write access.
+
+## Testing
+
+**Pure diff (`diffBypassActors`)** — exact match; extra/unexpected actor; missing
+declared actor; correct actor with wrong `bypass_mode`; repo absent from
+`bypass.by_repo`; `actor_id` normalization (`null` vs omitted); order-independence
+of the actor set.
+
+**Gate 2 (`evaluateAttestation`)** — fresh; stale by one day past grace; missing
+file; unparseable; parses to a scalar/array; `repos` set mismatch in both
+directions; `observed` drifting from declared; grace read from
+`general-branch.json` (a 30-day config makes a 45-day-old attestation stale
+where a 90-day config does not); hand-edited `grace_days` in the attestation
+ignored in favour of the config value.
+
+**Config** — `keys(bypass.by_repo)` equals `repos`.
+
+### Red-prove
+
+The gate ships green (premise 2), so unit tests are the primary red-proof, as
+with `audit:ci-latency`.
+
+One **live** red-prove is available at zero risk and should be run: temporarily
+flip a declared `bypass_mode` to `pull_request` in the working tree, run
+`audit:bypass-actors` against the real org, confirm exit 1 and the expected
+finding, then revert. This exercises the real `gh` read path and the real diff
+without mutating any org setting. Per the `review-coverage` precedent, **verify
+the mutation actually landed in the file before trusting the result.**
+
+Gate 2's stale path can also be red-proved live by backdating `attested_at`.
+
+## Files
+
+| path | change |
+| --- | --- |
+| `scripts/structure-audit/check-bypass-actors.ts` | new — Gate 1 CLI + `diffBypassActors` |
+| `scripts/structure-audit/check-bypass-actors.test.ts` | new |
+| `scripts/structure-audit/check-bypass-attestation.ts` | new — Gate 2 CLI + `evaluateAttestation` |
+| `scripts/structure-audit/check-bypass-attestation.test.ts` | new |
+| `scripts/structure-audit/_bypass-attestation.ts` | new — attestation shape, read/write |
+| `docs/structure-audit/bypass-actors-attestation.json` | new — committed snapshot |
+| `.github/rulesets/general-branch.json` | `bypass` block, grace switch, `$comment` + note corrections |
+| `scripts/structure-audit/check-ruleset-drift.ts` | comment correction only; no behaviour change |
+| `.github/workflows/org-drift-sweep.yml` | new `bypass-attestation` job, no token mint |
+| `scripts/lib/preflight-gates.ts` | both names → sweep-exemption list |
+| `package.json` | `audit:bypass-actors`, `audit:bypass-attestation` |
+| `docs/infrastructure-roadmap.md` | P6 row → done; P6 progress-log entry |
+
+## Definition of done
+
+1. Unit tests green, covering every case above.
+2. Live red-prove performed and reverted.
+3. `bun run preflight:fast` green.
+4. `audit:bypass-actors --attest` run by the owner; attestation committed.
+5. `bypass-attestation` job **green in a dispatched `org-drift-sweep`** — this
+   program's actual bar, not "the code merged".
+6. Roadmap P6 row updated with the run id.

--- a/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design.md
+++ b/docs/superpowers/specs/2026-07-30-p6-bypass-actor-audit-design.md
@@ -106,6 +106,28 @@ Declared entries omit `actor_id`. Comparison is therefore an order-independent
 set of `${actor_type}:${actor_id ?? "null"}:${bypass_mode}` triples. Set
 comparison, not array equality — actor order is not meaningful.
 
+**Supported scope: org-level actors with a null `actor_id`.** Every bypass actor
+in the org today is `OrganizationAdmin`, whose `actor_id` is `null` on all five
+repos. `Team`, `Integration` and `RepositoryRole` actors instead carry a numeric
+id, and that raises a problem this design does not yet solve — **not portability,
+but reviewability.** The whole control here is that the attestation and the
+declared config are PR-visible and diff-reviewed; `"actor_id": 4382579` in a JSON
+file is not something a human reviewer can meaningfully check, so a numeric id
+would quietly degrade the gate into a shape-check.
+
+An undeclared actor type is therefore a **hard error**, not a silent pass:
+`<repo>: unsupported bypass actor type <t> (id <n>) — declared bypass intent
+supports only null-id org-level actors; see the design`. Fail-closed: a Team
+bypass added in the UI reds the gate rather than being normalized away.
+
+**Wildcard `actor_id` matching is deliberately rejected.** Allowing `"*"` to
+match any id would mean *any* team's bypass satisfies a declared entry — which
+erases precisely the distinction the gate exists to detect. If a Team or
+Integration bypass is ever genuinely wanted, the follow-up is to resolve ids to
+names at read time (`/orgs/{org}/teams/{id}`) and diff on the **name**, keeping
+the config human-checkable. Deferred until such an actor actually exists (YAGNI);
+until then the hard error above ensures one cannot be added unnoticed.
+
 **Findings are directional**, because the repairs differ:
 
 - `unexpected bypass actor: <triple>` — someone added an override
@@ -113,9 +135,31 @@ comparison, not array equality — actor order is not meaningful.
 - `bypass_mode: expected <x>, got <y>` — an override was widened or narrowed
 - `<repo>: not declared in bypass.by_repo` — config gap, see check 3 below
 
-**`--attest`** writes `docs/structure-audit/bypass-actors-attestation.json`
-**only when the diff is green.** A fresh attestation can therefore never encode a
-known-bad state. On a red diff it exits 1 and writes nothing.
+**`--attest`** writes `docs/structure-audit/bypass-actors-attestation.json` under
+**two** conditions, both required:
+
+1. **the diff is green** — so a fresh attestation can never encode a known-bad
+   state; and
+2. **every declared repo was read successfully** — `queried === repos.length`,
+   `unreachable` empty.
+
+Condition 2 is not redundant, and omitting it was a real hole in the first draft
+of this design. `decideExit` deliberately returns **exit 0 with a warning** when
+some repos are unreachable but no drift was found on the ones that were read —
+correct for a *reporting* gate, wrong for an *attesting* one. Keying `--attest`
+off exit code alone would let a 4-of-5 read produce an attestation whose `repos`
+field claims all five, which Gate 2's check 3 would then accept as complete
+coverage. A partial read would launder itself into a green sweep for the whole
+grace window.
+
+So: on any unreachable repo, `--attest` exits 1 and writes nothing, with
+`cannot attest: <repo> unreachable (read N of M)`. **The `repos` field is
+derived from the set actually observed, never copied from config** — belt and
+braces, so even a future refactor that loses condition 2 cannot silently claim
+uncovered repos.
+
+Attesting is an interactive act the owner can simply re-run; refusing on partial
+data costs nothing and removes the entire class of false-coverage bug.
 
 ### Gate 2 — `audit:bypass-attestation` (sweep)
 
@@ -134,6 +178,21 @@ Four checks, all offline — no `gh`, no token mint, no network:
    maintainer gains write access — exactly when the other three switches flip.
    Encoding the window as a fourth switch keeps that reasoning in one place and
    makes tightening it part of the same reviewed diff.
+
+   **Time handling.** `attested_at` is written by `new Date().toISOString()`,
+   which is UTC with a `Z` suffix by JS spec, and compared as
+   `Date.now() - Date.parse(attested_at)` — epoch milliseconds on both sides, so
+   the arithmetic is inherently offset-free and no timezone normalization step is
+   needed. Two edge cases do need explicit handling, because both **fail open**:
+   - **an unparseable `attested_at`** yields `NaN`, and every comparison against
+     `NaN` is false — so a naive `elapsed > grace` check passes. Treated as
+     `unparseable` (check 1's verdict), never as fresh.
+   - **a future-dated `attested_at`** — clock skew on the attesting machine, or a
+     hand edit — yields negative elapsed time and would stay "fresh" until real
+     time caught up, i.e. potentially forever. Any timestamp more than **1 hour**
+     ahead of now is a hard error: `attested_at is N minutes in the future —
+     clock skew or a hand-edited file`. The tolerance absorbs ordinary NTP drift
+     without absorbing a meaningful backdate.
 3. **the attested `repos` set equals the declared `repos` set.** Load-bearing:
    adding a sixth repo to `general-branch.json` must invalidate an attestation
    that never covered it. Without this check a newly-added repo would be silently
@@ -174,8 +233,18 @@ operating rule warns about.
 ```
 
 `attested_by` comes from `gh api user --jq .login`, so the commit records who
-attested as well as when. `grace_days` is denormalized into the file for
-diagnostics only; **check 2 reads
+attested as well as when. It is **best-effort diagnostic metadata**: if that call
+fails the field is written as `"unknown"` and the attestation still succeeds — it
+is never a reason to fail an otherwise-complete audit.
+
+It must **not** fall back to `git config user.name`/`user.email` or `$USER`.
+Those name whoever configured the checkout, not the credential that performed the
+read, so on failure they would assert an identity the audit cannot support —
+worse than recording nothing. (The failure is near-impossible in isolation
+anyway: `gh api user` failing means `gh` auth is broken, in which case the
+ruleset reads have already failed and no attestation is written at all.)
+
+`grace_days` is denormalized into the file for diagnostics only; **check 2 reads
 `bypass.attestation_grace_days` from `general-branch.json`, never this field**,
 so a hand-edited `grace_days` cannot widen the window.
 
@@ -216,6 +285,17 @@ A unit test asserts `Object.keys(bypass.by_repo)` equals the `repos` set, so
 declaring a repo without its bypass intent fails locally rather than at sweep
 time.
 
+**Declared entries are schema-validated before diffing**: `bypass_mode` must be
+one of `always` / `pull_request`, and `actor_type` must be a known GitHub actor
+type. Not because an invalid value would slip through — a typo like `"alway"`
+produces a mismatch against live `"always"` and reds the gate loudly — but
+because of *which* error it produces. Unvalidated, the finding reads
+`bypass_mode: expected alway, got always`, which points the reader at the org
+setting when the defect is in the config. Validated, it reads `invalid
+bypass_mode "alway" in bypass.by_repo.Nimbus (expected always|pull_request)`.
+Same red, correct diagnosis — and misdiagnosis is expensive on a gate that fires
+a few times a year.
+
 ### Stale assertions this must correct
 
 Four places currently state that bypass actors are not audited. Leaving any is
@@ -254,14 +334,25 @@ in solo mode, 30 once a second maintainer has write access.
 **Pure diff (`diffBypassActors`)** — exact match; extra/unexpected actor; missing
 declared actor; correct actor with wrong `bypass_mode`; repo absent from
 `bypass.by_repo`; `actor_id` normalization (`null` vs omitted); order-independence
-of the actor set.
+of the actor set; **a non-null-id actor type (`Team`, `Integration`,
+`RepositoryRole`) is a hard error rather than being normalized away**; invalid
+declared `bypass_mode` / `actor_type` reports a config error, not a drift finding.
 
 **Gate 2 (`evaluateAttestation`)** — fresh; stale by one day past grace; missing
 file; unparseable; parses to a scalar/array; `repos` set mismatch in both
 directions; `observed` drifting from declared; grace read from
 `general-branch.json` (a 30-day config makes a 45-day-old attestation stale
 where a 90-day config does not); hand-edited `grace_days` in the attestation
-ignored in favour of the config value.
+ignored in favour of the config value; **`attested_at` unparseable → the
+`unparseable` verdict, never "fresh" via `NaN` comparison**; **`attested_at`
+2 hours in the future → hard error**; `attested_at` 10 minutes in the future →
+tolerated (NTP drift).
+
+**`--attest` write conditions** — writes on green + complete read; **refuses on a
+partial read even with zero drift** (the 1.2 hole: `decideExit` returns 0 there);
+refuses on drift; written `repos` derives from the observed set, not config;
+`attested_by` falls back to `"unknown"` when `gh api user` fails, and the write
+still succeeds.
 
 **Config** — `keys(bypass.by_repo)` equals `repos`.
 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,8 @@
     "audit:team-reachability": "bun scripts/structure-audit/check-team-reachability.ts",
     "audit:cla-coverage": "bun scripts/structure-audit/check-cla-coverage.ts",
     "audit:review-coverage": "bun scripts/structure-audit/check-review-coverage.ts",
+    "audit:bypass-actors": "bun scripts/structure-audit/check-bypass-actors.ts",
+    "audit:bypass-attestation": "bun scripts/structure-audit/check-bypass-attestation.ts",
     "audit:release-staleness": "bun scripts/structure-audit/check-release-staleness.ts",
     "audit:secret-inventory": "bun scripts/structure-audit/check-secret-inventory.ts",
     "audit:actions-allowlist": "bun scripts/structure-audit/check-actions-allowlist.ts",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -93,6 +93,8 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:actions-allowlist", // needs network + gh (reads each repo's Actions permissions); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:advisories", // needs network (npm registry via `bun audit`); runs beside `bun audit` in security.yml, never the local FAST tier
+  "audit:bypass-actors", // needs an OWNER gh token (admin:org) — the CI App token cannot read bypass_actors; an explicit human action, never a gate
+  "audit:bypass-attestation", // local + deterministic, but its red depends on the OWNER's re-attestation cadence; sweep-only so a stale attestation never blocks a contributor's PR
 ];
 
 export function selectGates(tier: GateTier): Gate[] {

--- a/scripts/structure-audit/_bypass-attestation.test.ts
+++ b/scripts/structure-audit/_bypass-attestation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { decideAttestWrite, parseAttestation } from "./_bypass-attestation.ts";
+
+describe("parseAttestation", () => {
+  test("parses a well-formed attestation", () => {
+    const raw = JSON.stringify({
+      attested_at: "2026-07-30T06:15:00.000Z",
+      attested_by: "asafgolombek",
+      grace_days: 90,
+      repos: ["Nimbus"],
+      observed: { Nimbus: [] },
+    });
+    const parsed = parseAttestation(raw);
+    expect(parsed).not.toBe("unparseable");
+    if (parsed === "unparseable") throw new Error("unreachable");
+    expect(parsed.attested_by).toBe("asafgolombek");
+  });
+
+  test("reports invalid JSON as unparseable", () => {
+    expect(parseAttestation("{not json")).toBe("unparseable");
+  });
+
+  test("reports legal JSON that is not an object as unparseable", () => {
+    expect(parseAttestation("[]")).toBe("unparseable");
+    expect(parseAttestation('"a string"')).toBe("unparseable");
+    expect(parseAttestation("null")).toBe("unparseable");
+  });
+});
+
+describe("decideAttestWrite", () => {
+  test("writes on a green, complete read", () => {
+    expect(decideAttestWrite({ ok: true, queried: 5, total: 5, unreachable: [] }).write).toBe(true);
+  });
+
+  test("refuses on drift", () => {
+    const d = decideAttestWrite({ ok: false, queried: 5, total: 5, unreachable: [] });
+    expect(d.write).toBe(false);
+    expect(d.reason).toContain("drift");
+  });
+
+  // The hole the design review caught: decideExit returns exit 0 for a partial
+  // read with no drift, so keying --attest off the exit code alone would write an
+  // attestation claiming 5 repos on 4 repos' evidence.
+  test("refuses on a PARTIAL read even with zero drift", () => {
+    const d = decideAttestWrite({
+      ok: true,
+      queried: 4,
+      total: 5,
+      unreachable: ["nimbus-sdk"],
+    });
+    expect(d.write).toBe(false);
+    expect(d.reason).toContain("nimbus-sdk");
+    expect(d.reason).toContain("read 4 of 5");
+  });
+});

--- a/scripts/structure-audit/_bypass-attestation.ts
+++ b/scripts/structure-audit/_bypass-attestation.ts
@@ -1,0 +1,84 @@
+/**
+ * The committed bypass-actor attestation: shape, parse, read, write.
+ *
+ * Shared by the owner-run gate (which writes it) and the sweep gate (which reads
+ * it). No network and no `gh` — deliberately, since the sweep job must run with
+ * no credential at all.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isRecord } from "./_gh-audit.ts";
+import type { BypassActor } from "./check-bypass-actors.ts";
+
+export const ATTESTATION_PATH = "docs/structure-audit/bypass-actors-attestation.json";
+
+export interface Attestation {
+  /** ISO-8601 UTC, from `new Date().toISOString()`. */
+  attested_at: string;
+  /** `gh api user` login, or "unknown" — diagnostic only, never a gating input. */
+  attested_by: string;
+  /** Denormalized for diagnostics ONLY; the gate reads grace from the config. */
+  grace_days: number;
+  /** Derived from the repos actually observed, never copied from config. */
+  repos: string[];
+  observed: Record<string, BypassActor[]>;
+}
+
+/** Parse a raw attestation blob. Anything that is not a JSON object is `unparseable`. */
+export function parseAttestation(raw: string): Attestation | "unparseable" {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "unparseable";
+  }
+  // Legal JSON can be a scalar, null or an array; none is a usable attestation.
+  return isRecord(parsed) ? (parsed as unknown as Attestation) : "unparseable";
+}
+
+/** Read the attestation file, or `null` when it does not exist. */
+export function readAttestation(repoRoot: string): string | null {
+  try {
+    return readFileSync(join(repoRoot, ATTESTATION_PATH), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function writeAttestation(repoRoot: string, attestation: Attestation): void {
+  writeFileSync(join(repoRoot, ATTESTATION_PATH), `${JSON.stringify(attestation, null, 2)}\n`);
+}
+
+export interface AttestWriteInput {
+  /** Whether the diff was clean. */
+  ok: boolean;
+  /** How many repos were read successfully. */
+  queried: number;
+  /** How many repos were declared. */
+  total: number;
+  unreachable: string[];
+}
+
+/**
+ * Whether `--attest` may write.
+ *
+ * TWO conditions, and the second is not redundant: `decideExit` returns exit 0
+ * for a partial read with no drift (correct for a reporting gate, wrong for an
+ * attesting one). Writing there would produce an attestation whose `repos` field
+ * claims full coverage on partial evidence, which the sweep gate would then
+ * accept for the whole grace window. Attesting is interactive and re-runnable,
+ * so refusing costs nothing.
+ */
+export function decideAttestWrite(input: AttestWriteInput): { write: boolean; reason?: string } {
+  if (!input.ok) {
+    return { write: false, reason: "refusing to attest: bypass-actor drift was found" };
+  }
+  if (input.unreachable.length > 0 || input.queried !== input.total) {
+    return {
+      write: false,
+      reason: `cannot attest: ${input.unreachable.join(", ")} unreachable (read ${input.queried} of ${input.total})`,
+    };
+  }
+  return { write: true };
+}

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type DeclaredBypassFile,
+  loadDeclaredBypass,
+  validateDeclaredBypass,
+} from "./check-bypass-actors.ts";
+
+/** A declared file that passes validation — the base each case mutates one field of. */
+function goodFile(): DeclaredBypassFile {
+  return {
+    repos: ["Nimbus", "nimbus-sdk"],
+    bypass: {
+      attestation_grace_days: 90,
+      by_repo: {
+        Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+        "nimbus-sdk": [],
+      },
+    },
+  };
+}
+
+describe("validateDeclaredBypass", () => {
+  test("accepts a well-formed file", () => {
+    expect(validateDeclaredBypass(goodFile())).toEqual([]);
+  });
+
+  test("rejects a by_repo key set that does not match repos", () => {
+    const f = goodFile();
+    f.repos = ["Nimbus", "nimbus-sdk", "nimbus-client"];
+    const errors = validateDeclaredBypass(f);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("do not match repos");
+  });
+
+  test("rejects an invalid bypass_mode by name, pointing at the config not the org", () => {
+    const f = goodFile();
+    f.bypass.by_repo["Nimbus"] = [{ actor_type: "OrganizationAdmin", bypass_mode: "alway" }];
+    const errors = validateDeclaredBypass(f);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('invalid bypass_mode "alway"');
+    expect(errors[0]).toContain("bypass.by_repo.Nimbus");
+    expect(errors[0]).toContain("always|pull_request");
+  });
+
+  test("rejects a known-but-unsupported actor type distinctly from an unknown one", () => {
+    const known = goodFile();
+    known.bypass.by_repo["Nimbus"] = [{ actor_type: "Team", actor_id: 42, bypass_mode: "always" }];
+    expect(validateDeclaredBypass(known)[0]).toContain("unsupported actor_type");
+
+    const unknown = goodFile();
+    unknown.bypass.by_repo["Nimbus"] = [{ actor_type: "Wizard", bypass_mode: "always" }];
+    expect(validateDeclaredBypass(unknown)[0]).toContain("unknown actor_type");
+  });
+
+  test("rejects a non-positive or non-integer grace window", () => {
+    for (const bad of [0, -1, 1.5]) {
+      const f = goodFile();
+      f.bypass.attestation_grace_days = bad;
+      expect(validateDeclaredBypass(f)[0]).toContain("attestation_grace_days");
+    }
+  });
+});
+
+describe("loadDeclaredBypass", () => {
+  test("the checked-in config is valid and covers all five active repos", () => {
+    const file = loadDeclaredBypass(process.cwd());
+    expect(validateDeclaredBypass(file)).toEqual([]);
+    expect(file.repos.length).toBe(5);
+    expect(Object.keys(file.bypass.by_repo).sort()).toEqual([...file.repos].sort());
+  });
+});

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -64,6 +64,20 @@ describe("validateDeclaredBypass", () => {
       expect(validateDeclaredBypass(f)[0]).toContain("attestation_grace_days");
     }
   });
+
+  test("Finding 2: rejects a null-id-eligible actor_type carrying a numeric actor_id, distinctly from an unknown type", () => {
+    const f = goodFile();
+    f.bypass.by_repo["Nimbus"] = [
+      { actor_type: "OrganizationAdmin", actor_id: 4382579, bypass_mode: "always" },
+    ];
+    const errors = validateDeclaredBypass(f);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("OrganizationAdmin");
+    expect(errors[0]).toContain("numeric actor_id (4382579)");
+    expect(errors[0]).toContain("not human-reviewable");
+    expect(errors[0]).not.toContain("unsupported actor_type");
+    expect(errors[0]).not.toContain("unknown actor_type");
+  });
 });
 
 describe("loadDeclaredBypass", () => {
@@ -146,21 +160,99 @@ describe("diffBypassActors", () => {
   });
 
   test("is order-independent across the actor set", () => {
-    const twoDeclared: Record<string, BypassActor[]> = {
+    // A legitimately-passing single-repo set: one null-id OrganizationAdmin on
+    // Nimbus, nothing on nimbus-sdk, reordered relative to `declared()`/
+    // `observed()`. (A SECOND actor on one repo is no longer expressible here
+    // without either a duplicate identity — Finding 1 — or a numeric actor_id
+    // — Finding 2 — both of which are now hard errors by design; see
+    // "is order-independent on the error path" below for that case instead.)
+    const oneDeclared: Record<string, BypassActor[]> = {
+      "nimbus-sdk": [],
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+    };
+    const oneLive: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+      "nimbus-sdk": [],
+    };
+    expect(diffBypassActors(REPOS, oneDeclared, oneLive).ok).toBe(true);
+  });
+
+  test("is order-independent on the error path: same findings regardless of input order", () => {
+    // Two repos, each contributing one finding, checked in both orders.
+    const declaredTwoRepos: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+      "nimbus-sdk": [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+    };
+    const liveTwoRepos: Record<string, BypassActor[]> = {
+      // Nimbus: a numeric-id OrganizationAdmin — unsupported (Finding 2).
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" }],
+      // nimbus-sdk: a duplicated identity — Finding 1.
+      "nimbus-sdk": [
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+      ],
+    };
+    const forward = diffBypassActors(["Nimbus", "nimbus-sdk"], declaredTwoRepos, liveTwoRepos);
+    const reversed = diffBypassActors(["nimbus-sdk", "Nimbus"], declaredTwoRepos, liveTwoRepos);
+    expect(forward.ok).toBe(false);
+    expect(reversed.ok).toBe(false);
+    expect([...forward.errors].sort()).toEqual([...reversed.errors].sort());
+  });
+
+  test("Finding 1: a duplicate OBSERVED identity is a hard error, never normalized to the last entry", () => {
+    // Proven failure: declared has a single pull_request-mode actor; observed
+    // repeats the same identity as `always` then `pull_request`. Map-based
+    // dedup on actorIdentity would keep only the LAST entry (pull_request),
+    // matching declared and returning a false green — silently discarding the
+    // more permissive `always` bypass, which is exactly what this gate exists
+    // to catch.
+    const declaredOne: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "pull_request" }],
+    };
+    const dupedActors: BypassActor[] = [
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+    ];
+    const r = diffBypassActors(["Nimbus"], declaredOne, { Nimbus: dupedActors });
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain(
+      "duplicate observed bypass actor identity OrganizationAdmin:null",
+    );
+
+    // Order-dependence proof: swapping the two observed entries must NOT change
+    // the verdict (both must be errors — this was the reported symptom).
+    const rSwapped = diffBypassActors(["Nimbus"], declaredOne, {
+      Nimbus: [...dupedActors].reverse(),
+    });
+    expect(rSwapped.ok).toBe(false);
+  });
+
+  test("Finding 1: a duplicate DECLARED identity is also a hard error", () => {
+    const declaredDuped: Record<string, BypassActor[]> = {
       Nimbus: [
         { actor_type: "OrganizationAdmin", bypass_mode: "always" },
-        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", bypass_mode: "pull_request" },
       ],
-      "nimbus-sdk": [],
     };
-    const twoLive: Record<string, BypassActor[]> = {
-      Nimbus: [
-        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
-        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
-      ],
-      "nimbus-sdk": [],
+    const live: Record<string, BypassActor[]> = {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
     };
-    expect(diffBypassActors(REPOS, twoDeclared, twoLive).ok).toBe(true);
+    const r = diffBypassActors(["Nimbus"], declaredDuped, live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain(
+      "duplicate declared bypass actor identity OrganizationAdmin:null",
+    );
+  });
+
+  test("Finding 2: a numeric-id OrganizationAdmin is a hard error on the diff side, not merely 'unknown type'", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [{ actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" }];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("unsupported bypass actor type OrganizationAdmin");
+    expect(r.errors[0]).toContain("numeric actor_id (7)");
+    expect(r.errors[0]).toContain("not human-reviewable");
+    expect(r.errors[0]).not.toContain("unknown actor_type");
   });
 });
 

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -4,6 +4,7 @@ import {
   actorKey,
   type BypassActor,
   type DeclaredBypassFile,
+  decideExit,
   diffBypassActors,
   loadDeclaredBypass,
   validateDeclaredBypass,
@@ -168,5 +169,34 @@ describe("actorKey", () => {
     expect(actorKey({ actor_type: "OrganizationAdmin", bypass_mode: "always" })).toBe(
       actorKey({ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }),
     );
+  });
+});
+
+describe("decideExit", () => {
+  test("skips green when nothing was readable and not strict", () => {
+    expect(decideExit({ queried: 0, errors: [], unreachable: ["Nimbus"] }).code).toBe(0);
+  });
+
+  test("fails when nothing was readable under --strict", () => {
+    expect(decideExit({ queried: 0, errors: [], unreachable: ["Nimbus"], strict: true }).code).toBe(
+      1,
+    );
+  });
+
+  test("keeps drift found on a reachable repo despite another repo failing", () => {
+    const out = decideExit({
+      queried: 1,
+      errors: ["Nimbus: unexpected"],
+      unreachable: ["nimbus-sdk"],
+    });
+    expect(out.code).toBe(1);
+    expect(out.message).toContain("Nimbus: unexpected");
+    expect(out.message).toContain("could not query: nimbus-sdk");
+  });
+
+  test("passes with a warning on a partial read with no drift", () => {
+    const out = decideExit({ queried: 4, errors: [], unreachable: ["nimbus-sdk"] });
+    expect(out.code).toBe(0);
+    expect(out.message).toContain("WARNING");
   });
 });

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  actorKey,
+  type BypassActor,
   type DeclaredBypassFile,
+  diffBypassActors,
   loadDeclaredBypass,
   validateDeclaredBypass,
 } from "./check-bypass-actors.ts";
@@ -68,5 +71,102 @@ describe("loadDeclaredBypass", () => {
     expect(validateDeclaredBypass(file)).toEqual([]);
     expect(file.repos.length).toBe(5);
     expect(Object.keys(file.bypass.by_repo).sort()).toEqual([...file.repos].sort());
+  });
+});
+
+const REPOS = ["Nimbus", "nimbus-sdk"];
+const ADMIN: BypassActor = { actor_type: "OrganizationAdmin", bypass_mode: "always" };
+
+function declared(): Record<string, BypassActor[]> {
+  return { Nimbus: [ADMIN], "nimbus-sdk": [] };
+}
+
+/** Live shape: GitHub always includes actor_id, null for org-level actors. */
+function observed(): Record<string, BypassActor[]> {
+  return {
+    Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+    "nimbus-sdk": [],
+  };
+}
+
+describe("diffBypassActors", () => {
+  test("passes when live matches declared, with actor_id null vs omitted", () => {
+    const r = diffBypassActors(REPOS, declared(), observed());
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("flags an unexpected bypass actor", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+    ];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("nimbus-sdk: unexpected bypass actor");
+  });
+
+  test("flags a missing declared bypass actor", () => {
+    const live = observed();
+    live["Nimbus"] = [];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("Nimbus: missing declared bypass actor");
+  });
+
+  test("reports a widened bypass_mode as a mode change, not as add+remove", () => {
+    const live = observed();
+    live["Nimbus"] = [
+      { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "pull_request" },
+    ];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]).toContain("bypass_mode: expected always, got pull_request");
+  });
+
+  test("treats a non-null-id actor type as a hard error, never normalizing it away", () => {
+    const live = observed();
+    live["nimbus-sdk"] = [{ actor_type: "Team", actor_id: 42, bypass_mode: "always" }];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("unsupported bypass actor type Team (id 42)");
+  });
+
+  test("flags a repo that is not declared at all", () => {
+    const r = diffBypassActors([...REPOS, "nimbus-new"], declared(), observed());
+    expect(r.errors[0]).toContain("nimbus-new: not declared in bypass.by_repo");
+  });
+
+  test("flags a declared repo with no observation", () => {
+    const live = observed();
+    delete live["nimbus-sdk"];
+    const r = diffBypassActors(REPOS, declared(), live);
+    expect(r.errors[0]).toContain("nimbus-sdk: no observed bypass_actors");
+  });
+
+  test("is order-independent across the actor set", () => {
+    const twoDeclared: Record<string, BypassActor[]> = {
+      Nimbus: [
+        { actor_type: "OrganizationAdmin", bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+      ],
+      "nimbus-sdk": [],
+    };
+    const twoLive: Record<string, BypassActor[]> = {
+      Nimbus: [
+        { actor_type: "OrganizationAdmin", actor_id: 7, bypass_mode: "always" },
+        { actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" },
+      ],
+      "nimbus-sdk": [],
+    };
+    expect(diffBypassActors(REPOS, twoDeclared, twoLive).ok).toBe(true);
+  });
+});
+
+describe("actorKey", () => {
+  test("normalizes an omitted actor_id to the same key as an explicit null", () => {
+    expect(actorKey({ actor_type: "OrganizationAdmin", bypass_mode: "always" })).toBe(
+      actorKey({ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }),
+    );
   });
 });

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -121,3 +121,76 @@ export function validateDeclaredBypass(file: DeclaredBypassFile): string[] {
 
   return errors;
 }
+
+/** Stable identity of an actor INCLUDING its mode — an omitted id equals an explicit null. */
+export function actorKey(actor: BypassActor): string {
+  return `${actor.actor_type}:${actor.actor_id ?? "null"}:${actor.bypass_mode}`;
+}
+
+/** Identity WITHOUT the mode, so a mode change reports as a change, not add+remove. */
+function actorIdentity(actor: BypassActor): string {
+  return `${actor.actor_type}:${actor.actor_id ?? "null"}`;
+}
+
+/**
+ * Pure diff — the whole verdict, so both gates share it and neither needs network.
+ * Gate 1 passes live `gh` data as `observed`; Gate 2 passes the attested snapshot.
+ *
+ * Findings are directional because the repairs differ: "someone added an override"
+ * is a different job from "an intended override was removed".
+ */
+export function diffBypassActors(
+  repos: string[],
+  declared: Record<string, BypassActor[]>,
+  observed: Record<string, BypassActor[]>,
+): AuditResult {
+  const errors: string[] = [];
+
+  for (const repo of repos) {
+    const want = declared[repo];
+    if (want === undefined) {
+      errors.push(`${repo}: not declared in bypass.by_repo`);
+      continue;
+    }
+    const got = observed[repo];
+    if (got === undefined) {
+      errors.push(`${repo}: no observed bypass_actors`);
+      continue;
+    }
+
+    // An actor type we cannot render human-checkably is a hard error, never
+    // silently normalized — otherwise a Team bypass added in the UI reads green.
+    const unsupported = got.filter((a) => !NULL_ID_ACTOR_TYPES.includes(a.actor_type));
+    if (unsupported.length > 0) {
+      for (const actor of unsupported) {
+        errors.push(
+          `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
+        );
+      }
+      continue;
+    }
+
+    const wantById = new Map(want.map((a) => [actorIdentity(a), a]));
+    const gotById = new Map(got.map((a) => [actorIdentity(a), a]));
+
+    for (const [identity, actor] of gotById) {
+      const expected = wantById.get(identity);
+      if (expected === undefined) {
+        errors.push(`${repo}: unexpected bypass actor: ${actorKey(actor)}`);
+        continue;
+      }
+      if (expected.bypass_mode !== actor.bypass_mode) {
+        errors.push(
+          `${repo}: ${identity} bypass_mode: expected ${expected.bypass_mode}, got ${actor.bypass_mode}`,
+        );
+      }
+    }
+    for (const [identity, actor] of wantById) {
+      if (!gotById.has(identity)) {
+        errors.push(`${repo}: missing declared bypass actor: ${actorKey(actor)}`);
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -17,6 +17,9 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { ATTESTATION_PATH, decideAttestWrite, writeAttestation } from "./_bypass-attestation.ts";
+import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+
 export interface AuditResult {
   ok: boolean;
   errors: string[];
@@ -193,4 +196,122 @@ export function diffBypassActors(
   }
 
   return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Exit decision for the per-repo loop.
+ *
+ * INVARIANT, mirroring check-ruleset-drift: real drift on a reachable repo is
+ * never discarded because a DIFFERENT repo's read failed. `queried === 0` is the
+ * only skip-green case.
+ */
+export function decideExit(input: {
+  queried: number;
+  errors: string[];
+  unreachable: string[];
+  strict?: boolean;
+}): { code: 0 | 1; message: string } {
+  const { queried, errors, unreachable, strict = false } = input;
+
+  if (queried === 0) return strictSkip("audit:bypass-actors", strict);
+
+  if (errors.length > 0) {
+    const lines = errors.map((err) => `audit:bypass-actors: ${err}`);
+    if (unreachable.length > 0) {
+      lines.push(`audit:bypass-actors: WARNING — could not query: ${unreachable.join(", ")}`);
+    }
+    return { code: 1, message: lines.join("\n") };
+  }
+
+  if (unreachable.length > 0) {
+    return {
+      code: 0,
+      message: `audit:bypass-actors: OK (${queried} repos) — WARNING: could not query ${unreachable.join(", ")}`,
+    };
+  }
+
+  return { code: 0, message: `audit:bypass-actors: OK (${queried} repos)` };
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const strict = isStrict(argv, process.env);
+  const attest = argv.includes("--attest");
+  const label = "audit:bypass-actors";
+  const file = loadDeclaredBypass(process.cwd());
+
+  const configErrors = validateDeclaredBypass(file);
+  if (configErrors.length > 0) {
+    for (const err of configErrors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+
+  const observed: Record<string, BypassActor[]> = {};
+  const unreachable: string[] = [];
+  let queried = 0;
+
+  for (const repo of file.repos) {
+    const listResult = runGh([
+      "gh",
+      "api",
+      `repos/nimbus-agent/${repo}/rulesets`,
+      "--jq",
+      '.[] | select(.name=="General") | .id',
+    ]);
+    if (!listResult.ok) {
+      unreachable.push(repo);
+      continue;
+    }
+    const id = listResult.stdout.trim();
+    if (id === "") {
+      // gh succeeded and simply found no matching ruleset — real drift, not a skip.
+      queried += 1;
+      observed[repo] = [];
+      continue;
+    }
+
+    const detail = runGh(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
+    if (!detail.ok) {
+      unreachable.push(repo);
+      continue;
+    }
+
+    queried += 1;
+    const live: unknown = JSON.parse(detail.stdout);
+    const actors =
+      isRecord(live) && Array.isArray(live["bypass_actors"]) ? live["bypass_actors"] : [];
+    observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
+  }
+
+  const result = diffBypassActors(file.repos, file.bypass.by_repo, observed);
+  const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
+
+  if (attest) {
+    const decision = decideAttestWrite({
+      ok: result.ok,
+      queried,
+      total: file.repos.length,
+      unreachable,
+    });
+    if (!decision.write) {
+      if (outcome.code === 1) console.error(outcome.message);
+      console.error(`${label}: ${decision.reason ?? "refusing to attest"}`);
+      process.exit(1);
+    }
+    const who = runGh(["gh", "api", "user", "--jq", ".login"]);
+    writeAttestation(process.cwd(), {
+      attested_at: new Date().toISOString(),
+      attested_by: who.ok ? who.stdout.trim() : "unknown",
+      grace_days: file.bypass.attestation_grace_days,
+      repos: Object.keys(observed).sort(),
+      observed,
+    });
+    console.log(`${label}: OK (${queried} repos) — wrote ${ATTESTATION_PATH}`);
+    process.exit(0);
+  }
+
+  if (outcome.code === 1) console.error(outcome.message);
+  else if (outcome.message.includes("skipped")) console.warn(outcome.message);
+  else console.log(outcome.message);
+  process.exit(outcome.code);
 }

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -18,7 +18,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { ATTESTATION_PATH, decideAttestWrite, writeAttestation } from "./_bypass-attestation.ts";
-import { isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
+import { classifyReadFailure, isRecord, isStrict, runGh, strictSkip } from "./_gh-audit.ts";
 
 export interface AuditResult {
   ok: boolean;
@@ -62,6 +62,17 @@ export const KNOWN_ACTOR_TYPES: readonly string[] = [
   "RepositoryRole",
   "DeployKey",
 ];
+
+/**
+ * True only for an actor this gate can render human-checkably: a type in
+ * `NULL_ID_ACTOR_TYPES` carrying an actually-null `actor_id`. Checking the type
+ * name alone is not enough — a null-id type can still show up with a numeric id
+ * (e.g. a GitHub API quirk or a hand-edited config), and that is exactly the
+ * shape the reviewability rationale above exists to reject.
+ */
+function isSupportedActor(actor: BypassActor): boolean {
+  return NULL_ID_ACTOR_TYPES.includes(actor.actor_type) && (actor.actor_id ?? null) === null;
+}
 
 const DECLARED_PATH = ".github/rulesets/general-branch.json";
 
@@ -113,6 +124,14 @@ export function validateDeclaredBypass(file: DeclaredBypassFile): string[] {
             ? `unsupported actor_type "${actor.actor_type}" in bypass.by_repo.${repo} — only null-id org-level actors (${NULL_ID_ACTOR_TYPES.join("|")}) are supported`
             : `unknown actor_type "${actor.actor_type}" in bypass.by_repo.${repo}`,
         );
+      } else if ((actor.actor_id ?? null) !== null) {
+        // The type is null-id-eligible, but THIS entry carries a numeric id — the
+        // exact shape the reviewability rationale (see NULL_ID_ACTOR_TYPES above)
+        // exists to reject. Distinct message from "unsupported actor_type" above:
+        // the type is fine, the numeric id is the defect.
+        errors.push(
+          `bypass.by_repo.${repo} declares "${actor.actor_type}" with a numeric actor_id (${actor.actor_id}) — unsupported: a numeric id is not human-reviewable in a PR diff`,
+        );
       }
     }
   }
@@ -133,6 +152,24 @@ export function actorKey(actor: BypassActor): string {
 /** Identity WITHOUT the mode, so a mode change reports as a change, not add+remove. */
 function actorIdentity(actor: BypassActor): string {
   return `${actor.actor_type}:${actor.actor_id ?? "null"}`;
+}
+
+/**
+ * Identity keys that occur more than once in an actor array.
+ *
+ * `new Map(array.map(...))` silently keeps only the LAST entry for a repeated
+ * key — a duplicate identity (e.g. the same actor listed twice with different
+ * `bypass_mode`s) would otherwise be discarded with no signal, and which entry
+ * "wins" depends on array order. Both sides of the diff must be checked before
+ * either is turned into a Map.
+ */
+function duplicateIdentities(actors: BypassActor[]): string[] {
+  const counts = new Map<string, number>();
+  for (const actor of actors) {
+    const id = actorIdentity(actor);
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).map(([id]) => id);
 }
 
 /**
@@ -161,13 +198,42 @@ export function diffBypassActors(
       continue;
     }
 
-    // An actor type we cannot render human-checkably is a hard error, never
-    // silently normalized — otherwise a Team bypass added in the UI reads green.
-    const unsupported = got.filter((a) => !NULL_ID_ACTOR_TYPES.includes(a.actor_type));
+    // A duplicate identity must never be silently resolved by `Map` keeping the
+    // last entry — that would discard the most permissive bypass_mode with no
+    // signal, and the surviving entry would depend on array order. Checked on
+    // BOTH sides before either is turned into a Map.
+    const wantDupes = duplicateIdentities(want);
+    if (wantDupes.length > 0) {
+      for (const id of wantDupes) {
+        errors.push(
+          `${repo}: duplicate declared bypass actor identity ${id} in bypass.by_repo.${repo}`,
+        );
+      }
+      continue;
+    }
+    const gotDupes = duplicateIdentities(got);
+    if (gotDupes.length > 0) {
+      for (const id of gotDupes) {
+        errors.push(
+          `${repo}: duplicate observed bypass actor identity ${id} — cannot safely diff against declared intent`,
+        );
+      }
+      continue;
+    }
+
+    // An actor we cannot render human-checkably is a hard error, never silently
+    // normalized — otherwise a Team bypass, or a null-id type carrying a numeric
+    // id, added in the UI reads green. The two cases get DISTINCT messages: an
+    // unknown/non-null-id type is a type problem, but a null-id type carrying a
+    // numeric actor_id is a reviewability problem, not a type problem — saying
+    // "unknown type" there would misdescribe the defect.
+    const unsupported = got.filter((a) => !isSupportedActor(a));
     if (unsupported.length > 0) {
       for (const actor of unsupported) {
         errors.push(
-          `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
+          NULL_ID_ACTOR_TYPES.includes(actor.actor_type)
+            ? `${repo}: unsupported bypass actor type ${actor.actor_type} with a numeric actor_id (${actor.actor_id}) — a numeric id is not human-reviewable in a PR diff`
+            : `${repo}: unsupported bypass actor type ${actor.actor_type} (id ${actor.actor_id ?? "null"}) — declared bypass intent supports only null-id org-level actors`,
         );
       }
       continue;
@@ -202,8 +268,12 @@ export function diffBypassActors(
  * Exit decision for the per-repo loop.
  *
  * INVARIANT, mirroring check-ruleset-drift: real drift on a reachable repo is
- * never discarded because a DIFFERENT repo's read failed. `queried === 0` is the
- * only skip-green case.
+ * never discarded because a DIFFERENT repo's read failed. `queried === 0` is
+ * the skip-green case — but ONLY when there are also no errors. A confirmed
+ * 404 (repo absent) is folded into `errors` even when it drove `queried` to 0
+ * (e.g. every declared repo turned out to be renamed/deleted); that is real
+ * signal that `gh` worked, not "nothing was readable", so it must never be
+ * swallowed by the soft skip.
  */
 export function decideExit(input: {
   queried: number;
@@ -213,7 +283,7 @@ export function decideExit(input: {
 }): { code: 0 | 1; message: string } {
   const { queried, errors, unreachable, strict = false } = input;
 
-  if (queried === 0) return strictSkip("audit:bypass-actors", strict);
+  if (queried === 0 && errors.length === 0) return strictSkip("audit:bypass-actors", strict);
 
   if (errors.length > 0) {
     const lines = errors.map((err) => `audit:bypass-actors: ${err}`);
@@ -248,6 +318,13 @@ if (import.meta.main) {
 
   const observed: Record<string, BypassActor[]> = {};
   const unreachable: string[] = [];
+  // A confirmed 404 on the repo itself is NOT "unreachable" — that bucket is for
+  // transient/indeterminate failures (5xx, rate-limit, network) that must never
+  // be read as a finding. A 404 means the repo is genuinely absent (renamed or
+  // deleted), which is real drift: it must exit 1, never a soft "could not
+  // query" warning that leaves the gate green. Mirrors check-cla-coverage.ts's
+  // classifyReadFailure handling.
+  const absentErrors: string[] = [];
   let queried = 0;
 
   for (const repo of file.repos) {
@@ -259,7 +336,13 @@ if (import.meta.main) {
       '.[] | select(.name=="General") | .id',
     ]);
     if (!listResult.ok) {
-      unreachable.push(repo);
+      if (classifyReadFailure(listResult.httpStatus) === "absent") {
+        absentErrors.push(
+          `${repo}: repository not found (HTTP 404 on rulesets) — likely renamed or deleted; update bypass.by_repo if intentional`,
+        );
+      } else {
+        unreachable.push(repo);
+      }
       continue;
     }
     const id = listResult.stdout.trim();
@@ -272,7 +355,13 @@ if (import.meta.main) {
 
     const detail = runGh(["gh", "api", `repos/nimbus-agent/${repo}/rulesets/${id}`]);
     if (!detail.ok) {
-      unreachable.push(repo);
+      if (classifyReadFailure(detail.httpStatus) === "absent") {
+        absentErrors.push(
+          `${repo}: repository not found (HTTP 404 on rulesets/${id}) — likely renamed or deleted; update bypass.by_repo if intentional`,
+        );
+      } else {
+        unreachable.push(repo);
+      }
       continue;
     }
 
@@ -283,7 +372,11 @@ if (import.meta.main) {
     observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
   }
 
-  const result = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
+  const diffResult = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
+  const result: AuditResult = {
+    ok: diffResult.ok && absentErrors.length === 0,
+    errors: [...absentErrors, ...diffResult.errors],
+  };
   const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
 
   if (attest) {

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -283,7 +283,7 @@ if (import.meta.main) {
     observed[repo] = actors.filter(isRecord) as unknown as BypassActor[];
   }
 
-  const result = diffBypassActors(file.repos, file.bypass.by_repo, observed);
+  const result = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
   const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
 
   if (attest) {

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:bypass-actors — asserts each active org repo's `General` ruleset carries
+ * exactly the bypass actors declared in `.github/rulesets/general-branch.json`.
+ *
+ * Why this is a SEPARATE gate from audit:ruleset-drift: that gate's credential is
+ * a repo-scoped App installation token with `Administration: read`, and GitHub
+ * returns an EMPTY `bypass_actors` to it for org-level actors. Proven live that
+ * `organization-administration: read` does not restore the field, and reading it
+ * otherwise needs `Administration: write` — which a read-only audit gate must not
+ * hold. So this one runs from the OWNER's machine (an `admin:org` token does
+ * return the field) and leaves a committed attestation the sweep can check
+ * without any credential at all. See docs/infrastructure-roadmap.md, P6.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface AuditResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** One entry of a ruleset's `bypass_actors` array. */
+export interface BypassActor {
+  actor_type: string;
+  /** `null` for org-level actors; a numeric id for Team/Integration/RepositoryRole. */
+  actor_id?: number | null;
+  bypass_mode: string;
+}
+
+export interface DeclaredBypassFile {
+  repos: string[];
+  bypass: {
+    attestation_grace_days: number;
+    by_repo: Record<string, BypassActor[]>;
+  };
+}
+
+export const VALID_BYPASS_MODES: readonly string[] = ["always", "pull_request"];
+
+/**
+ * The only actor types this gate supports — those whose `actor_id` is null.
+ *
+ * Not a portability concern (there is no staging org; every sweep gate hard-codes
+ * `nimbus-agent`) but a REVIEWABILITY one: the entire control here is that the
+ * config and attestation are PR-visible and diff-reviewed, and `"actor_id":
+ * 4382579` is not something a human reviewer can check. Supporting a numeric-id
+ * actor requires resolving ids to names first — see the design's 1.1 response.
+ */
+export const NULL_ID_ACTOR_TYPES: readonly string[] = ["OrganizationAdmin"];
+
+/** Every actor type GitHub can return, used only to sharpen the validation error. */
+export const KNOWN_ACTOR_TYPES: readonly string[] = [
+  "OrganizationAdmin",
+  "Team",
+  "Integration",
+  "RepositoryRole",
+  "DeployKey",
+];
+
+const DECLARED_PATH = ".github/rulesets/general-branch.json";
+
+export function loadDeclaredBypass(repoRoot: string): DeclaredBypassFile {
+  const raw = readFileSync(join(repoRoot, DECLARED_PATH), "utf8");
+  try {
+    return JSON.parse(raw) as DeclaredBypassFile;
+  } catch (err) {
+    // Deliberately NOT an "unparseable" verdict like the attestation's. That file
+    // is generated and could plausibly be corrupted; THIS one is hand-authored and
+    // already covered by `biome check .`, so a parse failure means a broken repo,
+    // not a runtime condition to degrade around. Rethrow with the path so the
+    // failure names the file instead of a bare character offset.
+    throw new Error(
+      `${DECLARED_PATH} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Validates the DECLARED config before any diffing.
+ *
+ * A typo like `"alway"` would already red the gate by mismatching live
+ * `"always"` — but as `bypass_mode: expected alway, got always`, which points the
+ * reader at the ORG when the defect is in the CONFIG. Validating first turns that
+ * into a finding that names the file. Same red, correct target.
+ */
+export function validateDeclaredBypass(file: DeclaredBypassFile): string[] {
+  const errors: string[] = [];
+
+  const declaredRepos = Object.keys(file.bypass.by_repo).sort();
+  const repos = [...file.repos].sort();
+  if (JSON.stringify(declaredRepos) !== JSON.stringify(repos)) {
+    errors.push(
+      `bypass.by_repo keys ${JSON.stringify(declaredRepos)} do not match repos ${JSON.stringify(repos)}`,
+    );
+  }
+
+  for (const [repo, actors] of Object.entries(file.bypass.by_repo)) {
+    for (const actor of actors) {
+      if (!VALID_BYPASS_MODES.includes(actor.bypass_mode)) {
+        errors.push(
+          `invalid bypass_mode "${actor.bypass_mode}" in bypass.by_repo.${repo} (expected ${VALID_BYPASS_MODES.join("|")})`,
+        );
+      }
+      if (!NULL_ID_ACTOR_TYPES.includes(actor.actor_type)) {
+        errors.push(
+          KNOWN_ACTOR_TYPES.includes(actor.actor_type)
+            ? `unsupported actor_type "${actor.actor_type}" in bypass.by_repo.${repo} — only null-id org-level actors (${NULL_ID_ACTOR_TYPES.join("|")}) are supported`
+            : `unknown actor_type "${actor.actor_type}" in bypass.by_repo.${repo}`,
+        );
+      }
+    }
+  }
+
+  const grace = file.bypass.attestation_grace_days;
+  if (!Number.isInteger(grace) || grace <= 0) {
+    errors.push(`bypass.attestation_grace_days must be a positive integer, got ${String(grace)}`);
+  }
+
+  return errors;
+}

--- a/scripts/structure-audit/check-bypass-attestation.test.ts
+++ b/scripts/structure-audit/check-bypass-attestation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BypassActor } from "./check-bypass-actors.ts";
+import { type AttestationCheckInput, evaluateAttestation } from "./check-bypass-attestation.ts";
+
+const NOW = Date.parse("2026-07-30T12:00:00.000Z");
+const DAY = 86_400_000;
+
+const DECLARED: Record<string, BypassActor[]> = {
+  Nimbus: [{ actor_type: "OrganizationAdmin", bypass_mode: "always" }],
+  "nimbus-sdk": [],
+};
+
+function attestation(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    attested_at: new Date(NOW - 3 * DAY).toISOString(),
+    attested_by: "asafgolombek",
+    grace_days: 90,
+    repos: ["Nimbus", "nimbus-sdk"],
+    observed: {
+      Nimbus: [{ actor_type: "OrganizationAdmin", actor_id: null, bypass_mode: "always" }],
+      "nimbus-sdk": [],
+    },
+    ...overrides,
+  });
+}
+
+function input(overrides: Partial<AttestationCheckInput> = {}): AttestationCheckInput {
+  return {
+    raw: attestation(),
+    declaredRepos: ["Nimbus", "nimbus-sdk"],
+    declaredBypass: DECLARED,
+    graceDays: 90,
+    nowMs: NOW,
+    ...overrides,
+  };
+}
+
+describe("evaluateAttestation", () => {
+  test("passes on a fresh, complete, agreeing attestation", () => {
+    const r = evaluateAttestation(input());
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("reports an absent file distinctly from an unparseable one", () => {
+    expect(evaluateAttestation(input({ raw: null })).errors[0]).toContain("no attestation file");
+    expect(evaluateAttestation(input({ raw: "{oops" })).errors[0]).toContain("not valid JSON");
+  });
+
+  test("reports legal JSON that is not an object as unparseable", () => {
+    expect(evaluateAttestation(input({ raw: "[]" })).errors[0]).toContain("not valid JSON");
+  });
+
+  test("fails one day past the grace window", () => {
+    const raw = attestation({ attested_at: new Date(NOW - 91 * DAY).toISOString() });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("91d old (grace 90d)");
+  });
+
+  test("reads grace from config, not from the attestation's own grace_days", () => {
+    const raw = attestation({
+      attested_at: new Date(NOW - 45 * DAY).toISOString(),
+      grace_days: 90,
+    });
+    expect(evaluateAttestation(input({ raw, graceDays: 90 })).ok).toBe(true);
+    // A hand-edited grace_days:90 cannot widen a config that says 30.
+    expect(evaluateAttestation(input({ raw, graceDays: 30 })).ok).toBe(false);
+  });
+
+  // NaN comparisons are ALL false, so a naive `elapsed > grace` check PASSES.
+  test("treats an unparseable attested_at as a finding, never as fresh", () => {
+    const raw = attestation({ attested_at: "not-a-date" });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("not a parseable timestamp");
+  });
+
+  test("rejects a future-dated attestation beyond the skew tolerance", () => {
+    const raw = attestation({ attested_at: new Date(NOW + 2 * 3_600_000).toISOString() });
+    const r = evaluateAttestation(input({ raw }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("in the future");
+  });
+
+  test("tolerates small forward clock skew", () => {
+    const raw = attestation({ attested_at: new Date(NOW + 10 * 60_000).toISOString() });
+    expect(evaluateAttestation(input({ raw })).ok).toBe(true);
+  });
+
+  test("fails when a newly declared repo is not covered by the attestation", () => {
+    const r = evaluateAttestation(
+      input({
+        declaredRepos: ["Nimbus", "nimbus-sdk", "nimbus-new"],
+        declaredBypass: { ...DECLARED, "nimbus-new": [] },
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("do not match declared repos"))).toBe(true);
+  });
+
+  // The second NaN fail-open: `elapsed > NaN` is false, so an unguarded missing
+  // attestation_grace_days would report a 10-year-old attestation as fresh.
+  test("a non-numeric grace window is a finding, not a silently disabled check", () => {
+    const raw = attestation({ attested_at: new Date(NOW - 3650 * DAY).toISOString() });
+    const r = evaluateAttestation(input({ raw, graceDays: Number.NaN }));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.includes("attestation_grace_days"))).toBe(true);
+  });
+
+  test("a zero or negative grace window is a finding", () => {
+    for (const bad of [0, -30]) {
+      const r = evaluateAttestation(input({ graceDays: bad }));
+      expect(r.ok).toBe(false);
+      expect(r.errors.some((e) => e.includes("attestation_grace_days"))).toBe(true);
+    }
+  });
+
+  test("fails when the attested snapshot no longer agrees with declared intent", () => {
+    const r = evaluateAttestation(input({ declaredBypass: { ...DECLARED, Nimbus: [] } }));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toContain("drifts from declared intent");
+  });
+});

--- a/scripts/structure-audit/check-bypass-attestation.ts
+++ b/scripts/structure-audit/check-bypass-attestation.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+
+/**
+ * audit:bypass-attestation — the sweep's half of the P6 bypass-actor gate.
+ *
+ * Runs with NO credential: it re-runs the same pure diff offline against the
+ * committed attestation, and checks that the attestation is fresh, covers every
+ * declared repo, and still agrees with declared intent.
+ *
+ * The gated property is NOT "the org is clean" — it is "a green attestation was
+ * committed recently and still agrees with declared intent". The attestation is a
+ * committed file and can be hand-edited; the real control is that it is PR-visible
+ * and diff-reviewed. See the design's "What this does not prove".
+ *
+ * Deliberately sweep-only, never the preflight FAST tier: its red depends on the
+ * OWNER's re-attestation cadence, so a stale attestation must never block an
+ * external contributor's unrelated PR.
+ */
+
+import { ATTESTATION_PATH, parseAttestation, readAttestation } from "./_bypass-attestation.ts";
+import type { AuditResult, BypassActor } from "./check-bypass-actors.ts";
+import {
+  diffBypassActors,
+  loadDeclaredBypass,
+  validateDeclaredBypass,
+} from "./check-bypass-actors.ts";
+
+/** Forward clock skew we absorb rather than treat as a hand edit. */
+export const FUTURE_TOLERANCE_MS = 60 * 60 * 1000;
+
+const DAY_MS = 86_400_000;
+
+export interface AttestationCheckInput {
+  /** Raw file contents, or `null` when the file is absent. */
+  raw: string | null;
+  declaredRepos: string[];
+  declaredBypass: Record<string, BypassActor[]>;
+  /** From `bypass.attestation_grace_days` — NEVER the attestation's own field. */
+  graceDays: number;
+  /** Injected so freshness is testable without touching the system clock. */
+  nowMs: number;
+}
+
+export function evaluateAttestation(input: AttestationCheckInput): AuditResult {
+  const { raw, declaredRepos, declaredBypass, graceDays, nowMs } = input;
+
+  if (raw === null) {
+    return {
+      ok: false,
+      errors: [
+        `no attestation file at ${ATTESTATION_PATH} — run \`bun run audit:bypass-actors --attest\``,
+      ],
+    };
+  }
+
+  const parsed = parseAttestation(raw);
+  if (parsed === "unparseable") {
+    return { ok: false, errors: [`${ATTESTATION_PATH} is not valid JSON (or is not an object)`] };
+  }
+
+  const errors: string[] = [];
+
+  // The SECOND NaN fail-open, one level up from `attested_at`. A missing
+  // `attestation_grace_days` makes `graceDays * DAY_MS` NaN, and `elapsed > NaN`
+  // is false — so deleting one config line would silently disable the freshness
+  // check while the gate stayed green. Guarded here as well as in the CLI, since
+  // this pure function is what the tests exercise.
+  const graceValid = Number.isFinite(graceDays) && graceDays > 0;
+  if (!graceValid) {
+    errors.push(
+      `grace window is not a positive number (${String(graceDays)}) — check bypass.attestation_grace_days`,
+    );
+  }
+
+  const attestedAtMs = Date.parse(parsed.attested_at);
+  if (Number.isNaN(attestedAtMs)) {
+    // Every comparison with NaN is false, so a naive staleness check would PASS.
+    errors.push(`attested_at "${parsed.attested_at}" is not a parseable timestamp`);
+  } else {
+    const elapsed = nowMs - attestedAtMs;
+    if (elapsed < -FUTURE_TOLERANCE_MS) {
+      errors.push(
+        `attested_at is ${Math.round(-elapsed / 60_000)} minutes in the future — clock skew or a hand-edited file`,
+      );
+    } else if (graceValid && elapsed > graceDays * DAY_MS) {
+      errors.push(
+        `attestation is ${Math.floor(elapsed / DAY_MS)}d old (grace ${graceDays}d) — re-run \`bun run audit:bypass-actors --attest\``,
+      );
+    }
+  }
+
+  const attestedRepos = [...parsed.repos].sort();
+  const declared = [...declaredRepos].sort();
+  if (JSON.stringify(attestedRepos) !== JSON.stringify(declared)) {
+    errors.push(
+      `attested repos ${JSON.stringify(attestedRepos)} do not match declared repos ${JSON.stringify(declared)} — re-attest to cover the change`,
+    );
+  }
+
+  const diff = diffBypassActors(declaredRepos, declaredBypass, parsed.observed);
+  for (const err of diff.errors) {
+    errors.push(`attested snapshot drifts from declared intent — ${err}`);
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+if (import.meta.main) {
+  const label = "audit:bypass-attestation";
+  const file = loadDeclaredBypass(process.cwd());
+
+  // Validate the declared config BEFORE consuming its grace window. Gate 1 does
+  // this too; skipping it here would let a missing `attestation_grace_days`
+  // reach the comparison as NaN and silently disable the freshness check.
+  const configErrors = validateDeclaredBypass(file);
+  if (configErrors.length > 0) {
+    for (const err of configErrors) console.error(`${label}: ${err}`);
+    process.exit(1);
+  }
+
+  const result = evaluateAttestation({
+    raw: readAttestation(process.cwd()),
+    declaredRepos: file.repos,
+    declaredBypass: file.bypass.by_repo,
+    graceDays: file.bypass.attestation_grace_days,
+    nowMs: Date.now(),
+  });
+
+  if (!result.ok) {
+    for (const err of result.errors) console.error(`${label}: ${err}`);
+    // This gate takes no `--strict` branch, unlike every other sweep gate. Those
+    // fail SOFT locally because they need `gh` auth an external contributor lacks.
+    // This one reads two committed files and nothing else, so there is no
+    // environment where it cannot run — an unreadable, stale or disagreeing
+    // attestation is always a real finding. The workflow still passes `--strict`
+    // for consistency; it is simply a no-op here.
+    process.exit(1);
+  }
+
+  console.log(
+    `${label}: OK (${file.repos.length} repos, grace ${file.bypass.attestation_grace_days}d)`,
+  );
+}

--- a/scripts/structure-audit/check-ruleset-drift.ts
+++ b/scripts/structure-audit/check-ruleset-drift.ts
@@ -38,9 +38,9 @@ export interface SharedRuleset {
 
 /**
  * The on-disk shape of `.github/rulesets/general-branch.json`: one shared
- * declared ruleset plus the flat list of repos it is asserted against. There are
- * no per-repo overrides — bypass actors are intentionally not diffed (see
- * `diffRuleset` / the P1 progress log), and everything else is uniform.
+ * declared ruleset plus the flat list of repos it is asserted against.
+ * `shared` is uniform across repos; per-repo bypass intent lives in the sibling
+ * `bypass` block and is consumed by check-bypass-actors.ts, not by this gate.
  */
 export interface DesiredRulesetFile {
   shared: SharedRuleset;
@@ -112,15 +112,14 @@ export function diffRuleset(desired: DesiredRuleset, live: unknown): AuditResult
     }
   }
 
-  // Bypass actors are intentionally NOT diffed. The CI credential is a repo-
-  // scoped App installation token with `Administration: read`, which returns an
-  // EMPTY `bypass_actors` for org-level actors (OrganizationAdmin) — proven live
-  // that even adding `organization-administration: read` does not restore it, and
-  // reading them would need `Administration: write`, which an audit gate must not
-  // hold. Diffing the field against a declared value therefore false-fails on
-  // every repo that carries an org-level bypass. Auditing bypass actors is a
-  // follow-up requiring a higher-privilege context (see the P1 progress log in
-  // docs/infrastructure-roadmap.md).
+  // Bypass actors are intentionally NOT diffed HERE. This gate's credential is a
+  // repo-scoped App installation token with `Administration: read`, which returns
+  // an EMPTY `bypass_actors` for org-level actors (OrganizationAdmin) — proven
+  // live that adding `organization-administration: read` does not restore it, and
+  // reading them would need `Administration: write`, which a read-only audit gate
+  // must not hold. The field IS gated, by the owner-run `audit:bypass-actors`
+  // plus the sweep's `audit:bypass-attestation`, both reading the `bypass` block
+  // of .github/rulesets/general-branch.json. See docs/infrastructure-roadmap.md, P6.
 
   const prRule = rules.find((r) => isRecord(r) && r["type"] === "pull_request");
   if (!isRecord(prRule)) {


### PR DESCRIPTION
Closes P6's last remaining item — the bypass-actor audit.

## The hole

`audit:ruleset-drift` structurally **cannot** check a ruleset's `bypass_actors`, and a bypass actor exempts a principal from every rule the ruleset enforces — including the `pull_request` rule that is the whole point of the `General` ruleset. The reason it can't is recorded in the P1 progress log: the sweep's credential is an App installation token with `Administration: read`, and GitHub returns an **empty** `bypass_actors` to it for org-level actors. Proven live that `organization-administration: read` does not restore the field, and reading it otherwise needs `Administration: write` — which a read-only audit gate must not hold.

So the intended shape has lived in a JSON `$comment` **string** since P1. Prose in a comment is not a gate.

## The approach: two gates sharing one pure diff

Rather than upgrade the credential, the field is gated by a pair:

| gate | runs | credential |
| --- | --- | --- |
| `audit:bypass-actors` | owner's machine | personal `admin:org` (which *does* return the field) |
| `audit:bypass-attestation` | weekly `org-drift-sweep` | **none** |

The owner-run gate diffs live state against a new machine-readable `bypass` block and, on a green **and complete** read, writes a committed attestation snapshot. The sweep gate re-runs the *same pure diff* offline against that snapshot, plus checks freshness (90 days, flipping to 30 at contributor-two as a fourth `$contributor_two` switch), repo coverage, and continued agreement with declared intent.

Sweep-only, deliberately not the fast preflight tier: this gate's red depends on the owner's re-attestation cadence, so a stale attestation must never block an external contributor's unrelated PR.

## What this does not prove

The attestation is a committed file and can be hand-edited. The gate proves *a green attestation was committed recently and still agrees with declared intent* — **not** *the org is clean right now*. The control is that the file is PR-visible and diff-reviewed. Signing it was considered and rejected as theatre: the only plausible signer is the same person who could forge it.

Stated explicitly because by this program's own standard — *"a gate that checks a control's presence cannot see that the control is structurally unable to execute"* — naming the limit is the difference between a real gate and a comforting one.

## Red-proves

These gates ship **green by construction** (live state already matches declared intent), so a passing gate proves nothing on its own. Five deliberate red-proves, each reverted:

| # | mutation | result |
| --- | --- | --- |
| 1 | flip a declared `bypass_mode` | exit 1, mode-change finding |
| 2 | add an unreachable repo, `--attest` | exit 1, `cannot attest: … unreachable (read 5 of 6)`, **no file written** |
| 3 | backdate `attested_at` 91 days | exit 1, `attestation is 91d old (grace 90d)` |
| 4 | duplicate actor identity | exit 1, both orderings |
| 5 | `OrganizationAdmin` with a numeric `actor_id` | exit 1, unsupported-actor finding |

## Defects found by review, before merge

Worth recording, because three were real and none were found by the implementation pass:

1. **Duplicate actor identities collapsed** through `new Map()`, silently dropping the *more permissive* bypass — exactly the state the gate exists to catch, and order-dependent. A test named "order-independent" was itself locking the defect in by asserting a numeric-id `OrganizationAdmin` passes.
2. **The null-id rule was enforced by type name only**, so `{actor_type: "OrganizationAdmin", actor_id: 4382579}` passed — defeating the reviewability rationale documented 100 lines above it.
3. **A 404 was laundered into a warning.** A renamed or deleted repo printed `OK (4 repos) — WARNING` and exited **0** — this sub-program's founding failure mode. Now a named finding at exit 1, using `classifyReadFailure` from `_gh-audit.ts` as the sibling `check-cla-coverage.ts` already does.
4. **Two NaN fail-opens**, caught at design and plan review: every comparison with `NaN` is false, so an unparseable `attested_at` *or* a missing `attestation_grace_days` would have made a naive staleness check silently pass. A 3650-day-old attestation read as fresh. Both guarded, both red-proved by test.

## Stale assertions corrected

Four places claimed bypass actors were ungated. `ruleset-drift` still doesn't diff them — its credential can't — but its comment now points at the gate that does, instead of describing a follow-up.

## Verification

- `bun test scripts/structure-audit/` — **469 pass, 0 fail**
- `bun run typecheck` — exit 0
- `bunx biome check packages scripts` — clean (`bun run lint` reports 0 files inside `.claude/worktrees/`; a known false pass)
- every fast-tier gate run individually — pass, including `audit:workflow-lint`, `audit:action-sha-pins`, `audit:secret-inventory`, `audit:coverage-gate-pal`
- `lint:markdown`, `audit:doc-refs` (635 refs), `audit:status-drift`, lychee — clean
- `audit:coverage-floor` does not apply: it tracks no paths under `scripts/`

## Not done here

- **P6's actual bar is not this merge.** It is `bypass-attestation` green in a dispatched `org-drift-sweep`. The roadmap row therefore reads `sweep proof pending (run id TBD)` with no invented run id; the run id gets backfilled after the first dispatch on `main`.
- **Follow-up, deliberately deferred:** nothing verifies the running credential can actually *see* `bypass_actors` — an empty array is indistinguishable from "none". Harmless while 3 of 5 repos declare actors (a wrong token reds immediately), but once `by_repo` goes all-empty, a run under the App token could write a false-clean attestation honoured for 90 days. A cheap scope probe would close it.

Design, review response, plan and plan review are all included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
