### PR TITLE
fix(cli): make nimbus connector remove work by answering the gateway HITL gate

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -955,7 +955,7 @@ nimbus connector remove github --yes    # Skip confirmation (-y also works)
 
 The CLI asks for confirmation before it sends `connector.remove`. Declining the prompt (or cancelling it with Ctrl-C) prints `Cancelled.` and sends nothing. Outside an interactive shell — piped, or run from a script — there is no prompt to answer, so the command refuses with a non-zero exit rather than waiting for input; pass `--yes` or `-y` to proceed non-interactively.
 
-`connector.remove` is also a HITL action on the Gateway side, so the Gateway asks the owner to approve it a second time over the IPC consent channel. `nimbus connector remove` does not currently answer that request, so the call times out after 30s and nothing is removed. Until that is fixed, use [`nimbus data delete --service <name>`](#nimbus-data-delete---service-name), which purges the same index rows and Vault credentials and does answer the consent prompt.
+`connector.remove` is also a HITL action on the Gateway side, but you are only asked once: the CLI confirmation *is* the consent decision, and the CLI answers the Gateway's consent request with it. A declined prompt never reaches the Gateway at all, and `--yes` covers both — the auto-approval is still noted on stderr (`[--yes] auto-approving HITL request: …`) so it shows up in a script's log. If the Gateway rejects the removal anyway (for example an org policy that forbids it), the command exits non-zero with the rejection reason and removes nothing.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -947,10 +947,15 @@ Output is always JSON.
 Remove a connector: deletes all associated Vault entries and index rows atomically.
 
 ```bash
-nimbus connector remove github
+nimbus connector remove github          # Prompts: y/n
+nimbus connector remove github --yes    # Skip confirmation (-y also works)
 ```
 
-> **Irreversible and unprompted.** There is no confirmation step and no `--yes` flag — the command sends `connector.remove` as soon as it is invoked, and prints the number of index rows deleted plus the Vault keys it cleared. Take a snapshot first (`nimbus db snapshot`) if you may want the index rows back.
+> **Irreversible.** On success the command prints the number of index rows deleted plus the Vault keys it cleared, and nothing restores them. Take a snapshot first (`nimbus db snapshot`) if you may want the index rows back.
+
+The CLI asks for confirmation before it sends `connector.remove`. Declining the prompt (or cancelling it with Ctrl-C) prints `Cancelled.` and sends nothing. Outside an interactive shell — piped, or run from a script — there is no prompt to answer, so the command refuses with a non-zero exit rather than waiting for input; pass `--yes` or `-y` to proceed non-interactively.
+
+`connector.remove` is also a HITL action on the Gateway side, so the Gateway asks the owner to approve it a second time over the IPC consent channel. `nimbus connector remove` does not currently answer that request, so the call times out after 30s and nothing is removed. Until that is fixed, use [`nimbus data delete --service <name>`](#nimbus-data-delete---service-name), which purges the same index rows and Vault credentials and does answer the consent prompt.
 
 ---
 

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -403,6 +403,78 @@ describe("runConnector remove", () => {
     Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
   }
 
+  type RecordedCall = { method: string; params: unknown };
+
+  /**
+   * A fake Gateway that behaves like the real one for a HITL-gated method: `connector.remove`
+   * does NOT resolve until the `consent.request` notification it pushes has been answered with
+   * `consent.respond`. That mirrors `ipc/consent.ts`, whose `requestConsent` has no timer at all
+   * — it settles only on a response or on client disconnect.
+   *
+   * This is the seam the old stub executors never exercised: a CLI client that registers no
+   * `consent.request` handler fails here loudly, instead of silently burning the client's 30s
+   * request timeout in production and removing nothing.
+   */
+  function makeConsentAwareIpc(removeResult: unknown): {
+    readonly calls: RecordedCall[];
+    readonly ipcClient: {
+      call: (method: string, params: unknown) => Promise<unknown>;
+      connect: () => void;
+      disconnect: () => void;
+      onNotification: (event: string, handler: (params: unknown) => void | Promise<void>) => void;
+    };
+  } {
+    const calls: RecordedCall[] = [];
+    let consentHandler: ((params: unknown) => void | Promise<void>) | undefined;
+    return {
+      calls,
+      ipcClient: {
+        connect: (): void => {},
+        disconnect: (): void => {},
+        onNotification: (event, handler): void => {
+          if (event === "consent.request") {
+            consentHandler = handler;
+          }
+        },
+        call: async (method, params): Promise<unknown> => {
+          calls.push({ method, params });
+          if (method === "consent.respond") {
+            return { ok: true };
+          }
+          if (method !== "connector.remove") {
+            throw new Error(`Unexpected IPC call: ${method}`);
+          }
+          if (consentHandler === undefined) {
+            throw new Error(
+              "gateway is blocked on consent.request: the CLI registered no consent.request handler",
+            );
+          }
+          await consentHandler({
+            requestId: "req-remove-1",
+            prompt: 'Approve connector.remove for "github"?',
+          });
+          return removeResult;
+        },
+      },
+    };
+  }
+
+  /** Capture raw `process.stderr.write` (the auto-approve notice bypasses `console.*`). */
+  async function withCapturedStderr(fn: () => Promise<void>): Promise<string> {
+    let buf = "";
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown): boolean => {
+      buf += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await fn();
+    } finally {
+      process.stderr.write = orig;
+    }
+    return buf;
+  }
+
   beforeEach(() => {
     out.reset();
     setTty(false);
@@ -542,6 +614,67 @@ describe("runConnector remove", () => {
     await runConnector(["remove", "github"]);
     expect(ipc.calls).toHaveLength(0);
     expect(out.stdout).toContain("Cancelled.");
+  });
+
+  it("answers the Gateway's HITL consent gate so --yes actually removes", async () => {
+    const gw = makeConsentAwareIpc({
+      ok: true,
+      itemsDeleted: 7,
+      vaultKeysRemoved: ["github.pat"],
+    });
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: gw.ipcClient,
+    });
+    const stderr = await withCapturedStderr(() => runConnector(["remove", "github", "--yes"]));
+    expect(gw.calls).toEqual([
+      { method: "connector.remove", params: { serviceId: "github" } },
+      { method: "consent.respond", params: { requestId: "req-remove-1", approved: true } },
+    ]);
+    expect(stderr).toContain("[--yes] auto-approving HITL request");
+    expect(out.stdout).toContain("Removed index rows: 7");
+  });
+
+  it("answers the Gateway's consent gate with the interactive decision, prompting once", async () => {
+    setTty(true);
+    const gw = makeConsentAwareIpc({ ok: true, itemsDeleted: 4, vaultKeysRemoved: [] });
+    let promptCount = 0;
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      // Getter, so every `confirm()` the mocked @clack/prompts serves is counted: the
+      // Gateway gate must be answered from THIS decision, not by asking the user again.
+      get clackAnswer(): boolean {
+        promptCount += 1;
+        return true;
+      },
+      ipcClient: gw.ipcClient,
+    });
+    const stderr = await withCapturedStderr(() => runConnector(["remove", "github"]));
+    expect(promptCount).toBe(1);
+    expect(gw.calls).toEqual([
+      { method: "connector.remove", params: { serviceId: "github" } },
+      { method: "consent.respond", params: { requestId: "req-remove-1", approved: true } },
+    ]);
+    expect(stderr).toContain("[confirmed] auto-approving HITL request");
+    expect(out.stdout).toContain("Removed index rows: 4");
+  });
+
+  it("fails loudly when the Gateway gate rejects instead of printing an undefined count", async () => {
+    const gw = makeConsentAwareIpc({ status: "rejected", reason: "User declined consent gate." });
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: gw.ipcClient,
+    });
+    let err: unknown;
+    const stderr = await withCapturedStderr(async () => {
+      await runConnector(["remove", "github", "--yes"]).catch((e: unknown) => {
+        err = e;
+      });
+    });
+    expect(stderr).toContain("auto-approving HITL request");
+    expect((err as Error).message).toContain('Gateway rejected the removal of "github"');
+    expect((err as Error).message).toContain("User declined consent gate.");
+    expect(out.stdout).not.toContain("Removed index rows:");
   });
 
   it("remove throws when service is missing", async () => {

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -2,7 +2,12 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test"
 import os from "node:os";
 import path from "node:path";
 
-import { clearFixture, FAKE_SOCKET_PATH, setFixture } from "../../test/helpers/cli-mocks.ts";
+import {
+  CLACK_CANCEL,
+  clearFixture,
+  FAKE_SOCKET_PATH,
+  setFixture,
+} from "../../test/helpers/cli-mocks.ts";
 import { captureOutput } from "../../test/helpers/cli-output.ts";
 import { createMockIpcClient } from "../../test/helpers/mock-ipc-client.ts";
 
@@ -387,14 +392,36 @@ describe("runConnector reindex", () => {
 });
 
 describe("runConnector remove", () => {
+  // `connector remove` is irreversible, so it prompts unless --yes. The prompt is only
+  // offered on an interactive shell (stdin AND stdout are TTYs, as in src/index.ts), so
+  // these tests drive both descriptors and restore them afterwards.
+  const origStdinTty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+  const origStdoutTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+  function setTty(value: boolean): void {
+    Object.defineProperty(process.stdin, "isTTY", { value, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
+  }
+
   beforeEach(() => {
     out.reset();
+    setTty(false);
   });
   afterEach(() => {
     clearFixture();
+    if (origStdinTty === undefined) {
+      delete (process.stdin as unknown as { isTTY?: boolean }).isTTY;
+    } else {
+      Object.defineProperty(process.stdin, "isTTY", origStdinTty);
+    }
+    if (origStdoutTty === undefined) {
+      delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+    } else {
+      Object.defineProperty(process.stdout, "isTTY", origStdoutTty);
+    }
   });
 
-  it("dispatches connector.remove and prints summary", async () => {
+  it("dispatches connector.remove and prints summary with --yes", async () => {
     const ipc = createMockIpcClient([
       { ok: true, itemsDeleted: 12, vaultKeysRemoved: ["github.pat"] },
     ]);
@@ -406,13 +433,30 @@ describe("runConnector remove", () => {
         disconnect: () => {},
       },
     });
-    await runConnector(["remove", "github"]);
+    await runConnector(["remove", "github", "--yes"]);
     expect(ipc.calls[0]).toEqual({
       method: "connector.remove",
       params: { serviceId: "github" },
     });
     expect(out.stdout).toContain("Removed index rows: 12");
     expect(out.stdout).toContain("github.pat");
+  });
+
+  it("accepts the -y short flag before the service name", async () => {
+    const ipc = createMockIpcClient([{ ok: true, itemsDeleted: 1, vaultKeysRemoved: [] }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["remove", "-y", "github"]);
+    expect(ipc.calls[0]).toEqual({
+      method: "connector.remove",
+      params: { serviceId: "github" },
+    });
   });
 
   it("omits the vault-keys line when none were removed", async () => {
@@ -425,14 +469,91 @@ describe("runConnector remove", () => {
         disconnect: () => {},
       },
     });
-    await runConnector(["remove", "github"]);
+    await runConnector(["remove", "github", "--yes"]);
     expect(out.stdout).toContain("Removed index rows: 0");
     expect(out.stdout).not.toContain("Cleared vault keys:");
+  });
+
+  it("refuses without --yes when there is no TTY to prompt on", async () => {
+    const ipc = createMockIpcClient([]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await expect(runConnector(["remove", "github"])).rejects.toThrow(
+      "Refusing to remove without confirmation in non-TTY mode. Pass --yes to proceed.",
+    );
+    expect(ipc.calls).toHaveLength(0);
+  });
+
+  it("dispatches when the interactive confirmation is accepted", async () => {
+    setTty(true);
+    const ipc = createMockIpcClient([{ ok: true, itemsDeleted: 3, vaultKeysRemoved: [] }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: true,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["remove", "github"]);
+    expect(ipc.calls[0]).toEqual({
+      method: "connector.remove",
+      params: { serviceId: "github" },
+    });
+    expect(out.stdout).toContain("Removed index rows: 3");
+  });
+
+  it("aborts without dispatching when the confirmation is declined", async () => {
+    setTty(true);
+    const ipc = createMockIpcClient([]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: false,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["remove", "github"]);
+    expect(ipc.calls).toHaveLength(0);
+    expect(out.stdout).toContain("Cancelled.");
+  });
+
+  it("aborts without dispatching when the prompt is cancelled (Ctrl-C)", async () => {
+    setTty(true);
+    const ipc = createMockIpcClient([]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: CLACK_CANCEL,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["remove", "github"]);
+    expect(ipc.calls).toHaveLength(0);
+    expect(out.stdout).toContain("Cancelled.");
   });
 
   it("remove throws when service is missing", async () => {
     setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH } });
     await expect(runConnector(["remove"])).rejects.toThrow("Usage: nimbus connector remove");
+  });
+
+  it("remove throws when only the --yes flag is given", async () => {
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH } });
+    await expect(runConnector(["remove", "--yes"])).rejects.toThrow(
+      "Usage: nimbus connector remove",
+    );
   });
 });
 

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -10,6 +10,7 @@ import {
   SLACK_OAUTH_CLIENT_ID_HELP,
 } from "../lib/connector-oauth-env-help.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
+import { registerAutoApproveConsentHandler } from "../lib/interactive-ipc-handlers.ts";
 import { parseDurationToMs } from "../lib/parse-duration.ts";
 import { stripTrailingSlashes } from "../lib/strip-trailing-slashes.ts";
 import { getCliPlatformPaths } from "../paths.ts";
@@ -68,7 +69,18 @@ type ConnectorFlags = {
   datadogSite?: string;
 };
 
-async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
+/**
+ * Connect to the Gateway, run `fn`, disconnect.
+ *
+ * `onConnect` runs after `connect()` and before `fn`, and is the seam for registering
+ * notification handlers on the freshly built client. Anything that calls a HITL-gated
+ * method MUST use it to register a `consent.request` handler — the Gateway blocks on
+ * `consent.respond` and a client that never answers just times out.
+ */
+async function withIpc<T>(
+  fn: (c: IPCClient) => Promise<T>,
+  onConnect?: (c: IPCClient) => void,
+): Promise<T> {
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) {
@@ -76,6 +88,7 @@ async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
   }
   const client = new IPCClient(state.socketPath);
   await client.connect();
+  onConnect?.(client);
   try {
     return await fn(client);
   } finally {
@@ -1078,18 +1091,39 @@ async function runConnectorAddMcp(tail: string[]): Promise<void> {
 
 const REMOVE_YES_FLAGS: ReadonlySet<string> = new Set(["--yes", "-y"]);
 
+type ConnectorRemoveResult = {
+  ok: boolean;
+  itemsDeleted: number;
+  vaultKeysRemoved: string[];
+};
+
+/**
+ * Shape the Gateway returns instead of {@link ConnectorRemoveResult} when the executor's HITL
+ * gate rejects the action (`{ kind: "hit", value: { status: "rejected", reason } }` in
+ * `ipc/connector-rpc.ts`). Detecting it keeps a declined removal from printing
+ * `Removed index rows: undefined` and exiting 0.
+ */
+type ConnectorRemoveRejection = { status: "rejected"; reason?: string };
+
+function isConnectorRemoveRejection(r: unknown): r is ConnectorRemoveRejection {
+  return typeof r === "object" && r !== null && (r as { status?: unknown }).status === "rejected";
+}
+
 /**
  * `nimbus connector remove` is irreversible (Vault entries + index rows are deleted
  * atomically), so it is gated the same way `nimbus extension remove` is: an interactive
  * confirmation, `--yes`/`-y` to skip it for scripts, and a fail-closed refusal rather
  * than a hanging prompt when there is no TTY to prompt on.
  *
- * This is NOT redundant with the Gateway-side HITL gate. `connector.remove` is in the
- * executor's frozen HITL set, so the Gateway pushes a `consent.request` notification and
- * blocks until a `consent.respond` arrives — but `withIpc` above builds a bare `IPCClient`
- * with no consent handler registered (unlike `data.ts`, which calls
- * `selectConsentHandler`), so nothing ever answers and the call dies on the client's 30s
- * request timeout. Until that is wired, this prompt is the only confirmation the user sees.
+ * `connector.remove` is ALSO in the executor's frozen HITL set, so the Gateway pushes a
+ * `consent.request` notification and blocks until `consent.respond` arrives. The two
+ * confirmations are composed, not stacked: this CLI prompt is the single point of consent,
+ * and the decision it produces is what answers the Gateway. A declined prompt returns before
+ * any IPC connection is made, so the Gateway never sees the request at all; an accepted
+ * prompt (or `--yes`) registers an auto-approve `consent.request` handler on the client that
+ * `withIpc` builds, so the gate is answered programmatically with the decision the user
+ * already gave. Without that handler nothing would ever answer and the call would die on the
+ * client's 30s request timeout, removing nothing.
  */
 async function runConnectorRemove(tail: string[]): Promise<void> {
   const accept = tail.some((a) => REMOVE_YES_FLAGS.has(a));
@@ -1112,11 +1146,20 @@ async function runConnectorRemove(tail: string[]): Promise<void> {
       return;
     }
   }
-  const res = await withIpc((c) =>
-    c.call<{ ok: boolean; itemsDeleted: number; vaultKeysRemoved: string[] }>("connector.remove", {
-      serviceId: service,
-    }),
+  const res = await withIpc(
+    (c) =>
+      c.call<ConnectorRemoveResult | ConnectorRemoveRejection>("connector.remove", {
+        serviceId: service,
+      }),
+    (c) => {
+      registerAutoApproveConsentHandler(c, accept ? "--yes" : "confirmed");
+    },
   );
+  if (isConnectorRemoveRejection(res)) {
+    throw new Error(
+      `Gateway rejected the removal of "${service}": ${res.reason ?? "no reason given"}`,
+    );
+  }
   console.log(`Removed index rows: ${String(res.itemsDeleted)}`);
   if (res.vaultKeysRemoved.length > 0) {
     console.log(`Cleared vault keys: ${res.vaultKeysRemoved.join(", ")}`);

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -1,3 +1,5 @@
+import { confirm, isCancel } from "@clack/prompts";
+
 import { IPCClient } from "../ipc-client/index.ts";
 import {
   GOOGLE_OAUTH_CLIENT_ID_HELP,
@@ -1074,10 +1076,41 @@ async function runConnectorAddMcp(tail: string[]): Promise<void> {
   console.log(`Registered user MCP connector: ${id}`);
 }
 
+const REMOVE_YES_FLAGS: ReadonlySet<string> = new Set(["--yes", "-y"]);
+
+/**
+ * `nimbus connector remove` is irreversible (Vault entries + index rows are deleted
+ * atomically), so it is gated the same way `nimbus extension remove` is: an interactive
+ * confirmation, `--yes`/`-y` to skip it for scripts, and a fail-closed refusal rather
+ * than a hanging prompt when there is no TTY to prompt on.
+ *
+ * This is NOT redundant with the Gateway-side HITL gate. `connector.remove` is in the
+ * executor's frozen HITL set, so the Gateway pushes a `consent.request` notification and
+ * blocks until a `consent.respond` arrives — but `withIpc` above builds a bare `IPCClient`
+ * with no consent handler registered (unlike `data.ts`, which calls
+ * `selectConsentHandler`), so nothing ever answers and the call dies on the client's 30s
+ * request timeout. Until that is wired, this prompt is the only confirmation the user sees.
+ */
 async function runConnectorRemove(tail: string[]): Promise<void> {
-  const service = tail[0];
+  const accept = tail.some((a) => REMOVE_YES_FLAGS.has(a));
+  const service = tail.find((a) => !REMOVE_YES_FLAGS.has(a));
   if (service === undefined) {
-    throw new Error("Usage: nimbus connector remove <service>");
+    throw new Error("Usage: nimbus connector remove <service> [--yes]");
+  }
+  if (!accept) {
+    const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
+    if (!interactive) {
+      throw new Error(
+        "Refusing to remove without confirmation in non-TTY mode. Pass --yes to proceed.",
+      );
+    }
+    const ok = await confirm({
+      message: `Remove connector "${service}"? This deletes its Vault credentials and index rows. This cannot be undone.`,
+    });
+    if (isCancel(ok) || ok !== true) {
+      console.log("Cancelled.");
+      return;
+    }
   }
   const res = await withIpc((c) =>
     c.call<{ ok: boolean; itemsDeleted: number; vaultKeysRemoved: string[] }>("connector.remove", {
@@ -1198,7 +1231,7 @@ Usage:
   nimbus connector pause <service>
   nimbus connector resume <service>
   nimbus connector set-interval <service> <duration>
-  nimbus connector remove <service>
+  nimbus connector remove <service> [--yes]         Irreversible; prompts unless --yes
 
 Services (examples): google_drive, gmail, google_photos, onedrive, outlook, teams, github, gitlab, linear, jira, notion, confluence, jenkins, circleci, pagerduty, kubernetes
 

--- a/packages/cli/src/lib/interactive-ipc-handlers.test.ts
+++ b/packages/cli/src/lib/interactive-ipc-handlers.test.ts
@@ -303,6 +303,28 @@ describe("registerAutoApproveConsentHandler — prompt fallback branches", () =>
     expect(warning).not.toContain("prompt: ");
   });
 
+  test("echoes a caller-supplied source label instead of the --yes default", async () => {
+    const { client, fireConsent, calls } = makeFakeClient();
+    registerAutoApproveConsentHandler(client, "confirmed");
+
+    let warning = "";
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown) => {
+      warning += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await fireConsent({ requestId: "req-labelled", prompt: "Remove connector?" });
+    } finally {
+      process.stderr.write = origErr;
+    }
+    expect(warning).toContain("[confirmed] auto-approving HITL request: Remove connector?");
+    expect(warning).not.toContain("[--yes]");
+    expect(calls).toEqual([
+      { method: "consent.respond", params: { requestId: "req-labelled", approved: true } },
+    ]);
+  });
+
   test("uses requestId as detail when prompt field is absent", async () => {
     const { client, fireConsent } = makeFakeClient();
     registerAutoApproveConsentHandler(client);

--- a/packages/cli/src/lib/interactive-ipc-handlers.ts
+++ b/packages/cli/src/lib/interactive-ipc-handlers.ts
@@ -34,14 +34,25 @@ export function registerConsentPromptHandler(
   });
 }
 
-export function registerAutoApproveConsentHandler(client: IPCClient): void {
+/**
+ * Answer the Gateway's HITL `consent.request` with an approval the caller has ALREADY obtained
+ * from the user, so the same removal/export is never confirmed twice.
+ *
+ * `sourceLabel` names where that approval came from and is echoed on stderr so the transcript
+ * still shows an auto-approval happened: `--yes` (the default) for a flag-driven run, or e.g.
+ * `confirmed` when an interactive CLI-side prompt already asked the same question. Registering
+ * this handler on a client is what turns an otherwise-hanging HITL call into a completed one —
+ * without a `consent.request` handler the Gateway's gate never receives `consent.respond` and
+ * the request dies on the client's 30s timeout.
+ */
+export function registerAutoApproveConsentHandler(client: IPCClient, sourceLabel = "--yes"): void {
   client.onNotification("consent.request", async (params: unknown) => {
     const p = params as { requestId?: string; prompt?: string };
     if (typeof p.requestId !== "string") {
       return;
     }
     const detail = typeof p.prompt === "string" && p.prompt.length > 0 ? p.prompt : p.requestId;
-    process.stderr.write(`[--yes] auto-approving HITL request: ${detail}\n`);
+    process.stderr.write(`[${sourceLabel}] auto-approving HITL request: ${detail}\n`);
     await client.call("consent.respond", {
       requestId: p.requestId,
       approved: true,


### PR DESCRIPTION
Closes #997 — but the issue understated the problem. **`nimbus connector remove` has never worked.**

## What was actually wrong

I filed #997 saying the command lacked a confirmation prompt. Investigating it found something worse: the command cannot complete at all.

1. `connector.remove` **is** in the HITL frozen set (`engine/executor.ts:100`), and `ipc/connector-rpc.ts` gates it via `toolExecutor.gate()`
2. `ipc/server/dispatchers.ts` **always** builds the `ToolExecutor` with a real consent channel — so no bypass and no auto-approve *(an invariant concern was ruled out)*
3. The gate emits a `consent.request` **notification**, and `ConsentCoordinatorImpl.requestConsent` has **no timer** — it settles only on `consent.respond` or on client disconnect
4. But `withIpc` in `connector.ts` built a bare `IPCClient` and registered **no notification handler**, and there is no global one
5. `@nimbus-dev/client` silently **drops** a notification nobody handles, and `call()` times out at 30s

**Net effect: gate blocks → 30s timeout → disconnect → gateway rejects the consent → audit records `hitlStatus:"rejected"` and a `blocked` egress row → nothing is removed.** Reproduced in-process: one `consent.request` emitted, still unsettled after 1500ms with `pendingCount()===1`, settling only on disconnect.

It survived because `connector-rpc-routing.test.ts` uses stub executors that resolve instantly, so **no test ever exercised a real consent round trip.**

## The fix

`withIpc` gains an `onConnect` seam for registering notification handlers, documented as **mandatory for any HITL-gated method**. `runConnectorRemove` uses it to answer the gateway with the decision the CLI prompt already produced.

The two confirmations are **composed, not stacked**: the CLI prompt is the single point of consent, a declined prompt returns *before any IPC connection exists*, and `--yes` covers both gates so it means one thing to the user.

## A second bug found on the way

A gateway-side rejection returns `{status:"rejected", reason}`. The CLI didn't recognise that shape and printed **`Removed index rows: undefined`** then **exited 0** — reporting success for a denied removal. It now throws with the reason.

## Tests that would have caught this

Three new CLI tests drive a **real consent round trip** against a fake gateway whose `connector.remove` does not resolve until the `consent.request` it pushed has been answered — mirroring `ipc/consent.ts`'s no-timer contract. Dependency injection via the existing fixture seam, no `mock.module` (which leaks process-globally and breaks the combined CLI run on CI Linux).

Red-proved:
- remove the registration → `gateway is blocked on consent.request: the CLI registered no consent.request handler`
- swap auto-approve for a prompt handler → `expect(promptCount).toBe(1)` fails with `Received: 2`, pinning the no-double-prompt property

## Notes

Docs updated to describe the working behaviour; the earlier paragraph claiming the command times out is gone, resolving the contradiction with three other places that already recommend `nimbus connector remove` for connector cleanup.

`bun test packages/cli/src` shows 8 pre-existing Ink/TUI flakes on the dev box (`App.test.tsx`, `dumb-terminal`, `query-history`, `QueryInput`) — reproduced in isolation with none of the touched files loaded. CI Linux is authoritative.
