### PR TITLE
feat(cli): implement --json on the six commands that documented it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,28 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-01 — `--json` implemented on the six commands that only documented it.** `nimbus status`,
+  `connector list`, `db verify`, `db repair`, `config list` and `audit` parsed no `--json` at all —
+  the flag reached only the top-level banner suppressor in `index.ts`, so a documented `| jq`
+  pipeline silently received human-rendered text. All six now emit machine-readable JSON, under one
+  written contract (documented in `docs/cli-reference.md` § Global Flags → "The `--json` contract"):
+  `--json` is **per-command, never global**; stdout carries exactly one pretty-printed JSON value and
+  nothing else (no banner, table, or empty-state hint); diagnostics go to stderr; exit codes are
+  unchanged by the flag, and a command that *fails* emits no JSON at all, so callers check the exit
+  code rather than the presence of output; and the shape is the gateway's own payload unwrapped —
+  no `{ ok, data }` envelope, matching the convention `nimbus query`/`extension list`/`egress`
+  already ship. Shapes: `status` is one always-fully-populated object (`null` for absent data, with
+  `running` meaning "state file exists **and** `gateway.ping` answered"; `error` carries the IPC
+  message in the narrow case where the socket **connected** but the ping then failed — a *stale*
+  state file whose socket has no listener never reaches that shape at all, because the connect
+  rejects first, so stdout stays empty and the process exits `1`, exactly as plain `nimbus status`
+  already did with the same file); `connector list` and `audit` are raw row arrays
+  (empty registry → `[]`, not the hint line; `actionJson` stays the stored string so a malformed
+  payload still appears); `db verify` is `{ clean, findings, exitCode }` and `db repair` the
+  `{ outcomes, repairedAt }` report, both dropping the gateway's pre-rendered `formatted` blob rather
+  than embedding it; `config list` is `{ path, exists, keys, raw }`. No gateway change was needed —
+  every payload was already structured behind the CLI's own formatting. No new IPC method, no new
+  invariant.
 - **2026-08-01 — `nimbus glossary` — manual term authoring.** Closes the "no manual authoring or
   correction" gap named in the base spec's §12: a `[glossary.terms]` / `[glossary.synonyms]` pair
   of flat TOML blocks in `nimbus.toml`, read by a dedicated parser that reports per-entry skip

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,19 @@ These flags are accepted by most commands, which silently ignore any dash-argume
 | `--help`, `-h` | Print command help and exit |
 | `--version`, `-v` | Print Nimbus version and exit |
 | `NO_COLOR` (env var, not a flag) | Disable ANSI colour output. There is no `--no-color` flag. |
-| `--json` | Machine-readable JSON output — **per-command**, not global. Only the commands whose Options table lists it change their output; anywhere else it is silently ignored (top level, `--json` only suppresses the interactive banner). |
+| `--json` | Machine-readable JSON output — **per-command**, not global. Only the commands whose Options table or examples list it change their output; anywhere else it is silently ignored (top level, `--json` only suppresses the interactive banner). |
+
+### The `--json` contract
+
+Every command that documents `--json` obeys the same four rules, so a script can rely on them without
+reading the command's implementation:
+
+1. **stdout is the document, and nothing else.** With `--json`, stdout carries exactly one JSON value
+   (pretty-printed, 2-space indent) — no banner, no table, no empty-state hint, no progress line. `nimbus <cmd> --json | jq` always works.
+2. **Diagnostics go to stderr.** Warnings, hints, and degradation notes are written to stderr, never
+   mixed into the document.
+3. **Exit codes are unchanged by `--json`.** A command that exits `1` on a finding (e.g. `nimbus db verify`) still does so. A command that *fails* prints its error to stderr, exits non-zero, and emits **no JSON at all** — check the exit code, not the presence of output. This covers failures raised before the command can build a document at all, including the one most likely to bite a monitoring script: `nimbus status --json` against a **stale state file** whose socket has no listener. Connecting to the socket throws (`connect ENOENT` / `ECONNREFUSED`) before any JSON exists, so stdout stays empty and the process exits `1` — exactly as `nimbus status` without `--json` does. Do not expect a `running: false` document there.
+4. **The shape is the gateway's own payload, unwrapped.** There is no `{ ok, data }` envelope: list commands emit a JSON array, single-result commands a JSON object, with the gateway's own field names. Pre-rendered human strings (the `formatted` blob some gateway methods return) are dropped rather than embedded.
 
 ---
 
@@ -100,11 +112,39 @@ Show Gateway status and connector health.
 nimbus status
 nimbus status --verbose         # Per-connector item counts, p95 query latency, health lines
 nimbus status --drift           # Include IaC drift hints alongside status
+nimbus status --json            # One JSON object; `--verbose` / `--drift` add keys to it
+nimbus status --json | jq -r '.version'
 ```
 
-`nimbus status` reads only `--verbose` and `--drift`; there is no JSON output mode.
+`nimbus status` reads exactly three flags — `--verbose`, `--drift`, and `--json`. Any other dash-argument is silently ignored.
 
 **Output includes:** Gateway PID, uptime, active profile, total indexed items, agent limits (`depth=N  tool-calls/session=N`), connector list with health state (`healthy` / `degraded` / `error` / `rate_limited` / `unauthenticated` / `paused`).
+
+**`--json` shape.** One object; **every key is always present**, using `null` for absent data, so `jq` never has to guard for existence:
+
+| Key | Type | Notes |
+|---|---|---|
+| `running` | boolean | `true` only when the state file exists **and** `gateway.ping` answered |
+| `pid` / `socketPath` / `logPath` | number / string / string, or `null` | Read from the gateway state file |
+| `version` | string \| null | Gateway version |
+| `uptimeMs` | number \| null | Milliseconds, not the rounded seconds the human view prints |
+| `agentLimits` | object \| null | `{ maxAgentDepth, maxToolCallsPerSession }` |
+| `embeddingBackfill` | object \| null | `{ done, total }` |
+| `drift` | object \| null | `{ lines: string[] }` — populated only with `--drift` |
+| `index` / `connectorHealth` | object / array, or `null` | The `diag.snapshot` payload — populated only with `--verbose` |
+| `error` | string \| null | Set when the socket **connected** but `gateway.ping` then failed — the JSON form of the human "state exists but IPC failed" line; `running` is `false`. A socket that cannot be connected to at all does not reach this field (see below) |
+
+Two "not running" cases, and they do **not** behave alike:
+
+- **No state file.** `running: false`, `error: null`, every other key `null`, exit `0`. Not an error.
+- **A stale state file whose socket has no listener.** The connect throws before the document can be
+  built, so **no JSON is emitted at all**: the connect error (`connect ENOENT` on a Windows named pipe,
+  `ECONNREFUSED` on a Unix socket) goes to stderr and the process exits `1`. This is `--json` obeying
+  rule 3 of the contract above, and it matches what plain `nimbus status` does with the same stale
+  file. `error` is populated only in the narrower case where the connection succeeded and the
+  subsequent `gateway.ping` failed — a gateway that is listening but wedged, or one that dies
+  mid-call. A script that must distinguish "gone" from "never started" should check the exit code
+  first and only parse stdout on `0`.
 
 ---
 
@@ -877,9 +917,13 @@ List all connectors and their current health state.
 
 ```bash
 nimbus connector list
