### PR TITLE
ci(release): create brew/scoop publish commits via createCommitOnBranch and assert they are verified

### DIFF
--- a/.github/workflows/publish-linux-repo.yml
+++ b/.github/workflows/publish-linux-repo.yml
@@ -194,6 +194,20 @@ jobs:
           # Disable Jekyll so Pages serves the apt/yum trees verbatim.
           touch repo/.nojekyll
 
+      # DELIBERATELY still `git commit` + `git push`, unlike the brew/scoop publisher.
+      #
+      # Those two moved to the GraphQL `createCommitOnBranch` mutation so their
+      # commits come out Verified (see publish-package-managers.yml). That mutation
+      # sends the ENTIRE commit as one base64 JSON request body, which is fine for a
+      # 1 KB formula and unworkable here: every publish adds a fresh .deb AND .rpm —
+      # each bundling both Bun-compiled binaries — plus regenerated apt/yum metadata,
+      # and base64 inflates that by a further ~4/3. It would fail at the API's request
+      # ceiling, not at anything we could tune.
+      #
+      # CONSEQUENCE FOR THE RULESET WORK: commits here stay unsigned, so
+      # `required_signatures` must NOT be added to the linux-repo ruleset — it would
+      # break the next apt/yum publish outright. Making these Verified needs a
+      # different mechanism (e.g. bot-side commit signing), tracked separately.
       - name: Commit + push to linux-repo
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -115,6 +115,14 @@ jobs:
       # to these repos' rulesets — a separate, later change. Enabling the ruleset
       # before this publisher moved would break the next publish.
       #
+      # SELF-PROVING: the helper does not assume the commit came out signed, it
+      # ASKS. The mutation selects the created commit's
+      # `signature { isValid state wasSignedByGitHub }` and the step FAILS (non-zero,
+      # with an ::error:: annotation) unless GitHub answers isValid:true + state:VALID
+      # — a null signature, which is exactly what an unsigned commit returns, is a
+      # failure, not a warning. So a green run here is evidence, not a hope, and
+      # that is the property the later `required_signatures` step depends on.
+      #
       # What is published is unchanged (the same generated manifest bytes); only the
       # commit mechanism differs. The helper is a no-op when the manifest already
       # matches (it compares git blob oids), replacing the old `git diff --cached`

--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -101,44 +101,45 @@ jobs:
           echo "--- nimbus.rb ---"; cat out/nimbus.rb
           echo "--- nimbus.json ---"; cat out/nimbus.json
 
-      - name: Publish to homebrew-tap
+      # SIGNED commits, not `git clone` + `git push`.
+      #
+      # A commit pushed over HTTPS with an App installation token is UNSIGNED
+      # (`verification.verified = false`) — indistinguishable from one an attacker
+      # holding a leaked token would produce. homebrew-tap and scoop-bucket are what
+      # `brew install` and `scoop install` read, so that is the shortest path from a
+      # stolen token to code on a user's machine.
+      #
+      # The GraphQL `createCommitOnBranch` mutation moves commit construction
+      # server-side: GitHub builds the tree, writes the commit and signs it, so the
+      # result is Verified. That is the PREREQUISITE for adding `required_signatures`
+      # to these repos' rulesets — a separate, later change. Enabling the ruleset
+      # before this publisher moved would break the next publish.
+      #
+      # What is published is unchanged (the same generated manifest bytes); only the
+      # commit mechanism differs. The helper is a no-op when the manifest already
+      # matches (it compares git blob oids), replacing the old `git diff --cached`
+      # check, and it re-reads + rebuilds rather than forcing if the branch moved.
+      - name: Publish to homebrew-tap (signed commit)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
-          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/nimbus-agent/homebrew-tap.git" tap
-          mkdir -p tap/Formula
-          cp out/nimbus.rb tap/Formula/nimbus.rb
-          cd tap
-          git config user.name "nimbus-release-bot"
-          git config user.email "release-bot@nimbus-agent.invalid"
-          # Stage first: on the first publish Formula/nimbus.rb is untracked, and
-          # `git diff` ignores untracked files — staging then diffing --cached makes
-          # the no-op check see new files too, so first-time publication isn't skipped.
-          git add Formula/nimbus.rb
-          if git diff --cached --quiet; then echo "no formula change"; exit 0; fi
-          git commit -m "nimbus ${TAG#v}"
-          git push
+          bun scripts/release/signed-commit.ts \
+            --repo nimbus-agent/homebrew-tap \
+            --message "nimbus ${TAG#v}" \
+            --add "Formula/nimbus.rb=out/nimbus.rb"
 
-      - name: Publish to scoop-bucket
+      - name: Publish to scoop-bucket (signed commit)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
-          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/nimbus-agent/scoop-bucket.git" bucket
-          mkdir -p bucket/bucket
-          cp out/nimbus.json bucket/bucket/nimbus.json
-          cd bucket
-          git config user.name "nimbus-release-bot"
-          git config user.email "release-bot@nimbus-agent.invalid"
-          # Stage first (see homebrew-tap step): untracked bucket/nimbus.json would
-          # otherwise be invisible to `git diff` and skip the first publication.
-          git add bucket/nimbus.json
-          if git diff --cached --quiet; then echo "no manifest change"; exit 0; fi
-          git commit -m "nimbus ${TAG#v}"
-          git push
+          bun scripts/release/signed-commit.ts \
+            --repo nimbus-agent/scoop-bucket \
+            --message "nimbus ${TAG#v}" \
+            --add "bucket/nimbus.json=out/nimbus.json"
 
   winget:
     name: Submit winget manifest PR

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -242,6 +242,17 @@ holding a leaked token would produce, on the exact repos `brew install` and
 commit server-side, so it lands **Verified**, which is the prerequisite for
 adding `required_signatures` to those two repos' rulesets.
 
+The publish **asserts** that rather than assuming it: the mutation selects the
+created commit's `signature { isValid state wasSignedByGitHub }`, and the step
+fails (non-zero, with an `::error::` annotation) unless GitHub answers
+`isValid: true` + `state: VALID`. A null signature — what GitHub returns for an
+unsigned commit — is a failure, not a shrug. So "the last publish was green"
+means "the last publish produced a Verified commit", which is exactly the
+precondition `required_signatures` needs. **Do not enable
+`required_signatures` on these two rulesets until a real release has run this
+step green**; the assertion proves the mechanism, but only an actual publish
+proves it against the live API.
+
 `publish-linux-repo.yml` deliberately still uses `git push`: the mutation
 carries the whole commit as one base64 request body, which cannot fit a
 `.deb` + `.rpm` publish. **Do not add `required_signatures` to the

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -227,11 +227,25 @@ Seven secrets feed the per-arch `.pkg` build/sign/notarize step:
 
 ### Homebrew tap + Scoop bucket — Nimbus Release Bot
 
-Pushes the updated formula/manifest to `nimbus-agent/homebrew-tap` and
+Publishes the updated formula/manifest to `nimbus-agent/homebrew-tap` and
 `nimbus-agent/scoop-bucket`. Both repos are installed targets of the Nimbus
 Release Bot App (see above); the job mints a token scoped to both with
 `Contents: Read and write` and uses it in place of the retired
 `PACKAGE_MANAGER_PAT`.
+
+Those two commits are created through the GraphQL `createCommitOnBranch`
+mutation (`scripts/release/signed-commit.ts`), **not** `git push`. A commit
+pushed with an App installation token is unsigned
+(`verification.verified = false`) — indistinguishable from one an attacker
+holding a leaked token would produce, on the exact repos `brew install` and
+`scoop install` read. `createCommitOnBranch` has GitHub build and sign the
+commit server-side, so it lands **Verified**, which is the prerequisite for
+adding `required_signatures` to those two repos' rulesets.
+
+`publish-linux-repo.yml` deliberately still uses `git push`: the mutation
+carries the whole commit as one base64 request body, which cannot fit a
+`.deb` + `.rpm` publish. **Do not add `required_signatures` to the
+`linux-repo` ruleset** — it would break the next apt/yum publish.
 
 ### `WINGET_PAT` — winget submission — **stays a classic PAT, on purpose**
 

--- a/scripts/release/signed-commit.test.ts
+++ b/scripts/release/signed-commit.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  assertCommitVerified,
   assertPayloadWithinLimit,
   buildBlobQuery,
   buildCommitInput,
+  CREATE_COMMIT_MUTATION,
   classifyMutationResult,
   createGraphQLClient,
   type DesiredFile,
@@ -20,10 +22,22 @@ import {
   planFileChanges,
   publishSignedCommit,
   qualifyBranch,
+  readCommitVerification,
   toRepoPath,
 } from "./signed-commit.ts";
 
 const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/**
+ * The signature block GitHub returns for a commit IT built and signed, copied
+ * from a live `gh api graphql` read of a real createCommitOnBranch commit.
+ */
+const GITHUB_SIGNED = { isValid: true, state: "VALID", wasSignedByGitHub: true } as const;
+
+/** A successful mutation response whose commit is properly signed. */
+const signedCommitResponse = (oid: string): GraphQLResponse => ({
+  data: { createCommitOnBranch: { commit: { oid, url: "u", signature: GITHUB_SIGNED } } },
+});
 
 /** Blob oids verified against `git hash-object --stdin` on a real git. */
 const OID_EMPTY = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
@@ -179,11 +193,20 @@ describe("isStaleHeadError / classifyMutationResult", () => {
     expect(isStaleHeadError([{ message: "Resource not accessible by integration" }])).toBe(false);
   });
 
