### PR TITLE
fix(db): finalize prepared statements so close() releases the database file

### DIFF
--- a/packages/gateway/src/connectors/connector-sync-test-helpers.ts
+++ b/packages/gateway/src/connectors/connector-sync-test-helpers.ts
@@ -57,7 +57,10 @@ export function expectSyncNoopResult(
 }
 
 export function expectServiceItemCount(db: Database, service: string, count: number): void {
-  const row = db.prepare("SELECT COUNT(*) AS c FROM item WHERE service = ?").get(service) as {
+  // db.query() is cache-managed by bun:sqlite and released on close; a bare
+  // db.prepare() here left the database file pinned open for every connector
+  // test that called this helper (#969).
+  const row = db.query("SELECT COUNT(*) AS c FROM item WHERE service = ?").get(service) as {
     c: number;
   };
   expect(row.c).toBe(count);

--- a/packages/gateway/src/connectors/lazy-mesh/mesh.test.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/mesh.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,8 +13,17 @@ import { LAZY_MESH, userMcpMeshKey } from "./keys.ts";
 import { createLazyConnectorMesh, LazyConnectorMesh } from "./mesh.ts";
 import type { LazyMcpSlot } from "./slot.ts";
 
+/**
+ * Roots handed out by `makePaths()`, removed in `afterEach`. Without this the
+ * suite leaked one temp directory per `makePaths()` call — 40 per run, on every
+ * platform — because the root was never referenced again after construction.
+ * Same family as #969, different cause: there was no cleanup at all here.
+ */
+const createdRoots: string[] = [];
+
 function makePaths(): PlatformPaths {
   const root = mkdtempSync(join(tmpdir(), "nimbus-mesh-"));
+  createdRoots.push(root);
   return {
     configDir: join(root, "config"),
     dataDir: join(root, "data"),
@@ -39,6 +48,10 @@ afterEach(async () => {
       /* ignore */
     }
     mesh = undefined;
+  }
+  // Remove after disconnect(), so nothing is still writing under the root.
+  for (const root of createdRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/packages/gateway/src/db/audit-chain.test.ts
+++ b/packages/gateway/src/db/audit-chain.test.ts
@@ -15,6 +15,47 @@ describe("computeAuditRowHash", () => {
     expect(computeAuditRowHash(row)).toBe(computeAuditRowHash(row));
   });
 
+  describe("federationJson participates in the hash", () => {
+    // The federated leg of the chain was entirely untested: every case above omits
+    // `federationJson`, so neither arm of the `typeof … === "string" && length > 0`
+    // guard was exercised. A federated audit row whose provenance did NOT change the
+    // hash would let that field be rewritten after the fact without breaking the chain.
+    const base = {
+      prevHash: GENESIS_HASH,
+      actionType: "federation.query",
+      hitlStatus: "approved",
+      actionJson: '{"q":"x"}',
+      timestamp: 42,
+    };
+
+    test("a non-empty federationJson changes the hash", () => {
+      const withFed = computeAuditRowHash({ ...base, federationJson: '{"peer":"alice"}' });
+      expect(withFed).not.toBe(computeAuditRowHash(base));
+      expect(withFed).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test("a different federationJson yields a different hash", () => {
+      expect(computeAuditRowHash({ ...base, federationJson: '{"peer":"alice"}' })).not.toBe(
+        computeAuditRowHash({ ...base, federationJson: '{"peer":"bob"}' }),
+      );
+    });
+
+    test("empty string and null are equivalent to the field being absent", () => {
+      // The `length > 0` guard exists so a nullish/blank provenance cannot silently
+      // fork the chain away from rows written before the column existed. (Passing an
+      // explicit `undefined` is a type error under exactOptionalPropertyTypes, so
+      // "absent" is expressed by omitting the key.)
+      const absent = computeAuditRowHash(base);
+      expect(computeAuditRowHash({ ...base, federationJson: "" })).toBe(absent);
+      expect(computeAuditRowHash({ ...base, federationJson: null })).toBe(absent);
+    });
+
+    test("is still deterministic with federationJson set", () => {
+      const row = { ...base, federationJson: '{"peer":"alice","ns":"team"}' };
+      expect(computeAuditRowHash(row)).toBe(computeAuditRowHash(row));
+    });
+  });
+
   test("differs when any field differs", () => {
     const base = {
       prevHash: GENESIS_HASH,

--- a/packages/gateway/src/db/query-guard.test.ts
+++ b/packages/gateway/src/db/query-guard.test.ts
@@ -233,4 +233,20 @@ describe("runReadOnlySelect — worker round-trip (S5-F4)", () => {
     });
     expect(rows).toEqual([]);
   });
+
+  // `options?.timeoutMs ?? DEFAULT_TIMEOUT_MS` — the DEFAULT arm. Every other
+  // round-trip test above passes an explicit `timeoutMs`, and the two that omit
+  // `options` reject inside assertReadOnlySelectSql before the default is ever
+  // read, so omitting options on VALID sql was untested.
+  test("succeeds with no options object, applying the default timeout", async () => {
+    const dbPath = tempDbPath();
+    const rows = await runReadOnlySelect(dbPath, "SELECT name FROM t ORDER BY id");
+    expect(rows).toEqual([{ name: "a" }, { name: "b" }, { name: "c" }]);
+  });
+
+  test("omitting only timeoutMs within an options object also uses the default", async () => {
+    const dbPath = tempDbPath();
+    const rows = await runReadOnlySelect(dbPath, "SELECT id FROM t ORDER BY id", {});
+    expect(rows).toHaveLength(3);
+  });
 });

--- a/packages/gateway/src/db/tool-call-log-retention.test.ts
+++ b/packages/gateway/src/db/tool-call-log-retention.test.ts
@@ -156,6 +156,22 @@ describe("startToolCallLogRetention", () => {
     }
   });
 
+  test("falls back to Date.now when no clock is injected", () => {
+    // `opts.nowMs ?? Date.now` — the DEFAULT arm. Every other case here injects a
+    // clock, so production's actual clock source was never exercised. Seeded far
+    // enough in the real past that the assertion cannot depend on the wall clock.
+    const db = freshDb();
+    seedCall(db, Date.now() - 200 * DAY_MS);
+    seedCall(db, Date.now() - 1 * DAY_MS);
+    const handle = startToolCallLogRetention(db, { retentionDays: 90 });
+    try {
+      // Only the 200-day-old row is past a 90-day cutoff measured from the real now.
+      expect(countCalls(db)).toBe(1);
+    } finally {
+      handle.stop();
+    }
+  });
+
   test("a prune error does not throw out of the tick", () => {
     const db = freshDb();
     db.exec("DROP TABLE audit_log");

--- a/packages/gateway/src/embedding/pipeline.ts
+++ b/packages/gateway/src/embedding/pipeline.ts
@@ -131,16 +131,24 @@ export class SqliteEmbeddingPipeline implements EmbeddingPipeline {
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       );
 
-      for (let i = 0; i < pieces.length; i++) {
-        const text = pieces[i] ?? "";
-        const vec = vectors[i];
-        if (vec === undefined) {
-          throw new Error(`missing vector for chunk ${String(i)}`);
+      // Both statements come from db.prepare(), which bun:sqlite does not
+      // auto-release on close — finalize them or the database file stays
+      // pinned open (#969).
+      try {
+        for (let i = 0; i < pieces.length; i++) {
+          const text = pieces[i] ?? "";
+          const vec = vectors[i];
+          if (vec === undefined) {
+            throw new Error(`missing vector for chunk ${String(i)}`);
+          }
+          const rowid = nextRowid;
+          nextRowid += 1;
+          dbStmtRun(insertVec, BigInt(rowid), new Float32Array(vec));
+          dbStmtRun(insertChunk, itemId, i, text, rowid, model, dims, now);
         }
-        const rowid = nextRowid;
-        nextRowid += 1;
-        dbStmtRun(insertVec, BigInt(rowid), new Float32Array(vec));
-        dbStmtRun(insertChunk, itemId, i, text, rowid, model, dims, now);
+      } finally {
+        insertVec.finalize();
+        insertChunk.finalize();
       }
     })();
   }

--- a/packages/gateway/src/index/migrations/runner.ts
+++ b/packages/gateway/src/index/migrations/runner.ts
@@ -243,16 +243,23 @@ function backfillAuditChain(db: Database): void {
   }>;
   let prev = "0".repeat(64);
   const update = db.prepare(`UPDATE audit_log SET row_hash = ?, prev_hash = ? WHERE id = ?`);
-  for (const r of rows) {
-    const row = computeAuditRowHash({
-      prevHash: prev,
-      actionType: r.action_type,
-      hitlStatus: r.hitl_status,
-      actionJson: r.action_json,
-      timestamp: r.timestamp,
-    });
-    dbStmtRun(update, row, prev, r.id);
-    prev = row;
+  // A statement from db.prepare() must be finalized explicitly: bun:sqlite only
+  // auto-releases the db.query() cache, so an unfinalized handle makes a later
+  // db.close() a silent no-op and pins the database file open (#969).
+  try {
+    for (const r of rows) {
+      const row = computeAuditRowHash({
+        prevHash: prev,
+        actionType: r.action_type,
+        hitlStatus: r.hitl_status,
+        actionJson: r.action_json,
+        timestamp: r.timestamp,
+      });
+      dbStmtRun(update, row, prev, r.id);
+      prev = row;
+    }
+  } finally {
+    update.finalize();
   }
 }
 

--- a/packages/gateway/src/ipc/engine-get-session-transcript.ts
+++ b/packages/gateway/src/ipc/engine-get-session-transcript.ts
@@ -74,7 +74,13 @@ export function createGetSessionTranscriptHandler(
       timestamp: number;
       action_json: string | null;
     };
-    const rows = stmt.all(sid, limit + 1) as Row[];
+    // db.prepare() statements are not released by db.close() (#969).
+    let rows: Row[];
+    try {
+      rows = stmt.all(sid, limit + 1) as Row[];
+    } finally {
+      stmt.finalize();
+    }
 
     const hasMore = rows.length > limit;
     const used = hasMore ? rows.slice(0, limit) : rows;

--- a/packages/gateway/src/ipc/server/dispatchers-happy-paths.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers-happy-paths.test.ts
@@ -87,11 +87,14 @@ describe("assertDiagnosticsRpcAccess fall-through (the `return;` after each guar
     const db = trackDb();
     const localIndex = new LocalIndex(db);
     const ctx = makeCtx({ dataDir: tmpDir, localIndex });
-    try {
-      await tryDispatchDiagnosticsRpc(ctx, "telemetry.preview", {});
-    } catch {
-      /* expected for some handlers */
-    }
+    // Same shape as the sibling cases above: the handler may report a typed error, and what
+    // is under test is that the access guard fell THROUGH rather than returning the `skipped`
+    // sentinel. Swallowing the rejection without asserting made this test pass even if the
+    // guard had started skipping — which is the whole behaviour it exists to pin.
+    const outcome = await tryDispatchDiagnosticsRpc(ctx, "telemetry.preview", {}).catch(
+      (e: unknown) => e,
+    );
+    expect(outcome).not.toBe(diagnosticsRpcSkipped);
   });
 });
 

--- a/packages/gateway/src/sync/rate-limiter.test.ts
+++ b/packages/gateway/src/sync/rate-limiter.test.ts
@@ -148,7 +148,11 @@ describe("ProviderRateLimiter – deterministic (clock-injected)", () => {
     const limiter = new ProviderRateLimiter({ google: fastQuota });
     const slackBase = DEFAULT_QUOTAS.slack;
     // burstSize tokens are available at start; acquire exactly burstSize
-    await limiter.acquire("slack", slackBase.burstSize);
+    await expect(limiter.acquire("slack", slackBase.burstSize)).resolves.toBeUndefined();
+    // One MORE than burstSize is refused outright — a capacity check, not a wait. This is
+    // the assertion that actually pins the fallback to DEFAULT_QUOTAS.slack: acquiring
+    // burstSize alone would also succeed under any quota with a larger bucket.
+    await expect(limiter.acquire("slack", slackBase.burstSize + 1)).rejects.toThrow(/burstSize/);
   });
 
   test("penalise then acquire: penalty arm in acquireUnderLock fires and resolves", async () => {

--- a/packages/gateway/test/integration/updater/wiring.test.ts
+++ b/packages/gateway/test/integration/updater/wiring.test.ts
@@ -74,6 +74,14 @@ describe("S6-F1: Updater wiring — factory + dispatch end-to-end", () => {
       emit: () => {},
       logger: noopLogger,
       _platformOverride: "linux-x86_64",
+      // null = "direct install"; do not probe the environment. Without this the
+      // factory calls resolveDistributionChannel(), which honours the ambient
+      // NIMBUS_DISTRIBUTION_CHANNEL marker — so on a developer machine that
+      // installed Nimbus via MSI/Homebrew/apt the factory correctly returns
+      // undefined and this assertion fails for a reason that has nothing to do
+      // with updater wiring (#967). CI has the var unset, which is why it only
+      // ever failed locally.
+      _channelOverride: null,
     });
     expect(updater).toBeDefined();
 
@@ -95,6 +103,11 @@ describe("S6-F1: Updater wiring — factory + dispatch end-to-end", () => {
       currentVersion: "0.1.0",
       emit: () => {},
       logger: noopLogger,
+      // Pinned for the same reason as above. This case passes either way today
+      // because the `enabled: false` guard returns before the channel probe —
+      // but that ordering is incidental, and pinning it keeps the assertion
+      // about the disabled flag rather than about the developer's environment.
+      _channelOverride: null,
     });
     expect(updater).toBeUndefined();
 

--- a/packages/gateway/test/unit/db/snapshot.test.ts
+++ b/packages/gateway/test/unit/db/snapshot.test.ts
@@ -1,6 +1,13 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -34,25 +41,52 @@ describe("db/snapshot", () => {
   let dbPath: string;
   let dataDir: string;
   let db: Database;
+  let templateDir: string;
+  let templateDbPath: string;
+
+  /**
+   * Running every migration against a fresh SQLite file cost ~232 ms per test
+   * on Windows — ~2,000x the per-test cleanup and the dominant term behind the
+   * 30 s hook-timeout flake in #968. Migrating once into a template and copying
+   * the file per test is measured 16.6x faster end-to-end (231.8 ms -> 6.1 ms
+   * per test) and yields an identical database: same `user_version`, same 69
+   * tables, same seed rows.
+   *
+   * `ensureSchema` still runs on each copy — on an already-current
+   * `user_version` it skips every migration and only applies the
+   * connection-level pragmas, which do not survive in the file.
+   */
+  beforeAll(() => {
+    templateDir = mkdtempSync(join(tmpdir(), "nimbus-snapshot-template-"));
+    templateDbPath = join(templateDir, "template.db");
+    makeDbAt(templateDbPath).close();
+  });
+
+  afterAll(() => {
+    rmSync(templateDir, { recursive: true, force: true });
+  });
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "nimbus-snapshot-test-"));
     dbPath = join(tmp, "nimbus.db");
     dataDir = tmp;
-    db = makeDbAt(dbPath);
+    copyFileSync(templateDbPath, dbPath);
+    db = new Database(dbPath);
+    LocalIndex.ensureSchema(db);
   });
 
   afterEach(() => {
     try {
       db.close();
     } catch {
-      /* already closed in some tests */
+      /* the restoreSnapshot cases close and reopen `db` themselves */
     }
-    try {
-      rmSync(tmp, { recursive: true, force: true });
-    } catch {
-      /* Windows may hold a file lock briefly after close; ignore cleanup errors */
-    }
+    // Cleanup is expected to succeed on every platform. It used to fail EBUSY
+    // 30/30 on Windows because an unfinalized prepared statement kept the
+    // database file open (#969, fixed in migrations/runner.ts); the error was
+    // swallowed here, so every run silently leaked a temp directory. Do not
+    // re-add a catch: a failure here now means a handle is being retained again.
+    rmSync(tmp, { recursive: true, force: true });
   });
 
   describe("takeSnapshot", () => {

--- a/packages/gateway/test/unit/db/snapshot.test.ts
+++ b/packages/gateway/test/unit/db/snapshot.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import {
   copyFileSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -186,6 +187,23 @@ describe("db/snapshot", () => {
       expect(row.c).toBe(2);
     });
 
+    it("reports currentItemCount 0 when the live DB has no item table yet", () => {
+      const snapshotPath = takeSnapshot(db, dataDir);
+
+      // The live-count read is wrapped in `catch { /* item table may not exist yet */ }`.
+      // That arm is reached with a database that has never been migrated — the real case
+      // being a restore attempted against a freshly created, schema-less file.
+      const bare = new Database(join(tmp, "bare.db"));
+      try {
+        const preview = previewRestore(bare, snapshotPath);
+        expect(preview.currentItemCount).toBe(0);
+        // The snapshot side still reads normally — only the live read degraded.
+        expect(preview.snapshotItemCount).toBe(2);
+      } finally {
+        bare.close();
+      }
+    });
+
     it("extracts snapshotTimestampMs from the filename", () => {
       const before = Date.now();
       const snapshotPath = takeSnapshot(db, dataDir);
@@ -274,6 +292,33 @@ describe("db/snapshot", () => {
       }
     });
 
+    it("counts only what it actually deleted when an entry cannot be removed", async () => {
+      takeSnapshot(db, dataDir);
+      await Bun.sleep(5);
+      takeSnapshot(db, dataDir);
+
+      // `pruneSnapshots` deletes with a bare `rmSync(path)` inside a best-effort
+      // try/catch. A DIRECTORY whose name matches the snapshot pattern is listed by
+      // `listSnapshots` (it only pattern-matches the name and stats the path) but
+      // `rmSync` without `recursive` refuses to remove it on every platform — so this
+      // exercises the catch arm without depending on file locking or a race.
+      const undeletable = join(dataDir, "snapshots", "nimbus-9999999999999.db.gz");
+      mkdirSync(undeletable);
+
+      expect(listSnapshots(dataDir)).toHaveLength(3);
+
+      // keepLast=0 → all three are candidates, but only the two real files go.
+      const deleted = pruneSnapshots(dataDir, 0);
+      expect(deleted).toBe(2);
+
+      // The directory survives and is still listed: prune degrades, it does not throw.
+      const remaining = listSnapshots(dataDir);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.filename).toBe("nimbus-9999999999999.db.gz");
+
+      rmSync(undeletable, { recursive: true, force: true });
+    });
+
     it("keeps exactly keepLast=1 (newest)", async () => {
       takeSnapshot(db, dataDir);
       await Bun.sleep(5);
@@ -324,6 +369,16 @@ describe("db/snapshot", () => {
 
       await Bun.sleep(100);
       expect(listSnapshots(dataDir)).toHaveLength(countAfterStop);
+    });
+
+    it("defaults runNow to false when the argument is omitted", () => {
+      // `runNow = false` is a default parameter; every other case here passes it
+      // explicitly, so the default arm was never taken. Omitting it must behave like
+      // passing false — i.e. no snapshot before the first interval elapses.
+      const config = { ...DEFAULT_SNAPSHOT_CONFIG, intervalMs: 100_000 };
+      const handle = startSnapshotScheduler(db, dataDir, config);
+      handle.stop();
+      expect(listSnapshots(dataDir)).toHaveLength(0);
     });
 
     it("stop() on a disabled scheduler does nothing (no throw)", () => {

--- a/packages/gateway/test/unit/db/statement-finalization.test.ts
+++ b/packages/gateway/test/unit/db/statement-finalization.test.ts
@@ -1,0 +1,143 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { LocalIndex } from "../../../src/index/local-index.ts";
+
+/**
+ * Regression cover for #969.
+ *
+ * `bun:sqlite`'s `Database.close()` is a no-op when a statement created by
+ * `db.prepare()` has not been finalized: the plain `close()` swallows the
+ * failure, and `close(true)` reports `database is locked`. The file handle is
+ * never released, so on Windows every subsequent `rmSync` of the containing
+ * directory fails `EBUSY` — which is how #969 was found (30/30 leaked temp
+ * dirs). The retained statement itself is platform-independent, so this
+ * asserts on `close(true)` rather than on the Windows-only delete symptom.
+ *
+ * `db.query()` is cache-managed by Bun and released on close; only bare
+ * `db.prepare()` needs an explicit `finalize()`.
+ */
+describe("db statement finalization (#969)", () => {
+  const dirs: string[] = [];
+
+  function freshDbPath(): string {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-stmt-final-"));
+    dirs.push(dir);
+    return join(dir, "nimbus.db");
+  }
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves no unfinalized statement after LocalIndex.ensureSchema", () => {
+    const db = new Database(freshDbPath());
+    LocalIndex.ensureSchema(db);
+
+    // close(true) throws "database is locked" if any prepared statement is
+    // still live. A clean close is the whole assertion.
+    expect(() => {
+      db.close(true);
+    }).not.toThrow();
+  });
+
+  it("leaves no unfinalized statement after the audit-chain backfill has rows to walk", () => {
+    const db = new Database(freshDbPath());
+    LocalIndex.ensureSchema(db);
+    // Exercise the loop body of backfillAuditChain, not just its prepare().
+    db.run(
+      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp)
+       VALUES ('test.action', 'approved', '{}', 1)`,
+    );
+    db.close(true);
+
+    const reopened = new Database(freshDbPath());
+    LocalIndex.ensureSchema(reopened);
+    expect(() => {
+      reopened.close(true);
+    }).not.toThrow();
+  });
+
+  it("releases the underlying file handle so the directory can be removed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-stmt-final-rm-"));
+    const db = new Database(join(dir, "nimbus.db"));
+    LocalIndex.ensureSchema(db);
+    db.close();
+
+    // On Windows this threw EBUSY for every iteration before #969 was fixed.
+    expect(() => {
+      rmSync(dir, { recursive: true, force: true });
+    }).not.toThrow();
+  });
+});
+
+/**
+ * Source-scanning guard for #969. The runtime tests above cover the schema
+ * path; this keeps the *class* of bug from returning at a new call site, which
+ * is how three of the five `prepare()` sites drifted in the first place.
+ */
+describe("db.prepare() call sites are balanced by finalize() (#969)", () => {
+  const SRC_ROOT = join(import.meta.dir, "..", "..", "..", "src");
+
+  function walkTs(dir: string, acc: string[] = []): string[] {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walkTs(full, acc);
+      } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        acc.push(full);
+      }
+    }
+    return acc;
+  }
+
+  function countOccurrences(haystack: string, needle: string): number {
+    let count = 0;
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1) {
+      count += 1;
+      idx = haystack.indexOf(needle, idx + needle.length);
+    }
+    return count;
+  }
+
+  /**
+   * Comments must be stripped before counting: prose that mentions
+   * `db.prepare()` — including the #969 comments at the fixed call sites —
+   * otherwise inflates the count and makes the guard fire on clean code.
+   */
+  function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  }
+
+  it("every source file calling .prepare( also finalizes at least as many statements", () => {
+    const offenders: string[] = [];
+    let scanned = 0;
+    let sitesSeen = 0;
+
+    for (const file of walkTs(SRC_ROOT)) {
+      const text = stripComments(readFileSync(file, "utf8"));
+      const prepares = countOccurrences(text, ".prepare(");
+      if (prepares === 0) {
+        continue;
+      }
+      scanned += 1;
+      sitesSeen += prepares;
+      const finalizes = countOccurrences(text, ".finalize()");
+      if (finalizes < prepares) {
+        offenders.push(
+          `${relative(SRC_ROOT, file).split(sep).join("/")}: ${String(prepares)} prepare( vs ${String(finalizes)} finalize()`,
+        );
+      }
+    }
+
+    // Guard the guard: if this drops to zero the scan silently stopped working.
+    expect(scanned).toBeGreaterThan(0);
+    expect(sitesSeen).toBeGreaterThanOrEqual(scanned);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/gateway/test/unit/db/statement-finalization.test.ts
+++ b/packages/gateway/test/unit/db/statement-finalization.test.ts
@@ -4,6 +4,13 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { LocalIndex } from "../../../src/index/local-index.ts";
+import { runIndexedSchemaMigrations } from "../../../src/index/migrations/runner.ts";
+
+/** How many of the V18 chain columns exist on `audit_log` right now (0 before V18, 2 after). */
+function auditLogHashColumnCount(db: Database): number {
+  const rows = db.query(`PRAGMA table_info(audit_log)`).all() as Array<{ name: string }>;
+  return rows.filter((r) => r.name === "row_hash" || r.name === "prev_hash").length;
+}
 
 /**
  * Regression cover for #969.
@@ -47,18 +54,35 @@ describe("db statement finalization (#969)", () => {
 
   it("leaves no unfinalized statement after the audit-chain backfill has rows to walk", () => {
     const db = new Database(freshDbPath());
-    LocalIndex.ensureSchema(db);
-    // Exercise the loop body of backfillAuditChain, not just its prepare().
-    db.run(
-      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp)
-       VALUES ('test.action', 'approved', '{}', 1)`,
-    );
-    db.close(true);
 
-    const reopened = new Database(freshDbPath());
-    LocalIndex.ensureSchema(reopened);
+    // The backfill only iterates on the V17 -> V18 step, and only over rows that
+    // ALREADY exist when it runs. Migrating straight to current and inserting
+    // afterwards would leave the loop body unexecuted — the statement leaks either
+    // way, which is exactly why that weaker version of this test looked fine.
+    // Stopping at 17 first is what puts real rows in front of the backfill.
+    runIndexedSchemaMigrations(db, 17);
+    expect(auditLogHashColumnCount(db)).toBe(0); // pre-V18 shape: no row_hash/prev_hash yet
+
+    for (const [i, action] of ["a.one", "a.two", "a.three"].entries()) {
+      db.run(
+        `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp)
+         VALUES (?, 'approved', '{}', ?)`,
+        [action, i + 1],
+      );
+    }
+
+    // Now run the rest, including V17 -> V18 with three rows to walk.
+    LocalIndex.ensureSchema(db);
+
+    // Prove the loop body actually ran, so this test cannot silently decay back
+    // into the no-op version: every pre-existing row must now carry a chain hash.
+    const unhashed = db
+      .query(`SELECT COUNT(*) AS c FROM audit_log WHERE row_hash IS NULL`)
+      .get() as { c: number };
+    expect(unhashed.c).toBe(0);
+
     expect(() => {
-      reopened.close(true);
+      db.close(true);
     }).not.toThrow();
   });
 

--- a/scripts/test-preload/hermetic-credentials.test.ts
+++ b/scripts/test-preload/hermetic-credentials.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { blankCredentialEnv, isCredentialEnvName } from "./hermetic-credentials.ts";
+import {
+  blankCredentialEnv,
+  isBehaviourMarkerEnvName,
+  isBlankedEnvName,
+  isCredentialEnvName,
+} from "./hermetic-credentials.ts";
 
 describe("isCredentialEnvName", () => {
   test("matches the credentials that actually leaked", () => {
@@ -62,7 +67,50 @@ describe("blankCredentialEnv", () => {
   });
 });
 
+describe("isBehaviourMarkerEnvName (#967)", () => {
+  test("matches the marker that silently reddened the updater wiring test", () => {
+    // resolveDistributionChannel() reads this and concludes "package-manager install,
+    // self-update disabled" — which made createUpdaterFromConfig return undefined and
+    // failed an assertion that had nothing to do with the environment.
+    expect(isBehaviourMarkerEnvName("NIMBUS_DISTRIBUTION_CHANNEL")).toBe(true);
+    expect(isBlankedEnvName("NIMBUS_DISTRIBUTION_CHANNEL")).toBe(true);
+  });
+
+  test("is not a credential — the two categories stay distinct", () => {
+    // It carries no secret; it is blanked for determinism, not for containment.
+    expect(isCredentialEnvName("NIMBUS_DISTRIBUTION_CHANNEL")).toBe(false);
+  });
+
+  test("does not blank unrelated settings by pattern", () => {
+    // Enumerated, not suffix-matched: `_CHANNEL` is too generic to blank wholesale.
+    expect(isBehaviourMarkerEnvName("NIMBUS_SLACK_CHANNEL")).toBe(false);
+    expect(isBehaviourMarkerEnvName("NIMBUS_AGENT_MODEL")).toBe(false);
+    expect(isBlankedEnvName("NIMBUS_AGENT_MODEL")).toBe(false);
+  });
+
+  test("blankCredentialEnv clears markers alongside credentials", () => {
+    const env: Record<string, string | undefined> = {
+      NIMBUS_DISTRIBUTION_CHANNEL: "msi",
+      NIMBUS_GITHUB_PAT: "ghp_notreal",
+      NIMBUS_AGENT_MODEL: "some-model",
+    };
+    expect(blankCredentialEnv(env)).toEqual(["NIMBUS_DISTRIBUTION_CHANNEL", "NIMBUS_GITHUB_PAT"]);
+    // "" is what resolveDistributionChannel treats as absent: it guards with
+    // `if (raw && KNOWN_CHANNELS.has(raw))`, so an empty value falls through to
+    // the path heuristics exactly as an unset var would.
+    expect(env["NIMBUS_DISTRIBUTION_CHANNEL"]).toBe("");
+    expect(env["NIMBUS_AGENT_MODEL"]).toBe("some-model");
+  });
+});
+
 describe("the preload is actually wired", () => {
+  test("behaviour markers are blank in this very process", () => {
+    // Companion to the credential assertion below: a developer who installed Nimbus
+    // through the MSI/Homebrew/apt has this exported, and #967 is exactly what happens
+    // when it survives into the suite.
+    expect(process.env["NIMBUS_DISTRIBUTION_CHANNEL"] ?? "").toBe("");
+  });
+
   test("credential vars are blank in this very process", () => {
     // The load-bearing assertion. The unit tests above prove the predicate; this proves the
     // preload RAN — the failure mode in #812 was a blanking step that was correct in isolation

--- a/scripts/test-preload/hermetic-credentials.test.ts
+++ b/scripts/test-preload/hermetic-credentials.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 
 import {
   blankCredentialEnv,
@@ -104,11 +105,44 @@ describe("isBehaviourMarkerEnvName (#967)", () => {
 });
 
 describe("the preload is actually wired", () => {
-  test("behaviour markers are blank in this very process", () => {
-    // Companion to the credential assertion below: a developer who installed Nimbus
-    // through the MSI/Homebrew/apt has this exported, and #967 is exactly what happens
-    // when it survives into the suite.
-    expect(process.env["NIMBUS_DISTRIBUTION_CHANNEL"] ?? "").toBe("");
+  /**
+   * Run a child Bun process that reports what it sees for the marker.
+   *
+   * Asserting on THIS process would be vacuous: CI never sets
+   * `NIMBUS_DISTRIBUTION_CHANNEL`, so `process.env[...] ?? "" === ""` passes
+   * whether or not the preload runs — it would still be green with the preload
+   * deleted, which is the one thing it exists to catch. A child with the marker
+   * explicitly set is the only way to observe the blanking actually happening.
+   */
+  function markerSeenByChild(withPreload: boolean): string | undefined {
+    const preloadPath = join(import.meta.dir, "hermetic-credentials.ts");
+    const args = withPreload
+      ? ["bun", "--preload", preloadPath, "-e", READ_MARKER]
+      : ["bun", "-e", READ_MARKER];
+    const proc = Bun.spawnSync(args, {
+      env: {
+        ...process.env,
+        NIMBUS_DISTRIBUTION_CHANNEL: "msi",
+        NIMBUS_TEST_PRELOAD_QUIET: "1",
+      },
+    });
+    const out = new TextDecoder().decode(proc.stdout).trim();
+    return (JSON.parse(out) as { marker?: string }).marker;
+  }
+
+  const READ_MARKER =
+    "console.log(JSON.stringify({ marker: process.env.NIMBUS_DISTRIBUTION_CHANNEL }))";
+
+  test("the preload blanks a behaviour marker that IS set in the environment", () => {
+    // A developer who installed Nimbus through the MSI/Homebrew/apt has this
+    // exported, and #967 is exactly what happens when it survives into the suite.
+    expect(markerSeenByChild(true)).toBe("");
+  });
+
+  test("control: the same child WITHOUT the preload sees the real value", () => {
+    // Proves the previous assertion is caused by the preload rather than by the
+    // variable being absent — without this pair, a no-op preload reads as a pass.
+    expect(markerSeenByChild(false)).toBe("msi");
   });
 
   test("credential vars are blank in this very process", () => {

--- a/scripts/test-preload/hermetic-credentials.ts
+++ b/scripts/test-preload/hermetic-credentials.ts
@@ -54,11 +54,39 @@ export function isCredentialEnvName(name: string): boolean {
   return CREDENTIAL_SUFFIXES.some((s) => name.endsWith(s));
 }
 
+/**
+ * Behaviour-affecting markers that are NOT credentials but still silently change what the
+ * product does, and therefore what a test observes.
+ *
+ * Issue #967: `NIMBUS_DISTRIBUTION_CHANNEL` is the marker `resolveDistributionChannel()` reads
+ * to decide "this is a package-manager install, disable self-update". A developer who installed
+ * Nimbus via the MSI, Homebrew or apt legitimately has it exported — and it silently flipped
+ * `updater/wiring.test.ts` to red, with a failure message that named an updater assertion and
+ * gave no hint that the environment was responsible. CI never set it, so CI never saw it.
+ *
+ * Enumerated rather than pattern-matched, unlike the credentials above: this set is small,
+ * and the suffix shapes here (`_CHANNEL`) are too generic to blank by pattern without also
+ * catching legitimate settings.
+ *
+ * A test that wants one of these set does it itself, after preload — `cli/src/commands/
+ * update.test.ts` already sets and restores this exact var. Only shell INHERITANCE is removed.
+ */
+const BEHAVIOUR_MARKER_NAMES = ["NIMBUS_DISTRIBUTION_CHANNEL"] as const;
+
+export function isBehaviourMarkerEnvName(name: string): boolean {
+  return (BEHAVIOUR_MARKER_NAMES as readonly string[]).includes(name);
+}
+
+/** True for any name the preload blanks — credential or behaviour marker. */
+export function isBlankedEnvName(name: string): boolean {
+  return isCredentialEnvName(name) || isBehaviourMarkerEnvName(name);
+}
+
 /** Blanks matching keys in `env`; returns the NAMES blanked (never the values). */
 export function blankCredentialEnv(env: Record<string, string | undefined>): string[] {
   const blanked: string[] = [];
   for (const name of Object.keys(env)) {
-    if (env[name] !== undefined && env[name] !== "" && isCredentialEnvName(name)) {
+    if (env[name] !== undefined && env[name] !== "" && isBlankedEnvName(name)) {
       env[name] = "";
       blanked.push(name);
     }
@@ -72,6 +100,6 @@ if (blanked.length > 0 && process.env["NIMBUS_TEST_PRELOAD_QUIET"] !== "1") {
   // into CI logs and terminal scrollback. Announced rather than silent so the behaviour is
   // discoverable: #812 was hard to read precisely because the leak was invisible.
   console.error(
-    `[test-preload] blanked ${blanked.length} credential env var(s) for hermetic tests: ${blanked.join(", ")}`,
+    `[test-preload] blanked ${blanked.length} env var(s) for hermetic tests: ${blanked.join(", ")}`,
   );
 }


### PR DESCRIPTION
Closes #969, closes #968, closes #967.

## #969 — root cause: an unfinalized `db.prepare()` statement, in production code

The reported symptom was `rmSync` failing `EBUSY` 30/30 in the `db/snapshot.test.ts` `afterEach`, with the error swallowed. The issue asked for the retained handle to be found before changing the deletion strategy. It was, and it is not in the test.

Isolating handle-by-handle on Windows:

```
A plain-file dir rm            : ok
B db+schema+close, dir rm      : EBUSY     <- no snapshot involved at all
C db+snapshot+close, dir rm    : EBUSY
D   rm file nimbus.db          : EBUSY     <- the retained handle
D   rm file snapshots/*.db.gz  : ok        <- takeSnapshot is exonerated
E close(true) error            : Error: database is locked
```

The gzip stream and the WAL/SHM sidecars were all ruled out — the pinned file is `nimbus.db` itself, and `db.close(true)` reports `database is locked`, meaning the plain `close()` was silently a **no-op**. Narrowing which sqlite call retains it:

```
db.run / db.exec / db.query(...).run()      : close=clean              rm=ok
db.prepare(...).run() no finalize           : close=database is locked rm=EBUSY
db.prepare(...).run() + finalize            : close=clean              rm=ok
```

`bun:sqlite` auto-releases the `db.query()` statement cache on close, but a bare `db.prepare()` handle must be finalized explicitly. The leak was `backfillAuditChain` in **`index/migrations/runner.ts`** — production code, on the V17 to V18 migration, which every fresh database runs. So `LocalIndex.ensureSchema` left one live statement behind on every open.

This is what the issue suspected mattered: production also closes databases and deletes files (snapshot pruning, restore, repair). Two of the five `prepare()` sites (`perf-fixture`, `bench-query-latency`) already used a `try/finally { finalize() }`; three had drifted from that convention and are fixed:

- `index/migrations/runner.ts` — `backfillAuditChain` (the root cause)
- `embedding/pipeline.ts` — `insertVec` / `insertChunk`
- `ipc/engine-get-session-transcript.ts` — the transcript read
- `connectors/connector-sync-test-helpers.ts` — switched to `db.query()` (cache-managed)

A source-scanning guard in `test/unit/db/statement-finalization.test.ts` keeps the class from returning. It strips comments before counting — prose mentioning `db.prepare()` otherwise inflates the count and fires on clean code. Verified green, then red (exactly 1 offender when a `finalize()` is removed), then green.

The misleading `afterEach` comment is gone. Cleanup is no longer wrapped in a `catch`: a failure there now means a handle is being retained again, and should be loud.

**Measured:** 252 leaked directories holding **170.9 MB** had accumulated in `%TEMP%` on one machine. After the fix, a clean run of that suite leaks **0**.

## #968 — the dominant cost was `beforeEach`, and it is now ~16x cheaper

Confirming the measurement in the issue: per-test database creation, not cleanup, is the cost. The fix migrates **once** into a template database and copies the file per test.

```
fresh migrations per test : 231.82 ms/test
template + copyFileSync   :   6.11 ms/test   (16.6x, incl. one-time 235 ms build)
```

The copy is verified identical, not assumed: same `user_version` (44), same 69 tables, same seed rows, same `journal_mode`. `ensureSchema` still runs on each copy — on an already-current `user_version` it skips every migration and only applies the connection-level pragmas, which do not persist in the file.

Suite wall clock: **5.6 s to 1.68 s** locally; the `test/unit/db` gate as CI runs it is **3.0 s** for 84 tests. That removes the headroom problem behind the 30 s hook timeout rather than raising the budget.

**Not claimed:** the 44 s hook on the Windows runner is still unreproduced, and which hook timed out is still unknown — bun does not report it. This attacks the measured dominant cost; it is not proof of the runner-specific stall.

## Also found: a second, unrelated leak in `lazy-mesh/mesh.test.ts`

While verifying, `mesh.test.ts` leaked 40 directories per run on **every** platform — a different cause (`makePaths()` never imported `rmSync`; there was no cleanup at all). Fixed: 40 to 0.

A broader sweep found the leak class is wider than these issues — one full `packages/gateway` run still leaves ~536 directories / ~72 MB from other suites that never clean up. That is out of scope here and filed separately.

## #967 — updater wiring test was not hermetic

Reproduced exactly as reported (this machine has `NIMBUS_DISTRIBUTION_CHANNEL=msi` set):

```
(fail) configured Updater returns CheckNowResult instead of ERR_UPDATER_NOT_CONFIGURED
expect(received).toBeDefined()  Received: undefined
```

Nothing was wrong with the product code. Both call sites in `wiring.test.ts` now pin `_channelOverride: null` — the seam the factory already supports, and the same thing `factory.test.ts` already does in its `baseArgs`, with a comment explaining why. `wiring.test.ts` had simply drifted from that convention.

Also closing the class, as the issue suggested: the `[test] preload` now blanks **behaviour-affecting** `NIMBUS_*` markers, not only credentials. `NIMBUS_DISTRIBUTION_CHANNEL` carries no secret, but it silently changed a test outcome, and CI never saw it because CI never sets it.

Verified safe rather than assumed: `resolveDistributionChannel` guards with `if (raw && KNOWN_CHANNELS.has(raw))`, so the blanked empty string is exactly equivalent to unset. The marker list is enumerated rather than suffix-matched — `_CHANNEL` is too generic to blank wholesale, and `NIMBUS_SLACK_CHANNEL` must survive. `cli/src/commands/update.test.ts` already sets and restores this var itself and is unaffected; only shell inheritance is removed.

## SonarCloud — both open MAINTAINABILITY issues (S2699, BLOCKER)

Both were tests with no assertion, fixed in code rather than excluded:

- `sync/rate-limiter.test.ts:146` — asserts the acquire resolves, **and** that `burstSize + 1` is refused. The second assertion is the one that actually pins the fallback to `DEFAULT_QUOTAS.slack`; acquiring `burstSize` alone would pass under any quota with a larger bucket.
- `ipc/server/dispatchers-happy-paths.test.ts:86` — was swallowing the rejection, so it passed even if the access guard had started returning the `skipped` sentinel, which is the whole behaviour it exists to pin. Now asserts `not.toBe(diagnosticsRpcSkipped)`, matching its siblings.

## Coverage

Targeted at branches confirmed reachable by reading the lcov, not guessed. Measuring corrected me twice — the `snapshot.ts` gap I first assumed was a prune `catch` arm turned out to be a **default-parameter** branch, and two behaviour tests I wrote added no coverage at all (kept anyway; they pin real best-effort behaviour).

`packages/gateway/src/db` branch coverage **90.83% to 92.35%** (297 to 302 of 327):

- `db/audit-chain.ts` 90.0% to **100%** — `federationJson` was never passed to `computeAuditRowHash` in any test, so neither arm of its guard was exercised. Worth having: a federated audit row whose provenance did not change the hash could be rewritten after the fact without breaking the chain.
- `db/tool-call-log-retention.ts` 90.0% to **100%** — the `?? Date.now` default arm; every existing case injected a clock.
- `db/snapshot.ts` 85.2% to 88.9% — the `runNow = false` default parameter.
- `db/query-guard.ts` 79.2% to 83.3% — the default-timeout arm; the two tests that omitted `options` rejected in the guard before it was ever read.

Deliberately not chased: `vacuum-gzip.ts:46-47` is reachable only where `renameSync` refuses to overwrite (Windows), so it cannot lift the Linux-authoritative gate; the remaining `repair.ts` / `latency-ring-buffer.ts` gaps are `?? 0` and TS-unreachable defensive arms.

## Verification

- `typecheck` PASS (128 s, all workspaces)
- `biome check --error-on-warnings packages scripts` PASS, 3038 files
- all 20 remaining `preflight:fast` static gates PASS individually, including `audit:any --check`, `audit:invariants`, `audit:cross-platform`, `audit:boundaries`
- `bun test packages/gateway` PASS — **11652 pass / 0 fail** (899 files)
- `bun test scripts` PASS — 1094 pass / 0 fail
- `security-invariants.test.ts` PASS — 93 pass

`bun run preflight:fast` aborts at its `lint` gate inside `.claude/worktrees/`: biome resolves 0 files there and exits 1. That is a known worktree artifact, not a finding; `bunx biome check packages scripts` is clean, and every gate after it was run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database resource cleanup to prevent locked files and lingering connections.
  - Increased reliability of embedding, audit history, session transcript, and snapshot operations.
  - Snapshot cleanup now handles undeletable entries gracefully and reports accurate results.
  - Test execution is less affected by ambient environment settings.

- **Tests**
  - Expanded coverage for audit integrity, query timeouts, retention policies, rate limits, snapshots, and updater behavior.
  - Added safeguards to detect resource leaks and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->