+nimbus connector list --json
+nimbus connector list --json | jq -r '.[] | select(.healthState != "healthy") | .serviceId'
 ```
 
 **Health states:** `healthy` · `degraded` · `error` · `rate_limited` · `unauthenticated` · `paused`
+
+**`--json` shape.** A JSON array of the raw `connector.listStatus` rows — `serviceId`, `status`, `lastSyncAt`, `nextSyncAt`, `intervalMs`, `itemCount`, `lastError`, `consecutiveFailures`, `healthState`, `healthRetryAfterMs` (timestamps are epoch ms or `null`, not the relative "5m ago" strings the table renders). With no connectors registered the output is `[]`, not the human "No connectors registered yet" hint.
 
 ---
 
@@ -1014,7 +1058,20 @@ Print the config file path, then a per-key line for whichever of the five env-ov
 
 ```bash
 nimbus config list
+nimbus config list --json
+nimbus config list --json | jq -r '.keys[] | select(.source == "env") | .envVar'
 ```
+
+**`--json` shape.** One object:
+
+| Key | Type | Notes |
+|---|---|---|
+| `path` | string | Resolved `nimbus.toml` path |
+| `exists` | boolean | Whether that file is present |
+| `keys` | array | `{ key, value, source: "file" \| "env", envVar: string \| null }` — `envVar` is the overriding variable, `null` for file-sourced keys |
+| `raw` | string \| null | The file body verbatim; `null` when the file is missing |
+
+The prose "other `NIMBUS_*` overrides" legend the human view prints is static documentation, not data, and has no JSON counterpart.
 
 ---
 
@@ -1860,21 +1917,28 @@ Run non-destructive integrity checks on the local index. Safe to run at any time
 
 ```bash
 nimbus db verify
+nimbus db verify --json
+nimbus db verify --json | jq -r '.findings[] | select(.status == "fail") | .label'
 ```
 
 **Checks:** SQLite `integrity_check`, FTS5 consistency, `vec_items_384` rowid alignment, orphaned sync tokens, schema version match, foreign key integrity.
 
-**Exit codes:** `0` = all pass, `1` = at least one finding.
+**Exit codes:** `0` = all pass, `1` = at least one finding. `--json` does not change them.
+
+**`--json` shape.** `{ clean: boolean, findings: [{ label, status: "ok" | "fail", detail? }], exitCode: number }`. The gateway's pre-rendered human report is dropped, not embedded; `exitCode` is both reported in the document and applied to the process.
 
 ---
 
 ### `nimbus db repair`
 
-Run targeted recovery actions for any findings reported by `nimbus db verify`. Writes a structured repair report to the audit log. `--yes` is **mandatory**, not a confirmation skip: there is no interactive prompt, and without the flag the command exits with `Usage: nimbus db repair --yes`.
+Run targeted recovery actions for any findings reported by `nimbus db verify`. Writes a structured repair report to the audit log. `--yes` is **mandatory**, not a confirmation skip: there is no interactive prompt, and without the flag the command exits with `Usage: nimbus db repair --yes` — including under `--json`, which emits nothing in that case.
 
 ```bash
 nimbus db repair --yes
+nimbus db repair --yes --json
 ```
+
+**`--json` shape.** The structured repair report: `{ outcomes: [{ action, status: "applied" | "skipped" | "error", detail? }], repairedAt: string }`, where `action` is one of `vec_orphan_delete` / `fts5_rebuild` / `orphaned_sync_tokens_delete` / `foreign_key_cascade_delete` and `repairedAt` is an ISO timestamp. The pre-rendered human report is dropped, not embedded.
 
 **Repair actions:** Delete orphaned vec rows + re-queue resync, FTS5 rebuild, delete unrecoverable rows, remove orphaned sync tokens.
 
@@ -2437,11 +2501,15 @@ Show the local audit log. Every action the agent takes — including every HITL 
 ```bash
 nimbus audit
 nimbus audit --limit 100
