### PR TITLE
refactor(mcp-connectors): re-export connector-kit helpers from @nimbus-dev/sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "nimbus",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
+        "@nimbus-dev/sdk": "^1.11.0",
         "astro": "^7.1.4",
         "zod": "^4.4.3",
       },
@@ -1817,7 +1818,7 @@
 
     "@nimbus-dev/client": ["@nimbus-dev/client@0.14.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-s4tNoOHq8JCjMuoNEDRVWmQ4afWHU6FMyBwRSjeqAAjsOrswjDiz8mlQycu/gejCyNp+VabqXcJ6nbuJZeTBcg=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.11.0", "", {}, "sha512-4X/wuT+/1FjJQUH9UXBmmKZqtnJcpt94h1oo3UpuC3DDYbMzzHMA+KVI15SIi3zC90CbJ1jHornI6nnR0CF/rA=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 
@@ -4174,6 +4175,10 @@
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.8.1", "", {}, "sha512-FzTiXa5GzG4Bdlw+gA1kg/cIFmvyH1FvLlQowGHZAhGbjX1BJB/ncFXQZijH9MO+mIDLkd/jMEwVfuiB7BNHkA=="],
+
+    "@nimbus/cli/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
+
+    "@nimbus/gateway/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.30.0",
+    "@nimbus-dev/sdk": "^1.11.0",
     "astro": "^7.1.4",
     "zod": "^4.4.3"
   },

--- a/packages/mcp-connectors/shared/fetch-bearer-json.ts
+++ b/packages/mcp-connectors/shared/fetch-bearer-json.ts
@@ -1,58 +1,18 @@
-export type BearerJsonFetchResult = {
-  ok: boolean;
-  status: number;
-  json: unknown;
-  text: string;
-};
-
 /**
- * Resolve a path-or-URL against `baseUrl`. A relative path is prefixed with the
- * base. An ABSOLUTE URL is only allowed when it shares the base's origin — this
- * is the single chokepoint that prevents a caller-supplied pagination link
- * (`@odata.nextLink`, etc.) from redirecting a credential-bearing fetch at an
- * attacker-controlled host (SSRF / bearer-token exfiltration). A cross-origin or
- * malformed absolute URL throws and is never fetched.
+ * fetch-bearer-json — re-export of the Bearer-auth JSON fetch helpers now owned
+ * by `@nimbus-dev/sdk/connector-kit`.
+ *
+ * These helpers originated here and were upstreamed to the SDK in 1.11.0. The
+ * SDK is now the single owner; this module stays as the connector-facing import
+ * path so the ~99 connectors keep their existing relative imports.
+ *
+ * Named re-exports, deliberately not `export *` — see the note in
+ * `mcp-tool-kit.ts`.
+ *
+ * `resolveUrlWithBase` remains the SSRF chokepoint that refuses a cross-origin
+ * absolute URL before a credential-bearing fetch; that behaviour now lives in
+ * the SDK and is covered by `fetch-bearer-json.test.ts` through this re-export.
  */
-export function resolveUrlWithBase(baseUrl: string, pathOrUrl: string): string {
-  if (!pathOrUrl.startsWith("http")) {
-    return `${baseUrl}${pathOrUrl}`;
-  }
-  const target = new URL(pathOrUrl);
-  const base = new URL(baseUrl);
-  if (target.origin !== base.origin) {
-    throw new Error(
-      `resolveUrlWithBase: refusing to fetch cross-origin URL (got ${target.origin}, expected ${base.origin})`,
-    );
-  }
-  return pathOrUrl;
-}
 
-export async function fetchBearerAuthorizedJson(
-  url: string,
-  token: string,
-  init?: RequestInit,
-  defaultHeaders?: Record<string, string>,
-): Promise<BearerJsonFetchResult> {
-  const mergedHeaders = new Headers({
-    Authorization: `Bearer ${token}`,
-    ...defaultHeaders,
-  });
-  if (init?.headers !== undefined) {
-    const extra = new Headers(init.headers);
-    for (const [k, v] of extra) {
-      mergedHeaders.set(k, v);
-    }
-  }
-  const res = await fetch(url, {
-    ...init,
-    headers: mergedHeaders,
-  });
-  const text = await res.text();
-  let json: unknown;
-  try {
-    json = JSON.parse(text) as unknown;
-  } catch {
-    json = null;
-  }
-  return { ok: res.ok, status: res.status, json, text };
-}
+export type { BearerJsonFetchResult } from "@nimbus-dev/sdk/connector-kit";
+export { fetchBearerAuthorizedJson, resolveUrlWithBase } from "@nimbus-dev/sdk/connector-kit";

