### PR TITLE
ci: retry bun audit transport failures and fail closed on a blind bypass-actor read

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,8 +47,43 @@ jobs:
         with:
           verify-lock: "false"
 
-      - name: bun audit
-        run: bun audit --audit-level high
+      # `bun audit` exits non-zero for two unrelated reasons: a HIGH/CRITICAL
+      # advisory (which MUST block) and an unreachable audit service (which says
+      # nothing about our dependencies). Conflating them let a registry 503 block
+      # the 1.12.0 release — see #966.
+      #
+      # So the two cases are separated rather than blanket-retried:
+      #   * a transport failure is retried up to 3 times with backoff;
+      #   * anything else fails IMMEDIATELY on attempt 1, with no retry and no
+      #     delay, because a real advisory fails identically on every attempt and
+      #     re-running it only slows down the feedback.
+      # If all 3 attempts hit transport failures the step still FAILS. That is
+      # deliberate: `continue-on-error` here would also swallow genuine
+      # HIGH/CRITICAL findings, which is the one thing this gate exists to catch.
+      - name: bun audit (retry transport failures only)
+        run: |
+          set +e
+          for attempt in 1 2 3; do
+            out="$(bun audit --audit-level high 2>&1)"
+            code=$?
+            printf '%s\n' "$out"
+            if [ "$code" -eq 0 ]; then
+              exit 0
+            fi
+            # Bun prints e.g. `error: audit request failed (status 503)` when the
+            # registry endpoint is unreachable or erroring.
+            if ! printf '%s' "$out" | grep -qE 'audit request failed \(status [0-9]+\)'; then
+              echo "bun audit reported a finding (exit $code) — not a transport error, failing without retry."
+              exit "$code"
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "bun audit was unreachable on all 3 attempts (exit $code) — failing closed."
+              exit "$code"
+            fi
+            delay=$((attempt * 10))
+            echo "Audit service unreachable (attempt $attempt, exit $code), retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       # `bun audit --audit-level high` only blocks HIGH/CRITICAL. Everything
       # below that used to persist silently — two advisories sat in the output

--- a/scripts/release/credential-registry.test.ts
+++ b/scripts/release/credential-registry.test.ts
@@ -47,15 +47,15 @@ describe("CREDENTIAL_REGISTRY", () => {
     }
   });
 
