### PR TITLE
fix(glossary): stop --refresh hanging when the gateway dies mid-pass

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
       "dependencies": {
         "@clack/prompts": "^1.7.0",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "@nimbus-dev/client": "^0.14.0",
+        "@nimbus-dev/client": "^0.15.0",
         "@nimbus-dev/sdk": "^1.8.1",
         "ink": "^7.1.1",
         "ink-text-input": "^6.0.0",
@@ -1816,7 +1816,7 @@
 
     "@nimbus-dev/admin-console": ["@nimbus-dev/admin-console@workspace:packages/admin-console"],
 
-    "@nimbus-dev/client": ["@nimbus-dev/client@0.14.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-s4tNoOHq8JCjMuoNEDRVWmQ4afWHU6FMyBwRSjeqAAjsOrswjDiz8mlQycu/gejCyNp+VabqXcJ6nbuJZeTBcg=="],
+    "@nimbus-dev/client": ["@nimbus-dev/client@0.15.0", "", { "dependencies": { "@nimbus-dev/sdk": "^1.6.0" } }, "sha512-/yxm52rW+Vy1mWKAsA4UhajG5tcTlJf5Q7cVUJmvtTE94OKC9P0OjMeRFWCJ47o2MggRbO0PLoI+VDSUv/HpUQ=="],
 
     "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.11.0", "", {}, "sha512-4X/wuT+/1FjJQUH9UXBmmKZqtnJcpt94h1oo3UpuC3DDYbMzzHMA+KVI15SIi3zC90CbJ1jHornI6nnR0CF/rA=="],
 
@@ -4173,10 +4173,6 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
-
-    "@nimbus-dev/client/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.8.1", "", {}, "sha512-FzTiXa5GzG4Bdlw+gA1kg/cIFmvyH1FvLlQowGHZAhGbjX1BJB/ncFXQZijH9MO+mIDLkd/jMEwVfuiB7BNHkA=="],
-
-    "@nimbus/cli/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
 
     "@nimbus/gateway/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.10.0", "", {}, "sha512-NIau3p9HWF6OcIRoyx4Rwzml+tPxSQITaxXH+QaNmk2H9nbMmey5Pb4lxD5eoDelATbOvpQpRceR+8HAlLXy2g=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,22 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-07-31 — `nimbus glossary --refresh` no longer hangs when the gateway dies mid-pass.**
+  `@nimbus-dev/client` bumped `^0.14.0` → `^0.15.0` for its new `IPCClient.onClose`, and
+  `awaitPass` now uses it. The gap this closes is specific to notification-delivered results:
+  `call()` is bounded by the client's `requestTimeoutMs`, but the call that *starts* a pass
+  resolves immediately with a job id and the result arrives later as a notification — so a gateway
+  that died in between left no pending call for the transport to reject and no notification ever
+  coming, and the CLI waited forever. There is deliberately still **no timeout** on that wait,
+  because a pass legitimately runs minutes at default config; the transport closing is the signal,
+  not a clock. A mid-pass death now fails fast with
+  `gateway connection closed during the pass: …` and exit code 2.
+  The same change pairs every notification handler with its removal on settle — `runAgentBriefCli`
+  reuses one client for the brief that runs straight afterwards, so a leaked handler was a live
+  cross-phase listener, not merely untidy. Client-side change:
+  [nimbus-client#48](https://github.com/nimbus-agent/nimbus-client/pull/48) (released as
+  `@nimbus-dev/client` 0.15.0).
+
 - **2026-07-31 — `nimbus glossary` — LLM wiring, snippet upgrades, and `--refresh`/`--rebuild`.**
   Three follow-ups to the 2026-07-30 glossary delivery below. (1) A `ConsolidatorLlm` adapter over
   the existing `LlmRouter` — hard-rejecting any non-local provider before generation, not after —

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@nimbus-dev/client": "^0.14.0",
+    "@nimbus-dev/client": "^0.15.0",
     "@nimbus-dev/sdk": "^1.8.1",
     "ink": "^7.1.1",
     "ink-text-input": "^6.0.0",

