### PR TITLE
fix(gateway): remove the data-export staging directory

### DIFF
--- a/packages/gateway/src/commands/data-export.test.ts
+++ b/packages/gateway/src/commands/data-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readdirSync } from "node:fs";
+import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { memVault, newIndex } from "../../test/fixtures/data-test-helpers.ts";
@@ -229,5 +229,51 @@ describe("data export", () => {
     expect(result.itemsExported).toBe(1);
     expect(result.recoverySeedGenerated).toBe(true);
     expect(result.outputPath).toBe(outPath);
+  });
+});
+
+describe("data export staging directory", () => {
+  const stageDirs = (): string[] =>
+    readdirSync(tmpdir()).filter((n) => n.startsWith("nimbus-export-stage-"));
+
+  const exportInput = (output: string) => ({
+    output,
+    includeIndex: false,
+    passphrase: "passphrase",
+    vault: memVault(),
+    index: newIndex(),
+    platform: "linux" as const,
+    nimbusVersion: "0.1.0",
+    schemaVersion: 21,
+    kdfParams: { t: 1, m: 1024, p: 1 },
+  });
+
+  test("is removed after a successful export", async () => {
+    const before = new Set(stageDirs());
+
+    await runDataExport(
+      exportInput(join(mkdtempSync(join(tmpdir(), "nimbus-export-cleanup-")), "backup.tar.gz")),
+    );
+
+    // The staging tree holds a full copy of the exported data — the audit chain among it,
+    // in plaintext — so leaving it in the OS temp directory means every export accumulates
+    // another copy that nothing ever removes.
+    expect(stageDirs().filter((n) => !before.has(n))).toEqual([]);
+  });
+
+  test("is removed even when the export fails part-way through", async () => {
+    const before = new Set(stageDirs());
+
+    // Output nested under a *file*, so mkdirSync fails with ENOTDIR after the staging tree
+    // is already populated. That is precisely when a half-written copy of vault and audit
+    // data must not be the thing left behind.
+    const blocker = join(mkdtempSync(join(tmpdir(), "nimbus-export-cleanup-")), "not-a-dir");
+    writeFileSync(blocker, "");
+
+    await expect(
+      runDataExport(exportInput(join(blocker, "sub", "backup.tar.gz"))),
+    ).rejects.toThrow();
+
+    expect(stageDirs().filter((n) => !before.has(n))).toEqual([]);
   });
 });

--- a/packages/gateway/src/commands/data-export.ts
+++ b/packages/gateway/src/commands/data-export.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildManifest } from "../db/backup-manifest.ts";
@@ -42,62 +42,75 @@ export async function runDataExport(input: RunDataExportInput): Promise<RunDataE
   const seed = await ensureRecoverySeed(input.vault);
   const stage = mkdtempSync(join(tmpdir(), "nimbus-export-stage-"));
 