+nimbus audit --json
+nimbus audit --limit 100 --json | jq -r '.[] | select(.hitlStatus == "rejected") | .actionType'
 ```
 
-`--limit` (default 50) is the only flag parsed. There is no `--service`, `--since` or `--json` filtering here — such arguments are silently ignored, and the most recent `--limit` rows are printed as a plain table regardless.
+`--limit` (default 50) and `--json` are the only flags parsed. There is no `--service` or `--since` **filtering** here — such arguments are silently ignored, and the most recent `--limit` rows are returned regardless; `--json` changes the rendering only, never the row set.
 
 **Columns:** `Timestamp`, `Action`, `Status` (`approved` / `rejected` / `not_required`), `Reason` (the HITL reject reason from `action_json`; `—` when absent).
+
+**`--json` shape.** A JSON array of the raw `audit.list` rows: `{ id, actionType, hitlStatus, actionJson, timestamp }`, newest first, honouring `--limit` (default 50). `actionJson` stays the **string** the chain stored — it is not parsed for you, so a row whose payload is malformed still appears rather than being dropped; the human table's "Reason" column is that string's `hitlRejectReason` field. `--json` applies to the listing only; `nimbus audit verify` and `nimbus audit export` have their own output contracts.
 
 ---
 

--- a/packages/cli/src/commands/audit.test.ts
+++ b/packages/cli/src/commands/audit.test.ts
@@ -282,3 +282,80 @@ describe("runAudit (dispatcher)", () => {
     expect(out.stdout).toContain(`wrote 1 audit rows to ${outPath}`);
   });
 });
+
+describe("nimbus audit --json", () => {
+  beforeEach(() => {
+    out.reset();
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH } });
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  type AuditJsonRow = {
+    id: number;
+    actionType: string;
+    hitlStatus: string;
+    actionJson: string;
+    timestamp: number;
+  };
+
+  /** Parses the whole of stdout — proves the table header never reached stdout. */
+  function parseStdout(): AuditJsonRow[] {
+    return JSON.parse(out.stdout) as AuditJsonRow[];
+  }
+
+  it("emits the audit.list rows as a parseable array with no table on stdout", async () => {
+    const { client } = createMockIpcClient([
+      [
+        {
+          id: 1,
+          actionType: "file.delete",
+          hitlStatus: "rejected",
+          actionJson: '{"hitlRejectReason":"user-cancelled"}',
+          timestamp: 1_700_000_000_000,
+        },
+      ],
+    ]);
+    await runAuditList(client, 25, { json: true });
+
+    const rows = parseStdout();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(1);
+    expect(rows[0]?.actionType).toBe("file.delete");
+    expect(rows[0]?.hitlStatus).toBe("rejected");
+    expect(rows[0]?.timestamp).toBe(1_700_000_000_000);
+    // actionJson stays the stored string, malformed payloads included.
+    expect(rows[0]?.actionJson).toBe('{"hitlRejectReason":"user-cancelled"}');
+    expect(out.stdout).not.toContain("Timestamp");
+  });
+
+  it("keeps malformed actionJson verbatim instead of dropping the row", async () => {
+    const { client } = createMockIpcClient([
+      [
+        {
+          id: 2,
+          actionType: "file.move",
+          hitlStatus: "approved",
+          actionJson: "not-json",
+          timestamp: 1_700_000_000_001,
+        },
+      ],
+    ]);
+    await runAuditList(client, 50, { json: true });
+
+    expect(parseStdout()[0]?.actionJson).toBe("not-json");
+  });
+
+  it("is routed from the bare dispatcher path, honouring --limit alongside --json", async () => {
+    const ipc = createMockIpcClient([[]]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runAudit(["--limit", "7", "--json"]);
+
+    expect(ipc.calls[0]).toEqual({ method: "audit.list", params: { limit: 7 } });
+    expect(parseStdout()).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -43,8 +43,18 @@ async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
   }
 }
 
-export async function runAuditList(client: IPCClient, limit: number): Promise<void> {
+export async function runAuditList(
+  client: IPCClient,
+  limit: number,
+  opts: { json?: boolean } = {},
+): Promise<void> {
   const rows = await client.call<AuditRow[]>("audit.list", { limit });
+  if (opts.json === true) {
+    // Raw `audit.list` rows, unwrapped. `actionJson` stays the string the chain stored — parsing it
+    // here would silently drop rows whose payload is malformed, which the human view tolerates.
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
   console.log(`${"Timestamp".padEnd(20)} ${"Action".padEnd(22)} ${"Status".padEnd(14)} Reason`);
   console.log("-".repeat(72));
   for (const r of rows) {
@@ -112,5 +122,6 @@ export async function runAudit(args: string[]): Promise<void> {
     return;
   }
   const limit = parseAuditListLimit(args);
-  await withIpc((c) => runAuditList(c, limit));
+  const json = args.includes("--json");
+  await withIpc((c) => runAuditList(c, limit, { json }));
 }

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -414,3 +414,93 @@ describe("runConfig (dispatcher)", () => {
     expect(calls).toHaveLength(1);
   });
 });
+
+describe("nimbus config list --json", () => {
+  let tmp: string;
+  beforeEach(() => {
+    out.reset();
+    tmp = makeTmp();
+  });
+  afterEach(() => {
+    clearFixture();
+    try {
+      rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  type ConfigListDoc = {
+    path: string;
+    exists: boolean;
+    keys: Array<{ key: string; value: string; source: string; envVar: string | null }>;
+    raw: string | null;
+  };
+
+  /** Parses the whole of stdout — proves the legend/prose never reached stdout. */
+  function parseStdout(): ConfigListDoc {
+    return JSON.parse(out.stdout) as ConfigListDoc;
+  }
+
+  it("emits path/exists/keys/raw with the file body verbatim", () => {
+    const tomlPath = join(tmp, "nimbus.toml");
+    const body = "[telemetry]\nenabled = false\n";
+    writeFileSync(tomlPath, body, "utf8");
+    const savedEnv = process.env["NIMBUS_TELEMETRY_ENABLED"];
+    delete process.env["NIMBUS_TELEMETRY_ENABLED"];
+    try {
+      runConfigList(tomlPath, { json: true });
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env["NIMBUS_TELEMETRY_ENABLED"] = savedEnv;
+      }
+    }
+
+    const doc = parseStdout();
+    expect(doc.path).toBe(tomlPath);
+    expect(doc.exists).toBe(true);
+    expect(doc.raw).toBe(body);
+    const telemetry = doc.keys.find((k) => k.key === "telemetry.enabled");
+    expect(telemetry?.source).toBe("file");
+    expect(telemetry?.value).toBe("false");
+    expect(telemetry?.envVar).toBeNull();
+    // The prose env-override legend is human-only.
+    expect(out.stdout).not.toContain("NIMBUS_PROFILE");
+  });
+
+  it("marks env-sourced keys with source 'env' and the variable name", () => {
+    const tomlPath = join(tmp, "nimbus.toml");
+    const savedEnv = process.env["NIMBUS_TELEMETRY_ENABLED"];
+    process.env["NIMBUS_TELEMETRY_ENABLED"] = "true";
+    try {
+      runConfigList(tomlPath, { json: true });
+    } finally {
+      if (savedEnv === undefined) {
+        delete process.env["NIMBUS_TELEMETRY_ENABLED"];
+      } else {
+        process.env["NIMBUS_TELEMETRY_ENABLED"] = savedEnv;
+      }
+    }
+
+    const telemetry = parseStdout().keys.find((k) => k.key === "telemetry.enabled");
+    expect(telemetry?.source).toBe("env");
+    expect(telemetry?.envVar).toBe("NIMBUS_TELEMETRY_ENABLED");
+    expect(telemetry?.value).toBe("true");
+  });
+
+  it("reports exists:false and raw:null when the file is missing", () => {
+    const tomlPath = join(tmp, "nimbus.toml");
+    runConfigList(tomlPath, { json: true });
+
+    const doc = parseStdout();
+    expect(doc.exists).toBe(false);
+    expect(doc.raw).toBeNull();
+    expect(out.stdout).not.toContain("(file missing)");
+  });
+
+  it("is routed from the dispatcher when --json follows the subcommand", async () => {
+    await runConfig(["list", "--json"]);
+    expect(() => parseStdout()).not.toThrow();
+    expect(out.stdout).not.toContain("NIMBUS_PROFILE");
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { IPCClient } from "../ipc-client/index.ts";
+import type { TomlKeySource } from "../lib/nimbus-toml-config.ts";
 import {
   getTomlValueFromFile,
   listTomlKeysWithEnv,
@@ -17,7 +18,7 @@ function printConfigHelp(): void {
 
 Usage:
   nimbus config validate   (requires Gateway — checks nimbus.toml in config dir)
-  nimbus config list       Print known keys with file vs env source + full file body
+  nimbus config list [--json]   Print known keys with file vs env source + full file body
   nimbus config get <section.key>   (e.g. telemetry.enabled) — env overrides file
   nimbus config set <section.key> <value>
   nimbus config edit       Open nimbus.toml in $EDITOR (default: notepad on Windows, vi elsewhere)
@@ -58,7 +59,36 @@ function printAdditionalEnvOverrideLegend(): void {
   );
 }
 
-export function runConfigList(tomlPath: string): void {
+/**
+ * The `nimbus config list --json` document: the resolved config path, whether the file exists, the
+ * known keys with their winning source, and the raw file body (`null` when the file is missing).
+ * The prose env-override legend the human view prints is static documentation, not data, so it has
+ * no JSON counterpart.
+ */
+export type ConfigListJson = {
+  path: string;
+  exists: boolean;
+  keys: Array<{ key: string; value: string; source: TomlKeySource; envVar: string | null }>;
+  raw: string | null;
+};
+
+export function runConfigList(tomlPath: string, opts: { json?: boolean } = {}): void {
+  const exists = existsSync(tomlPath);
+  if (opts.json === true) {
+    const payload: ConfigListJson = {
+      path: tomlPath,
+      exists,
+      keys: listTomlKeysWithEnv(tomlPath).map((r) => ({
+        key: r.key,
+        value: r.value,
+        source: r.source,
+        envVar: r.envVar ?? null,
+      })),
+      raw: exists ? readFileSync(tomlPath, "utf8") : null,
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
   console.log(tomlPath);
   const rows = listTomlKeysWithEnv(tomlPath);
   if (rows.length > 0) {
@@ -70,7 +100,7 @@ export function runConfigList(tomlPath: string): void {
     }
   }
   printAdditionalEnvOverrideLegend();
-  if (!existsSync(tomlPath)) {
+  if (!exists) {
     console.log("");
     console.log("(file missing)");
     return;
@@ -150,7 +180,7 @@ export async function runConfig(args: string[]): Promise<void> {
   }
 
   if (sub === "list") {
-    runConfigList(tomlPath);
+    runConfigList(tomlPath, { json: args.includes("--json") });
     return;
   }
 

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -1202,3 +1202,70 @@ describe("runConnector — remaining dispatch + formatter edges", () => {
     expect(out.stdout).toContain("—");
   });
 });
+
+describe("nimbus connector list --json", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  type ConnectorRow = {
+    serviceId: string;
+    status: string;
+    itemCount: number;
+    healthState?: string;
+    lastError: string | null;
+  };
+
+  /** Parses the whole of stdout — proves the table never reached stdout alongside the JSON. */
+  function parseStdout(): ConnectorRow[] {
+    return JSON.parse(out.stdout) as ConnectorRow[];
+  }
+
+  it("emits the connector.listStatus rows as a parseable array", async () => {
+    const ipc = createMockIpcClient([
+      [
+        {
+          serviceId: "github",
+          status: "ok",
+          lastSyncAt: 1_700_000_000_000,
+          nextSyncAt: null,
+          intervalMs: 60_000,
+          itemCount: 12,
+          lastError: null,
+          consecutiveFailures: 0,
+          healthState: "healthy",
+          healthRetryAfterMs: null,
+        },
+      ],
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runConnector(["list", "--json"]);
+
+    expect(ipc.calls[0]).toEqual({ method: "connector.listStatus", params: undefined });
+    const rows = parseStdout();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.serviceId).toBe("github");
+    expect(rows[0]?.itemCount).toBe(12);
+    expect(rows[0]?.healthState).toBe("healthy");
+    // No table header / decoration on stdout.
+    expect(out.stdout).not.toContain("SERVICE");
+  });
+
+  it("emits [] instead of the empty-state hint when no connectors are registered", async () => {
+    const ipc = createMockIpcClient([[]]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runConnector(["list", "--json"]);
+
+    expect(parseStdout()).toEqual([]);
+    expect(out.stdout).not.toContain("No connectors registered yet");
+  });
+});

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -937,8 +937,14 @@ function fmtHealthRetry(ms: number | null | undefined): string {
   return d.toISOString();
 }
 
-async function runConnectorList(): Promise<void> {
+async function runConnectorList(opts: { json?: boolean } = {}): Promise<void> {
   const rows = await withIpc((c) => c.call<SyncStatus[]>("connector.listStatus"));
+  if (opts.json === true) {
+    // Raw `connector.listStatus` array, unwrapped — the `nimbus query --json` convention. An empty
+    // registry is `[]`, never the human "No connectors registered yet" line.
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
   if (rows.length === 0) {
     console.log("No connectors registered yet. Use: nimbus connector auth <service>");
     return;
@@ -1158,7 +1164,7 @@ export async function runConnector(args: string[]): Promise<void> {
       throw new Error("Usage: nimbus connector add --mcp <mcp_id> <command...>");
     }
     case "list":
-      await runConnectorList();
+      await runConnectorList({ json: tail.includes("--json") });
       return;
     case "history":
       await runConnectorHistory(tail);
@@ -1191,7 +1197,7 @@ function printConnectorHelp(): void {
 Usage:
   nimbus connector auth <service> [--port <n>] [--scopes a,b] [--token <pat>] [--api-base <url>] [--help]
   nimbus connector add --mcp <mcp_id> <command...>   Register a user MCP server (id must be mcp_*)
-  nimbus connector list
+  nimbus connector list [--json]
   nimbus connector history <service> [--limit N]
   nimbus connector status <service> [--stats]
   nimbus connector sync <service> [--full | --force]

--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -274,3 +274,100 @@ describe("runDb (unknown subcommand)", () => {
     await expect(runDb(["bogus"])).rejects.toThrow("Unknown db subcommand: bogus");
   });
 });
+
+describe("nimbus db verify --json / db repair --json", () => {
+  beforeEach(() => {
+    out.reset();
+    process.exitCode = 0;
+  });
+  afterEach(() => {
+    clearFixture();
+    process.exitCode = 0;
+  });
+
+  type VerifyJson = {
+    clean: boolean;
+    findings: Array<{ label: string; status: string; detail?: string }>;
+    exitCode: number;
+  };
+  type RepairJson = {
+    outcomes: Array<{ action: string; status: string; detail?: string }>;
+    repairedAt: string;
+  };
+
+  it("verify emits clean/findings/exitCode and no formatted text on stdout", async () => {
+    const ipc = createMockIpcClient([
+      {
+        clean: false,
+        findings: [
+          { label: "integrity_check", status: "ok" },
+          { label: "vec_rowid_mismatch", status: "fail", detail: "3 orphans" },
+        ],
+        formatted: "Issues found in the human report.",
+        exitCode: 1,
+      },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runDb(["verify", "--json"]);
+
+    expect(ipc.calls[0]).toEqual({ method: "db.verify", params: {} });
+    const doc = JSON.parse(out.stdout) as VerifyJson;
+    expect(doc.clean).toBe(false);
+    expect(doc.exitCode).toBe(1);
+    expect(doc.findings).toHaveLength(2);
+    expect(doc.findings[1]).toEqual({
+      label: "vec_rowid_mismatch",
+      status: "fail",
+      detail: "3 orphans",
+    });
+    expect(out.stdout).not.toContain("Issues found in the human report.");
+  });
+
+  it("verify still propagates the gateway exit code under --json", async () => {
+    const ipc = createMockIpcClient([
+      { clean: false, findings: [], formatted: "Issues found.", exitCode: 1 },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runDb(["verify", "--json"]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("repair emits the structured report and no formatted text on stdout", async () => {
+    const ipc = createMockIpcClient([
+      {
+        report: {
+          outcomes: [
+            { action: "vec_orphan_delete", status: "applied", detail: "3 rows" },
+            { action: "fts5_rebuild", status: "skipped" },
+          ],
+          repairedAt: "2026-08-01T00:00:00.000Z",
+        },
+        formatted: "Repaired (human report).",
+      },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runDb(["repair", "--yes", "--json"]);
+
+    expect(ipc.calls[0]).toEqual({ method: "db.repair", params: { confirm: true } });
+    const doc = JSON.parse(out.stdout) as RepairJson;
+    expect(doc.repairedAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(doc.outcomes.map((o) => o.action)).toEqual(["vec_orphan_delete", "fts5_rebuild"]);
+    expect(doc.outcomes[0]?.status).toBe("applied");
+    expect(out.stdout).not.toContain("Repaired (human report).");
+  });
+
+  it("repair still requires --yes under --json", async () => {
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH } });
+    await expect(runDb(["repair", "--json"])).rejects.toThrow("Usage: nimbus db repair --yes");
+    expect(out.stdout).toBe("");
+  });
+});

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -14,11 +14,32 @@ function takeFlag(args: string[], flag: string): string | undefined {
   return args[i + 1];
 }
 
-async function dbCmdVerify(): Promise<void> {
+/** Mirrors the gateway's `VerifyFinding` (packages/gateway/src/db/verify.ts). */
+type VerifyFinding = { label: string; status: "ok" | "fail"; detail?: string };
+
+/** Mirrors the gateway's `RepairReport` (packages/gateway/src/db/repair.ts). */
+type RepairReport = {
+  outcomes: Array<{ action: string; status: "applied" | "skipped" | "error"; detail?: string }>;
+  repairedAt: string;
+};
+
+async function dbCmdVerify(tail: string[]): Promise<void> {
+  const json = tail.includes("--json");
   const r = await withGatewayIpc((c) =>
-    c.call<{ clean: boolean; formatted: string; exitCode: number }>("db.verify", {}),
+    c.call<{ clean: boolean; findings: VerifyFinding[]; formatted: string; exitCode: number }>(
+      "db.verify",
+      {},
+    ),
   );
-  console.log(r.formatted);
+  if (json) {
+    // `formatted` is the gateway's pre-rendered human report — dropped here so stdout carries only
+    // structured data. `exitCode` is kept in the document AND applied to the process.
+    console.log(
+      JSON.stringify({ clean: r.clean, findings: r.findings, exitCode: r.exitCode }, null, 2),
+    );
+  } else {
+    console.log(r.formatted);
+  }
   process.exitCode = r.exitCode;
 }
 
@@ -27,9 +48,15 @@ async function dbCmdRepair(tail: string[]): Promise<void> {
   if (!yes) {
     throw new Error("Usage: nimbus db repair --yes");
   }
+  const json = tail.includes("--json");
   const r = await withGatewayIpc((c) =>
-    c.call<{ formatted: string }>("db.repair", { confirm: true }),
+    c.call<{ report: RepairReport; formatted: string }>("db.repair", { confirm: true }),
   );
+  if (json) {
+    // The structured `report` only; `formatted` is its human rendering.
+    console.log(JSON.stringify(r.report, null, 2));
+    return;
+  }
   console.log(r.formatted);
 }
 
@@ -115,7 +142,7 @@ export async function runDb(args: string[]): Promise<void> {
   }
 
   if (sub === "verify") {
-    await dbCmdVerify();
+    await dbCmdVerify(tail);
     return;
   }
 
@@ -165,8 +192,8 @@ function printDbHelp(): void {
   console.log(`nimbus db — index integrity and snapshots (Gateway IPC)
 
 Usage:
