### PR TITLE
chore(deps): refresh @nimbus-dev/sdk resolution to 1.10.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1817,7 +1817,7 @@
 
     "@nimbus-dev/client": ["@nimbus-dev/client@0.14.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-s4tNoOHq8JCjMuoNEDRVWmQ4afWHU6FMyBwRSjeqAAjsOrswjDiz8mlQycu/gejCyNp+VabqXcJ6nbuJZeTBcg=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.8.1", "", {}, "sha512-FzTiXa5GzG4Bdlw+gA1kg/cIFmvyH1FvLlQowGHZAhGbjX1BJB/ncFXQZijH9MO+mIDLkd/jMEwVfuiB7BNHkA=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 
@@ -4172,6 +4172,8 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.8.1", "", {}, "sha512-FzTiXa5GzG4Bdlw+gA1kg/cIFmvyH1FvLlQowGHZAhGbjX1BJB/ncFXQZijH9MO+mIDLkd/jMEwVfuiB7BNHkA=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 


### PR DESCRIPTION
Clears the `sdk:Nimbus` edge in `audit:release-staleness`.

**Lockfile-only.** Every workspace manifest already declares `^1.8.1`, which 1.10.0 satisfies — the `1.x` case the P2 progress log describes, where a lockfile refresh is sufficient and no manifest edit is needed.

**Targets 1.10.0, not the 1.9.0 the sweep reported.** 1.10.0 published at 09:00Z today and was still inside the gate's 6h grace window, so the edge read green while actually sitting two minors behind. Bumping to 1.9.0 would have gone red again this afternoon.

**On the leftover 1.8.1 in the lockfile:** it remains at path `@nimbus-dev/client/@nimbus-dev/sdk` — nested inside a third-party package, which is that package's business, not ours. The gate's reader is workspace-scoped and correctly reads the hoisted 1.10.0. This is the same situation the P2 log already records.

I also reverted a side effect: `bun update` adds `@nimbus-dev/sdk` as a **root** dependency, but the sdk belongs to the workspace packages, not the root. The committed diff is `bun.lock` only.

## Verification

- `bun run typecheck` — PASS
- `bunx biome check packages scripts` — PASS
- `bun test packages/mcp-connectors` — **948 pass, 0 fail** (the connectors import the sdk directly, so this is the suite that would catch a breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)