-  const vaultPlaintext = await collectVaultManifestPlaintext(input.vault);
-  const encrypted = await encryptVaultManifest({
-    plaintext: vaultPlaintext,
-    passphrase: input.passphrase,
-    seed: seed.mnemonic,
-    ...(input.kdfParams === undefined ? {} : { kdfParams: input.kdfParams }),
-  });
-  const vaultPath = join(stage, "vault-manifest.json.enc");
-  writeFileSync(vaultPath, JSON.stringify(encrypted));
+  // The staging tree holds a second copy of everything being exported: the audit chain in
+  // plaintext, the encrypted vault manifest, and the watcher/workflow/extension/profile
+  // files. Once packBundle has written the archive it serves no further purpose, but it
+  // lives in the OS temp directory, so leaving it behind means every export silently
+  // accumulates another copy of the user's exported data with no expiry.
+  //
+  // Removed in `finally` rather than after packBundle: a failure part-way through is
+  // exactly when a half-written copy of vault and audit data should not be the thing left
+  // on disk.
+  try {
+    const vaultPlaintext = await collectVaultManifestPlaintext(input.vault);
+    const encrypted = await encryptVaultManifest({
+      plaintext: vaultPlaintext,
+      passphrase: input.passphrase,
+      seed: seed.mnemonic,
+      ...(input.kdfParams === undefined ? {} : { kdfParams: input.kdfParams }),
+    });
+    const vaultPath = join(stage, "vault-manifest.json.enc");
+    writeFileSync(vaultPath, JSON.stringify(encrypted));
 
-  const watchersPath = join(stage, "watchers.json");
-  writeFileSync(watchersPath, "[]");
-  const workflowsPath = join(stage, "workflows.json");
-  writeFileSync(workflowsPath, "[]");
-  const extensionsPath = join(stage, "extensions.json");
-  writeFileSync(extensionsPath, "[]");
-  const profilesPath = join(stage, "profiles.json");
-  writeFileSync(profilesPath, "[]");
-  const auditPath = join(stage, "audit-chain.json");
-  writeFileSync(auditPath, JSON.stringify(input.index.listAuditWithChain(10_000)));
+    const watchersPath = join(stage, "watchers.json");
+    writeFileSync(watchersPath, "[]");
+    const workflowsPath = join(stage, "workflows.json");
+    writeFileSync(workflowsPath, "[]");
+    const extensionsPath = join(stage, "extensions.json");
+    writeFileSync(extensionsPath, "[]");
+    const profilesPath = join(stage, "profiles.json");
+    writeFileSync(profilesPath, "[]");
+    const auditPath = join(stage, "audit-chain.json");
+    writeFileSync(auditPath, JSON.stringify(input.index.listAuditWithChain(10_000)));
 
-  const files: Record<string, string> = {
-    "vault-manifest.json.enc": vaultPath,
-    "watchers.json": watchersPath,
-    "workflows.json": workflowsPath,
-    "extensions.json": extensionsPath,
-    "profiles.json": profilesPath,
-    "audit-chain.json": auditPath,
-  };
+    const files: Record<string, string> = {
+      "vault-manifest.json.enc": vaultPath,
+      "watchers.json": watchersPath,
+      "workflows.json": workflowsPath,
+      "extensions.json": extensionsPath,
+      "profiles.json": profilesPath,
+      "audit-chain.json": auditPath,
+    };
 
-  const parsedVault = JSON.parse(vaultPlaintext) as Array<unknown>;
-  const manifest = await buildManifest({
-    bundleDir: stage,
-    nimbusVersion: input.nimbusVersion,
-    schemaVersion: input.schemaVersion,
-    platform: input.platform,
-    contents: {
-      index_rows: 0,
-      vault_entries: parsedVault.length,
-      watchers: 0,
-      workflows: 0,
-      extensions: 0,
-      profiles: 0,
-    },
-    files,
-    indexIncluded: input.includeIndex,
-  });
-  writeFileSync(join(stage, "manifest.json"), JSON.stringify(manifest, null, 2));
+    const parsedVault = JSON.parse(vaultPlaintext) as Array<unknown>;
+    const manifest = await buildManifest({
+      bundleDir: stage,
+      nimbusVersion: input.nimbusVersion,
+      schemaVersion: input.schemaVersion,
+      platform: input.platform,
+      contents: {
+        index_rows: 0,
+        vault_entries: parsedVault.length,
+        watchers: 0,
+        workflows: 0,
+        extensions: 0,
+        profiles: 0,
+      },
+      files,
+      indexIncluded: input.includeIndex,
+    });
+    writeFileSync(join(stage, "manifest.json"), JSON.stringify(manifest, null, 2));
 
-  mkdirSync(join(input.output, ".."), { recursive: true });
-  await packBundle(stage, input.output);
+    mkdirSync(join(input.output, ".."), { recursive: true });
+    await packBundle(stage, input.output);
 
-  return {
-    outputPath: input.output,
-    recoverySeed: seed.generated ? seed.mnemonic : "",
-    recoverySeedGenerated: seed.generated,
-    itemsExported: parsedVault.length,
-  };
+    return {
+      outputPath: input.output,
+      recoverySeed: seed.generated ? seed.mnemonic : "",
+      recoverySeedGenerated: seed.generated,
+      itemsExported: parsedVault.length,
+    };
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
 }


### PR DESCRIPTION
`runDataExport` creates a staging tree under the OS temp directory and **never removes it**.

Every export therefore leaves behind a second copy of everything it just exported:

| File | |
|---|---|
| `audit-chain.json` | **plaintext** |
| `vault-manifest.json.enc` | encrypted |
| `watchers.json`, `workflows.json`, `extensions.json`, `profiles.json` | |
| `manifest.json` | |

Nothing ever cleans it up, so the copies accumulate indefinitely — unbounded disk growth, and exported data persisting outside the bundle the user asked for. `mkdtemp` gives the directory 0700, so this is not a permissions exposure; it is data living longer and in more places than intended.

## The fix

The body is wrapped in `try`/`finally` with `rmSync(stage, { recursive: true, force: true })`.

`finally` rather than "after `packBundle`" is the point: a failure part-way through is *exactly* when a half-written copy of vault and audit data should not be the thing left on disk.

## Tests that were verified to fail without it

Two cases — a successful export and one that fails mid-way (output nested under a file, so `mkdirSync` fails with `ENOTDIR` after the staging tree is already populated).

Both were run with the cleanup line disabled to confirm they catch the leak, rather than assuming:

```
cleanup disabled:  (fail) is removed after a successful export
                   (fail) is removed even when the export fails part-way through
                   8 pass, 2 fail
restored:          10 pass, 0 fail
```

They compare the set of `nimbus-export-stage-*` directories before and after, so they assert on this export's leftovers rather than on a global count that other tests could disturb.

## Gates

`bun run typecheck` exit 0 (whole workspace) · `biome check` on both changed files exit 0 · `bun test src/commands/` 27 pass / 0 fail.

## How it was found, and what is still outstanding

While investigating temp-directory accumulation: one full run of this repo's test suite left ~6,080 directories in `%TEMP%`. Most are test fixtures that never clean up (`nimbus-ext-test` ~384, `nimbus-mesh` ~320, `nimbus-snapshot-test` ~280, and others across 213 files using `mkdtemp`).

`nimbus-export-stage` was ~293 of those — and unlike the rest it traced back to **production code**, which is why it is fixed here on its own. The test-fixture leaks are real but cosmetic by comparison, and fixing 213 call sites belongs in its own change; `packages/gateway/test/fixtures/extension.ts` is the single biggest and would be the place to start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files created during data exports are now automatically cleaned up after successful exports.
  * Temporary files are also removed when an export fails, helping prevent leftover data and disk usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->