-  nimbus db verify
-  nimbus db repair --yes
+  nimbus db verify [--json]
+  nimbus db repair --yes [--json]
   nimbus db snapshot
   nimbus db snapshots list
   nimbus db snapshots prune --yes [--keep-last N]

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -5,14 +5,14 @@ Usage:
   nimbus init [--no-sync]   Index the current git repo — no credentials, no LLM. Start here.
   nimbus start [--no-wizard] Start gateway (background); omit first-run hint with --no-wizard
   nimbus stop               Stop gateway
-  nimbus status [--verbose] [--drift]   Ping gateway; --verbose adds health + index metrics; --drift adds IaC/AWS index hints
-  nimbus db verify | repair --yes | snapshot | snapshots list | snapshots prune --yes | backups list | restore <snap> --yes
+  nimbus status [--verbose] [--drift] [--json]   Ping gateway; --verbose adds health + index metrics; --drift adds IaC/AWS index hints
+  nimbus db verify [--json] | repair --yes [--json] | snapshot | snapshots list | snapshots prune --yes | backups list | restore <snap> --yes
   nimbus diag [--json] | diag slow-queries [--limit N] [--since 7d]
   nimbus query --service <id> [--type <t>] [--since 7d] [--sql "SELECT …"] [--json | --pretty]
   nimbus telemetry show | disable
   nimbus tui                Rich Ink TUI (falls back to REPL on dumb terminals).
   nimbus doctor             Bun version, data dir, Linux vault (secret-tool), gateway state + IPC
