### PR TITLE
test(gateway): drive the pidusage-throws sampler test from the virtual clock

### DIFF
--- a/packages/gateway/src/perf/rss-sampler.test.ts
+++ b/packages/gateway/src/perf/rss-sampler.test.ts
@@ -184,14 +184,26 @@ describe("sampleRss", () => {
   });
 
   test("intervalsMissed increments when pidusage throws", async () => {
+    // Clock-injected for the reason `virtualClock` above exists. What this test cares about is
+    // the throw/sample bookkeeping, not the scheduler's punctuality — but `samples.length >= 2`
+    // needed 3 of the 5 boundaries to land inside the window, so a loaded runner that overshot
+    // into the deadline collected 1 sample and failed it. That is the flake that blocked the
+    // v1.11.0 release gate; it is the same overshoot the comment above records, on the one count
+    // assertion left against the real clock.
+    const clock = virtualClock();
     const result = await sampleRss({
       pid: 1,
       durationMs: 100,
       intervalMs: 20,
       pidusage: fakePidusage([100, "throw", 200, "throw", 300]),
+      now: clock.now,
+      sleep: clock.sleep,
     });
-    expect(result.intervalsMissed).toBeGreaterThan(0);
-    expect(result.samples.length).toBeGreaterThanOrEqual(2);
+    // Exact, not a floor: boundaries at 0/20/40/60/80, and the sequence throws on the 2nd and
+    // 4th. Pinning all three numbers makes the test stricter than the band it replaces — it now
+    // also catches a miscount that a `>= 2` floor would have accepted.
+    expect(result.intervalsMissed).toBe(2);
+    expect(result.samples).toEqual([100, 200, 300]);
   });
 
   test("respects abort signal", async () => {


### PR DESCRIPTION
## Summary

The `v1.11.0` Release run failed its *Unit + Coverage* gate on **one** test out of 11,670 — `sampleRss > intervalsMissed increments when pidusage throws`. Because that gate is a release gate, every build and publish job was skipped, so **`v1.11.0` was never published** (the tag exists at `31177cd`; there is no release). This makes that test deterministic.

The test ran on **real timers** while asserting a *count*:

```ts
durationMs: 100, intervalMs: 20        // boundaries at 0/20/40/60/80
pidusage: fakePidusage([100, "throw", 200, "throw", 300])
expect(result.samples.length).toBeGreaterThanOrEqual(2);   // needs 3 of the 5 boundaries
```

`sampleRss` loops on `while (now() < deadline)` against a fixed `start + durationMs`, so on a loaded runner each `setTimeout` overshoot accumulates against that deadline and fewer boundaries fit. Two boundaries produce one sample, and `>= 2` fails. The failing run took **109.35 ms** — right at the edge.

This is precisely the failure mode `virtualClock()` in this same file was written to eliminate, as its own comment records:

> a loaded CI runner overshoots each `setTimeout`, the overshoot accumulates against the deadline, and a run that should produce 5 samples produced 3 — which is how `>= 4` flaked on a release PR.

That fix reached the sibling count test but this one kept a count assertion against the real clock. This injects the clock here too.

**The assertions get stricter, not more forgiving** — exact values rather than floors, which is what the file's own comment argues for:

```diff
-    expect(result.intervalsMissed).toBeGreaterThan(0);
-    expect(result.samples.length).toBeGreaterThanOrEqual(2);
+    expect(result.intervalsMissed).toBe(2);
+    expect(result.samples).toEqual([100, 200, 300]);
```

The other real-clock tests in the file are deliberately left alone — they exercise the real-clock default, abort-listener accumulation, and one-sided injection, where real timers are the point.

## Related Issue

Relates to #957

Deliberately *not* `Closes` — merging this removes the cause, but it does not publish `v1.11.0`. That still needs a release re-run, which is a separate decision (the existing tag points at `31177cd`, which predates this fix).

## Type of Change

- [x] Test improvement
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [ ] Documentation only
- [ ] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [ ] All existing tests pass (`bun test`) — **see the note below; one pre-existing unrelated failure on Windows**
- [x] New behaviour is covered by tests — no behaviour change; this strengthens an existing test's assertions
- [x] No `any` types introduced — `unknown` is used for external data
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction (no OS checks in business logic)
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] If this PR touches `docs/README.md`, a screenshot of the rendered page (light + dark) is attached — n/a, not touched

`bun run preflight:fast` passes in full (all static gates + typecheck + lint + 20 audits).

## Coverage (if engine/ or vault/ was changed)

n/a — neither `engine/` nor `vault/` was modified. One test file under `packages/gateway/src/perf/` changed.

## Testing

- `bun test packages/gateway/src/perf/rss-sampler.test.ts` — 9 pass, 0 fail.
- **Determinism:** the test no longer reads the real clock, so runner load cannot affect the sample count — the count is now a pure function of `durationMs`/`intervalMs`. Also ran 16 concurrent instances under CPU contention with no failures (weak evidence on its own, since the original also survived that locally on a many-core machine; the structural argument is the real one).
- **Strictness, verified by mutation:** introducing an off-by-one extra boundary in the sampler (`deadline = start + durationMs + intervalMs`) makes the amended test **fail**, where the previous `>= 2` floor accepted it. Reverted after checking.
- `bun test packages/gateway` — 11637 pass, 32 skip, **1 fail**, and that failure is unrelated and pre-existing (see below).
- Platform: Windows. The flake itself is load-dependent and did not reproduce locally; the diagnosis rests on the loop arithmetic plus the history already recorded in the file.

## Notes for Reviewers

**One pre-existing failure, unrelated to this change.** `packages/gateway/test/integration/updater/wiring.test.ts:78` — *"S6-F1: Updater wiring … configured Updater returns CheckNowResult instead of ERR_UPDATER_NOT_CONFIGURED"* fails on Windows. Verified identical with this change stashed, and the Ubuntu CI run that failed the release did **not** hit it, so it is Windows-only and predates this PR.

It may be worth its own issue: the test passes `_platformOverride: "linux-x86_64"` specifically so it is platform-independent, and `createUpdaterFromConfig` still returns `undefined` on Windows — so the override does not appear to be fully honoured, which reads like a platform-equality gap rather than a test bug. Not touched here to keep this PR to the release blocker.

**Local checkout note:** `bun run typecheck` initially failed with `Cannot find type definition file for 'bun'` in `@nimbus-dev/admin-console`. That was an incomplete local install, not a code issue — `bun install --frozen-lockfile` pulled 2342 missing packages and left `bun.lock` untouched. Mentioned only in case another contributor hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved performance sampling test reliability by using a virtual clock.
  * Added precise assertions for missed intervals and collected memory samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->