--- a/packages/mcp-connectors/shared/mcp-tool-kit.ts
+++ b/packages/mcp-connectors/shared/mcp-tool-kit.ts
@@ -1,170 +1,35 @@
-export type McpListResult = { content: Array<{ type: "text"; text: string }> };
-
-export function mcpJsonResult(data: unknown): McpListResult {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
-}
-
-export type ZodObjectSchema<T> = {
-  readonly shape: Record<string, unknown>;
-  safeParse: (
-    args: unknown,
-  ) => { success: true; data: T } | { success: false; error: { message: string } };
-};
-
-export function registerZodTool<T>(
-  registerSimpleTool: RegisterSimpleToolFn,
-  name: string,
-  description: string,
-  schema: ZodObjectSchema<T>,
-  handler: (args: T) => Promise<McpListResult>,
-): void {
-  registerSimpleTool(
-    name,
-    description,
-    schema.shape,
-    async (args: unknown): Promise<McpListResult> => {
-      const parsed = schema.safeParse(args);
-      if (!parsed.success) {
-        throw new Error(parsed.error.message);
-      }
-      return handler(parsed.data);
-    },
-  );
-}
-
-export function createZodToolRegistrar(registerSimpleTool: RegisterSimpleToolFn) {
-  return <T>(
-    name: string,
-    description: string,
-    schema: ZodObjectSchema<T>,
-    handler: (args: T) => Promise<McpListResult>,
-  ): void => {
-    registerZodTool(registerSimpleTool, name, description, schema, handler);
-  };
-}
-
-export type HttpTextResponse = { ok: boolean; status: number; text: string };
-
-export type HttpJsonBodyResponse = { ok: boolean; status: number; json: unknown; text: string };
-
-/** After a JSON-body fetch: throw with status + body snippet, else wrap `json` for MCP. */
-export function mcpJsonResultIfOk(
-  serviceLabel: string,
-  res: HttpJsonBodyResponse,
-  snippetMax = 300,
-): McpListResult {
-  if (!res.ok) {
-    throw new Error(`${serviceLabel} ${String(res.status)}: ${res.text.slice(0, snippetMax)}`);
-  }
-  return mcpJsonResult(res.json);
-}
-
 /**
- * After a text-body fetch: throw with status + body snippet, else parse JSON and wrap for MCP.
- * Use `jsonParseErrorMessage` when parse failures need a stable diagnostic (e.g. Jira tools).
+ * mcp-tool-kit — re-export of the MCP connector helpers now owned by
+ * `@nimbus-dev/sdk/connector-kit`.
+ *
+ * These helpers originated here and were upstreamed to the SDK in 1.11.0. The
+ * SDK is now the single owner; this module stays as the connector-facing import
+ * path so the ~99 connectors keep their existing relative imports.
+ *
+ * Named re-exports, deliberately not `export *`: a star would also re-export the
+ * sibling kits' symbols (fetch-bearer-json, rest-tool-kit) through this path,
+ * widening the surface each connector sees and making a two-module import
+ * ambiguous. Keep this list matched to the symbols this file used to define.
  */
-export function mcpJsonResultFromTextIfOk(
-  serviceLabel: string,
-  res: HttpTextResponse,
-  options?: { maxSnippet?: number; jsonParseErrorMessage?: string },
-): McpListResult {
-  const max = options?.maxSnippet ?? 400;
-  if (!res.ok) {
-    throw new Error(`${serviceLabel} ${String(res.status)}: ${res.text.slice(0, max)}`);
-  }
-  try {
-    return mcpJsonResult(JSON.parse(res.text) as unknown);
-  } catch {
-    if (options?.jsonParseErrorMessage !== undefined) {
-      throw new Error(options.jsonParseErrorMessage);
-    }
-    throw new Error(`${serviceLabel}: invalid JSON response`);
-  }
-}
 