--- a/packages/cli/src/commands/glossary.test.ts
+++ b/packages/cli/src/commands/glossary.test.ts
@@ -26,22 +26,49 @@ function makeFakeIpcClient(callImpl?: (method: string, params: unknown) => Promi
   client: IPCClient;
   calls: RecordedCall[];
   fire: (method: string, params: unknown) => void;
+  fireClose: (err: Error) => void;
+  liveHandlers: () => number;
 } {
   const calls: RecordedCall[] = [];
-  const handlers = new Map<string, (params: unknown) => void>();
+  // Sets, not a single handler per method — the real `IPCClient` keeps a Set,
+  // and a fake that silently replaced a second registration would hide exactly
+  // the leak `liveHandlers` exists to catch.
+  const handlers = new Map<string, Set<(params: unknown) => void>>();
+  const closeHandlers = new Set<(err: Error) => void>();
   const fake = {
     call: async (method: string, params: unknown): Promise<unknown> => {
       calls.push({ method, params });
       return callImpl === undefined ? { sessionId: "s1" } : callImpl(method, params);
     },
     onNotification: (method: string, handler: (params: unknown) => void): void => {
-      handlers.set(method, handler);
+      const set = handlers.get(method) ?? new Set<(params: unknown) => void>();
+      set.add(handler);
+      handlers.set(method, set);
+    },
+    offNotification: (method: string, handler: (params: unknown) => void): void => {
+      handlers.get(method)?.delete(handler);
+    },
+    onClose: (handler: (err: Error) => void): void => {
+      closeHandlers.add(handler);
+    },
+    offClose: (handler: (err: Error) => void): void => {
+      closeHandlers.delete(handler);
     },
   };
   const fire = (method: string, params: unknown): void => {
-    handlers.get(method)?.(params);
+    for (const handler of [...(handlers.get(method) ?? [])]) handler(params);
   };
-  return { client: fake as unknown as IPCClient, calls, fire };
+  /** Simulate the transport dying — what `IPCClient.onClose` reports. */
+  const fireClose = (err: Error): void => {
+    for (const handler of [...closeHandlers]) handler(err);
+  };
+  /** Total live handlers, so a test can prove teardown actually removed them. */
+  const liveHandlers = (): number => {
+    let n = closeHandlers.size;
+    for (const set of handlers.values()) n += set.size;
+    return n;
+  };
+  return { client: fake as unknown as IPCClient, calls, fire, fireClose, liveHandlers };
 }
 
 test("no arguments yields a list request", () => {
@@ -588,5 +615,79 @@ describe("runGlossaryCommand — rebuild-preview error exit code", () => {
     }
     expect(exitCalls).toEqual([2]);
     expect(stderrBuf).toContain("Malformed glossary.briefReady payload");
+  });
+});
+
+describe("awaitPass — transport death", () => {
+  const DONE_SUMMARY = {
+    consolidated: 1,
+    upgraded: 0,
+    upgradesVetoed: 0,
+    vetoedTerms: [] as string[],
+    retried: 0,
+    llmConfigured: false,
+    llmProduced: false,
+  };
+
+  /**
+   * The failure this closes: `--refresh` starts a pass whose result arrives as
+   * a NOTIFICATION, so the `call()` that started it has already resolved and
+   * the client's `requestTimeoutMs` no longer protects anything. Before
+   * `@nimbus-dev/client` 0.15.0 exposed `onClose`, a gateway dying here left the
+   * CLI waiting forever — no pending call to reject, no notification ever
+   * coming. There is deliberately no timeout instead, because a pass
+   * legitimately runs minutes; only the transport closing is a reliable signal.
+   */
+  test("a gateway death mid-pass rejects instead of hanging forever", async () => {
+    const { client, fireClose } = makeFakeIpcClient();
+    const deps = {
+      withGatewayIpc: async <T>(fn: (c: IPCClient) => Promise<T>): Promise<T> => fn(client),
+      runAgentBriefCli: async <T>(spec: AgentBriefCliSpec<T>): Promise<void> => {
+        if (spec.beforeCall === undefined) return;
+        const passWait = spec.beforeCall(client);
+        // `awaitPass` registers its handlers synchronously before yielding, so
+        // the transport can die right here.
+        fireClose(new Error("IPC connection closed"));
+        // Raced against a short deadline on purpose. Without the `onClose`
+        // wiring this wait never settles, and an unraced `await` would express
+        // that as a suite TIMEOUT — a slow, generic failure a future reader
+        // could easily mistake for flake. The race turns the regression into a
+        // fast assertion that names itself.
+        await Promise.race([
+          passWait,
+          Bun.sleep(250).then(() => {
+            throw new Error("awaitPass never settled after the transport closed — it hung");
+          }),
+        ]);
+      },
+    };
+
+    await expect(runGlossaryCommand(["--refresh"], deps)).rejects.toThrow(
+      "gateway connection closed during the pass",
+    );
+  });
+
+  test("removes every handler once the pass settles", async () => {
+    const { client, fire, liveHandlers } = makeFakeIpcClient();
+    let liveDuringPass = 0;
+    const deps = {
+      withGatewayIpc: async <T>(fn: (c: IPCClient) => Promise<T>): Promise<T> => fn(client),
+      runAgentBriefCli: async <T>(spec: AgentBriefCliSpec<T>): Promise<void> => {
+        if (spec.beforeCall === undefined) return;
+        const passWait = spec.beforeCall(client);
+        liveDuringPass = liveHandlers();
+        fire("glossary.passDone", DONE_SUMMARY);
+        await passWait;
+      },
+    };
+
+    await runGlossaryCommand(["--refresh"], deps);
+
+    expect(liveDuringPass).toBeGreaterThan(0);
+    // `runAgentBriefCli` reuses this same client for the brief that runs
+    // immediately afterwards, so a leaked handler is a live cross-phase
+    // listener rather than merely untidy — which is why the client documents
+    // pairing every `on*` with its `off*`.
+    expect(liveHandlers()).toBe(0);
   });
 });

