### PR TITLE
docs(changelog): record v1.11.0 as never published, superseded by 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `nimbus` core (headless Gateway + CLI binary + first-
 
 ## [1.11.0](https://github.com/nimbus-agent/Nimbus/compare/v1.10.0...v1.11.0) (2026-07-30)
 
+> **Never published — superseded by 1.12.0.** This tag's release build failed its
+> Unit + Coverage gate, which skipped every build and publish job, so no GitHub Release,
+> installer, or updater manifest was ever produced for `v1.11.0`; the git tag is its only
+> trace. The tag is immutable under the *Protected release tags* ruleset and was left in
+> place rather than moved, so the feature below shipped in 1.12.0 instead.
+> See [#957](https://github.com/nimbus-agent/Nimbus/issues/957).
 
 ### Features
 


### PR DESCRIPTION
## Summary

Abandons `v1.11.0` in place and ships its content as **1.12.0**.

`v1.11.0` was tagged but **never published**: its release build failed the *Unit + Coverage* gate on a flaky test, which skipped every build and publish job. There is no GitHub Release, installer, or updater manifest for it — the git tag is the only trace. Users are still on 1.10.0, and the one feature tagged as 1.11.0 (#954, ruleset bypass-actor gating) has never shipped.

Moving the tag onto the fix is **not possible, by design**: the *Protected release tags* ruleset enforces `deletion`, `non_fast_forward`, and `update` on `refs/tags/v*` with **no bypass actors**. A retag was attempted and correctly refused (`GH013: Cannot delete this tag`). That ruleset is doing exactly its job, so the tag stays and the version is abandoned instead.

This PR does two things:

1. **Marks 1.11.0 as never published** in `CHANGELOG.md`, so the entry stops implying a release anyone can install and points at its successor. Without this, `CHANGELOG.md` lists a feature under a version that does not exist as an artifact.
2. **Forces the next version** via a `Release-As: 1.12.0` footer. release-please would otherwise cut nothing at all — every commit since the `v1.11.0` tag is `docs:` or `test:`, so no bump is triggered and the stranded feature would sit unpublished until some unrelated feature happened to land.

### Why 1.12.0 and not 1.11.1

The delta against the last **published** release (1.10.0) is one `feat`. A patch number would describe a feature release as a patch, relative to a version nobody can install. 1.12.0 is the semver-honest successor and leaves 1.11.0 as a visible, documented gap.

### ⚠️ Merging this PR — the footer must survive the squash

release-please reads `Release-As:` from commit messages in the release range. **If the squash commit message drops the `Release-As: 1.12.0` line, no release PR will be created** and this PR accomplishes only the changelog note. GitHub's squash default includes the commit body, so the footer normally survives — but please confirm it is present in the squash message before confirming the merge.

Failure mode is benign and recoverable: no release PR appears. Fixes, in order of preference — land another commit carrying the footer, or set `"release-as": "1.12.0"` on the `.` package in `.release-please-config.json` (remembering to remove it after the release, or every subsequent release pins to 1.12.0).

### What happens after merge

1. release-please opens a `chore: release main` PR for **1.12.0**.
2. Merging that tags `v1.12.0`, which triggers `release.yml`.
3. That build runs the **deterministic** gate — #958 fixed the flaky test — so the failure that killed 1.11.0 should not recur.
4. `v1.12.0` publishes with its assets, and #957 can be closed.

## Related Issue

Relates to #957

Not `Closes` — merging this does not itself publish anything. #957 should close when `v1.12.0` publishes with assets.

## Type of Change

- [x] Documentation only
- [x] CI / tooling — carries the `Release-As:` footer that drives the version bump
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [ ] Test improvement

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`) — no code touched; one `CHANGELOG.md` line block changed
- [x] New behaviour is covered by tests — n/a, no behaviour change
- [x] No `any` types introduced — `unknown` is used for external data
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction (no OS checks in business logic)
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] If this PR touches `docs/README.md`, a screenshot is attached — n/a, not touched

`bun run preflight:fast` passes in full, including `audit:release-please`.

## Coverage (if engine/ or vault/ was changed)

n/a — neither was modified.

## Testing

- `bun run audit:release-please` — OK (manifest/config consistency unaffected).
- `bun run preflight:fast` — PASSED (typecheck, lint, 20 audits, duplication).
- No test suite run: this changes one prose block in `CHANGELOG.md` and a commit footer.

## Notes for Reviewers

**The v1.11.0 tag is deliberately left pointing at `31177cd`.** It is immutable and unpublished. Anyone can still `git checkout v1.11.0`; nobody can install it.

**Nothing in the repo documents that release tags are immutable**, which is why moving the tag looked like a viable recovery at first. A line under *Development Workflow* in `CLAUDE.md` would make the constraint discoverable before someone attempts a retag during an incident — happy to add it in a follow-up if wanted.

**Separately, an unrelated pre-existing failure**, noted while verifying #958 and worth its own issue: `packages/gateway/test/integration/updater/wiring.test.ts:78` fails on Windows. The test passes `_platformOverride: "linux-x86_64"` precisely to be platform-independent, yet `createUpdaterFromConfig` still returns `undefined` there, which reads like a platform-equality gap rather than a test bug. It passes on Ubuntu, so CI is green on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
