### PR TITLE
fix(release): prune the yum channel, keeping the newest N and the published release

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -156,6 +156,9 @@ jobs:
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
           # Optional override for the retention count; unset falls back to
           # DEFAULT_RETAINED_RELEASES in scripts/release/linux-repo-config.ts.
+          # An unset repo variable expands to "" and means "default"; a value
+          # that is not an integer FAILS the publish rather than quietly pruning
+          # with a retention nobody chose.
           NIMBUS_LINUX_REPO_RETAIN: ${{ vars.NIMBUS_LINUX_REPO_RETAIN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Build the apt repo (reprepro) + the yum repo (createrepo_c)
         env:
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
+          # Optional override for the retention count; unset falls back to
+          # DEFAULT_RETAINED_RELEASES in scripts/release/linux-repo-config.ts.
+          NIMBUS_LINUX_REPO_RETAIN: ${{ vars.NIMBUS_LINUX_REPO_RETAIN }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
@@ -165,13 +168,32 @@ jobs:
           cp staging/apt/conf/distributions repo/apt/conf/distributions
           # Drop any prior version first so re-running a tag (or bumping) never
           # trips reprepro's "already registered" guard. Tolerate "not present".
+          # This is also apt's retention: reprepro garbage-collects the pool file
+          # the removal left unreferenced, so apt/ holds only the newest release.
           reprepro -b repo/apt remove stable nimbus-headless 2>/dev/null || true
           reprepro -b repo/apt includedeb stable "$DEB"
 
           # --- yum (createrepo_c) ---
+          # ORDER IS LOAD-BEARING, and these three commands must stay in this
+          # order inside THIS step (`set -e` aborts the whole publish if any of
+          # them fails, before the later commit/push step can run):
+          #   1. stage the new RPM
+          #   2. prune old RPMs        <- deletes packages only, never metadata
+          #   3. createrepo_c          <- (re)builds metadata from what is left
+          # Generating metadata last is what makes the two halves of the danger
+          # impossible: the repodata is derived from the post-prune directory, so
+          # it cannot reference a deleted RPM, and nothing deletes anything after
+          # it is written, so no RPM it references can vanish. A prune that left
+          # stale repodata behind would break `yum install` outright — worse than
+          # the oversized channel this prune exists to fix.
           mkdir -p repo/yum
           cp "$RPM" repo/yum/
-          createrepo_c --update repo/yum
+          bun scripts/release/linux-repo-config.ts --prune-yum repo/yum --version "$VERSION"
+          # Full regeneration, NOT `--update`: `--update` treats the existing
+          # repodata as a cache, and after a delete we want the metadata built
+          # from nothing but the current directory listing. Re-checksumming a
+          # handful of retained RPMs costs seconds.
+          createrepo_c repo/yum
 
       - name: Sign apt Release + yum repomd (loopback gpg)
         env:

--- a/docs/install.md
+++ b/docs/install.md
@@ -69,6 +69,11 @@ sudo dnf install nimbus-headless
 `apt upgrade` / `dnf upgrade` then keep Nimbus current. (Uses the modern `signed-by`
 keyring form — not the deprecated `apt-key add`.)
 
+Both channels are pruned on publish: apt carries the newest release, yum the newest
+few, so `dnf downgrade nimbus-headless` reaches back only a release or two. Older
+versions stay available on the [releases page](https://github.com/nimbus-agent/Nimbus/releases)
+as direct `.deb`/`.rpm` downloads.
+
 ## Direct downloads
 
 Every artifact — the native installers above, the raw `nimbus` / `nimbus-gateway`

--- a/scripts/release/linux-repo-config.test.ts
+++ b/scripts/release/linux-repo-config.test.ts
@@ -147,9 +147,28 @@ describe("planYumRetention", () => {
     });
     expect(plan.keep).toContain(rpmAssetName("1.0.0"));
     expect(plan.remove).not.toContain(rpmAssetName("1.0.0"));
-    // The current release counts against the budget, so N stays a hard cap.
-    expect(plan.keep).toHaveLength(2);
+    // UNION of "newest 2" and "the one being published" -> 3 entries, not 2.
+    // The republished tag is an EXTRA, so retain is a floor on how many newest
+    // releases survive rather than a cap the old tag can eat into.
+    expect(plan.keep).toEqual(rpms("2.2.0", "2.1.0", "1.0.0"));
+    expect(plan.remove).toEqual(rpms("2.0.0"));
+  });
+
+  test("a re-publish of an old tag at retain=1 still keeps the newest release", () => {
+    // Regression, and the sharpest form of it: with the current release seeded
+    // into the keep-set BEFORE the newest-N pass, retain=1 filled the single
+    // slot with 1.0.0 and planned the deletion of every newer RPM in the
+    // channel — keep=[1.0.0], remove=[2.2.0, 2.1.0, 2.0.0]. One
+    // workflow_dispatch of an old tag would have taken `dnf install
+    // nimbus-headless` back two majors.
+    const plan = planYumRetention({
+      entries: rpms("1.0.0", "2.0.0", "2.1.0", "2.2.0"),
+      currentVersion: "1.0.0",
+      retain: 1,
+    });
     expect(plan.keep).toEqual(rpms("2.2.0", "1.0.0"));
+    expect(plan.remove).toEqual(rpms("2.1.0", "2.0.0"));
+    expect(plan.remove).not.toContain(rpmAssetName("2.2.0"));
   });
 
   test("is a no-op when the tree already holds N or fewer releases", () => {
@@ -256,6 +275,58 @@ describe("--prune-yum CLI", () => {
       );
       expect(run.status).toBe(0);
       expect(readdirSync(dir)).toEqual([rpmAssetName("1.2.0")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["the --retain flag", ["--retain", "five"], {}],
+    ["the NIMBUS_LINUX_REPO_RETAIN variable", [], { NIMBUS_LINUX_REPO_RETAIN: "five" }],
+    ["a non-integer retain", ["--retain", "3.5"], {}],
+  ])("fails loud on a malformed retention override via %s", (_label, args, env) => {
+    // A misconfigured override must NOT silently fall back to the default and
+    // prune with a retention nobody chose: the operator would believe the value
+    // they set was in force, and the only evidence would be the deleted RPMs.
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-yum-"));
+    try {
+      for (const v of ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]) {
+        writeFileSync(join(dir, rpmAssetName(v)), v, "utf8");
+      }
+      const run = spawnSync(
+        process.execPath,
+        [SCRIPT, "--prune-yum", dir, "--version", "1.3.0", ...args],
+        { encoding: "utf8", env: { ...process.env, NIMBUS_LINUX_REPO_RETAIN: "", ...env } },
+      );
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain("must be an integer");
+      // Fail-closed: nothing is deleted on the way out.
+      expect(readdirSync(dir).sort()).toEqual(
+        ["1.0.0", "1.1.0", "1.2.0", "1.3.0"].map(rpmAssetName).sort(),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["an unset", ""],
+    ["a whitespace-only", "  "],
+  ])("treats %s NIMBUS_LINUX_REPO_RETAIN as not configured, not as a value", (_label, value) => {
+    // An unset repo variable arrives as "" — the one blank that must keep
+    // meaning "use the default" rather than erroring or (worse, pre-fix)
+    // parsing to 0 and clamping the whole channel down to a single release.
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-yum-"));
+    try {
+      for (const v of ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]) {
+        writeFileSync(join(dir, rpmAssetName(v)), v, "utf8");
+      }
+      const run = spawnSync(process.execPath, [SCRIPT, "--prune-yum", dir, "--version", "1.3.0"], {
+        encoding: "utf8",
+        env: { ...process.env, NIMBUS_LINUX_REPO_RETAIN: value },
+      });
+      expect(run.status).toBe(0);
+      expect(readdirSync(dir).sort()).toEqual(["1.1.0", "1.2.0", "1.3.0"].map(rpmAssetName).sort());
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/release/linux-repo-config.test.ts
+++ b/scripts/release/linux-repo-config.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import yaml from "js-yaml";
+
 import {
   APT_ARCH,
   APT_CODENAME,
   APT_COMPONENT,
   assetSha256,
+  DEFAULT_RETAINED_RELEASES,
   debAssetName,
+  planYumRetention,
   renderRepreproDistributions,
   renderYumRepoFile,
   rpmAssetName,
+  rpmVersionOf,
 } from "./linux-repo-config.ts";
 
 const SUMS = [
@@ -81,5 +91,275 @@ describe("renderYumRepoFile", () => {
     const r = renderYumRepoFile({ baseUrl: "https://nimbus-agent.github.io/linux-repo/" });
     expect(r).toContain("baseurl=https://nimbus-agent.github.io/linux-repo/yum");
     expect(r).not.toContain("linux-repo//yum");
+  });
+});
+
+describe("rpmVersionOf", () => {
+  test("reads the version out of a published RPM name", () => {
+    expect(rpmVersionOf(rpmAssetName("1.2.3"))).toBe("1.2.3");
+    expect(rpmVersionOf("nimbus-headless-1.10.0-x86_64.rpm")).toBe("1.10.0");
+  });
+
+  test("returns null for anything that is not one of our RPMs", () => {
+    // Never a deletion candidate: not an RPM, another package, another arch,
+    // or a version string Bun.semver cannot order.
+    expect(rpmVersionOf("repodata")).toBeNull();
+    expect(rpmVersionOf("nimbus-headless-1.2.3-x86_64.rpm.asc")).toBeNull();
+    expect(rpmVersionOf("other-tool-1.2.3-x86_64.rpm")).toBeNull();
+    expect(rpmVersionOf("nimbus-headless-1.2.3-aarch64.rpm")).toBeNull();
+    expect(rpmVersionOf("nimbus-headless-not-a-version-x86_64.rpm")).toBeNull();
+  });
+});
+
+describe("planYumRetention", () => {
+  const rpms = (...versions: string[]): string[] => versions.map(rpmAssetName);
+
+  test("keeps the newest N and removes the rest, ordering by semver not string", () => {
+    // 1.9.0 > 1.10.0 lexically; the plan must not fall for that.
+    const plan = planYumRetention({
+      entries: rpms("1.2.0", "1.9.0", "1.10.0", "1.11.0"),
+      currentVersion: "1.11.0",
+      retain: 2,
+    });
+    expect(plan.keep).toEqual(rpms("1.11.0", "1.10.0"));
+    expect(plan.remove).toEqual(rpms("1.9.0", "1.2.0"));
+  });
+
+  test("defaults to DEFAULT_RETAINED_RELEASES when no retain is given", () => {
+    const plan = planYumRetention({
+      entries: rpms("1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"),
+      currentVersion: "1.4.0",
+    });
+    expect(plan.retain).toBe(DEFAULT_RETAINED_RELEASES);
+    expect(plan.keep).toHaveLength(DEFAULT_RETAINED_RELEASES);
+    expect(plan.keep).toContain(rpmAssetName("1.4.0"));
+    expect(plan.remove).not.toContain(rpmAssetName("1.4.0"));
+  });
+
+  test("never removes the release being published, even when older tags sort above it", () => {
+    // Re-publishing an older tag (workflow_dispatch) stages its RPM into a tree
+    // whose other entries are all newer. Deleting it would publish metadata for
+    // a package that is not there.
+    const plan = planYumRetention({
+      entries: rpms("1.0.0", "2.0.0", "2.1.0", "2.2.0"),
+      currentVersion: "1.0.0",
+      retain: 2,
+    });
+    expect(plan.keep).toContain(rpmAssetName("1.0.0"));
+    expect(plan.remove).not.toContain(rpmAssetName("1.0.0"));
+    // The current release counts against the budget, so N stays a hard cap.
+    expect(plan.keep).toHaveLength(2);
+    expect(plan.keep).toEqual(rpms("2.2.0", "1.0.0"));
+  });
+
+  test("is a no-op when the tree already holds N or fewer releases", () => {
+    const plan = planYumRetention({
+      entries: rpms("1.0.0", "1.1.0"),
+      currentVersion: "1.1.0",
+      retain: 5,
+    });
+    expect(plan.remove).toEqual([]);
+    expect(plan.keep).toEqual(rpms("1.1.0", "1.0.0"));
+  });
+
+  test("leaves every non-RPM entry alone — repodata is regenerated, never pruned", () => {
+    const entries = [
+      "repodata",
+      ".nojekyll",
+      "nimbus-headless-1.0.0-x86_64.rpm.asc",
+      "other-tool-9.9.9-x86_64.rpm",
+      ...rpms("1.0.0", "1.1.0"),
+    ];
+    const plan = planYumRetention({ entries, currentVersion: "1.1.0", retain: 1 });
+    expect(plan.remove).toEqual(rpms("1.0.0"));
+    for (const untouched of entries.filter((e) => rpmVersionOf(e) === null)) {
+      expect(plan.remove).not.toContain(untouched);
+      expect(plan.keep).not.toContain(untouched);
+    }
+  });
+
+  test("clamps a zero/negative/NaN retain to 1 so the channel is never emptied", () => {
+    for (const retain of [0, -3, Number.NaN]) {
+      const plan = planYumRetention({
+        entries: rpms("1.0.0", "1.1.0"),
+        currentVersion: "1.1.0",
+        retain,
+      });
+      // NaN is "not configured" -> default; 0 and -3 clamp to 1. Either way the
+      // release just staged survives.
+      expect(plan.retain).toBeGreaterThanOrEqual(1);
+      expect(plan.keep).toContain(rpmAssetName("1.1.0"));
+      expect(plan.remove).not.toContain(rpmAssetName("1.1.0"));
+    }
+    expect(
+      planYumRetention({ entries: rpms("1.0.0"), currentVersion: "1.0.0", retain: 0 }).retain,
+    ).toBe(1);
+  });
+
+  test("keep and remove partition the candidate RPMs with no overlap", () => {
+    const entries = [...rpms("1.0.0", "1.1.0", "1.2.0", "1.3.0"), "repodata"];
+    const plan = planYumRetention({ entries, currentVersion: "1.3.0", retain: 2 });
+    expect([...plan.keep, ...plan.remove].sort()).toEqual(
+      entries.filter((e) => rpmVersionOf(e) !== null).sort(),
+    );
+    expect(plan.keep.filter((f) => plan.remove.includes(f))).toEqual([]);
+  });
+
+  test("tolerates a duplicated directory entry without double-listing it", () => {
+    const plan = planYumRetention({
+      entries: [...rpms("1.0.0", "1.1.0"), rpmAssetName("1.0.0")],
+      currentVersion: "1.1.0",
+      retain: 1,
+    });
+    expect(plan.remove).toEqual(rpms("1.0.0"));
+  });
+});
+
+const ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(ROOT, "scripts", "release", "linux-repo-config.ts");
+
+describe("--prune-yum CLI", () => {
+  // Closes the loop between the flag the workflow types and the flag the script
+  // parses: a rename on either side would leave the publish silently un-pruned.
+  test("deletes exactly the planned RPMs from a real directory, leaving repodata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-yum-"));
+    try {
+      mkdirSync(join(dir, "repodata"));
+      writeFileSync(join(dir, "repodata", "repomd.xml"), "<stale/>", "utf8");
+      for (const v of ["1.0.0", "1.1.0", "1.9.0", "1.10.0"]) {
+        writeFileSync(join(dir, rpmAssetName(v)), v, "utf8");
+      }
+      const run = spawnSync(process.execPath, [SCRIPT, "--prune-yum", dir, "--version", "1.10.0"], {
+        encoding: "utf8",
+      });
+      expect(run.status).toBe(0);
+      expect(readdirSync(dir).sort()).toEqual(
+        ["repodata", ...["1.10.0", "1.9.0", "1.1.0"].map(rpmAssetName)].sort(),
+      );
+      // The prune must NOT touch metadata — createrepo_c regenerates it next.
+      expect(readFileSync(join(dir, "repodata", "repomd.xml"), "utf8")).toBe("<stale/>");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--retain overrides the default", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-yum-"));
+    try {
+      for (const v of ["1.0.0", "1.1.0", "1.2.0"]) {
+        writeFileSync(join(dir, rpmAssetName(v)), v, "utf8");
+      }
+      const run = spawnSync(
+        process.execPath,
+        [SCRIPT, "--prune-yum", dir, "--version", "1.2.0", "--retain", "1"],
+        { encoding: "utf8" },
+      );
+      expect(run.status).toBe(0);
+      expect(readdirSync(dir)).toEqual([rpmAssetName("1.2.0")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails loud without --version rather than guessing which release is current", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-yum-"));
+    try {
+      writeFileSync(join(dir, rpmAssetName("1.0.0")), "x", "utf8");
+      const run = spawnSync(process.execPath, [SCRIPT, "--prune-yum", dir], {
+        encoding: "utf8",
+        env: { ...process.env, NIMBUS_RELEASE_VERSION: "" },
+      });
+      expect(run.status).toBe(1);
+      expect(readdirSync(dir)).toEqual([rpmAssetName("1.0.0")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+interface WorkflowStep {
+  name: string;
+  run: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Every step of every job, flattened, with only the fields this test reads. */
+function workflowSteps(doc: unknown): WorkflowStep[] {
+  const jobs = isRecord(doc) && isRecord(doc["jobs"]) ? Object.values(doc["jobs"]) : [];
+  const steps: WorkflowStep[] = [];
+  for (const job of jobs) {
+    const list = isRecord(job) && Array.isArray(job["steps"]) ? job["steps"] : [];
+    for (const step of list) {
+      if (!isRecord(step)) continue;
+      steps.push({
+        name: typeof step["name"] === "string" ? step["name"] : "",
+        run: typeof step["run"] === "string" ? step["run"] : "",
+      });
+    }
+  }
+  return steps;
+}
+
+/**
+ * Fail-closed like `parseWorkflow` in
+ * `scripts/structure-audit/check-workflow-run-triggers.ts`: a syntax error is
+ * reported as a finding rather than thrown out of module scope, so the failure
+ * names the problem instead of aborting the whole test file.
+ */
+function parseWorkflowYaml(text: string): { steps: WorkflowStep[]; parseError: string | null } {
+  try {
+    return { steps: workflowSteps(yaml.load(text)), parseError: null };
+  } catch (err) {
+    return { steps: [], parseError: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+describe("publish-linux-repo.yml yum prune ordering", () => {
+  const path = join(ROOT, ".github", "workflows", "publish-linux-repo.yml");
+  const { steps, parseError } = parseWorkflowYaml(readFileSync(path, "utf8"));
+
+  test("the workflow parses as YAML and exposes its steps", () => {
+    expect(parseError).toBeNull();
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("exactly one step builds the yum metadata, and it also runs the prune", () => {
+    const building = steps.filter((s) => s.run.includes("createrepo_c repo/yum"));
+    expect(building).toHaveLength(1);
+    expect(building[0]?.run).toContain("--prune-yum repo/yum");
+  });
+
+  test("the prune runs BEFORE createrepo_c, so repodata never references a deleted RPM", () => {
+    // The whole point of the change: metadata is generated from the post-prune
+    // directory listing. Reversing these two lines silently ships a broken
+    // channel (repodata pointing at RPMs that are gone).
+    const step = steps.find((s) => s.run.includes("createrepo_c repo/yum"));
+    const script = step?.run ?? "";
+    const prune = script.indexOf("--prune-yum repo/yum");
+    const createrepo = script.indexOf("createrepo_c repo/yum");
+    expect(prune).toBeGreaterThan(-1);
+    expect(createrepo).toBeGreaterThan(prune);
+    // ...and the RPM is staged before the prune, so it is in the listing the
+    // plan sees (otherwise the "always keep the current release" rule is moot).
+    expect(script.indexOf('cp "$RPM" repo/yum/')).toBeLessThan(prune);
+  });
+
+  test("no later step deletes from the yum tree after the metadata is built", () => {
+    const buildIndex = steps.findIndex((s) => s.run.includes("createrepo_c repo/yum"));
+    const after = steps.slice(buildIndex + 1);
+    expect(after.length).toBeGreaterThan(0); // the sign + commit steps
+    for (const step of after) {
+      expect(step.run).not.toContain("--prune-yum");
+      expect(step.run).not.toMatch(/\brm\b[^\n]*repo\/yum/);
+    }
+  });
+
+  test("the repomd signature is produced after the metadata it signs", () => {
+    const buildIndex = steps.findIndex((s) => s.run.includes("createrepo_c repo/yum"));
+    const signIndex = steps.findIndex((s) => s.run.includes("repo/yum/repodata/repomd.xml"));
+    expect(signIndex).toBeGreaterThan(buildIndex);
   });
 });

--- a/scripts/release/linux-repo-config.ts
+++ b/scripts/release/linux-repo-config.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env bun
-import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import {
+  appendFileSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { parseSha256Sums } from "./package-manager-manifests.ts";
 
 /** apt distribution coordinates. `stable` tracks the latest stable release. */
@@ -97,13 +104,163 @@ export function renderYumRepoFile(opts: YumRepoOptions): string {
   ].join("\n");
 }
 
+/**
+ * How many `nimbus-headless` releases the yum channel keeps.
+ *
+ * The apt side has always been self-pruning: the publish workflow runs
+ * `reprepro remove stable nimbus-headless` before `includedeb`, and reprepro
+ * garbage-collects the pool file that removal left unreferenced — so `apt/`
+ * structurally holds exactly the newest release. `yum/` never had an
+ * equivalent: every `.rpm` ever published stayed in the tree (44 of them,
+ * ~3.2 GB, against the ~1 GB GitHub Pages budget, growing ~76 MB per release),
+ * and past the limit `yum install nimbus-headless` degrades toward not working
+ * at all.
+ *
+ * This is that same retention concept, made explicit as a number instead of
+ * being implicit in reprepro's behaviour: keep the newest N, delete the rest,
+ * then regenerate the metadata from what is left. N is >1 where apt is
+ * effectively 1 because RPM has no separate pool and `dnf downgrade
+ * nimbus-headless` is a real recovery path — at ~76 MB per release, 3 costs
+ * ~230 MB and stays well inside the budget.
+ *
+ * Override per run with `--retain <n>` or `NIMBUS_LINUX_REPO_RETAIN`.
+ */
+export const DEFAULT_RETAINED_RELEASES = 3;
+
+/** Mirror of {@link rpmAssetName}: `nimbus-headless-<version>-x86_64.rpm`. */
+const RPM_ASSET_PATTERN = /^nimbus-headless-(.+)-x86_64\.rpm$/;
+
+/**
+ * `Bun.semver.order` throws on an unparseable version. A yum tree is external
+ * state (anyone can commit a file into the Pages repo), so an unreadable name
+ * must degrade to "not one of ours" — never to a deletion candidate.
+ * Same never-throw treatment as `compareSemver` in
+ * `scripts/structure-audit/_release-train-core.ts`.
+ */
+function orderVersions(a: string, b: string): number {
+  try {
+    return Bun.semver.order(a, b);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The release version encoded in a yum-tree filename, or `null` when the entry
+ * is not a recognisable `nimbus-headless` RPM (a directory such as `repodata/`,
+ * a detached `.asc`, a hand-added file, or a name whose version is not semver).
+ * `null` means "leave it alone" everywhere below.
+ */
+export function rpmVersionOf(filename: string): string | null {
+  const version = RPM_ASSET_PATTERN.exec(filename)?.[1];
+  if (version === undefined) return null;
+  try {
+    Bun.semver.order(version, version);
+  } catch {
+    return null;
+  }
+  return version;
+}
+
+export interface YumRetentionInput {
+  /** Directory listing of the yum tree (`readdirSync(repo/yum)`). */
+  entries: readonly string[];
+  /** The version being published right now; never a deletion candidate. */
+  currentVersion: string;
+  /**
+   * Releases to keep; defaults to {@link DEFAULT_RETAINED_RELEASES}. Spelled
+   * `| undefined` because `exactOptionalPropertyTypes` is on and callers pass a
+   * possibly-unset CLI flag straight through.
+   */
+  retain?: number | undefined;
+}
+
+export interface YumRetentionPlan {
+  /** RPMs that stay, newest first. */
+  keep: string[];
+  /** RPMs to delete, newest first. Disjoint from {@link YumRetentionPlan.keep}. */
+  remove: string[];
+  /** The effective retention count after clamping. */
+  retain: number;
+}
+
+function normalizeRetain(retain: number | undefined): number {
+  if (retain === undefined || !Number.isFinite(retain)) return DEFAULT_RETAINED_RELEASES;
+  // Never below 1: a 0/negative retention would delete the release we are
+  // publishing this very run and leave the channel with no package at all.
+  return Math.max(1, Math.floor(retain));
+}
+
+/**
+ * Decide which RPMs the yum tree keeps — pure, so "which files survive" is
+ * verifiable without running the workflow.
+ *
+ * Rules, all of them fail-safe (the failure direction of a wrong answer is a
+ * slightly larger repo, never a broken channel):
+ * - only entries matching {@link RPM_ASSET_PATTERN} with a semver version are
+ *   ever candidates; anything else is untouched and absent from both lists;
+ * - the version being published is always kept, even when older tags sort above
+ *   it (a re-publish of an older tag must not delete the RPM just staged);
+ * - the newest `retain` releases (counting the current one) are kept.
+ */
+export function planYumRetention(input: YumRetentionInput): YumRetentionPlan {
+  const retain = normalizeRetain(input.retain);
+  const currentRpm = rpmAssetName(input.currentVersion);
+
+  const candidates = [...new Set(input.entries)]
+    .map((file) => ({ file, version: rpmVersionOf(file) }))
+    .filter((c): c is { file: string; version: string } => c.version !== null)
+    // Newest first; filename as the tie-break keeps the plan deterministic.
+    .sort((a, b) => orderVersions(b.version, a.version) || a.file.localeCompare(b.file));
+
+  const keep = new Set<string>();
+  if (candidates.some((c) => c.file === currentRpm)) keep.add(currentRpm);
+  for (const { file } of candidates) {
+    if (keep.size >= retain) break;
+    keep.add(file);
+  }
+
+  return {
+    keep: candidates.filter((c) => keep.has(c.file)).map((c) => c.file),
+    remove: candidates.filter((c) => !keep.has(c.file)).map((c) => c.file),
+    retain,
+  };
+}
+
+/**
+ * Apply {@link planYumRetention} to a real yum tree.
+ *
+ * ORDERING CONTRACT — this deletes RPMs and does NOT touch `repodata/`. The
+ * caller (`.github/workflows/publish-linux-repo.yml`) must run `createrepo_c`
+ * AFTER this returns, so the metadata is generated from the post-prune
+ * directory. That is what makes it impossible to publish repodata referencing a
+ * deleted RPM: nothing deletes anything after the metadata is built.
+ */
+function runYumPrune(dir: string, version: string, retain: number | undefined): void {
+  const plan = planYumRetention({ entries: readdirSync(dir), currentVersion: version, retain });
+  for (const file of plan.remove) {
+    rmSync(join(dir, file), { force: true });
+    console.log(`pruned ${file}`);
+  }
+  console.log(
+    `linux-repo prune: retain=${plan.retain} kept=${plan.keep.length} removed=${plan.remove.length} (regenerate repodata now)`,
+  );
+}
+
 function parseArg(flag: string): string | undefined {
   const idx = process.argv.indexOf(flag);
   return idx >= 0 ? process.argv[idx + 1] : undefined;
 }
 
-if (import.meta.main) {
-  const version = parseArg("--version") ?? process.env["NIMBUS_RELEASE_VERSION"];
+function parseRetainArg(): number | undefined {
+  // An unset repo variable arrives as "", which must fall back to the default
+  // rather than parse to NaN and look like an explicit setting.
+  const raw = parseArg("--retain") ?? process.env["NIMBUS_LINUX_REPO_RETAIN"];
+  return raw ? Number(raw) : undefined;
+}
+
+/** Default mode: render the apt/yum config files + echo the verified checksums. */
+function runConfigGeneration(version: string | undefined): void {
   const sha256SumsPath = parseArg("--sha256sums");
   const baseUrl = parseArg("--base-url") ?? "https://nimbus-agent.github.io/linux-repo";
   const distributionsPath = parseArg("--distributions-out");
@@ -133,4 +290,20 @@ if (import.meta.main) {
   for (const line of lines) console.log(line);
   const ghOut = process.env["GITHUB_OUTPUT"];
   if (ghOut) appendFileSync(ghOut, `${lines.join("\n")}\n`);
+}
+
+if (import.meta.main) {
+  const version = parseArg("--version") ?? process.env["NIMBUS_RELEASE_VERSION"];
+  const pruneDir = parseArg("--prune-yum");
+  if (pruneDir) {
+    if (!version) {
+      console.error(
+        "Usage: bun scripts/release/linux-repo-config.ts --prune-yum <dir> --version <v> [--retain <n>]",
+      );
+      process.exit(1);
+    }
+    runYumPrune(pruneDir, version, parseRetainArg());
+  } else {
+    runConfigGeneration(version);
+  }
 }

--- a/scripts/release/linux-repo-config.ts
+++ b/scripts/release/linux-repo-config.ts
@@ -176,7 +176,11 @@ export interface YumRetentionInput {
 }
 
 export interface YumRetentionPlan {
-  /** RPMs that stay, newest first. */
+  /**
+   * RPMs that stay, newest first: the newest {@link YumRetentionPlan.retain}
+   * releases, plus the release being published when it is not already among
+   * them — so this can hold `retain + 1` entries on a re-publish of an old tag.
+   */
   keep: string[];
   /** RPMs to delete, newest first. Disjoint from {@link YumRetentionPlan.keep}. */
   remove: string[];
@@ -199,9 +203,20 @@ function normalizeRetain(retain: number | undefined): number {
  * slightly larger repo, never a broken channel):
  * - only entries matching {@link RPM_ASSET_PATTERN} with a semver version are
  *   ever candidates; anything else is untouched and absent from both lists;
- * - the version being published is always kept, even when older tags sort above
- *   it (a re-publish of an older tag must not delete the RPM just staged);
- * - the newest `retain` releases (counting the current one) are kept.
+ * - the newest `retain` releases are kept;
+ * - the version being published is kept as well, even when older tags sort
+ *   above it (a re-publish of an older tag must not delete the RPM just
+ *   staged).
+ *
+ * The last two are a UNION, not a priority order, and that is the whole point:
+ * seeding the keep-set with the current release first and then filling up to
+ * `retain` made the current release CROWD OUT the newest ones, so a
+ * `workflow_dispatch` re-publish of an old tag at a low retain deleted every
+ * newer RPM in the channel (entries 1.0.0/2.0.0/2.1.0/2.2.0 at
+ * `currentVersion=1.0.0, retain=1` kept 1.0.0 alone). Keeping the union means
+ * `retain` is the floor on how many newest releases survive and the plan can
+ * hold at most one extra entry (the republished tag) — a slightly larger repo,
+ * which is the safe direction.
  */
 export function planYumRetention(input: YumRetentionInput): YumRetentionPlan {
   const retain = normalizeRetain(input.retain);
@@ -214,11 +229,13 @@ export function planYumRetention(input: YumRetentionInput): YumRetentionPlan {
     .sort((a, b) => orderVersions(b.version, a.version) || a.file.localeCompare(b.file));
 
   const keep = new Set<string>();
-  if (candidates.some((c) => c.file === currentRpm)) keep.add(currentRpm);
   for (const { file } of candidates) {
     if (keep.size >= retain) break;
     keep.add(file);
   }
+  // Added AFTER the newest-N pass, never before it: the release being published
+  // joins the keep-set, it never takes a slot away from a newer release.
+  if (candidates.some((c) => c.file === currentRpm)) keep.add(currentRpm);
 
   return {
     keep: candidates.filter((c) => keep.has(c.file)).map((c) => c.file),
@@ -252,11 +269,29 @@ function parseArg(flag: string): string | undefined {
   return idx >= 0 ? process.argv[idx + 1] : undefined;
 }
 
+/**
+ * The retention override, or `undefined` for "not configured".
+ *
+ * Absent/blank is the only silent fall-back: an unset `vars.*` repo variable
+ * arrives as `""` (and a whitespace-only value is the same accident), which
+ * must mean the default rather than parse to `NaN`. Anything else that is not
+ * an integer literal — `five`, `3.5`, `1,000` — is a MISCONFIGURED override and
+ * throws. Swallowing it would silently prune to
+ * {@link DEFAULT_RETAINED_RELEASES} while the operator believes the repo
+ * variable they set is in force, and the only evidence would be the deleted
+ * RPMs. Out-of-range integers still clamp in {@link normalizeRetain}; this
+ * guard is about values that are not numbers at all.
+ */
 function parseRetainArg(): number | undefined {
-  // An unset repo variable arrives as "", which must fall back to the default
-  // rather than parse to NaN and look like an explicit setting.
   const raw = parseArg("--retain") ?? process.env["NIMBUS_LINUX_REPO_RETAIN"];
-  return raw ? Number(raw) : undefined;
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === "") return undefined;
+  if (!/^[+-]?\d+$/.test(trimmed)) {
+    throw new Error(
+      `linux-repo-config: retention override must be an integer, got ${JSON.stringify(raw)} (--retain / NIMBUS_LINUX_REPO_RETAIN)`,
+    );
+  }
+  return Number(trimmed);
 }
 
 /** Default mode: render the apt/yum config files + echo the verified checksums. */
@@ -302,7 +337,15 @@ if (import.meta.main) {
       );
       process.exit(1);
     }
-    runYumPrune(pruneDir, version, parseRetainArg());
+    let retain: number | undefined;
+    try {
+      retain = parseRetainArg();
+    } catch (err) {
+      // Fail the publish rather than prune with a retention nobody chose.
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    runYumPrune(pruneDir, version, retain);
   } else {
     runConfigGeneration(version);
   }


### PR DESCRIPTION
Closes #995.

The `linux-repo` yum channel had grown to **~3.2 GB against a documented 1 GB GitHub Pages limit** (3,410,232,418 bytes across 69 blobs), retaining 44 `nimbus-headless` RPMs forever and growing ~76 MB per release. The `apt/` pool was already pruned; `yum/` never was. This mirrors that logic for yum.

## The destructive bug found in review, and fixed

The first cut of the retention planner prioritised *"always keep the release being published"* **over** *"always keep the newest"*. A reviewer reproduced the consequence by running it:

```
entries 1.0.0 / 2.0.0 / 2.1.0 / 2.2.0, currentVersion=1.0.0, retain=1
  before:  keep=[1.0.0]           remove=[2.2.0, 2.1.0, 2.0.0]   ← deletes every newer release
  after:   keep=[2.2.0, 1.0.0]    remove=[2.1.0, 2.0.0]
```

So a `workflow_dispatch` re-publish of an **old** tag would have deleted every newer RPM in the channel. The rule is now the **union** of "newest N" and "the release being published" — `retain` is a floor on how many newest releases survive, never a ceiling that the current release can displace. Pinned by a test using exactly that scenario.

Also fixed: a malformed retention override was silently swallowed. `NIMBUS_LINUX_REPO_RETAIN="five"` (or `"3 "`) became `NaN` and fell back to the default. It now requires an integer literal and errors otherwise.

## Ordering is the safety property

The prune must run **before** `createrepo_c` regenerates the metadata. A prune that leaves stale repodata *breaks* the channel — worse than it being large. That ordering is asserted by a test, and that test still passes.

## What this does NOT do — worth being explicit

It shrinks the **served Pages tree**, not the **git repository**. The publish workflow commits its output, so the deleted RPMs remain in history and the repo's packed size is unchanged. That stops the Pages-limit bleed but does not reclaim the existing ~2.2 GB.

Reclaiming that needs either a history rewrite or — better — moving binaries to GitHub Releases assets and keeping only signed metadata in the Pages tree, which makes the question moot. Both are deliberately out of scope here; this is prune-forward only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux package repositories now support configurable retention settings.
  * Yum repositories retain the newest releases while safely removing older packages and regenerating metadata.
  * Apt repositories remove superseded packages during publication.
  * Invalid retention settings are rejected instead of publishing incomplete repositories.

* **Documentation**
  * Installation guidance now explains repository retention and how to access older versions through the releases page.

* **Tests**
  * Added comprehensive coverage for retention planning, configuration validation, package handling, and publication ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->