-/** Like {@link mcpJsonResultFromTextIfOk} but returns parsed JSON for composing multi-part tool results. */
-export function parseJsonTextIfOk(
-  serviceLabel: string,
-  res: HttpTextResponse,
-  maxSnippet = 400,
-): unknown {
-  if (!res.ok) {
-    throw new Error(`${serviceLabel} ${String(res.status)}: ${res.text.slice(0, maxSnippet)}`);
-  }
-  return JSON.parse(res.text) as unknown;
-}
-
-export function putOptionalNonEmptyString(
-  body: Record<string, unknown>,
-  key: string,
-  value: string | undefined,
-): void {
-  if (value !== undefined && value !== "") {
-    body[key] = value;
-  }
-}
-
-export function putOptionalBoolean(
-  body: Record<string, unknown>,
-  key: string,
-  value: boolean | undefined,
-): void {
-  if (value !== undefined) {
-    body[key] = value;
-  }
-}
-
-/** Input shape matches MCP `server.tool` zod fields; typed as unknown to avoid a zod import from this shared path. */
-export type RegisterSimpleToolFn = (
-  name: string,
-  description: string,
-  inputShape: Record<string, unknown>,
-  handler: (args: unknown) => Promise<McpListResult>,
-) => unknown;
-
-export function createRegisterSimpleTool(server: unknown): RegisterSimpleToolFn {
-  if (
-    typeof server !== "object" ||
-    server === null ||
-    !("tool" in server) ||
-    typeof server.tool !== "function"
-  ) {
-    throw new Error("createRegisterSimpleTool: expected MCP server with .tool");
-  }
-  const host = server as { tool: (...args: never) => unknown };
-  return host.tool.bind(server) as RegisterSimpleToolFn;
-}
-
-export function requireProcessEnv(envVarName: string): string {
-  const t = process.env[envVarName];
-  if (t === undefined || t === "") {
-    throw new Error(`${envVarName} is not set`);
-  }
-  return t;
-}
-
-export async function fetchWithTimeout(
-  url: string,
-  init: RequestInit = {},
-  timeoutMs = 15_000,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  // Compose with a caller-provided signal rather than clobbering it, so callers
-  // can still cancel via their own abort signal on top of the timeout.
-  const signal = init.signal
-    ? AbortSignal.any([init.signal, controller.signal])
-    : controller.signal;
-  try {
-    return await fetch(url, { ...init, signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-/** HTTP Basic header for email:API-token style Atlassian credentials (never log the raw value). */
-export function encodeBasicAuthHeader(email: string, token: string): string {
-  const raw = `${email}:${token}`;
-  const b64 = Buffer.from(raw, "utf8").toString("base64");
-  return `Basic ${b64}`;
-}
+export type {
+  HttpJsonBodyResponse,
+  HttpTextResponse,
+  McpListResult,
+  RegisterSimpleToolFn,
+  ZodObjectSchema,
+} from "@nimbus-dev/sdk/connector-kit";
+export {
+  createRegisterSimpleTool,
+  createZodToolRegistrar,
+  encodeBasicAuthHeader,
+  fetchWithTimeout,
+  mcpJsonResult,
+  mcpJsonResultFromTextIfOk,
+  mcpJsonResultIfOk,
+  parseJsonTextIfOk,
+  putOptionalBoolean,
+  putOptionalNonEmptyString,
+  registerZodTool,
+  requireProcessEnv,
+} from "@nimbus-dev/sdk/connector-kit";

--- a/packages/mcp-connectors/shared/rest-tool-kit.ts
+++ b/packages/mcp-connectors/shared/rest-tool-kit.ts
@@ -1,89 +1,18 @@
 /**
- * rest-tool-kit — shared REST fetch wrapper for Bearer-auth connectors.
+ * rest-tool-kit — re-export of the shared REST fetch wrapper for Bearer-auth
+ * connectors, now owned by `@nimbus-dev/sdk/connector-kit`.
  *
- * Covers: github, github-actions, gmail, outlook (all use Bearer token + fetchBearerAuthorizedJson).
- * Deferred: gitlab (PRIVATE-TOKEN header), onedrive (arrayBuffer/bytes graphRequest).
- */
-
-import { fetchBearerAuthorizedJson, resolveUrlWithBase } from "./fetch-bearer-json.ts";
-import {
-  type HttpJsonBodyResponse,
-  type McpListResult,
-  mcpJsonResultIfOk,
-  requireProcessEnv,
-  type ZodObjectSchema,
-} from "./mcp-tool-kit.ts";
-
-export type RestFetchResult = {
-  ok: boolean;
-  status: number;
-  json: unknown;
-  text: string;
-};
-
-export type RestFetcherConfig = {
-  /** Base URL, e.g. "https://api.github.com" or "https://graph.microsoft.com/v1.0". */
-  apiBase: string;
-  /** Bearer token injected as Authorization header. */
-  token: string;
-  /** Additional headers merged on every request (e.g. GH_HEADERS). */
-  defaultHeaders?: Record<string, string>;
-};
-
-/**
- * Returns a fetcher function bound to `cfg.apiBase` + `cfg.token`.
+ * These helpers originated here and were upstreamed to the SDK in 1.11.0. The
+ * SDK is now the single owner; this module stays as the connector-facing import
+ * path so the ~99 connectors keep their existing relative imports.
  *
- * Relative paths are prefixed with `apiBase`; absolute URLs pass through unchanged.
- * The returned function mirrors the `BearerJsonFetchResult` shape used throughout the
- * connector tree: `{ ok, status, json, text }`.
+ * Named re-exports, deliberately not `export *` — see the note in
+ * `mcp-tool-kit.ts`.
  */
-export function makeRestFetcher(
-  cfg: RestFetcherConfig,
-): (pathOrUrl: string, init?: RequestInit) => Promise<RestFetchResult> {
-  return async (pathOrUrl: string, init?: RequestInit): Promise<RestFetchResult> => {
-    const url = resolveUrlWithBase(cfg.apiBase, pathOrUrl);
-    return fetchBearerAuthorizedJson(url, cfg.token, init, cfg.defaultHeaders);
-  };
-}
 
-/** A connector's Zod tool registrar (the `reg` from `createZodToolRegistrar`). */
-export type RestToolRegistrar = <T>(
-  name: string,
-  description: string,
-  schema: ZodObjectSchema<T>,
-  handler: (args: T) => Promise<McpListResult>,
-) => void;
-
-/**
- * Build a per-connector "register a standard REST tool" helper. Collapses the
- * repeated tool body shared by the hand-rolled REST connectors:
- * `const token = requireProcessEnv(<env>); const res = await <fetch>(token,
- * buildPath(p)[, buildInit(p)]); return mcpJsonResultIfOk(<label>, res)`. The
- * connector supplies its registrar, token env, service label, and token-bearing
- * fetcher once; each tool then provides only its name/description/schema +
- * `buildPath` (and optional `buildInit` for method/body). Tools with a
- * non-standard tail (custom error text, 204 tolerance, raw text) stay
- * hand-written on the connector's own `reg`.
- */
-export function makeRestToolRegistrar(cfg: {
-  registrar: RestToolRegistrar;
-  tokenEnv: string;
-  serviceLabel: string;
-  fetch: (token: string, pathOrUrl: string, init?: RequestInit) => Promise<HttpJsonBodyResponse>;
-  /** Body-snippet length for the `<label> <status>: <snippet>` error (mcpJsonResultIfOk default 300). */
-  snippetMax?: number;
-}): <T>(
-  name: string,
-  description: string,
-  schema: ZodObjectSchema<T>,
-  buildPath: (args: T) => string,
-  buildInit?: (args: T) => RequestInit,
-) => void {
-  return (name, description, schema, buildPath, buildInit) => {
-    cfg.registrar(name, description, schema, async (args) => {
-      const token = requireProcessEnv(cfg.tokenEnv);
-      const res = await cfg.fetch(token, buildPath(args), buildInit?.(args));
-      return mcpJsonResultIfOk(cfg.serviceLabel, res, cfg.snippetMax);
-    });
-  };
-}
+export type {
+  RestFetcherConfig,
+  RestFetchResult,
+  RestToolRegistrar,
+} from "@nimbus-dev/sdk/connector-kit";
+export { makeRestFetcher, makeRestToolRegistrar } from "@nimbus-dev/sdk/connector-kit";


### PR DESCRIPTION
Converts three files in `packages/mcp-connectors/shared/` from local implementations into named re-exports of `@nimbus-dev/sdk/connector-kit`, which shipped in SDK 1.11.0.

**5 files, +67 / −307.** No connector package is modified — all ~99 keep their existing relative imports (`../../shared/mcp-tool-kit.ts` and friends) exactly as they are.

## Why

These helpers originated here and were upstreamed to the SDK in 1.11.0, so the SDK is now the owner. Keeping a second copy here means two implementations that can silently drift. The files remain as the connector-facing import path; only their bodies change.

Named re-exports, deliberately **not** `export *`: a star would re-export the sibling kits' symbols through each path, widening the surface every connector sees and making a two-module import ambiguous.

## A note for reviewers who remember `96bb3a25`

That commit removed `@nimbus-dev/sdk` from the root `package.json`, stating *"the sdk belongs to the workspace packages, not the root."* This PR adds that line back, and that is deliberate rather than a regression.

It was correct then: no root-level code imported the SDK, so the declaration was dead weight. `shared/` is a plain directory, **not** a workspace package, and this is the first time anything outside a workspace package imports the SDK — which makes the root declaration load-bearing.

The precedent supports it: `shared/*.ts` has exactly two other bare imports, `@modelcontextprotocol/sdk` and `zod`, and **both are already declared at the root**. That block exists precisely to serve this non-workspace directory; this adds a third entry to it.

A first attempt instead bumped the dependency in all 94 connector manifests. That was not merely larger — it was **non-functional**: Bun nested 1.11.0 under each connector and left the hoisted copy at 1.10.0, so root `node_modules/@nimbus-dev/` never appeared and `shared/` failed to resolve at all.

## Verification

**No behavioral change.** The three existing test files (`mcp-tool-kit.test.ts`, `rest-tool-kit.test.ts`, `fetch-bearer-json.test.ts`) are kept **unmodified**, so they now exercise the SDK's implementation through the re-export — a direct equivalence check. **40 pass, 0 fail.** Full connector suite: **948 pass, 0 fail**, matching the pre-change baseline.

Corroborated structurally: unpacking the published 1.11.0 tarball and diffing it against the previous contents of these files, `mcp-tool-kit.ts` and `fetch-bearer-json.ts` are **byte-identical**, and `rest-tool-kit.ts` differs only in two `.ts` → `.js` import extensions. There was no drift to find.

**No generated output moved.** `create-nimbus-connector`'s golden harness byte-diffs generated connector packages against the real ones in this repo. Run against this branch: all 8 fixtures match their declared expectations, with `newrelic`/`datadog`/`grafana`/`sentry` still 6/6. The refactor changes not one generated byte.

**Gates:** `typecheck` and `lint` pass; resolution from `shared/` lands on the installed 1.11.0.

**Audits — no exclusion added, no baseline bumped, no test edited:** `js-licenses` (1175 packages; MIT is already allowlisted and an AGPL-core / MIT-SDK split is a stated non-negotiable in CLAUDE.md), `boundaries`, `duplication`, `structure`, `any`, `consumed-by`, `invariants`, `cross-platform`, `exclusion-parity`, `release-staleness`, `pin-freshness`, `test:coverage:mcp`.

`coverage-floor` was the main risk, since three previously-covered files became re-exports. The lcov was built and run against both this branch and a stashed clean tree: **identical results, one pre-existing violation** (gateway `socket-listeners.ts`), and the three re-export files are never flagged.

## Unrelated flake worth noting

One intermediate `coverage-floor` run reported a second violation in `bigeye/src/search-filter.ts` that did not reproduce on a rebuild of the same tree. It appears to be flake in the 71-shard lcov merge, unrelated to this change, but it could resurface in CI.

## Not in scope

`run-read-only-mcp-connector.ts` stays here — it imports `@modelcontextprotocol/sdk` directly, and it imports from `./mcp-tool-kit.ts`, which still resolves.