-  test("the manifest holds exactly the audited set: 38 entries across 4 locations", () => {
-    expect(CREDENTIAL_REGISTRY.length).toBe(38);
+  test("the manifest holds exactly the audited set: 39 entries across 4 locations", () => {
+    expect(CREDENTIAL_REGISTRY.length).toBe(39);
 
     const counts = new Map<string, number>();
     for (const e of CREDENTIAL_REGISTRY) {
       const loc = e.location.scope === "org" ? "ORG" : (e.location.repo ?? "-");
       counts.set(loc, (counts.get(loc) ?? 0) + 1);
     }
-    expect(counts.get("ORG")).toBe(6);
+    expect(counts.get("ORG")).toBe(7);
     expect(counts.get("Nimbus")).toBe(23);
     expect(counts.get("nimbus-vscode")).toBe(2);
     expect(counts.get("nimbus-web-clipper")).toBe(7);

--- a/scripts/release/credential-registry.ts
+++ b/scripts/release/credential-registry.ts
@@ -190,6 +190,18 @@ export const CREDENTIAL_REGISTRY: readonly CredentialEntry[] = [
 
   // --- Nimbus: CLA bot ---
   {
+    name: "CLA_BOT_APP_ID",
+    state: "forbidden",
+    location: { scope: "org" },
+    product: "actions",
+    type: "app-key",
+    owner: OWNER,
+    consumedBy: [],
+    maxAgeDays: null,
+    hardDeadline: null,
+    note: "Deleted 2026-07-30 (Nimbus#854). Same shape as RELEASE_BOT_APP_ID: created 2026-07-24T09:30Z while wiring the CLA Assistant App, then superseded hours later by CLA_BOT_CLIENT_ID (12:39Z) when the mint step used the `client-id` input rather than the deprecated `app-id`. It was never removed, so it sat in the org unreferenced — secret-health could only report it as `undocumented`, which is why it is registered here rather than silently deleted. `cla.yml` reads only CLA_BOT_CLIENT_ID + CLA_BOT_PRIVATE_KEY. If it reappears, someone has reintroduced the deprecated input.",
+  },
+  {
     name: "CLA_BOT_CLIENT_ID",
     state: "required",
     location: { scope: "org" },

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, test } from "bun:test";
 
 import {
   actorKey,
+  assessBypassReadCapability,
   type BypassActor,
+  capabilityErrors,
   type DeclaredBypassFile,
   decideExit,
   diffBypassActors,
   loadDeclaredBypass,
+  parseOAuthScopes,
+  probeCredentialScopes,
+  scopesCanReadBypassActors,
   validateDeclaredBypass,
 } from "./check-bypass-actors.ts";
 
@@ -290,5 +295,132 @@ describe("decideExit", () => {
     const out = decideExit({ queried: 4, errors: [], unreachable: ["nimbus-sdk"] });
     expect(out.code).toBe(0);
     expect(out.message).toContain("WARNING");
+  });
+});
+
+const ORG_ADMIN: BypassActor = {
+  actor_type: "OrganizationAdmin",
+  actor_id: null,
+  bypass_mode: "always",
+};
+
+describe("assessBypassReadCapability (#961)", () => {
+  test("verified when a repo declaring actors actually reads them back", () => {
+    const verdict = assessBypassReadCapability({
+      declared: { Nimbus: [ORG_ADMIN], "nimbus-sdk": [] },
+      observed: { Nimbus: [ORG_ADMIN], "nimbus-sdk": [] },
+    });
+    expect(verdict).toEqual({ kind: "verified", witness: "Nimbus" });
+  });
+
+  test("blind when every declared-non-empty repo reads back empty", () => {
+    // The proven App-token behaviour: bypass_actors comes back empty for org-level actors.
+    const verdict = assessBypassReadCapability({
+      declared: { Nimbus: [ORG_ADMIN], "nimbus-vscode": [ORG_ADMIN], "nimbus-sdk": [] },
+      observed: { Nimbus: [], "nimbus-vscode": [], "nimbus-sdk": [] },
+    });
+    expect(verdict).toEqual({ kind: "blind", declaredNonEmpty: ["Nimbus", "nimbus-vscode"] });
+  });
+
+  test("one surviving witness is enough — a genuine single removal is not called blind", () => {
+    const verdict = assessBypassReadCapability({
+      declared: { Nimbus: [ORG_ADMIN], "nimbus-vscode": [ORG_ADMIN] },
+      observed: { Nimbus: [], "nimbus-vscode": [ORG_ADMIN] },
+    });
+    expect(verdict.kind).toBe("verified");
+  });
+
+  test("no-positive-control once bypass.by_repo is all-empty — the future state #961 is about", () => {
+    const verdict = assessBypassReadCapability({
+      declared: { Nimbus: [], "nimbus-sdk": [] },
+      observed: { Nimbus: [], "nimbus-sdk": [] },
+    });
+    expect(verdict).toEqual({ kind: "no-positive-control" });
+  });
+
+  test("an unreachable repo is absence of evidence, not evidence of blindness", () => {
+    // `observed` only carries repos actually queried; a declared-non-empty repo that
+    // failed to read must not be counted as a repo that read empty.
+    const verdict = assessBypassReadCapability({
+      declared: { Nimbus: [ORG_ADMIN], "nimbus-vscode": [ORG_ADMIN] },
+      observed: { Nimbus: [ORG_ADMIN] },
+    });
+    expect(verdict).toEqual({ kind: "verified", witness: "Nimbus" });
+  });
+});
+
+describe("parseOAuthScopes / scopesCanReadBypassActors (#961)", () => {
+  test("parses a classic token's scope header case-insensitively", () => {
+    expect(parseOAuthScopes("HTTP/2 200\r\nX-OAuth-Scopes: admin:org, repo\r\n")).toEqual([
+      "admin:org",
+      "repo",
+    ]);
+    expect(parseOAuthScopes("x-oauth-scopes: repo\n")).toEqual(["repo"]);
+  });
+
+  test("absent header is UNDEFINED, not an empty list", () => {
+    // An App installation token / fine-grained PAT sends no header at all. That is
+    // "unknown", and must not be conflated with a token that has zero scopes.
+    expect(parseOAuthScopes("HTTP/2 200\r\ncontent-type: application/json\r\n")).toBeUndefined();
+    expect(parseOAuthScopes("x-oauth-scopes: \n")).toEqual([]);
+  });
+
+  test("only admin:org (or site_admin) demonstrates capability", () => {
+    expect(scopesCanReadBypassActors(["admin:org"])).toBe(true);
+    expect(scopesCanReadBypassActors(["site_admin"])).toBe(true);
+    expect(scopesCanReadBypassActors(["repo", "read:org"])).toBe(false);
+    expect(scopesCanReadBypassActors([])).toBe(false);
+    expect(scopesCanReadBypassActors(undefined)).toBe(false);
+  });
+});
+
+describe("capabilityErrors (#961) — fail-closed", () => {
+  test("verified is the only silent path", () => {
+    expect(capabilityErrors({ kind: "verified", witness: "Nimbus" }, undefined)).toEqual([]);
+  });
+
+  test("blind fails closed and names the repos that read empty", () => {
+    const errs = capabilityErrors({ kind: "blind", declaredNonEmpty: ["Nimbus"] }, ["admin:org"]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("Nimbus");
+    expect(errs[0]).toContain("Refusing to report a clean read");
+  });
+
+  test("no-positive-control passes only when the token proves admin:org", () => {
+    expect(capabilityErrors({ kind: "no-positive-control" }, ["admin:org", "repo"])).toEqual([]);
+  });
+
+  test("no-positive-control fails closed for an App/fine-grained token (no scope header)", () => {
+    // THE #961 scenario: all-empty config + a credential that cannot see the field.
+    // Without this, the diff is green, the read is complete, decideAttestWrite permits
+    // the write, and a false-clean attestation is honoured for the full grace window.
+    const errs = capabilityErrors({ kind: "no-positive-control" }, undefined);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("no X-OAuth-Scopes header");
+    expect(errs[0]).toContain("Refusing to report a clean read");
+  });
+
+  test("no-positive-control fails closed for a token holding the wrong scopes", () => {
+    const errs = capabilityErrors({ kind: "no-positive-control" }, ["repo", "read:org"]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain("scopes: repo, read:org");
+  });
+});
+
+describe("probeCredentialScopes (#961)", () => {
+  test("returns the parsed scopes when gh succeeds", () => {
+    expect(
+      probeCredentialScopes(() => ({
+        ok: true,
+        stdout: "HTTP/2 200\r\nX-OAuth-Scopes: admin:org\r\n\r\n{}",
+        stderr: "",
+      })),
+    ).toEqual(["admin:org"]);
+  });
+
+  test("returns undefined when gh fails, so the caller fails closed", () => {
+    expect(
+      probeCredentialScopes(() => ({ ok: false, stdout: "", stderr: "HTTP 401" })),
+    ).toBeUndefined();
   });
 });

--- a/scripts/structure-audit/check-bypass-actors.ts
+++ b/scripts/structure-audit/check-bypass-actors.ts
@@ -265,6 +265,122 @@ export function diffBypassActors(
 }
 
 /**
+ * Whether this run's reads can be TRUSTED to reflect the org, as opposed to
+ * reflecting a credential that cannot see `bypass_actors` at all (#961).
+ *
+ * The gate reads an absent-or-empty `bypass_actors` as `[]`, and `[]` diffs
+ * cleanly against a declared `[]`. So "this repo has no bypass actors" and "my
+ * token cannot see them" are the same observation — and the second is not
+ * hypothetical, it is the proven behaviour of the App installation token, which
+ * is the entire reason this gate is separate from `audit:ruleset-drift`.
+ *
+ * Today the config is accidentally load-bearing: three repos declare a non-empty
+ * actor list, so a blind credential reds immediately with three `missing declared
+ * bypass actor` findings. The moment `bypass.by_repo` is all-`[]` — which is the
+ * program's stated direction — that accident is gone and a blind read produces a
+ * green diff, a complete read, and a false-clean attestation honoured for the
+ * full 90-day grace window.
+ */
+export type CapabilityVerdict =
+  /** At least one repo whose declared intent is non-empty actually read non-empty. */
+  | { kind: "verified"; witness: string }
+  /** Every repo whose declared intent is non-empty read empty — almost certainly blind. */
+  | { kind: "blind"; declaredNonEmpty: string[] }
+  /** Nothing is declared non-empty, so no positive control exists in the data. */
+  | { kind: "no-positive-control" };
+
+/**
+ * The cheapest correct probe: use the DECLARED non-empty repos as a positive
+ * control. If every one of them reads empty, that is far more likely a blind
+ * credential than a simultaneous org-wide bypass removal — and the two are worth
+ * distinguishing precisely because the second is the outcome the program wants,
+ * so it is the moment someone will be tempted to believe the green.
+ *
+ * Only repos actually queried this run are considered; an unreachable repo is
+ * absence of evidence, not evidence of blindness.
+ */
+export function assessBypassReadCapability(input: {
+  declared: Record<string, BypassActor[]>;
+  observed: Record<string, BypassActor[]>;
+}): CapabilityVerdict {
+  const { declared, observed } = input;
+  const declaredNonEmpty = Object.keys(observed)
+    .filter((repo) => (declared[repo] ?? []).length > 0)
+    .sort();
+
+  if (declaredNonEmpty.length === 0) {
+    return { kind: "no-positive-control" };
+  }
+  const witness = declaredNonEmpty.find((repo) => (observed[repo] ?? []).length > 0);
+  if (witness !== undefined) {
+    return { kind: "verified", witness };
+  }
+  return { kind: "blind", declaredNonEmpty };
+}
+
+/**
+ * Fallback for the all-empty config, where no positive control exists in the
+ * data: ask the CREDENTIAL directly.
+ *
+ * Reading org-level `bypass_actors` needs `admin:org` — the same finding that
+ * root-caused the App `403` in the P2 progress log. A classic OAuth/PAT token
+ * advertises its grants in `X-OAuth-Scopes`; an App installation token and a
+ * fine-grained PAT send no such header, which is reported as UNKNOWN rather than
+ * as absence, because "no header" must not be read as "no scope" — nor as "fine".
+ */
+export function parseOAuthScopes(headerBlock: string): string[] | undefined {
+  const match = /^x-oauth-scopes:\s*(.*)$/im.exec(headerBlock);
+  if (match === null) return undefined;
+  return (match[1] ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** `admin:org` (or the broader `site_admin`) is what exposes org-level bypass actors. */
+export function scopesCanReadBypassActors(scopes: string[] | undefined): boolean {
+  if (scopes === undefined) return false;
+  return scopes.includes("admin:org") || scopes.includes("site_admin");
+}
+
+/** Impure companion: ask GitHub what the ambient credential is allowed to do. */
+export function probeCredentialScopes(
+  run: (args: string[]) => { ok: boolean; stdout: string; stderr: string } = runGh,
+): string[] | undefined {
+  const res = run(["gh", "api", "-i", "user"]);
+  if (!res.ok) return undefined;
+  return parseOAuthScopes(res.stdout);
+}
+
+/**
+ * Turns a verdict into findings. Fail-closed by construction: the only silent
+ * path is `verified`, and the only way to reach it is to have actually SEEN an
+ * actor this run.
+ */
+export function capabilityErrors(
+  verdict: CapabilityVerdict,
+  scopes: string[] | undefined,
+): string[] {
+  if (verdict.kind === "verified") return [];
+  if (verdict.kind === "blind") {
+    return [
+      `every repo declaring a non-empty bypass actor list read back EMPTY (${verdict.declaredNonEmpty.join(", ")}) — ` +
+        `this is far more likely a credential that cannot see bypass_actors than a simultaneous org-wide removal. ` +
+        `Re-run with a personal admin:org token, not an App installation token. Refusing to report a clean read.`,
+    ];
+  }
+  // no-positive-control: nothing declared non-empty, so the data cannot vouch
+  // for the credential and the credential must vouch for itself.
+  if (scopesCanReadBypassActors(scopes)) return [];
+  return [
+    `no repo declares a non-empty bypass actor list, so an empty read cannot be distinguished from a blind credential, ` +
+      `and the token does not demonstrate admin:org ` +
+      `(${scopes === undefined ? "no X-OAuth-Scopes header — App installation or fine-grained token" : `scopes: ${scopes.join(", ") || "none"}`}). ` +
+      `Re-run with a personal admin:org token. Refusing to report a clean read.`,
+  ];
+}
+
+/**
  * Exit decision for the per-repo loop.
  *
  * INVARIANT, mirroring check-ruleset-drift: real drift on a reachable repo is
@@ -373,9 +489,22 @@ if (import.meta.main) {
   }
 
   const diffResult = diffBypassActors(Object.keys(observed), file.bypass.by_repo, observed);
+
+  // #961: a clean diff is only meaningful if the credential could see the field
+  // at all. Probed only when something was actually read — with `queried === 0`
+  // the strict-skip path below already owns the outcome, and probing there would
+  // turn an unauthenticated contributor's soft skip into a hard red.
+  let capabilityFindings: string[] = [];
+  if (queried > 0) {
+    const verdict = assessBypassReadCapability({ declared: file.bypass.by_repo, observed });
+    // Only pay for the network probe when the data cannot vouch for itself.
+    const scopes = verdict.kind === "no-positive-control" ? probeCredentialScopes() : undefined;
+    capabilityFindings = capabilityErrors(verdict, scopes);
+  }
+
   const result: AuditResult = {
-    ok: diffResult.ok && absentErrors.length === 0,
-    errors: [...absentErrors, ...diffResult.errors],
+    ok: diffResult.ok && absentErrors.length === 0 && capabilityFindings.length === 0,
+    errors: [...capabilityFindings, ...absentErrors, ...diffResult.errors],
   };
   const outcome = decideExit({ queried, errors: result.errors, unreachable, strict });
 


### PR DESCRIPTION
Closes #966, closes #961, closes #854.

Three independent CI/audit hardening items, each one that lets a green result mean less than it appears to.

## #966 — a registry 503 could block merges and releases

`bun audit` exits non-zero for two unrelated reasons: a HIGH/CRITICAL advisory (which must block) and an unreachable audit service (which says nothing about our dependencies). The step conflated them, so a 503 blocked the 1.12.0 release with no vulnerability involved.

Rather than blanket-retrying, the two cases are **separated**:

- a **transport failure** — matched on Bun's `audit request failed (status NNN)` — is retried up to 3 times with 10s/20s backoff;
- **anything else fails immediately on attempt 1**, with no retry and no delay, because a real advisory fails identically on every attempt and re-running it only delays the feedback.

If all three attempts hit transport failures the step still **fails**. That is deliberate — `continue-on-error` here would also swallow genuine HIGH/CRITICAL findings, which the issue explicitly warned against.

Verified against a stubbed `bun` covering all four paths, since this sits on the release path and a mistake here is invisible until it matters:

```
PASS  clean            : exit=0 attempts=1   (no retries on success)
PASS  transport_then_ok: exit=0 attempts=3   (absorbs two 503s, then passes)
PASS  transport_always : exit=1 attempts=3   (fails closed, does not go green)
PASS  real_finding     : exit=1 attempts=1   (fails FAST — no retry, no delay)
```

The retry-loop shape follows the existing convention in `_perf.yml` / `_test-suite.yml` / `ci.yml`.

## #961 — `audit:bypass-actors` could not tell "clean" from "blind"

The gate reads an absent-or-empty `bypass_actors` as `[]`, and `[]` diffs cleanly against a declared `[]`. So "this repo has no bypass actors" and "my token cannot see them" were the same observation — and the second is the *proven* behaviour of the App installation token, which is the entire reason this gate is separate from `audit:ruleset-drift`.

As the issue notes, the current config is only **accidentally** load-bearing: three repos declare a non-empty list, so a blind credential reds with three `missing declared bypass actor` findings. The moment `bypass.by_repo` goes all-`[]` — the program's stated direction — a blind read yields a green diff, a complete read, `decideAttestWrite` permits the write, and a false-clean attestation is honoured for the full **90-day** grace window.

Implemented exactly as the issue specified, as pure functions plus one thin impure probe:

1. **Positive control** (`assessBypassReadCapability`) — if at least one repo whose declared intent is non-empty actually reads back non-empty, the credential can see the field: `verified`. If *every* declared-non-empty repo reads empty, that is far more likely a blind credential than a simultaneous org-wide removal: `blind`, fail closed. One surviving witness is enough, so a genuine single removal is not misreported.
2. **Fallback** (`no-positive-control`) — with nothing declared non-empty there is no control in the data, so the credential must vouch for itself: `parseOAuthScopes` reads `X-OAuth-Scopes` from `gh api -i user` and requires `admin:org`. Same technique that root-caused the App `403` in the P2 progress log.

Two details that matter for fail-closed-ness:

- A missing `X-OAuth-Scopes` header (App installation token, fine-grained PAT) is reported as **unknown**, not as "no scopes" and certainly not as "fine" — it fails closed.
- An **unreachable** repo is absence of evidence, not evidence of blindness: only repos actually queried this run are considered, so a read failure elsewhere cannot manufacture a `blind` verdict.

The findings feed `result.ok`, which `decideAttestWrite` already consumes — so a blind read now cannot write an attestation at all, which is the specific failure scenario in the issue.

The network probe only runs in the `no-positive-control` branch, and the whole check is skipped when `queried === 0` so an unauthenticated contributor's soft skip does not become a hard red.

Verified live, not just in unit tests: `bun run audit:bypass-actors` against the real org still exits 0 (`OK (5 repos)`) — the positive control is satisfied by today's config, so **no behaviour change now**. The `no-positive-control` fallback was exercised end-to-end by temporarily blanking `by_repo`, confirming the real `gh api -i user` probe reads this machine's `admin:org` scope and adds no spurious finding. Deliberately **not** in scope, per the issue: the credential model is unchanged.

## #854 — `org/CLA_BOT_APP_ID` was an unreferenced leftover

The secret-health report flagged it as `undocumented — add it or delete it`. Investigated rather than just documented:

- Created **2026-07-24T09:30Z**, then superseded hours later by `CLA_BOT_CLIENT_ID` (**12:39Z**) when the mint step used `client-id` instead of the deprecated `app-id` input.
- `cla.yml` reads only `CLA_BOT_CLIENT_ID` + `CLA_BOT_PRIVATE_KEY`. Nothing in the repo references `CLA_BOT_APP_ID`.

Exactly the shape of `RELEASE_BOT_APP_ID`, retired the same way on 2026-07-22. So it is registered `state: "forbidden"` (present now means someone reintroduced the deprecated input) and the org secret has been **deleted** — confirmed, only `CLA_BOT_CLIENT_ID` and `CLA_BOT_PRIVATE_KEY` remain. `audit:secret-inventory` and `audit:consumed-by` both pass, and the registry count assertions were updated (38 to 39 entries, ORG 6 to 7).

## Verification

- `typecheck` PASS (all workspaces)
- `biome check --error-on-warnings packages scripts .github` PASS, 3040 files
- 13 static gates PASS individually, including `audit:workflow-lint` (actionlint over the changed `security.yml`), `audit:any --check`, `audit:invariants`, `audit:consumed-by`, `audit:secret-inventory`
- `bun test scripts` PASS — 1104 pass / 0 fail (92 files), including 18 new tests for the capability probe
- `bun run audit:bypass-actors` PASS live against the org — exit 0, `OK (5 repos)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