--- a/packages/cli/src/commands/glossary.ts
+++ b/packages/cli/src/commands/glossary.ts
@@ -184,25 +184,60 @@ function awaitPass(client: IPCClient, method: string): Promise<GlossaryPassSumma
     const endProgress = (): void => {
       if (wrote) process.stderr.write("\n");
     };
-    client.onNotification("glossary.passProgress", (n: unknown) => {
+
+    const onProgress = (n: unknown): void => {
       if (!tty) return;
       const p = n as { done: number; total: number };
       process.stderr.write(progressLine(p.done, p.total));
       wrote = true;
-    });
+    };
     // Single-flight in the gateway guarantees at most one job, so there is no
     // jobId to filter on — and filtering would race the `{ jobId }` reply.
-    client.onNotification("glossary.passDone", (n: unknown) => {
+    const onDone = (n: unknown): void => {
+      settleResolve(n as GlossaryPassSummaryLike);
+    };
+    const onError = (n: unknown): void => {
+      settleReject(new Error((n as { message: string }).message));
+    };
+    /**
+     * A pass legitimately runs minutes, so this wait deliberately has NO
+     * timeout — the client's `requestTimeoutMs` bounds the `call()` below, but
+     * that resolves immediately with a job id and the RESULT arrives later as a
+     * notification. Nothing was left to detect a gateway that died in between:
+     * no pending call for the transport to reject, and no notification ever
+     * coming, so the CLI hung forever. `onClose` (added in @nimbus-dev/client
+     * 0.15.0 for exactly this) turns that into a fast, explicit failure.
+     */
+    const onClose = (err: Error): void => {
+      settleReject(new Error(`gateway connection closed during the pass: ${err.message}`));
+    };
+
+    // Every handler is removed on the first settle. The client documents this
+    // as a rule ("leaking handlers keeps dead streams firing") and it is not
+    // theoretical here: `runAgentBriefCli` reuses this same client for the
+    // brief that runs immediately afterwards.
+    const teardown = (): void => {
+      client.offNotification("glossary.passProgress", onProgress);
+      client.offNotification("glossary.passDone", onDone);
+      client.offNotification("glossary.passError", onError);
+      client.offClose(onClose);
       endProgress();
-      resolve(n as GlossaryPassSummaryLike);
-    });
-    client.onNotification("glossary.passError", (n: unknown) => {
-      endProgress();
-      reject(new Error((n as { message: string }).message));
-    });
+    };
+    function settleResolve(v: GlossaryPassSummaryLike): void {
+      teardown();
+      resolve(v);
+    }
+    function settleReject(e: Error): void {
+      teardown();
+      reject(e);
+    }
+
+    client.onNotification("glossary.passProgress", onProgress);
+    client.onNotification("glossary.passDone", onDone);
+    client.onNotification("glossary.passError", onError);
+    client.onClose(onClose);
     client.call<{ jobId: string }>(method, {}).catch((err: unknown) => {
-      endProgress();
-      reject(err instanceof Error ? err : new Error(String(err)));
+      settleReject(err instanceof Error ? err : new Error(String(err)));
     });
   });
 }


