### PR TITLE
fix(extensions): accept entrypoint as a fallback for entry

### DIFF
--- a/packages/gateway/src/extensions/manifest.test.ts
+++ b/packages/gateway/src/extensions/manifest.test.ts
@@ -188,6 +188,32 @@ describe("parseExtensionManifestJson — updateChannel + changelog (T2 PR 3)", (
   });
 });
 
+describe("parseExtensionManifestForRegistry — entry / entrypoint fallback (Task 9)", () => {
+  test("accepts entrypoint as a fallback when entry is absent", () => {
+    const m = parseExtensionManifestJson(
+      JSON.stringify({ id: "x", version: "1.0.0", entrypoint: "dist/server.js" }),
+    );
+    expect(m.entry).toBe("dist/server.js");
+  });
+
+  test("prefers entry when both entry and entrypoint are present", () => {
+    const m = parseExtensionManifestJson(
+      JSON.stringify({
+        id: "x",
+        version: "1.0.0",
+        entry: "dist/from-entry.js",
+        entrypoint: "dist/from-entrypoint.js",
+      }),
+    );
+    expect(m.entry).toBe("dist/from-entry.js");
+  });
+
+  test("leaves entry undefined when neither entry nor entrypoint is present", () => {
+    const m = parseExtensionManifestJson(JSON.stringify({ id: "x", version: "1.0.0" }));
+    expect(m.entry).toBeUndefined();
+  });
+});
+
 describe("parseExtensionManifestJson — dependsOn (T2 PR 4)", () => {
   test("accepts manifest with valid dependsOn ranges", () => {
     const m = parseExtensionManifestJson(

--- a/packages/gateway/src/extensions/manifest.ts
+++ b/packages/gateway/src/extensions/manifest.ts
@@ -165,8 +165,12 @@ export function parseExtensionManifestForRegistry(text: string): RegistryParseRe
     throw new Error("extension manifest requires non-empty id and version");
   }
   const name = typeof o["name"] === "string" ? o["name"].trim() : undefined;
-  const entry =
-    typeof o["entry"] === "string" ? o["entry"].trim().replaceAll("\\", "/") : undefined;
+  // All 94 mcp-connectors and `nimbus scaffold extension` declare `entrypoint`; this parser
+  // read only `entry`, so every one of them fell back to "dist/index.js" while building
+  // dist/server.js — an install recorded an empty entry hash and verification then failed
+  // with "entry file missing". `entry` still wins where both are present.
+  const entryRaw = typeof o["entry"] === "string" ? o["entry"] : o["entrypoint"];
+  const entry = typeof entryRaw === "string" ? entryRaw.trim().replaceAll("\\", "/") : undefined;
   const publisher = parsePublisher(o["publisher"]);
   const signature = parseSignature(o["signature"]);
   if ((publisher === undefined) !== (signature === undefined)) {

--- a/packages/gateway/src/extensions/manifest.ts
+++ b/packages/gateway/src/extensions/manifest.ts
@@ -135,6 +135,15 @@ function parseDependsOn(value: unknown): Readonly<Record<string, string>> | unde
   return Object.keys(out).length === 0 ? undefined : out;
 }
 
+// All 94 mcp-connectors and `nimbus scaffold extension` declare `entrypoint`; this parser
+// read only `entry`, so every one of them fell back to "dist/index.js" while building
+// dist/server.js — an install recorded an empty entry hash and verification then failed
+// with "entry file missing". `entry` still wins where both are present.
+function parseEntry(o: Record<string, unknown>): string | undefined {
+  const raw = typeof o["entry"] === "string" ? o["entry"] : o["entrypoint"];
+  return typeof raw === "string" ? raw.trim().replaceAll("\\", "/") : undefined;
+}
+
 export function parseExtensionManifestJson(text: string): ExtensionManifest {
   return parseExtensionManifestForRegistry(text).manifest;
 }
@@ -165,12 +174,7 @@ export function parseExtensionManifestForRegistry(text: string): RegistryParseRe
     throw new Error("extension manifest requires non-empty id and version");
   }
   const name = typeof o["name"] === "string" ? o["name"].trim() : undefined;
-  // All 94 mcp-connectors and `nimbus scaffold extension` declare `entrypoint`; this parser
-  // read only `entry`, so every one of them fell back to "dist/index.js" while building
-  // dist/server.js — an install recorded an empty entry hash and verification then failed
-  // with "entry file missing". `entry` still wins where both are present.
-  const entryRaw = typeof o["entry"] === "string" ? o["entry"] : o["entrypoint"];
-  const entry = typeof entryRaw === "string" ? entryRaw.trim().replaceAll("\\", "/") : undefined;
+  const entry = parseEntry(o);
   const publisher = parsePublisher(o["publisher"]);
   const signature = parseSignature(o["signature"]);
   if ((publisher === undefined) !== (signature === undefined)) {


### PR DESCRIPTION
`parseExtensionManifestForRegistry` reads `o["entry"]` with no fallback. **All 94 connectors in `packages/mcp-connectors/` declare `"entrypoint"`**, as does `packages/cli/src/commands/scaffold.ts`. Nothing normalises between the two names.

Consumers then default to `"dist/index.js"` (`install-from-local.ts:725`, `verify-extensions.ts:177`) while every connector builds `dist/server.js`. So installing one records an **empty entry hash**, and verification later fails with `"entry file missing"`.

## Who this actually affects

The 94 are unaffected in practice — they are workspace packages that never traverse `install-from-local`. The reason this matters is `create-nimbus-connector`, which *generates* connectors intended to be installed as extensions. Every one of them would hit this.

There is also a wry detail worth recording: `nimbus scaffold extension` emits the same ignored `entrypoint` key, but pairs it with `dist/index.js` — which happens to equal the default. **It works by coincidence, not by correctness.**

## The change

One expression. `entry` still wins where both keys are present; behaviour is unchanged when `entry` is present and when neither is.

## Scope, confirmed by a surprise

The **71 tests pinning the `dist/index.js` default live outside `manifest.test.ts`** — in `install-from-local.test.ts`, `verify-extensions.test.ts` and `hard-disable.test.ts`. `manifest.ts` never applied that default itself; it is applied downstream by the consumers.

That confirms the fix is correctly scoped to the parser alone and does not need to touch those defaults, which continue to apply whenever neither key is present.

## Verification

Three tests written first — fallback, entry-wins-when-both-present, neither-present-stays-undefined — and the fallback test was confirmed to fail for the right reason (`Received: undefined`) before the fix.

```
bun test packages/gateway/src/extensions/     373 pass, 4 skip, 0 fail
install-from-local + verify-extensions + hard-disable   109 pass, 0 fail
bun run typecheck (full monorepo)             exit 0
biome check (both changed files)              clean
```

No repo audit covers this parser — all `audit:*` scripts and `scripts/structure-audit/*` were checked; the only manifest-related one (`check-nimbus-invariants.ts`) targets an unrelated `connector-secrets-manifest.ts`.