-  nimbus config validate | list | edit
+  nimbus config validate | list [--json] | edit
   nimbus profile create|list|switch|delete
   nimbus serve [--port 7474]   Start gateway with NIMBUS_HTTP_PORT (read-only HTTP sidecar)
   nimbus test [dir]         Extension manifest contract + bun test when package.json has a test script
@@ -37,7 +37,7 @@ Usage:
   nimbus vault get <k>      Read a secret (prompts first)
   nimbus vault delete <k>    Remove a secret
   nimbus vault list [pfx]   List vault key names
-  nimbus audit [--limit N]  Recent HITL audit rows
+  nimbus audit [--limit N] [--json]  Recent HITL audit rows
   nimbus connector …       Register connectors, OAuth, user MCP (add --mcp), sync (see: nimbus connector help)
   nimbus extension …       Install/list/enable/disable/remove local extensions (needs gateway)
   nimbus people …          Cross-service people graph (list, search, get, items, link)

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { clearFixture, FAKE_SOCKET_PATH, setFixture } from "../../test/helpers/cli-mocks.ts";
 import { captureOutput } from "../../test/helpers/cli-output.ts";
 import { createMockIpcClient } from "../../test/helpers/mock-ipc-client.ts";
+import type { StatusJson } from "./status.ts";
 
 const statusMod = await import("./status.ts");
 const { runStatus, runStatusImpl } = statusMod;