### PR DESCRIPTION
Closes the known limit recorded in #987: `nimbus glossary --refresh` could hang forever if the gateway died mid-pass.

## The gap

Specific to results delivered by **notification**. `IPCClient.call()` is bounded by the client's `requestTimeoutMs`, but the call that *starts* a pass resolves immediately with a job id — the result arrives later as `glossary.passDone`. A gateway dying in between left nothing to detect it: no pending call for the transport to reject, and no notification ever coming. The CLI waited forever.

Fixed upstream first: [`nimbus-client#48`](https://github.com/nimbus-agent/nimbus-client/pull/48) added `IPCClient.onClose` / `offClose`, released as `@nimbus-dev/client` 0.15.0. This bumps `^0.14.0` → `^0.15.0` and uses it.

## There is still deliberately no timeout

A pass legitimately runs up to `max_new_terms_per_pass × consolidate_timeout_ms` — 12.5 minutes at defaults — so a clock cannot distinguish "still working" from "gone". Imposing one would either cut off legitimate long passes or be so generous it never fires. The transport closing is the signal instead.

A mid-pass death now fails with `gateway connection closed during the pass: …` and exit code **2** (agent error), consistent with every other pass failure. Note this is distinct from exit **1**, which the `--rebuild` preview path uses for gateway-*not-running* — that split was itself a fix in #987 and is still pinned by tests on both sides.

## Handler teardown

Every notification handler is now paired with its removal on settle. The client documents this as a rule, and it is not theoretical here: `runAgentBriefCli` reuses the *same* client for the brief that runs immediately afterwards, so a leaked handler was a live cross-phase listener rather than merely untidy.

## Tests

Two new cases, each red-proved by a mutation failing a different test:

| Mutation | Test that fails | Time |
|---|---|---|
| Drop `client.onClose(onClose)` | "a gateway death mid-pass rejects instead of hanging forever" | 252 ms |
| Teardown stops removing handlers | "removes every handler once the pass settles" | 0.9 ms |

The hang test **races a 250 ms deadline** rather than awaiting bare. Without the `onClose` wiring an unraced `await` expresses the regression as a suite *timeout* — a slow, generic failure that this repo's own history shows is easily mistaken for flake. The race turns it into a fast assertion that names itself: `awaitPass never settled after the transport closed — it hung`.

The DI fake gained `onClose`/`offClose`/`offNotification` and now stores handlers in **Sets**, mirroring the real client. A fake keyed one-handler-per-method would silently drop a second registration and hide the very leak the new `liveHandlers()` assertion exists to catch.

## Verification

`packages/cli/src` 1950 pass / 0 fail · e2e 36 pass · `tsc` 0 · biome 0 · markdownlint 0 · `audit:doc-refs` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