-  test("classifies a successful mutation as ok with the commit oid", () => {
-    const res: GraphQLResponse = {
-      data: { createCommitOnBranch: { commit: { oid: "deadbeef", url: "u" } } },
-    };
-    expect(classifyMutationResult(res)).toEqual({ kind: "ok", oid: "deadbeef" });
+  test("classifies a successful mutation as ok with the commit oid + signature verdict", () => {
+    const out = classifyMutationResult(signedCommitResponse("deadbeef"));
+    expect(out.kind).toBe("ok");
+    expect(out).toMatchObject({ kind: "ok", oid: "deadbeef", verification: { verified: true } });
+  });
+
+  test("still reports ok (a commit exists) when it is unsigned — the verdict rides along", () => {
+    // Separation of concerns: classify answers "did a commit happen?", the
+    // verification gate answers "is it acceptable?". Conflating them would make
+    // an unsigned commit look like a retryable API failure.
+    const out = classifyMutationResult({
+      data: { createCommitOnBranch: { commit: { oid: "abc", signature: null } } },
+    });
+    expect(out).toMatchObject({ kind: "ok", oid: "abc", verification: { verified: false } });
   });
   test("classifies a stale-head failure as retryable", () => {
     const out = classifyMutationResult({ errors: [{ message: "x", type: "STALE_DATA" }] });
@@ -197,6 +220,119 @@ describe("isStaleHeadError / classifyMutationResult", () => {
   });
   test("classifies a missing commit oid as fatal rather than silently succeeding", () => {
     expect(classifyMutationResult({ data: { createCommitOnBranch: null } }).kind).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signature verification. The whole point of createCommitOnBranch is that the
+// commit comes out GitHub-Verified; these are the tests that make the workflow
+// assert that rather than assume it.
+// ---------------------------------------------------------------------------
+
+describe("CREATE_COMMIT_MUTATION", () => {
+  test("requests the signature fields the assertion reads", () => {
+    // Drift guard: dropping any of these from the document would make every
+    // response look like the "missing field" case forever.
+    expect(CREATE_COMMIT_MUTATION).toContain("signature{");
+    expect(CREATE_COMMIT_MUTATION).toContain("isValid");
+    expect(CREATE_COMMIT_MUTATION).toContain("state");
+    expect(CREATE_COMMIT_MUTATION).toContain("wasSignedByGitHub");
+  });
+});
+
+describe("readCommitVerification", () => {
+  const wrap = (commit: unknown): unknown => ({ createCommitOnBranch: { commit } });
+
+  test("verified: the exact shape GitHub returns for a commit it signed", () => {
+    const v = readCommitVerification(wrap({ oid: "abc", signature: GITHUB_SIGNED }));
+    expect(v.verified).toBe(true);
+    expect(v.state).toBe("VALID");
+    expect(v.isValid).toBe(true);
+    expect(v.wasSignedByGitHub).toBe(true);
+  });
+
+  test("null signature is UNVERIFIED — this is what a runner-pushed commit returns", () => {
+    // Read live from an existing unsigned nimbus-agent/homebrew-tap commit:
+    // `signature` comes back literally null. Treating null as "no data, assume
+    // fine" would defeat the entire change.
+    const v = readCommitVerification(wrap({ oid: "abc", signature: null }));
+    expect(v.verified).toBe(false);
+    expect(v.detail).toContain("UNSIGNED");
+  });
+
+  test("a MISSING signature field is unverified, and says the selection set drifted", () => {
+    const v = readCommitVerification(wrap({ oid: "abc" }));
+    expect(v.verified).toBe(false);
+    expect(v.detail).toContain("CREATE_COMMIT_MUTATION");
+  });
+
+  test("isValid:false is unverified even when a signature object exists", () => {
+    const v = readCommitVerification(
+      wrap({ oid: "abc", signature: { isValid: false, state: "VALID", wasSignedByGitHub: true } }),
+    );
+    expect(v.verified).toBe(false);
+  });
+
+  test("a non-VALID GitSignatureState is unverified", () => {
+    for (const state of ["UNSIGNED", "INVALID", "UNKNOWN_KEY", "EXPIRED_KEY", "BAD_CERT"]) {
+      const v = readCommitVerification(
+        wrap({ oid: "abc", signature: { isValid: true, state, wasSignedByGitHub: true } }),
+      );
+      expect(v.verified).toBe(false);
+      expect(v.state).toBe(state);
+    }
+  });
+
+  test("does not gate on wasSignedByGitHub (it reports which key, not validity)", () => {
+    const v = readCommitVerification(
+      wrap({ oid: "abc", signature: { isValid: true, state: "VALID", wasSignedByGitHub: false } }),
+    );
+    expect(v.verified).toBe(true);
+    expect(v.wasSignedByGitHub).toBe(false);
+  });
+
+  test("wrong-typed fields read as missing rather than being coerced true", () => {
+    const v = readCommitVerification(
+      wrap({ oid: "abc", signature: { isValid: "true", state: 1, wasSignedByGitHub: "yes" } }),
+    );
+    expect(v.verified).toBe(false);
+    expect(v.isValid).toBeNull();
+    expect(v.state).toBeNull();
+    expect(v.detail).toContain("<missing>");
+  });
+
+  test("an absent commit node, a non-object signature, and junk data are unverified", () => {
+    expect(readCommitVerification({ createCommitOnBranch: null }).verified).toBe(false);
+    expect(readCommitVerification(undefined).verified).toBe(false);
+    expect(readCommitVerification(wrap({ oid: "a", signature: "VALID" })).verified).toBe(false);
+    expect(readCommitVerification(wrap({ oid: "a", signature: [] })).verified).toBe(false);
+  });
+
+  test("always reports a non-empty reason, whatever the shape", () => {
+    for (const commit of [null, {}, { signature: null }, { signature: 7 }]) {
+      expect(readCommitVerification(wrap(commit)).detail.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("assertCommitVerified", () => {
+  const ctx = { repo: "nimbus-agent/homebrew-tap", oid: "abc123" };
+
+  test("passes a verified commit", () => {
+    const v = readCommitVerification({
+      createCommitOnBranch: { commit: { oid: "abc123", signature: GITHUB_SIGNED } },
+    });
+    expect(() => assertCommitVerified(v, ctx)).not.toThrow();
+  });
+
+  test("throws with the repo, the oid, the reason, and the required_signatures warning", () => {
+    const v = readCommitVerification({
+      createCommitOnBranch: { commit: { oid: "abc123", signature: null } },
+    });
+    expect(() => assertCommitVerified(v, ctx)).toThrow(/nimbus-agent\/homebrew-tap/);
+    expect(() => assertCommitVerified(v, ctx)).toThrow(/abc123/);
+    expect(() => assertCommitVerified(v, ctx)).toThrow(/NOT GitHub-verified/);
+    expect(() => assertCommitVerified(v, ctx)).toThrow(/required_signatures/);
   });
 });
 
@@ -327,7 +463,7 @@ describe("publishSignedCommit", () => {
     const client = scriptedClient({
       heads: ["head1"],
       blobOids: [null],
-      mutationResults: [{ data: { createCommitOnBranch: { commit: { oid: "new1" } } } }],
+      mutationResults: [signedCommitResponse("new1")],
       calls,
     });
     const result = await publishSignedCommit({
@@ -337,7 +473,7 @@ describe("publishSignedCommit", () => {
       files: [file],
       log: () => {},
     });
-    expect(result).toEqual({ status: "committed", oid: "new1", attempts: 1 });
+    expect(result).toMatchObject({ status: "committed", oid: "new1", attempts: 1 });
     const mutation = calls.find((c) => c.query.includes("createCommitOnBranch"));
     const input = mutation?.variables["input"] as { expectedHeadOid: string; branch: unknown };
     expect(input.expectedHeadOid).toBe("head1");
@@ -373,7 +509,7 @@ describe("publishSignedCommit", () => {
       blobOids: [null, null],
       mutationResults: [
         { errors: [{ message: 'Expected branch to point to "head1" but it did not.' }] },
-        { data: { createCommitOnBranch: { commit: { oid: "new2" } } } },
+        signedCommitResponse("new2"),
       ],
       calls,
     });
@@ -384,7 +520,7 @@ describe("publishSignedCommit", () => {
       files: [file],
       log: () => {},
     });
-    expect(result).toEqual({ status: "committed", oid: "new2", attempts: 2 });
+    expect(result).toMatchObject({ status: "committed", oid: "new2", attempts: 2 });
     const oids = calls
       .filter((c) => c.query.includes("createCommitOnBranch"))
       .map((c) => (c.variables["input"] as { expectedHeadOid: string }).expectedHeadOid);
@@ -446,6 +582,47 @@ describe("publishSignedCommit", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/Resource not accessible by integration/);
+  });
+
+  test("aborts the publish when the created commit came back UNSIGNED", async () => {
+    const logged: string[] = [];
+    const client = scriptedClient({
+      heads: ["head1"],
+      blobOids: [null],
+      mutationResults: [
+        { data: { createCommitOnBranch: { commit: { oid: "unsigned1", signature: null } } } },
+      ],
+      calls: [],
+    });
+    await expect(
+      publishSignedCommit({
+        client,
+        repo: "nimbus-agent/homebrew-tap",
+        message: { headline: "nimbus 1.5.0" },
+        files: [file],
+        log: (line) => logged.push(line),
+      }),
+    ).rejects.toThrow(/NOT GitHub-verified/);
+    // It must not have claimed success on the way out.
+    expect(logged.join("\n")).not.toContain("VERIFIED");
+  });
+
+  test("aborts when the mutation response omits the signature field entirely", async () => {
+    const client = scriptedClient({
+      heads: ["head1"],
+      blobOids: [null],
+      mutationResults: [{ data: { createCommitOnBranch: { commit: { oid: "nosig" } } } }],
+      calls: [],
+    });
+    await expect(
+      publishSignedCommit({
+        client,
+        repo: "nimbus-agent/scoop-bucket",
+        message: { headline: "m" },
+        files: [file],
+        log: () => {},
+      }),
+    ).rejects.toThrow(/NOT GitHub-verified/);
   });
 
   test("refuses an oversized payload before it reaches the API", async () => {

--- a/scripts/release/signed-commit.test.ts
+++ b/scripts/release/signed-commit.test.ts
@@ -1,0 +1,511 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertPayloadWithinLimit,
+  buildBlobQuery,
+  buildCommitInput,
+  classifyMutationResult,
+  createGraphQLClient,
+  type DesiredFile,
+  encodeContents,
+  type FileChanges,
+  type GraphQLClient,
+  type GraphQLResponse,
+  gitBlobOid,
+  isStaleHeadError,
+  parseAddSpec,
+  parseBlobQueryResult,
+  parseCliArgs,
+  parseNameWithOwner,
+  payloadByteLength,
+  planFileChanges,
+  publishSignedCommit,
+  qualifyBranch,
+  toRepoPath,
+} from "./signed-commit.ts";
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** Blob oids verified against `git hash-object --stdin` on a real git. */
+const OID_EMPTY = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+const OID_HELLO_NL = "ce013625030ba8dba906f756967f9e9ca394464a";
+const OID_DOC = "bd9dbf5aae1a3862dd1526723246b20206e5fc37";
+
+describe("gitBlobOid", () => {
+  test("matches git's own object ids for known vectors", () => {
+    expect(gitBlobOid(new Uint8Array(0))).toBe(OID_EMPTY);
+    expect(gitBlobOid(bytes("hello\n"))).toBe(OID_HELLO_NL);
+    expect(gitBlobOid(bytes("what is up, doc?"))).toBe(OID_DOC);
+  });
+
+  test("hashes raw bytes, so binary content with NULs and 0xFF is handled", () => {
+    const binary = new Uint8Array([0x00, 0xff, 0x0a, 0x0d, 0x00, 0x80]);
+    // Same value git would produce: sha1("blob 6\0" + those bytes).
+    expect(gitBlobOid(binary)).toMatch(/^[0-9a-f]{40}$/);
+    // Distinct content must not collide with a text-truncated-at-NUL reading.
+    expect(gitBlobOid(binary)).not.toBe(gitBlobOid(new Uint8Array([0x00])));
+  });
+});
+
+describe("toRepoPath", () => {
+  test("converts Windows separators to the forward slashes the API requires", () => {
+    expect(toRepoPath("Formula\\nimbus.rb")).toBe("Formula/nimbus.rb");
+    expect(toRepoPath("bucket\\sub\\nimbus.json")).toBe("bucket/sub/nimbus.json");
+  });
+  test("strips a leading ./ or /", () => {
+    expect(toRepoPath("./Formula/nimbus.rb")).toBe("Formula/nimbus.rb");
+    expect(toRepoPath("/Formula/nimbus.rb")).toBe("Formula/nimbus.rb");
+  });
+  test("leaves an already-clean path alone", () => {
+    expect(toRepoPath("bucket/nimbus.json")).toBe("bucket/nimbus.json");
+  });
+});
+
+describe("encodeContents", () => {
+  test("base64-encodes text", () => {
+    expect(encodeContents(bytes("hello"))).toBe("aGVsbG8=");
+  });
+  test("round-trips arbitrary binary bytes", () => {
+    const binary = new Uint8Array([0, 1, 2, 253, 254, 255, 0, 128]);
+    const decoded = new Uint8Array(Buffer.from(encodeContents(binary), "base64"));
+    expect([...decoded]).toEqual([...binary]);
+  });
+});
+
+describe("planFileChanges", () => {
+  const formula: DesiredFile = { path: "Formula/nimbus.rb", contents: bytes("hello\n") };
+
+  test("adds a file that does not exist on the branch", () => {
+    const plan = planFileChanges([formula], [], new Map([["Formula/nimbus.rb", null]]));
+    expect(plan.isNoOp).toBe(false);
+    expect(plan.changes.additions).toEqual([
+      { path: "Formula/nimbus.rb", contents: encodeContents(bytes("hello\n")) },
+    ]);
+    expect(plan.changes.deletions).toBeUndefined();
+  });
+
+  test("adds a file whose remote blob oid differs", () => {
+    const plan = planFileChanges([formula], [], new Map([["Formula/nimbus.rb", OID_DOC]]));
+    expect(plan.isNoOp).toBe(false);
+    expect(plan.changes.additions).toHaveLength(1);
+  });
+
+  test("is a no-op when the remote blob oid already matches the desired content", () => {
+    const plan = planFileChanges([formula], [], new Map([["Formula/nimbus.rb", OID_HELLO_NL]]));
+    expect(plan.isNoOp).toBe(true);
+    expect(plan.unchanged).toEqual(["Formula/nimbus.rb"]);
+    expect(plan.changes.additions).toBeUndefined();
+  });
+
+  test("normalizes Windows-separator desired paths before comparing and sending", () => {
+    const plan = planFileChanges(
+      [{ path: "Formula\\nimbus.rb", contents: bytes("hello\n") }],
+      [],
+      new Map([["Formula/nimbus.rb", OID_HELLO_NL]]),
+    );
+    expect(plan.isNoOp).toBe(true);
+  });
+
+  test("puts deletions in their own array, never mixed into additions", () => {
+    const plan = planFileChanges([], ["old/nimbus.rb"], new Map([["old/nimbus.rb", OID_DOC]]));
+    expect(plan.changes.deletions).toEqual([{ path: "old/nimbus.rb" }]);
+    expect(plan.changes.additions).toBeUndefined();
+    expect(plan.isNoOp).toBe(false);
+  });
+
+  test("drops a deletion for a path that is not on the branch (the API errors on it)", () => {
+    const plan = planFileChanges([], ["gone.rb"], new Map([["gone.rb", null]]));
+    expect(plan.changes.deletions).toBeUndefined();
+    expect(plan.alreadyAbsent).toEqual(["gone.rb"]);
+    expect(plan.isNoOp).toBe(true);
+  });
+
+  test("emits additions and deletions together when both apply", () => {
+    const plan = planFileChanges(
+      [formula],
+      ["old.rb"],
+      new Map([
+        ["Formula/nimbus.rb", null],
+        ["old.rb", OID_DOC],
+      ]),
+    );
+    expect(plan.changes.additions).toHaveLength(1);
+    expect(plan.changes.deletions).toEqual([{ path: "old.rb" }]);
+  });
+});
+
+describe("assertPayloadWithinLimit", () => {
+  const changes: FileChanges = { additions: [{ path: "a", contents: "x".repeat(1000) }] };
+
+  test("passes under the ceiling", () => {
+    expect(() => assertPayloadWithinLimit(changes, 10_000)).not.toThrow();
+  });
+  test("throws an actionable error over the ceiling", () => {
+    expect(() => assertPayloadWithinLimit(changes, 100)).toThrow(/over the .* MiB ceiling/);
+  });
+  test("measures the base64 payload, not the source bytes", () => {
+    expect(payloadByteLength(changes)).toBeGreaterThan(1000);
+  });
+});
+
+describe("buildCommitInput", () => {
+  test("produces the exact CreateCommitOnBranchInput wire shape", () => {
+    const input = buildCommitInput({
+      nameWithOwner: "nimbus-agent/homebrew-tap",
+      branchName: "main",
+      expectedHeadOid: "a".repeat(40),
+      message: { headline: "nimbus 1.5.0" },
+      changes: { additions: [{ path: "Formula/nimbus.rb", contents: "aGk=" }] },
+    });
+    expect(input).toEqual({
+      branch: { repositoryNameWithOwner: "nimbus-agent/homebrew-tap", branchName: "main" },
+      expectedHeadOid: "a".repeat(40),
+      message: { headline: "nimbus 1.5.0" },
+      fileChanges: { additions: [{ path: "Formula/nimbus.rb", contents: "aGk=" }] },
+    });
+  });
+});
+
+describe("isStaleHeadError / classifyMutationResult", () => {
+  test("recognizes the STALE_DATA error type", () => {
+    expect(isStaleHeadError([{ message: "whatever", type: "STALE_DATA" }])).toBe(true);
+  });
+  test("recognizes the expectedHeadOid mismatch message wordings", () => {
+    expect(
+      isStaleHeadError([{ message: 'Expected branch to point to "abc" but it did not.' }]),
+    ).toBe(true);
+    expect(isStaleHeadError([{ message: "main is at def456 but expected abc123" }])).toBe(true);
+  });
+  test("does NOT treat an unrelated error as stale (that would retry forever)", () => {
+    expect(isStaleHeadError([{ message: "Resource not accessible by integration" }])).toBe(false);
+  });
+
+  test("classifies a successful mutation as ok with the commit oid", () => {
+    const res: GraphQLResponse = {
+      data: { createCommitOnBranch: { commit: { oid: "deadbeef", url: "u" } } },
+    };
+    expect(classifyMutationResult(res)).toEqual({ kind: "ok", oid: "deadbeef" });
+  });
+  test("classifies a stale-head failure as retryable", () => {
+    const out = classifyMutationResult({ errors: [{ message: "x", type: "STALE_DATA" }] });
+    expect(out.kind).toBe("stale");
+  });
+  test("classifies a permission failure as fatal", () => {
+    const out = classifyMutationResult({
+      errors: [{ message: "Resource not accessible by integration" }],
+    });
+    expect(out.kind).toBe("error");
+  });
+  test("classifies a missing commit oid as fatal rather than silently succeeding", () => {
+    expect(classifyMutationResult({ data: { createCommitOnBranch: null } }).kind).toBe("error");
+  });
+});
+
+describe("buildBlobQuery / parseBlobQueryResult", () => {
+  test("passes paths as variables, aliased one per file", () => {
+    const q = buildBlobQuery("nimbus-agent", "homebrew-tap", "abc123", [
+      "Formula/nimbus.rb",
+      "README.md",
+    ]);
+    expect(q.variables["e0"]).toBe("abc123:Formula/nimbus.rb");
+    expect(q.variables["e1"]).toBe("abc123:README.md");
+    expect(q.query).toContain("b0: object(expression:$e0)");
+    expect(q.query).toContain("b1: object(expression:$e1)");
+    // The path itself must never be interpolated into the document.
+    expect(q.query).not.toContain("Formula/nimbus.rb");
+  });
+  test("normalizes Windows separators inside the expression variable", () => {
+    const q = buildBlobQuery("o", "n", "abc", ["Formula\\nimbus.rb"]);
+    expect(q.variables["e0"]).toBe("abc:Formula/nimbus.rb");
+  });
+  test("maps aliased results back onto paths, null when the blob is absent", () => {
+    const map = parseBlobQueryResult({ repository: { b0: { oid: "aaa" }, b1: null } }, [
+      "a.rb",
+      "b.rb",
+    ]);
+    expect(map.get("a.rb")).toBe("aaa");
+    expect(map.get("b.rb")).toBeNull();
+  });
+});
+
+describe("parseNameWithOwner / qualifyBranch", () => {
+  test("splits owner/name", () => {
+    expect(parseNameWithOwner("nimbus-agent/scoop-bucket")).toEqual({
+      owner: "nimbus-agent",
+      name: "scoop-bucket",
+    });
+  });
+  test("rejects a malformed repo", () => {
+    expect(() => parseNameWithOwner("scoop-bucket")).toThrow(/owner\/name/);
+    expect(() => parseNameWithOwner("a/b/c")).toThrow(/owner\/name/);
+  });
+  test("qualifies a bare branch name and leaves a qualified one alone", () => {
+    expect(qualifyBranch("main")).toBe("refs/heads/main");
+    expect(qualifyBranch("refs/heads/main")).toBe("refs/heads/main");
+  });
+});
+
+describe("parseAddSpec / parseCliArgs", () => {
+  test("splits --add on the first = so a local path may contain one", () => {
+    expect(parseAddSpec("Formula/nimbus.rb=out/a=b.rb")).toEqual({
+      repoPath: "Formula/nimbus.rb",
+      localPath: "out/a=b.rb",
+    });
+  });
+  test("rejects an --add without both halves", () => {
+    expect(() => parseAddSpec("Formula/nimbus.rb")).toThrow(/--add expects/);
+    expect(() => parseAddSpec("=out/nimbus.rb")).toThrow(/--add expects/);
+  });
+  test("parses a full publish invocation", () => {
+    const args = parseCliArgs([
+      "--repo",
+      "nimbus-agent/homebrew-tap",
+      "--message",
+      "nimbus 1.5.0",
+      "--add",
+      "Formula/nimbus.rb=out/nimbus.rb",
+    ]);
+    expect(args.repo).toBe("nimbus-agent/homebrew-tap");
+    expect(args.headline).toBe("nimbus 1.5.0");
+    expect(args.branch).toBeUndefined();
+    expect(args.adds).toEqual([{ repoPath: "Formula/nimbus.rb", localPath: "out/nimbus.rb" }]);
+  });
+  test("requires --repo, --message and at least one change", () => {
+    expect(() => parseCliArgs(["--message", "m", "--add", "a=b"])).toThrow(/--repo/);
+    expect(() => parseCliArgs(["--repo", "o/n", "--add", "a=b"])).toThrow(/--message/);
+    expect(() => parseCliArgs(["--repo", "o/n", "--message", "m"])).toThrow(/--add or --delete/);
+  });
+  test("rejects an unknown flag instead of silently ignoring it", () => {
+    expect(() => parseCliArgs(["--repo", "o/n", "--force", "yes"])).toThrow(/unknown flag/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestration: read → plan → mutate, with the stale-head retry.
+// ---------------------------------------------------------------------------
+
+interface Call {
+  readonly query: string;
+  readonly variables: Record<string, unknown>;
+}
+
+/** A scripted GraphQL client: head reads answer from `heads`, mutations from `mutationResults`. */
+function scriptedClient(opts: {
+  heads: readonly string[];
+  blobOids: readonly (string | null)[];
+  mutationResults: readonly GraphQLResponse[];
+  calls: Call[];
+}): GraphQLClient {
+  let headIdx = 0;
+  let blobIdx = 0;
+  let mutIdx = 0;
+  return {
+    request(query, variables) {
+      opts.calls.push({ query, variables });
+      if (query.includes("createCommitOnBranch")) {
+        const res = opts.mutationResults[mutIdx++];
+        if (res === undefined) throw new Error("test: unexpected extra mutation");
+        return Promise.resolve(res);
+      }
+      if (query.includes("object(expression")) {
+        const oid = opts.blobOids[blobIdx++] ?? null;
+        return Promise.resolve({ data: { repository: { b0: oid === null ? null : { oid } } } });
+      }
+      const head = opts.heads[headIdx++];
+      if (head === undefined) throw new Error("test: unexpected extra head read");
+      return Promise.resolve({
+        data: { repository: { defaultBranchRef: { name: "main", target: { oid: head } } } },
+      });
+    },
+  };
+}
+
+describe("publishSignedCommit", () => {
+  const file: DesiredFile = { path: "Formula/nimbus.rb", contents: bytes("hello\n") };
+
+  test("commits with the head oid it just read as expectedHeadOid", async () => {
+    const calls: Call[] = [];
+    const client = scriptedClient({
+      heads: ["head1"],
+      blobOids: [null],
+      mutationResults: [{ data: { createCommitOnBranch: { commit: { oid: "new1" } } } }],
+      calls,
+    });
+    const result = await publishSignedCommit({
+      client,
+      repo: "nimbus-agent/homebrew-tap",
+      message: { headline: "nimbus 1.5.0" },
+      files: [file],
+      log: () => {},
+    });
+    expect(result).toEqual({ status: "committed", oid: "new1", attempts: 1 });
+    const mutation = calls.find((c) => c.query.includes("createCommitOnBranch"));
+    const input = mutation?.variables["input"] as { expectedHeadOid: string; branch: unknown };
+    expect(input.expectedHeadOid).toBe("head1");
+    expect(input.branch).toEqual({
+      repositoryNameWithOwner: "nimbus-agent/homebrew-tap",
+      branchName: "main",
+    });
+  });
+
+  test("skips the mutation entirely when the branch already has the content", async () => {
+    const calls: Call[] = [];
+    const client = scriptedClient({
+      heads: ["head1"],
+      blobOids: [OID_HELLO_NL],
+      mutationResults: [],
+      calls,
+    });
+    const result = await publishSignedCommit({
+      client,
+      repo: "nimbus-agent/homebrew-tap",
+      message: { headline: "nimbus 1.5.0" },
+      files: [file],
+      log: () => {},
+    });
+    expect(result).toEqual({ status: "unchanged", attempts: 1 });
+    expect(calls.some((c) => c.query.includes("createCommitOnBranch"))).toBe(false);
+  });
+
+  test("re-reads the head and retries when the mutation reports a stale head", async () => {
+    const calls: Call[] = [];
+    const client = scriptedClient({
+      heads: ["head1", "head2"],
+      blobOids: [null, null],
+      mutationResults: [
+        { errors: [{ message: 'Expected branch to point to "head1" but it did not.' }] },
+        { data: { createCommitOnBranch: { commit: { oid: "new2" } } } },
+      ],
+      calls,
+    });
+    const result = await publishSignedCommit({
+      client,
+      repo: "nimbus-agent/homebrew-tap",
+      message: { headline: "nimbus 1.5.0" },
+      files: [file],
+      log: () => {},
+    });
+    expect(result).toEqual({ status: "committed", oid: "new2", attempts: 2 });
+    const oids = calls
+      .filter((c) => c.query.includes("createCommitOnBranch"))
+      .map((c) => (c.variables["input"] as { expectedHeadOid: string }).expectedHeadOid);
+    // The retry must use the RE-READ head, never the stale one, and never force.
+    expect(oids).toEqual(["head1", "head2"]);
+  });
+
+  test("collapses to unchanged if the racing writer already wrote our exact content", async () => {
+    const calls: Call[] = [];
+    const client = scriptedClient({
+      heads: ["head1", "head2"],
+      blobOids: [null, OID_HELLO_NL],
+      mutationResults: [{ errors: [{ message: "x", type: "STALE_DATA" }] }],
+      calls,
+    });
+    const result = await publishSignedCommit({
+      client,
+      repo: "nimbus-agent/homebrew-tap",
+      message: { headline: "nimbus 1.5.0" },
+      files: [file],
+      log: () => {},
+    });
+    expect(result).toEqual({ status: "unchanged", attempts: 2 });
+  });
+
+  test("gives up after maxAttempts instead of forcing", async () => {
+    const stale: GraphQLResponse = { errors: [{ message: "x", type: "STALE_DATA" }] };
+    const client = scriptedClient({
+      heads: ["h1", "h2"],
+      blobOids: [null, null],
+      mutationResults: [stale, stale],
+      calls: [],
+    });
+    await expect(
+      publishSignedCommit({
+        client,
+        repo: "nimbus-agent/homebrew-tap",
+        message: { headline: "m" },
+        files: [file],
+        maxAttempts: 2,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/kept moving after 2 attempts/);
+  });
+
+  test("fails loudly on a non-stale error rather than retrying", async () => {
+    const client = scriptedClient({
+      heads: ["h1"],
+      blobOids: [null],
+      mutationResults: [{ errors: [{ message: "Resource not accessible by integration" }] }],
+      calls: [],
+    });
+    await expect(
+      publishSignedCommit({
+        client,
+        repo: "nimbus-agent/homebrew-tap",
+        message: { headline: "m" },
+        files: [file],
+        log: () => {},
+      }),
+    ).rejects.toThrow(/Resource not accessible by integration/);
+  });
+
+  test("refuses an oversized payload before it reaches the API", async () => {
+    const client = scriptedClient({
+      heads: ["h1"],
+      blobOids: [null],
+      mutationResults: [],
+      calls: [],
+    });
+    await expect(
+      publishSignedCommit({
+        client,
+        repo: "nimbus-agent/linux-repo",
+        message: { headline: "m" },
+        files: [{ path: "yum/nimbus.rpm", contents: new Uint8Array(4096) }],
+        maxPayloadBytes: 512,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/MiB ceiling/);
+  });
+});
+
+describe("createGraphQLClient", () => {
+  test("POSTs the query + variables with bearer auth and the api-version header", async () => {
+    let captured: { url: string | undefined; init: RequestInit | undefined } = {
+      url: undefined,
+      init: undefined,
+    };
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      captured = { url: String(url), init };
+      return new Response(JSON.stringify({ data: { ok: true } }), { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createGraphQLClient({ token: "t0", fetchFn });
+    const res = await client.request("query{x}", { a: 1 });
+    expect(captured.url).toBe("https://api.github.com/graphql");
+    expect(captured.init?.method).toBe("POST");
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer t0");
+    expect(headers["x-github-api-version"]).toBe("2022-11-28");
+    expect(JSON.parse(String(captured.init?.body))).toEqual({
+      query: "query{x}",
+      variables: { a: 1 },
+    });
+    expect(res.data).toEqual({ ok: true });
+  });
+
+  test("throws on a non-200 transport failure", async () => {
+    const fetchFn = (async () =>
+      new Response("bad credentials", { status: 401 })) as unknown as typeof fetch;
+    const client = createGraphQLClient({ token: "t", fetchFn });
+    await expect(client.request("query{x}", {})).rejects.toThrow(/HTTP 401/);
+  });
+
+  test("normalizes GraphQL errors into {message,type}", async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ errors: [{ message: "nope", type: "STALE_DATA" }] }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const client = createGraphQLClient({ token: "t", fetchFn });
+    const res = await client.request("mutation{x}", {});
+    expect(res.errors).toEqual([{ message: "nope", type: "STALE_DATA" }]);
+  });
+});

--- a/scripts/release/signed-commit.ts
+++ b/scripts/release/signed-commit.ts
@@ -1,0 +1,661 @@
+#!/usr/bin/env bun
+
+/**
+ * signed-commit — publish files to a branch through the GitHub GraphQL
+ * `createCommitOnBranch` mutation instead of `git commit` + `git push`.
+ *
+ * WHY THIS EXISTS. A commit pushed over HTTPS with an App installation token is
+ * UNSIGNED: git builds the commit object on the runner and the server stores it
+ * verbatim, so `verification.verified` is false. Every commit in homebrew-tap,
+ * scoop-bucket and linux-repo looks exactly like one an attacker holding a
+ * leaked token would produce — and those repos are what `brew install`,
+ * `scoop install` and `yum install` read, which makes them the shortest path
+ * from a stolen token to code on a user's machine.
+ *
+ * `createCommitOnBranch` moves commit construction server-side: GitHub builds
+ * the tree, writes the commit, and signs it with its own key, so the result is
+ * Verified. That is the prerequisite for `required_signatures` on those repos'
+ * rulesets — which is a SEPARATE, LATER change. Turning on `required_signatures`
+ * before every publisher has moved to this path breaks the next publish.
+ *
+ * WHAT IT DOES NOT CHANGE. The file contents published are byte-for-byte what
+ * the caller passes; only the mechanism that creates the commit differs.
+ *
+ * SIZE. The whole commit travels as one base64 JSON request body, so this is
+ * only appropriate for small text manifests. `linux-repo` publishes .deb/.rpm
+ * payloads (two Bun-compiled binaries each) plus regenerated repo metadata and
+ * is deliberately NOT converted — see MAX_PAYLOAD_BYTES.
+ *
+ * CONCURRENCY. The mutation requires `expectedHeadOid` and is rejected if the
+ * branch moved since we read it. That is a feature: we re-read and rebuild
+ * rather than force anything. There is no force path here by design.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const GITHUB_GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
+
+/**
+ * Self-imposed ceiling on the serialized `fileChanges` payload. GitHub rejects
+ * oversized GraphQL request bodies with an opaque 4xx that is miserable to
+ * diagnose from a release job; failing locally with the actual byte count is
+ * far more actionable. Base64 inflates by ~4/3, which this counts because it
+ * measures the encoded payload, not the source bytes.
+ */
+export const MAX_PAYLOAD_BYTES = 20 * 1024 * 1024;
+
+/** Default number of read→mutate attempts before giving up on a moving branch. */
+export const DEFAULT_MAX_ATTEMPTS = 4;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** One `FileAddition` as the GraphQL API wants it: repo path + base64 contents. */
+export interface FileAddition {
+  readonly path: string;
+  /** Base64-encoded file contents (`Base64String` in the GraphQL schema). */
+  readonly contents: string;
+}
+
+/** One `FileDeletion`. Deletions are a SEPARATE array from additions. */
+export interface FileDeletion {
+  readonly path: string;
+}
+
+/** The `fileChanges` half of `CreateCommitOnBranchInput`. */
+export interface FileChanges {
+  readonly additions?: readonly FileAddition[];
+  readonly deletions?: readonly FileDeletion[];
+}
+
+/** A file we want the branch to contain, as raw (possibly binary) bytes. */
+export interface DesiredFile {
+  readonly path: string;
+  readonly contents: Uint8Array;
+}
+
+export interface CommitMessage {
+  readonly headline: string;
+  readonly body?: string;
+}
+
+export interface CreateCommitOnBranchInput {
+  readonly branch: { readonly repositoryNameWithOwner: string; readonly branchName: string };
+  readonly expectedHeadOid: string;
+  readonly message: CommitMessage;
+  readonly fileChanges: FileChanges;
+}
+
+export interface GraphQLError {
+  readonly message: string;
+  readonly type?: string;
+}
+
+export interface GraphQLResponse {
+  readonly data?: unknown;
+  readonly errors?: readonly GraphQLError[];
+}
+
+export interface GraphQLClient {
+  request(query: string, variables: Record<string, unknown>): Promise<GraphQLResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize a path to the forward-slash, repo-relative form the API requires.
+ *
+ * Load-bearing on Windows: a path built with `path.join()` arrives with
+ * backslashes, and GitHub would create a file literally NAMED `Formula\nimbus.rb`
+ * rather than one inside `Formula/`.
+ */
+export function toRepoPath(p: string): string {
+  const slashed = p.replaceAll("\\", "/");
+  return slashed.replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+/** Base64-encode file bytes. Binary-safe (no text decoding anywhere). */
+export function encodeContents(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+/**
+ * The git object id (SHA-1 of `blob <len>\0<bytes>`) the given bytes would have.
+ *
+ * Used to decide whether a file actually changed WITHOUT downloading it: the API
+ * hands us the remote blob's oid, and comparing oids is exact for binary content
+ * and immune to any text/encoding round-trip.
+ */
+export function gitBlobOid(bytes: Uint8Array): string {
+  const header = Buffer.from(`blob ${String(bytes.byteLength)}\0`, "utf8");
+  return createHash("sha1").update(header).update(bytes).digest("hex");
+}
+
+export interface FileChangePlan {
+  readonly changes: FileChanges;
+  /** Desired paths already at the wanted content on the branch. */
+  readonly unchanged: readonly string[];
+  /** Requested deletions for paths that do not exist on the branch. */
+  readonly alreadyAbsent: readonly string[];
+  /** True when there is nothing to commit — the caller should skip the mutation. */
+  readonly isNoOp: boolean;
+}
+
+/**
+ * Decide the exact `fileChanges` to send, given what we want and what the branch
+ * already has (`remoteBlobOids`: path → blob oid, or null when absent).
+ *
+ * - additions carry only files whose content differs (or are new);
+ * - deletions are emitted only for paths that actually exist — the API errors on
+ *   deleting a missing path, which would turn a re-run into a hard failure;
+ * - empty arrays are omitted so a no-op never sends a degenerate mutation.
+ */
+export function planFileChanges(
+  desired: readonly DesiredFile[],
+  deletions: readonly string[],
+  remoteBlobOids: ReadonlyMap<string, string | null>,
+): FileChangePlan {
+  const additions: FileAddition[] = [];
+  const unchanged: string[] = [];
+  for (const file of desired) {
+    const path = toRepoPath(file.path);
+    if (remoteBlobOids.get(path) === gitBlobOid(file.contents)) {
+      unchanged.push(path);
+      continue;
+    }
+    additions.push({ path, contents: encodeContents(file.contents) });
+  }
+
+  const toDelete: FileDeletion[] = [];
+  const alreadyAbsent: string[] = [];
+  for (const raw of deletions) {
+    const path = toRepoPath(raw);
+    const oid = remoteBlobOids.get(path);
+    if (oid === undefined || oid === null) alreadyAbsent.push(path);
+    else toDelete.push({ path });
+  }
+
+  const changes: FileChanges = {
+    ...(additions.length > 0 ? { additions } : {}),
+    ...(toDelete.length > 0 ? { deletions: toDelete } : {}),
+  };
+  return {
+    changes,
+    unchanged,
+    alreadyAbsent,
+    isNoOp: additions.length === 0 && toDelete.length === 0,
+  };
+}
+
+/** Serialized size of the file payload, in bytes. */
+export function payloadByteLength(changes: FileChanges): number {
+  return Buffer.byteLength(JSON.stringify(changes), "utf8");
+}
+
+/**
+ * Throw with an actionable message when the payload is too large to be a
+ * sensible GraphQL request body.
+ */
+export function assertPayloadWithinLimit(changes: FileChanges, max = MAX_PAYLOAD_BYTES): void {
+  const size = payloadByteLength(changes);
+  if (size <= max) return;
+  const mib = (n: number): string => (n / (1024 * 1024)).toFixed(1);
+  throw new Error(
+    `signed-commit: file payload is ${mib(size)} MiB (base64), over the ${mib(max)} MiB ceiling. ` +
+      "createCommitOnBranch sends the whole commit as one request body, so it is only viable for " +
+      "small text manifests. Publish large/binary trees another way.",
+  );
+}
+
+/** Build the mutation input. Kept pure so the exact wire shape is testable. */
+export function buildCommitInput(opts: {
+  nameWithOwner: string;
+  branchName: string;
+  expectedHeadOid: string;
+  message: CommitMessage;
+  changes: FileChanges;
+}): CreateCommitOnBranchInput {
+  return {
+    branch: {
+      repositoryNameWithOwner: opts.nameWithOwner,
+      branchName: opts.branchName,
+    },
+    expectedHeadOid: opts.expectedHeadOid,
+    message: opts.message,
+    fileChanges: opts.changes,
+  };
+}
+
+/**
+ * Messages GitHub returns when `expectedHeadOid` no longer matches the branch.
+ * Kept deliberately broad: a MISS costs one loud failure (safe), while treating
+ * an unrelated error as "stale" would retry something that will never succeed.
+ */
+const STALE_HEAD_PATTERNS: readonly RegExp[] = [
+  /expected .*head/i,
+  /but it did not/i,
+  /is at .* but expected/i,
+  /head of .* branch/i,
+  /stale/i,
+];
+
+/** True when the errors indicate the branch head moved between read and write. */
+export function isStaleHeadError(errors: readonly GraphQLError[]): boolean {
+  return errors.some(
+    (e) =>
+      e.type === "STALE_DATA" || STALE_HEAD_PATTERNS.some((pattern) => pattern.test(e.message)),
+  );
+}
+
+export type MutationOutcome =
+  | { readonly kind: "ok"; readonly oid: string }
+  | { readonly kind: "stale"; readonly message: string }
+  | { readonly kind: "error"; readonly message: string };
+
+function commitOidOf(data: unknown): string | null {
+  if (!isRecord(data)) return null;
+  const mutation = data["createCommitOnBranch"];
+  if (!isRecord(mutation)) return null;
+  const commit = mutation["commit"];
+  if (!isRecord(commit)) return null;
+  const oid = commit["oid"];
+  return typeof oid === "string" ? oid : null;
+}
+
+/**
+ * Classify a mutation response into commit / retry / fail. Pure: this is the
+ * stale-head retry DECISION, separated from the network so it can be tested.
+ */
+export function classifyMutationResult(res: GraphQLResponse): MutationOutcome {
+  const errors = res.errors ?? [];
+  if (errors.length > 0) {
+    const message = errors.map((e) => e.message).join("; ");
+    return isStaleHeadError(errors) ? { kind: "stale", message } : { kind: "error", message };
+  }
+  const oid = commitOidOf(res.data);
+  if (oid === null) {
+    return {
+      kind: "error",
+      message: "createCommitOnBranch returned no commit oid (unexpected response shape)",
+    };
+  }
+  return { kind: "ok", oid };
+}
+
+/** Split `owner/name` into its parts. Throws on anything else. */
+export function parseNameWithOwner(nwo: string): { owner: string; name: string } {
+  const parts = nwo.split("/");
+  const owner = parts[0];
+  const name = parts[1];
+  if (
+    parts.length !== 2 ||
+    owner === undefined ||
+    owner === "" ||
+    name === undefined ||
+    name === ""
+  )
+    throw new Error(`signed-commit: --repo must be "owner/name", got "${nwo}"`);
+  return { owner, name };
+}
+
+/** Accept `main` or `refs/heads/main`; the API wants the qualified form. */
+export function qualifyBranch(branch: string): string {
+  return branch.startsWith("refs/") ? branch : `refs/heads/${branch}`;
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL documents
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BRANCH_QUERY = `query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){ defaultBranchRef{ name target{ oid } } }
+}`;
+
+const NAMED_BRANCH_QUERY = `query($owner:String!,$name:String!,$qn:String!){
+  repository(owner:$owner,name:$name){ ref(qualifiedName:$qn){ name target{ oid } } }
+}`;
+
+export const CREATE_COMMIT_MUTATION = `mutation($input:CreateCommitOnBranchInput!){
+  createCommitOnBranch(input:$input){ commit{ oid url } }
+}`;
+
+export interface BlobQuery {
+  readonly query: string;
+  readonly variables: Record<string, string>;
+}
+
+/**
+ * Build an aliased query reading one blob oid per path at a fixed commit, so the
+ * "did it change?" check costs a single round trip regardless of file count.
+ * Paths travel as variables — never interpolated into the document.
+ */
+export function buildBlobQuery(
+  owner: string,
+  name: string,
+  headOid: string,
+  paths: readonly string[],
+): BlobQuery {
+  const variables: Record<string, string> = { owner, name };
+  const declarations = ["$owner:String!", "$name:String!"];
+  const fields: string[] = [];
+  paths.forEach((path, i) => {
+    const key = `e${String(i)}`;
+    variables[key] = `${headOid}:${toRepoPath(path)}`;
+    declarations.push(`$${key}:String!`);
+    fields.push(`b${String(i)}: object(expression:$${key}){ ... on Blob { oid } }`);
+  });
+  return {
+    query: `query(${declarations.join(",")}){repository(owner:$owner,name:$name){${fields.join(" ")}}}`,
+    variables,
+  };
+}
+
+/** Map the aliased blob response back onto the requested paths. */
+export function parseBlobQueryResult(
+  data: unknown,
+  paths: readonly string[],
+): Map<string, string | null> {
+  const out = new Map<string, string | null>();
+  const repository = isRecord(data) ? data["repository"] : undefined;
+  paths.forEach((path, i) => {
+    const node = isRecord(repository) ? repository[`b${String(i)}`] : undefined;
+    const oid = isRecord(node) ? node["oid"] : undefined;
+    out.set(toRepoPath(path), typeof oid === "string" ? oid : null);
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Network
+// ---------------------------------------------------------------------------
+
+function parseGraphQLResponse(raw: unknown): GraphQLResponse {
+  if (!isRecord(raw)) throw new Error("GitHub GraphQL: response was not a JSON object");
+  const rawErrors = raw["errors"];
+  const errors = Array.isArray(rawErrors)
+    ? rawErrors.map((e): GraphQLError => {
+        const rec = isRecord(e) ? e : {};
+        const message = rec["message"];
+        const type = rec["type"];
+        return {
+          message: typeof message === "string" ? message : JSON.stringify(e),
+          ...(typeof type === "string" ? { type } : {}),
+        };
+      })
+    : undefined;
+  return { data: raw["data"], ...(errors !== undefined ? { errors } : {}) };
+}
+
+export function createGraphQLClient(opts: {
+  token: string;
+  fetchFn?: typeof fetch;
+  endpoint?: string;
+}): GraphQLClient {
+  const f = opts.fetchFn ?? fetch;
+  const endpoint = opts.endpoint ?? GITHUB_GRAPHQL_ENDPOINT;
+  return {
+    async request(query, variables) {
+      const res = await f(endpoint, {
+        method: "POST",
+        headers: {
+          accept: "application/vnd.github+json",
+          "content-type": "application/json",
+          "x-github-api-version": "2022-11-28",
+          authorization: `Bearer ${opts.token}`,
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `GitHub GraphQL: HTTP ${String(res.status)} — ${(await res.text()).slice(0, 300)}`,
+        );
+      }
+      return parseGraphQLResponse((await res.json()) as unknown);
+    },
+  };
+}
+
+function throwOnErrors(res: GraphQLResponse, label: string): void {
+  const errors = res.errors ?? [];
+  if (errors.length > 0) throw new Error(`${label}: ${errors.map((e) => e.message).join("; ")}`);
+}
+
+export interface BranchHead {
+  readonly branchName: string;
+  readonly headOid: string;
+}
+
+function branchHeadOf(data: unknown, key: string): BranchHead | null {
+  const repository = isRecord(data) ? data["repository"] : undefined;
+  const ref = isRecord(repository) ? repository[key] : undefined;
+  if (!isRecord(ref)) return null;
+  const target = ref["target"];
+  const name = ref["name"];
+  const oid = isRecord(target) ? target["oid"] : undefined;
+  if (typeof name !== "string" || typeof oid !== "string") return null;
+  return { branchName: name, headOid: oid };
+}
+
+/** Resolve the branch (or the repo's default branch) and its current head oid. */
+export async function readBranchHead(
+  client: GraphQLClient,
+  target: { owner: string; name: string; branch?: string | undefined },
+): Promise<BranchHead> {
+  const nwo = `${target.owner}/${target.name}`;
+  if (target.branch === undefined) {
+    const res = await client.request(DEFAULT_BRANCH_QUERY, {
+      owner: target.owner,
+      name: target.name,
+    });
+    throwOnErrors(res, `signed-commit: reading the default branch of ${nwo}`);
+    const head = branchHeadOf(res.data, "defaultBranchRef");
+    if (head === null) throw new Error(`signed-commit: ${nwo} has no resolvable default branch`);
+    return head;
+  }
+  const res = await client.request(NAMED_BRANCH_QUERY, {
+    owner: target.owner,
+    name: target.name,
+    qn: qualifyBranch(target.branch),
+  });
+  throwOnErrors(res, `signed-commit: reading branch ${target.branch} of ${nwo}`);
+  const head = branchHeadOf(res.data, "ref");
+  if (head === null) {
+    throw new Error(
+      `signed-commit: ${nwo} has no branch "${target.branch}" — createCommitOnBranch cannot create one`,
+    );
+  }
+  return head;
+}
+
+/** Read the current blob oid of each path at `headOid` (null when absent). */
+export async function readBlobOids(
+  client: GraphQLClient,
+  target: { owner: string; name: string },
+  headOid: string,
+  paths: readonly string[],
+): Promise<Map<string, string | null>> {
+  if (paths.length === 0) return new Map();
+  const { query, variables } = buildBlobQuery(target.owner, target.name, headOid, paths);
+  const res = await client.request(query, variables);
+  throwOnErrors(res, `signed-commit: reading existing files in ${target.owner}/${target.name}`);
+  return parseBlobQueryResult(res.data, paths);
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface PublishOptions {
+  readonly client: GraphQLClient;
+  /** "owner/name". */
+  readonly repo: string;
+  /** Branch name; omitted means the repository's default branch. */
+  readonly branch?: string | undefined;
+  readonly message: CommitMessage;
+  readonly files: readonly DesiredFile[];
+  readonly deletions?: readonly string[];
+  readonly maxAttempts?: number;
+  readonly maxPayloadBytes?: number;
+  readonly log?: (line: string) => void;
+}
+
+export type PublishResult =
+  | { readonly status: "unchanged"; readonly attempts: number }
+  | { readonly status: "committed"; readonly oid: string; readonly attempts: number };
+
+/**
+ * Read → plan → commit, retrying from a fresh read when the branch head moved.
+ *
+ * The retry re-reads the head AND the existing blobs, so a concurrent publish
+ * that already wrote our exact content collapses to "unchanged" instead of an
+ * empty commit. Nothing here forces or overwrites: exhausting the attempts
+ * raises, it does not push harder.
+ */
+export async function publishSignedCommit(opts: PublishOptions): Promise<PublishResult> {
+  const { owner, name } = parseNameWithOwner(opts.repo);
+  const log = opts.log ?? ((line: string): void => console.log(line));
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const deletions = opts.deletions ?? [];
+  const paths = [...opts.files.map((f) => f.path), ...deletions];
+
+  let lastStale = "";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const head = await readBranchHead(opts.client, { owner, name, branch: opts.branch });
+    const remote = await readBlobOids(opts.client, { owner, name }, head.headOid, paths);
+    const plan = planFileChanges(opts.files, deletions, remote);
+    for (const absent of plan.alreadyAbsent) log(`skip delete (not present): ${absent}`);
+    if (plan.isNoOp) {
+      log(`${opts.repo}@${head.branchName}: no change (${plan.unchanged.join(", ")})`);
+      return { status: "unchanged", attempts: attempt };
+    }
+    assertPayloadWithinLimit(plan.changes, opts.maxPayloadBytes ?? MAX_PAYLOAD_BYTES);
+
+    const input = buildCommitInput({
+      nameWithOwner: opts.repo,
+      branchName: head.branchName,
+      expectedHeadOid: head.headOid,
+      message: opts.message,
+      changes: plan.changes,
+    });
+    const outcome = classifyMutationResult(
+      await opts.client.request(CREATE_COMMIT_MUTATION, { input }),
+    );
+    if (outcome.kind === "ok") {
+      log(`${opts.repo}@${head.branchName}: created signed commit ${outcome.oid}`);
+      return { status: "committed", oid: outcome.oid, attempts: attempt };
+    }
+    if (outcome.kind === "error") {
+      throw new Error(`signed-commit: createCommitOnBranch failed — ${outcome.message}`);
+    }
+    lastStale = outcome.message;
+    log(`branch head moved during attempt ${String(attempt)}; re-reading (${outcome.message})`);
+  }
+  throw new Error(
+    `signed-commit: branch head kept moving after ${String(maxAttempts)} attempts — ` +
+      `refusing to force. Last error: ${lastStale}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export interface CliArgs {
+  readonly repo: string;
+  readonly branch?: string;
+  readonly headline: string;
+  readonly body?: string;
+  /** `repoPath` → local file to read. */
+  readonly adds: readonly { readonly repoPath: string; readonly localPath: string }[];
+  readonly deletes: readonly string[];
+}
+
+/** `Formula/nimbus.rb=out/nimbus.rb` → both halves. Splits on the FIRST `=`. */
+export function parseAddSpec(spec: string): { repoPath: string; localPath: string } {
+  const at = spec.indexOf("=");
+  if (at <= 0 || at === spec.length - 1) {
+    throw new Error(`signed-commit: --add expects "<repo-path>=<local-path>", got "${spec}"`);
+  }
+  return { repoPath: toRepoPath(spec.slice(0, at)), localPath: spec.slice(at + 1) };
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  let repo: string | undefined;
+  let branch: string | undefined;
+  let headline: string | undefined;
+  let body: string | undefined;
+  const adds: { repoPath: string; localPath: string }[] = [];
+  const deletes: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === undefined || !flag.startsWith("--")) continue;
+    if (value === undefined) throw new Error(`signed-commit: ${flag} requires a value`);
+    i++;
+    if (flag === "--repo") repo = value;
+    else if (flag === "--branch") branch = value;
+    else if (flag === "--message") headline = value;
+    else if (flag === "--body") body = value;
+    else if (flag === "--add") adds.push(parseAddSpec(value));
+    else if (flag === "--delete") deletes.push(toRepoPath(value));
+    else throw new Error(`signed-commit: unknown flag ${flag}`);
+  }
+
+  if (repo === undefined) throw new Error("signed-commit: --repo <owner/name> is required");
+  if (headline === undefined) throw new Error("signed-commit: --message <headline> is required");
+  if (adds.length === 0 && deletes.length === 0) {
+    throw new Error("signed-commit: at least one --add or --delete is required");
+  }
+  return {
+    repo,
+    ...(branch !== undefined ? { branch } : {}),
+    headline,
+    ...(body !== undefined ? { body } : {}),
+    adds,
+    deletes,
+  };
+}
+
+const USAGE = `Usage: bun scripts/release/signed-commit.ts \\
+  --repo <owner/name> [--branch <name>] \\
+  --message <headline> [--body <text>] \\
+  [--add <repo-path>=<local-path> ...] [--delete <repo-path> ...]
+
+Requires GH_TOKEN (or GITHUB_TOKEN) with contents:write on the target repo.`;
+
+if (import.meta.main) {
+  const token = process.env["GH_TOKEN"] ?? process.env["GITHUB_TOKEN"];
+  if (token === undefined || token === "") {
+    console.error(`signed-commit: GH_TOKEN (or GITHUB_TOKEN) is required.\n\n${USAGE}`);
+    process.exit(2);
+  }
+  let args: CliArgs;
+  try {
+    args = parseCliArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`${err instanceof Error ? err.message : String(err)}\n\n${USAGE}`);
+    process.exit(2);
+  }
+  const result = await publishSignedCommit({
+    client: createGraphQLClient({ token }),
+    repo: args.repo,
+    branch: args.branch,
+    message: {
+      headline: args.headline,
+      ...(args.body !== undefined ? { body: args.body } : {}),
+    },
+    files: args.adds.map((a) => ({ path: a.repoPath, contents: readFileSync(a.localPath) })),
+    deletions: args.deletes,
+  });
+  if (result.status === "unchanged") process.exit(0);
+  console.log(`::notice::signed commit ${result.oid} on ${args.repo}`);
+}

--- a/scripts/release/signed-commit.ts
+++ b/scripts/release/signed-commit.ts
@@ -18,6 +18,14 @@
  * rulesets — which is a SEPARATE, LATER change. Turning on `required_signatures`
  * before every publisher has moved to this path breaks the next publish.
  *
+ * SELF-PROVING. "The commit is signed" is not taken on faith. The mutation asks
+ * for the created commit's `signature { isValid state wasSignedByGitHub }` and
+ * the publish ABORTS unless it comes back `isValid: true` + `state: VALID` —
+ * see `readCommitVerification` / `assertCommitVerified`. Without that assertion
+ * a silent regression (GitHub stops signing, the selection set drifts, someone
+ * reverts to a runner-side commit) would look exactly like success right up
+ * until `required_signatures` is enabled and every publish starts failing.
+ *
  * WHAT IT DOES NOT CHANGE. The file contents published are byte-for-byte what
  * the caller passes; only the mechanism that creates the commit differs.
  *
@@ -255,24 +263,130 @@ export function isStaleHeadError(errors: readonly GraphQLError[]): boolean {
   );
 }
 
-export type MutationOutcome =
-  | { readonly kind: "ok"; readonly oid: string }
-  | { readonly kind: "stale"; readonly message: string }
-  | { readonly kind: "error"; readonly message: string };
-
-function commitOidOf(data: unknown): string | null {
+function commitNodeOf(data: unknown): Record<string, unknown> | null {
   if (!isRecord(data)) return null;
   const mutation = data["createCommitOnBranch"];
   if (!isRecord(mutation)) return null;
   const commit = mutation["commit"];
-  if (!isRecord(commit)) return null;
+  return isRecord(commit) ? commit : null;
+}
+
+function commitOidOf(data: unknown): string | null {
+  const commit = commitNodeOf(data);
+  if (commit === null) return null;
   const oid = commit["oid"];
   return typeof oid === "string" ? oid : null;
 }
 
+// ---------------------------------------------------------------------------
+// Signature verification — the assertion that makes this workflow self-proving
+// ---------------------------------------------------------------------------
+
+/** The one `GitSignatureState` that means "GitHub shows this commit as Verified". */
+export const VERIFIED_SIGNATURE_STATE = "VALID";
+
+/**
+ * What the mutation told us about the created commit's signature.
+ *
+ * Every field is nullable on purpose: this describes an UNTRUSTED response, and
+ * "we could not read it" must be representable so it can be reported as
+ * unverified rather than silently coerced into a boolean.
+ */
+export interface CommitVerification {
+  /** The only field callers should gate on. False whenever anything is off. */
+  readonly verified: boolean;
+  /** `GitSignatureState`, or null when absent/not a string. */
+  readonly state: string | null;
+  readonly isValid: boolean | null;
+  /**
+   * Informational, deliberately NOT gated on: it reports WHICH key signed, not
+   * whether the signature verifies. `createCommitOnBranch` cannot be made to
+   * emit a non-GitHub signature, so gating on it would add no security while
+   * coupling every release to GitHub's key-attribution reporting.
+   */
+  readonly wasSignedByGitHub: boolean | null;
+  /** Human-readable reason, always populated — this is what lands in the log. */
+  readonly detail: string;
+}
+
+function unverified(detail: string): CommitVerification {
+  return { verified: false, state: null, isValid: null, wasSignedByGitHub: null, detail };
+}
+
+/**
+ * Read the signature block out of a `createCommitOnBranch` response `data`.
+ *
+ * FAIL-CLOSED IN EVERY DIRECTION. A null signature is what GitHub returns for an
+ * unsigned commit (confirmed against a real runner-pushed commit), so null is
+ * "not verified" — never "no data, assume fine". A MISSING `signature` key means
+ * the mutation's selection set drifted and is treated the same way, because a
+ * silently-unasserted publish is the exact regression this guards.
+ */
+export function readCommitVerification(data: unknown): CommitVerification {
+  const commit = commitNodeOf(data);
+  if (commit === null) return unverified("the response carried no commit node");
+  if (!("signature" in commit)) {
+    return unverified(
+      "the response carried no `signature` field — CREATE_COMMIT_MUTATION no longer requests it",
+    );
+  }
+  const signature = commit["signature"];
+  if (signature === null || signature === undefined) {
+    return unverified("`signature` was null — GitHub recorded this commit as UNSIGNED");
+  }
+  if (!isRecord(signature)) return unverified("`signature` was not an object");
+
+  const rawIsValid = signature["isValid"];
+  const rawState = signature["state"];
+  const rawByGitHub = signature["wasSignedByGitHub"];
+  const isValid = typeof rawIsValid === "boolean" ? rawIsValid : null;
+  const state = typeof rawState === "string" ? rawState : null;
+  const wasSignedByGitHub = typeof rawByGitHub === "boolean" ? rawByGitHub : null;
+  const verified = isValid === true && state === VERIFIED_SIGNATURE_STATE;
+  return {
+    verified,
+    state,
+    isValid,
+    wasSignedByGitHub,
+    detail:
+      `signature state=${state ?? "<missing>"} isValid=${isValid === null ? "<missing>" : String(isValid)} ` +
+      `wasSignedByGitHub=${wasSignedByGitHub === null ? "<missing>" : String(wasSignedByGitHub)}`,
+  };
+}
+
+/**
+ * Stop the publish unless GitHub signed the commit it just created.
+ *
+ * Loud on purpose. The commit has already landed by the time we can look at it,
+ * so this cannot prevent it — what it prevents is a release that QUIETLY stops
+ * producing Verified commits, which would only surface later as a hard publish
+ * failure once `required_signatures` is on the ruleset.
+ */
+export function assertCommitVerified(
+  verification: CommitVerification,
+  ctx: { readonly repo: string; readonly oid: string },
+): void {
+  if (verification.verified) return;
+  throw new Error(
+    `signed-commit: ${ctx.repo} commit ${ctx.oid} is NOT GitHub-verified — ${verification.detail}. ` +
+      "createCommitOnBranch is supposed to build and sign the commit server-side, so this means " +
+      "either the commit was not created through that mutation, GitHub did not sign it, or the " +
+      "mutation's signature selection drifted. Do NOT enable required_signatures on this repo's " +
+      "ruleset until a publish reports a verified commit; investigate the commit above first.",
+  );
+}
+
+export type MutationOutcome =
+  | { readonly kind: "ok"; readonly oid: string; readonly verification: CommitVerification }
+  | { readonly kind: "stale"; readonly message: string }
+  | { readonly kind: "error"; readonly message: string };
+
 /**
  * Classify a mutation response into commit / retry / fail. Pure: this is the
  * stale-head retry DECISION, separated from the network so it can be tested.
+ *
+ * `ok` means "a commit exists", NOT "the commit is acceptable" — the signature
+ * verdict rides along and is enforced by the caller via `assertCommitVerified`.
  */
 export function classifyMutationResult(res: GraphQLResponse): MutationOutcome {
   const errors = res.errors ?? [];
@@ -287,7 +401,7 @@ export function classifyMutationResult(res: GraphQLResponse): MutationOutcome {
       message: "createCommitOnBranch returned no commit oid (unexpected response shape)",
     };
   }
-  return { kind: "ok", oid };
+  return { kind: "ok", oid, verification: readCommitVerification(res.data) };
 }
 
 /** Split `owner/name` into its parts. Throws on anything else. */
@@ -323,8 +437,21 @@ const NAMED_BRANCH_QUERY = `query($owner:String!,$name:String!,$qn:String!){
   repository(owner:$owner,name:$name){ ref(qualifiedName:$qn){ name target{ oid } } }
 }`;
 
+/**
+ * The publish mutation. The `signature` selection is what makes this workflow
+ * self-proving — do NOT drop it to "simplify" the document.
+ *
+ * `Commit.signature` is a nullable `GitSignature` interface; `isValid`, `state`
+ * and `wasSignedByGitHub` are declared on the interface itself, so no inline
+ * fragment is needed (verified against the live GitHub schema — the concrete
+ * types are GpgSignature / SmimeSignature / SshSignature / UnknownSignature).
+ * A commit GitHub built and signed answers `{isValid:true,state:VALID,
+ * wasSignedByGitHub:true}`; an unsigned commit answers `signature: null`.
+ */
 export const CREATE_COMMIT_MUTATION = `mutation($input:CreateCommitOnBranchInput!){
-  createCommitOnBranch(input:$input){ commit{ oid url } }
+  createCommitOnBranch(input:$input){
+    commit{ oid url signature{ isValid state wasSignedByGitHub } }
+  }
 }`;
 
 export interface BlobQuery {
@@ -509,7 +636,13 @@ export interface PublishOptions {
 
 export type PublishResult =
   | { readonly status: "unchanged"; readonly attempts: number }
-  | { readonly status: "committed"; readonly oid: string; readonly attempts: number };
+  | {
+      readonly status: "committed";
+      readonly oid: string;
+      readonly attempts: number;
+      /** Always `verified: true` — an unverified commit throws instead of returning. */
+      readonly verification: CommitVerification;
+    };
 
 /**
  * Read → plan → commit, retrying from a fresh read when the branch head moved.
@@ -549,8 +682,19 @@ export async function publishSignedCommit(opts: PublishOptions): Promise<Publish
       await opts.client.request(CREATE_COMMIT_MUTATION, { input }),
     );
     if (outcome.kind === "ok") {
-      log(`${opts.repo}@${head.branchName}: created signed commit ${outcome.oid}`);
-      return { status: "committed", oid: outcome.oid, attempts: attempt };
+      // Prove it, do not assume it: throws unless GitHub reports the commit as
+      // Verified. Deliberately BEFORE the success log, so a failed publish can
+      // never leave a "created signed commit …" line behind to be believed.
+      assertCommitVerified(outcome.verification, { repo: opts.repo, oid: outcome.oid });
+      log(
+        `${opts.repo}@${head.branchName}: created VERIFIED commit ${outcome.oid} (${outcome.verification.detail})`,
+      );
+      return {
+        status: "committed",
+        oid: outcome.oid,
+        attempts: attempt,
+        verification: outcome.verification,
+      };
     }
     if (outcome.kind === "error") {
       throw new Error(`signed-commit: createCommitOnBranch failed — ${outcome.message}`);
@@ -645,17 +789,26 @@ if (import.meta.main) {
     console.error(`${err instanceof Error ? err.message : String(err)}\n\n${USAGE}`);
     process.exit(2);
   }
-  const result = await publishSignedCommit({
-    client: createGraphQLClient({ token }),
-    repo: args.repo,
-    branch: args.branch,
-    message: {
-      headline: args.headline,
-      ...(args.body !== undefined ? { body: args.body } : {}),
-    },
-    files: args.adds.map((a) => ({ path: a.repoPath, contents: readFileSync(a.localPath) })),
-    deletions: args.deletes,
-  });
+  // Any failure — including "the commit GitHub created is not Verified" — must
+  // surface as a red step with an Actions annotation, never a stack trace that
+  // scrolls past. A verification failure is not a warning: it exits non-zero.
+  let result: PublishResult;
+  try {
+    result = await publishSignedCommit({
+      client: createGraphQLClient({ token }),
+      repo: args.repo,
+      branch: args.branch,
+      message: {
+        headline: args.headline,
+        ...(args.body !== undefined ? { body: args.body } : {}),
+      },
+      files: args.adds.map((a) => ({ path: a.repoPath, contents: readFileSync(a.localPath) })),
+      deletions: args.deletes,
+    });
+  } catch (err) {
+    console.error(`::error::${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
   if (result.status === "unchanged") process.exit(0);
-  console.log(`::notice::signed commit ${result.oid} on ${args.repo}`);
+  console.log(`::notice::verified signed commit ${result.oid} on ${args.repo}`);
 }


### PR DESCRIPTION
Addresses #996 — **step 1 only**, deliberately.

homebrew-tap, scoop-bucket and linux-repo accept **unsigned, unreviewed bot pushes straight to `main`**. Every recent commit is `nimbus-release-bot` with `verification.verified = false`. These three repos are what `brew install`, `scoop install` and `yum install` read, which makes them the shortest path in the estate from a leaked token to code on a user's machine.

## Scope, and why it stops here

The full fix is two **ordered** steps:

1. **This PR** — create publish commits via the GraphQL `createCommitOnBranch` mutation so App-token commits come out **Verified**
2. **NOT this PR** — add `required_signatures` to the three rulesets

Doing (2) first, or both together, breaks the next publish. **No ruleset is touched here.**

## The workflow now proves itself

An earlier review found the mutation selected only `commit { oid url }` — so nothing asserted the one property the change exists to deliver. It now selects the signature and **fails the publish** if the commit is not verified.

Field names were taken from **GraphQL schema introspection, not guesswork** — a wrong field would break publishing at release time rather than in review. Confirmed: `Commit.signature` is a **nullable** `GitSignature` **interface**, with `isValid` / `state` / `wasSignedByGitHub` declared on the interface itself (no inline fragment needed), and the full `GitSignatureState` enum enumerated.

**Fails closed:** a null signature is treated as *not verified*, never as "no data, assume fine". The step stops the publish rather than warning, because that is the property step 2 will depend on.

## What is proven, and what is not

**Proven by tests:** payload building (additions, deletions, base64 encoding), the stale-`expectedHeadOid` retry decision, and the verification assertion across verified / unverified / null-signature / missing-field shapes.

**Not proven, and cannot be locally:** that GitHub actually stamps `verification.verified = true` for *this App's installation token*, and that the token's `Contents: write` scope is accepted for the GraphQL mutation as it was for the REST path. Both rest on documented GitHub behaviour until a real release runs.

That is precisely why the assertion matters: after this lands, the **first real publish either proves it or fails loudly** — rather than silently producing unverified commits that only surface when `required_signatures` is switched on and every publish starts breaking.