@@ -522,5 +523,191 @@ describe("runStatus (dispatcher)", () => {
     expect(ipc.calls[1]?.method).toBe("diag.snapshot");
     expect(out.stdout).toContain("Connector health");
     expect(out.stdout).toContain("slack");
+  });
+});
+
+describe("nimbus status --json", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  /** Parses the whole of stdout — proves nothing but the JSON document was written there. */
+  function parseStdout(): StatusJson {
+    return JSON.parse(out.stdout) as StatusJson;
+  }
+
+  it("emits a parseable status document and nothing else on stdout", async () => {
+    const ipc = createMockIpcClient([
+      {
+        version: "9.9",
+        uptime: 61_000,
+        agentLimits: { maxAgentDepth: 3, maxToolCallsPerSession: 20 },
+        embeddingBackfill: { done: 10, total: 100 },
+      },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 42 },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runStatus(["--json"]);
+
+    const doc = parseStdout();
+    expect(doc.running).toBe(true);
+    expect(doc.pid).toBe(42);
+    expect(doc.socketPath).toBe(FAKE_SOCKET_PATH);
+    expect(doc.version).toBe("9.9");
+    expect(doc.uptimeMs).toBe(61_000);
+    expect(doc.agentLimits).toEqual({ maxAgentDepth: 3, maxToolCallsPerSession: 20 });
+    expect(doc.embeddingBackfill).toEqual({ done: 10, total: 100 });
+    expect(doc.error).toBeNull();
+    // No human decoration leaked onto stdout.
+    expect(out.stdout).not.toContain("Gateway: running");
+    expect(out.stdout).not.toContain("Uptime:");
+  });
+
+  it("reports running:false with every key still present when no state file exists", async () => {
+    setFixture({});
+    await runStatus(["--json"]);
+
+    const doc = parseStdout();
+    expect(doc.running).toBe(false);
+    expect(doc.pid).toBeNull();
+    expect(doc.socketPath).toBeNull();
+    expect(doc.version).toBeNull();
+    expect(doc.uptimeMs).toBeNull();
+    expect(doc.error).toBeNull();
+    expect(Object.keys(doc).sort()).toEqual([
+      "agentLimits",
+      "connectorHealth",
+      "drift",
+      "embeddingBackfill",
+      "error",
+      "index",
+      "logPath",
+      "pid",
+      "running",
+      "socketPath",
+      "uptimeMs",
+      "version",
+    ]);
+    expect(out.stdout).not.toContain("not running (no state file)");
+  });
+
+  it("reports running:false and the IPC message in `error` when the socket connects but the ping fails", async () => {
+    const ipc = createMockIpcClient([new Error("socket closed")]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 7 },
+      // connect() RESOLVES — this is the wedged-but-listening gateway, the only
+      // shape that populates `error`. See the stale-state-file tests below for
+      // the case where connect() itself rejects.
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runStatus(["--json"]);
+
+    const doc = parseStdout();
+    expect(doc.running).toBe(false);
+    expect(doc.pid).toBe(7);
+    expect(doc.error).toBe("socket closed");
+  });
+
+  // ── stale state file: connect() itself rejects ────────────────────────────
+  //
+  // A state file left behind by a dead gateway points at a socket nothing is
+  // listening on. `runStatus` connects BEFORE it builds any document and the
+  // connect is outside `runStatusImpl`'s try/catch, so the rejection escapes the
+  // command entirely — `index.ts`'s top-level handler prints it to stderr and
+  // sets exit 1. There is no `running: false` document for this case, and these
+  // two tests exist to keep the docs from claiming otherwise again.
+
+  it("emits NO json at all and rejects when the state file is stale (connect fails)", async () => {
+    const connectError = new Error("connect ENOENT \\\\.\\pipe\\nimbus-gateway");
+    let called = false;
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 7 },
+      ipcClient: {
+        call: async (): Promise<never> => {
+          called = true;
+          throw new Error("unreachable: call() must never run after a failed connect");
+        },
+        connect: () => {
+          throw connectError;
+        },
+        disconnect: () => {},
+      },
+    });
+
+    await expect(runStatus(["--json"])).rejects.toThrow("connect ENOENT");
+    expect(called).toBe(false);
+    // Nothing on stdout — not a document, not a fragment, not a newline.
+    expect(out.stdout).toBe("");
+  });
+
+  it("fails identically without --json when the state file is stale", async () => {
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 7 },
+      ipcClient: {
+        call: async (): Promise<never> => {
+          throw new Error("unreachable");
+        },
+        connect: () => {
+          throw new Error("connect ECONNREFUSED");
+        },
+        disconnect: () => {},
+      },
+    });
+
+    await expect(runStatus([])).rejects.toThrow("connect ECONNREFUSED");
+    expect(out.stdout).toBe("");
+    // The human "state exists but IPC failed" line belongs to the ping-failure
+    // case, NOT to a stale state file — it is not printed here.
+    expect(out.stdout).not.toContain("state exists but IPC failed");
+  });
+
+  it("includes drift lines under --drift --json", async () => {
+    const ipc = createMockIpcClient([
+      { version: "2.0", uptime: 2000, drift: { lines: ["hint-a", "hint-b"] } },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 7 },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runStatus(["--drift", "--json"]);
+
+    expect(ipc.calls[0]).toEqual({ method: "gateway.ping", params: { includeDrift: true } });
+    expect(parseStdout().drift).toEqual({ lines: ["hint-a", "hint-b"] });
+  });
+
+  it("includes the diag snapshot under --verbose --json", async () => {
+    const ipc = createMockIpcClient([
+      { version: "2.0", uptime: 2000 },
+      {
+        connectorHealth: [{ connectorId: "slack", state: "healthy" }],
+        index: { totalItems: 20, queryLatencyP95Ms: 8 },
+      },
+    ]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 7 },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runStatus(["--verbose", "--json"]);
+
+    expect(ipc.calls[1]?.method).toBe("diag.snapshot");
+    const doc = parseStdout();
+    expect(doc.index).toEqual({ totalItems: 20, queryLatencyP95Ms: 8 });
+    expect(doc.connectorHealth).toEqual([{ connectorId: "slack", state: "healthy" }]);
+  });
+
+  it("leaves the human rendering untouched without --json", async () => {
+    const ipc = createMockIpcClient([{ version: "9.9", uptime: 1000 }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 42 },
+      ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runStatus([]);
+    expect(out.stdout).toContain("Gateway: running (pid 42)");
+    expect(() => JSON.parse(out.stdout)).toThrow();
   });
 });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -93,20 +93,120 @@ function printDriftHints(lines: string[]): void {
   }
 }
 
-export async function runStatusImpl(
+type GatewayPing = {
+  version: string;
+  uptime: number;
+  embeddingBackfill?: { done: number; total: number } | null;
+  agentLimits?: { maxAgentDepth: number; maxToolCallsPerSession: number };
+  drift?: { lines: string[] };
+};
+
+type GatewayState = { pid?: number; socketPath: string; logPath?: string };
+
+/**
+ * The `nimbus status --json` document. Every key is always present — absent data is `null`, never
+ * a missing key — so `jq '.version'` never has to guard for existence. `running` means "the state
+ * file exists AND `gateway.ping` answered".
+ *
+ * There are two distinct not-running cases and only ONE of them produces a document:
+ *
+ * - **No state file** — `running: false`, `error: null`, everything else `null`, exit `0`.
+ * - **Connected, but `gateway.ping` failed** — `running: false` with the IPC message in `error`,
+ *   the JSON form of the human "state exists but IPC failed" line. This is the narrow case of a
+ *   gateway that is listening but wedged, or one that dies mid-call.
+ *
+ * A **stale state file whose socket has no listener** is neither: `runStatus` connects before it
+ * ever reaches this shape, so the connect rejection (`ENOENT` on a Windows named pipe,
+ * `ECONNREFUSED` on a Unix socket) propagates out of the command to the top-level handler in
+ * `index.ts`, which writes it to stderr and sets exit `1`. Nothing is written to stdout — no
+ * partial document, no `running: false`. That is `--json` honouring the documented contract that a
+ * command which *fails* emits no JSON at all, and it is indistinguishable from what plain
+ * `nimbus status` does with the same stale file — zero stdout bytes, the same stderr line, exit `1`
+ * — because the connect sits outside {@link runStatusImpl}'s try/catch on both paths. Callers must
+ * check the exit code before parsing stdout. Pinned by the two stale-state-file tests in the
+ * `nimbus status --json` suite.
+ */
+export type StatusJson = {
+  running: boolean;
+  pid: number | null;
+  socketPath: string | null;
+  logPath: string | null;
+  version: string | null;
+  uptimeMs: number | null;
+  agentLimits: { maxAgentDepth: number; maxToolCallsPerSession: number } | null;
+  embeddingBackfill: { done: number; total: number } | null;
+  drift: { lines: string[] } | null;
+  index: unknown;
+  connectorHealth: unknown;
+  error: string | null;
+};
+
+function baseStatusJson(state?: GatewayState): StatusJson {
+  return {
+    running: false,
+    pid: state?.pid ?? null,
+    socketPath: state?.socketPath ?? null,
+    logPath: state?.logPath === undefined || state.logPath === "" ? null : state.logPath,
+    version: null,
+    uptimeMs: null,
+    agentLimits: null,
+    embeddingBackfill: null,
+    drift: null,
+    index: null,
+    connectorHealth: null,
+    error: null,
+  };
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function runStatusJson(
   client: IPCClient,
-  state: { pid?: number; socketPath: string; logPath?: string },
+  state: GatewayState,
   opts: { wantDrift: boolean; verbose: boolean },
 ): Promise<void> {
-  const { wantDrift, verbose } = opts;
+  const payload = baseStatusJson(state);
   try {
-    const ping = await client.call<{
-      version: string;
-      uptime: number;
-      embeddingBackfill?: { done: number; total: number } | null;
-      agentLimits?: { maxAgentDepth: number; maxToolCallsPerSession: number };
-      drift?: { lines: string[] };
-    }>("gateway.ping", wantDrift ? { includeDrift: true } : {});
+    const ping = await client.call<GatewayPing>(
+      "gateway.ping",
+      opts.wantDrift ? { includeDrift: true } : {},
+    );
+    payload.running = true;
+    payload.version = ping.version;
+    payload.uptimeMs = ping.uptime;
+    payload.agentLimits = ping.agentLimits ?? null;
+    payload.embeddingBackfill = ping.embeddingBackfill ?? null;
+    if (opts.verbose) {
+      const snap = await client.call<DiagSnapshot>("diag.snapshot", {});
+      payload.index = snap.index ?? null;
+      payload.connectorHealth = snap.connectorHealth ?? null;
+    }
+    if (opts.wantDrift && ping.drift !== undefined && Array.isArray(ping.drift.lines)) {
+      payload.drift = { lines: ping.drift.lines };
+    }
+  } catch (e) {
+    payload.error = e instanceof Error ? e.message : String(e);
+  }
+  printJson(payload);
+}
+
+export async function runStatusImpl(
+  client: IPCClient,
+  state: GatewayState,
+  opts: { wantDrift: boolean; verbose: boolean; json?: boolean },
+): Promise<void> {
+  const { wantDrift, verbose } = opts;
+  if (opts.json === true) {
+    await runStatusJson(client, state, { wantDrift, verbose });
+    return;
+  }
+  try {
+    const ping = await client.call<GatewayPing>(
+      "gateway.ping",
+      wantDrift ? { includeDrift: true } : {},
+    );
     console.log(`Gateway: running (pid ${String(state.pid)})`);
     console.log(`Version: ${ping.version}`);
     console.log(`Uptime:  ${String(Math.round(ping.uptime / 1000))}s`);
@@ -139,9 +239,14 @@ export async function runStatusImpl(
 }
 
 export async function runStatus(args: string[]): Promise<void> {
+  const json = args.includes("--json");
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) {
+    if (json) {
+      printJson(baseStatusJson());
+      return;
+    }
     console.log("Gateway: not running (no state file)");
     return;
   }
@@ -152,7 +257,7 @@ export async function runStatus(args: string[]): Promise<void> {
   const client = new IPCClient(state.socketPath);
   try {
     await client.connect();
-    await runStatusImpl(client, state, { wantDrift, verbose });
+    await runStatusImpl(client, state, { wantDrift, verbose, json });
   } finally {
     await client.disconnect().catch(() => {});
   }


### PR DESCRIPTION
Closes #998.

`--json` was documented on six commands and parsed by none — silently ignored, with human-readable output printed instead. A script piping `nimbus status --json` into `jq` got formatted text and failed confusingly.

Now implemented on **`status`**, **`connector list`**, **`db verify`**, **`db repair`**, **`config list`** and **`audit`**. Each emits parseable JSON on stdout with **nothing else on stdout**, verified end-to-end against a live gateway.

## A false claim, corrected

The first cut documented behaviour that a reviewer proved wrong in three places: `status.ts`'s `StatusJson` docblock and `docs/cli-reference.md` both claimed *"a stale state file whose socket no longer responds reports `running: false` with the IPC message in `error`"*. That isn't what happens. All three places now describe the behaviour actually established by experiment, pinned by two red-proved tests.

Behaviour was **documented, not changed** — `runStatus` is untouched. There's a defensible alternative (catch and report the IPC error rather than describing the current shape), but changing runtime behaviour belongs in its own PR, not one whose remit is making a documented flag real.

## Interaction with #1000

#1000 corrected 52 wrong doc claims, including adding *"`nimbus status` reads only `--verbose` and `--drift`; there is no JSON output mode"* — which this PR makes false. Rebased onto it and resolved by documenting the new support **on top of** #1000's corrected text. An independent reviewer confirmed **none of #1000's other corrections were reverted** in the process.

## Note on scope

This is an API commitment: the JSON shapes are now something consumers can depend on. The shapes follow the convention already used by `nimbus query --json` rather than inventing a new envelope. Tests assert the **parsed shape**, not string matches against formatted text.
