### PR TITLE
docs: add the ecosystem roadmap, the agents-as-MCP-tools design/plan, and the I29/D22 security spec

### DIFF
--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -1,6 +1,7 @@
 # Nimbus Ecosystem Roadmap
 
-**Status:** landscape, not a commitment · first drafted 2026-08-02
+**Status:** landscape, not a commitment · first drafted 2026-08-02 · extended 2026-08-02 with
+verified defects, the eleven clusters, and the sequencing rules
 
 This is the fourth roadmap surface, and the only one that looks *outward*:
 
@@ -21,6 +22,14 @@ Items are grouped into **Track 0** (things already built that need finishing), *
 carries a *Needs:* line naming the primitive it waits on, so the tracks can be read in any
 order and sequenced later.
 
+The tracks are how items were **found**. The [eleven clusters](#the-eleven-clusters) are how they
+should be **built** — each cluster is a spec-sized unit that could carry one design doc and one
+implementation plan. Read the clusters to plan; read the tracks to check nothing was dropped.
+
+Read [Verified defects](#verified-defects) first regardless. Several are repairs to claims the
+product already makes in shipped documentation, which makes them more urgent than anything in the
+tracks.
+
 Two conventions matter:
 
 - **"Shipped but dark"** means the code exists, passes CI, and is reachable by no user. This is
@@ -28,6 +37,83 @@ Two conventions matter:
   rebuild.
 - **Effort** is relative (S/M/L/XL) and deliberately coarse. The useful signal is the *Needs:*
   line, not the size.
+
+## Verified defects
+
+Found while deepening the landscape, and confirmed against the tree on 2026-08-02. These are not
+proposals. They are gaps between what shipped code does and what shipped documentation says it
+does, which puts them ahead of every item below.
+
+### D22 is not the total chokepoint it documents itself as
+
+`I29`'s static rule is a regex on a string literal —
+`D22_DISPATCH_RE = /\bconnectors\.dispatch\b/` — while its own comment insists there is "no escape
+hatch, no 'approved wrapper' carve-out … Any future shortcut or custom-wrapper bypass therefore
+fails this preflight static check immediately."
+
+That is false. A bypass that never types the string passes trivially, and three already ship. Each
+resolves a tool off a lazy-mesh tool map and calls `tool.execute()` directly:
+
+| Path | Site | What leaves the machine |
+|---|---|---|
+| `share.replay` | `ipc/share-rpc.ts:172` | Recipe steps against the **live** mesh, gated only by `isReadOnlyToolId` — from a file a third party sent you |
+| ChatOps replies | `chatops/chatops-bot-spawn-call.ts:40` | Every operational reply, including posting answer text into a channel — the most content-bearing egress in the product |
+| Team-vault session | `teamvault/connector-session.ts:127` | A federated **peer's** invoke, under shared org credentials |
+
+None appends a ledger row, so a zero-row `nimbus prove` window is not the false-negative-proof
+claim `I29` makes. The remedy is not another append site: it is replacing the string match with a
+rule confining `.execute(` on a mesh tool map, which will fail on day one against three production
+files.
+
+Note also that scheduled connector syncs call `Syncable.sync()` directly and never reach the
+executor, so the ledger covers agent-initiated egress only. That caveat must be carried into every
+report built on it.
+
+### The share subsystem is disjoint from the ledger
+
+`grep egress` across `share/*.ts` returns nothing, and `share_records` has no `row_hash` /
+`prev_hash` columns. The one subsystem whose entire purpose is emitting data off the machine is
+invisible to the ledger whose entire purpose is recording what left — so `nimbus prove` can
+honestly report zero egress in a window during which the owner approved, signed and published a
+share.
+
+The asymmetry runs both ways: `egress.prune` is HITL-gated and leaves a continuing tombstone, while
+`pruneExpiredShares` is a bare `DELETE` with no tombstone and no consent. A `source_type='share'`
+row appended from inside `createShare` after approval closes both, and lets `prove` say "one signed
+artifact left, here is its hash" — a better answer than silence.
+
+### The egress receipt signs a bare digest
+
+`signWindowDigest` signs `UTF8(digest)` only. The window bounds, machine identity, completeness tier
+and row count are all **outside** the signature. Tolerable while the verifier recomputes from its
+own ledger; not tolerable the moment a receipt travels — and three proposed items make receipts
+travel between machines.
+
+The correction is in-tree and free: `ShareBody` in the same repo, signed with the same key by the
+same library, already folds `kind`, `createdAt`, `expiresAt`, `redactionSet` and `origin` inside the
+canonicalized signed bytes. The receipt needs a `ReceiptBody` of the same shape. This must land
+before machine link, because a receipt format is a wire protocol between machines running different
+versions.
+
+### Briefs are broadcast to every connected client
+
+`emitBriefWithSynthesis` publishes through `broadcastNotification`, which writes to every session.
+So every connected client receives the full markdown and typed findings of every brief any other
+client requested. A confidentiality defect no single-client surface can observe — and a
+**client-side** correlation fix does not close it, because the data has already been written to the
+other sockets.
+
+### Other confirmed gaps
+
+- **Runtime assets resolve against source layout.** Several modules locate assets by walking up from
+  `import.meta.dir`, in a binary that ships alone. The `/admin` 503 is the visible, harmless
+  instance; the connector spawn path is the one that matters.
+- **The author-facing contract validator always passes.** `runContractTests` is invoked without
+  `await`, so `nimbus test` can print success before the failure surfaces.
+- **Two first-party generators emit mutually incompatible manifests**, and the gateway's rejection
+  path points at a command that does not exist.
+- **The migration runner has no newer-than-target guard**, so a database written by a later binary
+  opens silently against a schema the running binary does not know.
 
 ## Track 0 — Shipped but dark
 
@@ -63,7 +149,26 @@ Ranked by how many downstream ecosystem items each one unblocks.
 
 A note on the fourth row: it is the cheapest item in this table and the one most likely to be
 skipped, because the one-shot CLI it was written for cannot observe the bug. Every concurrent
-consumer can.
+consumer can. It is now solved client-side by the agents-as-MCP-tools plan; the **gateway** half —
+per-caller notification instead of broadcast — is not, and is the confidentiality defect recorded
+above.
+
+**This table is mis-ranked, and the correction matters.** Counting how many items each primitive
+transitively unblocks:
+
+- **Extension execution path — real leverage zero.** Its three dependents are all independently
+  classified do-not-build. It is listed first above because it *looked* like the biggest unlock;
+  building it first would be the single largest wasted slot in the landscape.
+- **Approval routing — leverage two**, L-sized, and gated on an unresolved consent contradiction
+  (see the cross-cutting decisions below).
+- Three items filed **outside** Layer 0 out-leverage most of it: the per-profile data root (seven
+  downstream, and it converts three L-sized items into buildable ones), the manifest contract
+  reconciliation (six), and console packaging (seven views currently have no surface to render
+  into).
+
+The real enabling set is: inference-in-the-ledger, per-profile data root, manifest reconciliation,
+per-caller brief notification, resolve-by-URL, `agents.list`, the IPC registry, and console
+packaging.
 
 ## Track A — Customer surfaces
 
@@ -264,6 +369,289 @@ Recorded so they are re-decided rather than re-discovered:
   wants on a support command and implies share-grade redaction guarantees. A plain file with a
   golden test asserting no secret survives is the better shape — and that test is the feature.
 
+## The eleven clusters
+
+The tracks above are a catalogue. These are the buildable units — each one delivers value on its
+own, is one design conversation rather than five, and keeps together the items that must ship
+together. Ordered by value over cost-plus-risk.
+
+Four of the top five are **repair, not addition**. That inverts the instinct the tracks were
+written with, and it is the most useful single output of this exercise.
+
+### 1 — What we ship is what we claim
+
+*A person who installs the released binary gets a gateway that can sync, embed and serve its own
+console — and every remaining sentence of user-facing documentation describes something that
+exists.*
+
+One decision (how a `--compile` gateway carries non-code assets) applied to four sites, plus a
+subtraction pass over documentation that describes unshipped behaviour. Contains: verify-on-a-clean-
+machine; the asset-carrying decision; the console build step in the release workflow, the compile
+script **and** the preflight manifest; moving install-smoke outside the repo checkout so CI can
+observe the class at all; retracting docs for capability that has no production wiring; and adding
+the contributor docs to the status-drift scanner so they cannot rot again.
+
+**Size:** S to verify, M–L to fix — the connector-spawn answer determines which. **Depends on:**
+nothing; it is upstream of everything.
+
+### 2 — Data durability: the guards, the schedule, the drill
+
+*The local index — which is the product — survives a version downgrade, a bad restore and a disk
+event, and the product can prove it did.*
+
+The newer-than-target migration guard at both entry points including the Worker; a restore that
+removes `-wal`/`-shm` in the same operation and refuses if it cannot; post-restore verification that
+leaves the original intact on failure; wiring the backup scheduler that ships default-on and has
+never run; and `nimbus db drill` — snapshot, restore to temp, verify, compare item count and ledger
+head against live, never touch the live database.
+
+**Size:** M, of which the guards are about a day. **Depends on:** nothing. Build this in parallel
+with anything; it needs no design conversation, and it is the only work here that protects data
+already on users' disks.
+
+### 3 — Provenance completeness
+
+*`nimbus prove` stops omitting the largest continuous egress in the product, and every report later
+built on the ledger inherits a true scope claim instead of amplifying a false one.*
+
+The three shipped bypasses above, plus remote inference (embeddings and model calls both leave with
+no row), plus the vocabulary: a closed `source_type` union and a completeness **vector** replacing
+the scalar tier. Local inference must produce **no** rows, or the ledger is worse than silence. The
+`sync_telemetry` join that expresses the scheduled-sync caveat belongs here once, not re-derived by
+each downstream report.
+
+**Size:** M. **Depends on:** land after the MCP plan's `D22(c)`, so both chokepoints share one
+static-rule shape.
+
+### 4 — The agent invocation seam and its first contextual surfaces
+
+*Any surface — browser, editor, chat, CI, a git hook, an external model — can run an agent against
+the thing the user is looking at and get findings back, without a notification channel and without
+leaking that brief to every other connected client.*
+
+One seam, six consumers. Per-caller notification replacing broadcast; renaming the misnamed
+`sessionId` to `runId`; hoisting the brief router into the shared client so no consumer re-derives
+the bug; resolve-by-URL — where the **backfill** is the load-bearing part, since roughly half the
+mapping files never set `canonical_url` at all; a synchronous findings-returning HTTP route
+intercepted ahead of the write dispatcher so the write allowlist does not grow; a no-synthesis path
+that the hook, the route and the MCP callee all want; `agents.list`; then the thin consumers.
+
+**Mandatory precondition inside the cluster:** the ChatOps namespace filter. The namespace argument
+is currently discarded, so a chat read in a channel bound to one project already answers from the
+whole index — and an agent reply that deterministically names files, PRs and people is a materially
+worse leak than a free-text answer.
+
+**Size:** L. **Depends on:** the MCP plan's session-correlation and caller-threading tasks.
+
+### 5 — One contract, one gate
+
+*The declared surface and the real surface agree — manifests, connector health, IPC methods, agent
+lists — and CI fails when they drift again.*
+
+Pays off entirely with zero third-party authors, because what it repairs is first-party surface that
+is silently wrong today. Pick the normative manifest shape and land it across both repos; the
+missing `await`; reject legacy manifests at install with a message naming a command that exists;
+delete the stubs that let an author follow the docs and register zero tools with zero errors; fold
+conformance into the existing test command rather than adding a sibling; turn on the connector
+sandbox tests that have never executed; wire the two already-written, already-tested, unwired audit
+scripts; the IPC registry and drift gate; and repair user-MCP permissions, which are hardcoded
+deny-all today.
+
+**Size:** L. **Depends on:** nothing.
+
+### 6 — Approval you can act on away from the terminal
+
+*A pending consent prompt reaches the human wherever they are, and can be answered from a surface
+that is not the terminal that issued the ask — without weakening the gate.*
+
+Real per-platform notifications behind the platform abstraction (argv arrays, never composed shell
+strings — the body is index-derived text); the consent hop as a pointer carrying action type and a
+client label only, with a golden test that no payload field can reach it; a read-only pending
+listing with no answer path; and the desktop app as the first non-CLI approver, including replacing
+the renderer-supplied import path with a native dialog.
+
+Explicitly **no** approve-from-toast in v1: actionable toasts need Windows app-identity registration
+and a signed macOS bundle, which would make the approval channel Linux-only.
+
+**Size:** L. **Depends on:** nothing structurally; the publish half depends on code-signing
+procurement.
+
+### 7 — Profiles as a real data root, and the demo corpus that proves it
+
+*A second, throwaway Nimbus on the same machine — simultaneously the isolation boundary consultants
+need, the seeded demo that makes the agents show real output, and the fixture that makes agent
+regressions visible in CI.*
+
+These ship together because without the data root, `nimbus demo` seeds synthetic rows into the
+user's real index — a data-loss-grade defect, not a rough edge. Contains the per-profile data root
+across both path modules, a profile-suffixed socket so two profiles run at once, the isolation
+invariant with its enforcement test, and a corpus whose timestamps are **all** generated relative to
+seed time — the agents filter to 90d/3d/24h/48h windows, so a baked-date fixture returns empty
+within a week.
+
+Ship an honest statement that the federation-dependent agents return gap notes with zero peers.
+
+**Size:** L. **Depends on:** nothing to start. The isolation claim must not appear in any document
+before the enforcement test exists.
+
+### 8 — Policy you can explain, simulate and push
+
+*An operator can see what the policy resolves to, dry-run a candidate against real local history,
+and have a managed device place a signed policy the gateway verifies or refuses.*
+
+One escalating conversation about the same object: the explanation is the baseline the simulation
+diffs against, and the simulation is the dry-run the provisioning path needs. All three surface the
+same defect, which the explanation reports first — one of the five policy dimensions is declared and
+enforced nowhere.
+
+Signed-policy provisioning fails closed: a bad signature pins nothing and the gateway stays
+ungoverned rather than half-governed.
+
+**Size:** M; the per-machine installer half is L and procurement-gated. **Depends on:** nothing —
+and the recorded prerequisite "config layering" is the expensive path to a weaker guarantee than the
+signed-policy path that already ships.
+
+### 9 — Reports a buyer can check
+
+*Everything the gateway did is a row in a surface the buyer already has open, and the same reads
+serialise into a signed, offline-verifiable bundle a third party can check with no network and no
+account.*
+
+The evidence bundle is literally the console's views serialised, so building the reads twice is the
+waste to avoid. Contains audit windowing and cursor paging (the export currently returns the newest
+rows regardless of the window asked for); the paged chain-verified egress view; HITL analytics with
+disjoint buckets and a refusal to compute a single headline number, plus the never-exercised list,
+which is the real posture; connector permission review at tool granularity; the forensics timeline;
+the evidence bundle with a per-artifact assurance field and wording enforced by a golden test rather
+than author discipline; and the offline verifier page.
+
+**Size:** L. **Depends on:** clusters 1 and 3. Building it earlier means serialising a false
+completeness claim into a signed bundle.
+
+### 10 — Nimbus beyond one laptop
+
+*A Nimbus that boots on a box with no keyring, no browser and no egress; and several Nimbuses that
+know about each other well enough that "prove nothing left my machines" has a defined meaning.*
+
+One conversation about what a Nimbus *instance* is. A fourth vault backend selected **only** by
+explicit configuration — never auto-selected, because an implicit fallback is the plaintext-fallback
+anti-pattern — with a locked-start state machine; the signed model bundle that makes an offline
+first run possible; container, service and launch-agent artifacts; machine link as an owner-scoped
+preset that explicitly does **not** merge indexes; and the real content, cross-chain `prove`
+semantics: enrolment recorded as ledger rows so unlink-act-relink forces indeterminate, verification
+staying local with only signed per-machine receipts travelling, never merging on wall clock, and the
+merged answer being the minimum of the per-machine answers.
+
+**Size:** XL. **Depends on:** clusters 7, 2 and 9. Write the cross-chain design down long before
+building it, or cluster 9's receipt envelope will be shaped wrong.
+
+### 11 — Meetings as first-class
+
+*Fifteen minutes before a meeting, Nimbus tells you what changed since you last met with the people
+in the room — and, once meetings are graph nodes, the why and decisions agents gain an evidence
+class they cannot currently see.*
+
+Two waves. The brief first, because it writes and proves the attendee-to-person resolver against
+real synced data and needs no schema change; the graph edges second, with a regraph path so already
+indexed meetings backfill rather than only new syncs benefiting. Unresolved attendees are reported
+as gaps, never silently dropped.
+
+The only cluster that is a **new end-user capability** rather than a repair or a substrate — worth
+noting, given everything above it.
+
+**Size:** M for the brief, M–L for the edges. **Depends on:** nothing.
+
+## Sequencing rules
+
+Three rules do most of the work. Everything else is parallelisable — about two thirds of the items
+are roots with nothing blocking them, and no live dependency chain exceeds four hops. **The
+constraint is ordering-induced rework, not blocking.**
+
+1. **Ledger truth before every ledger report.** Eight items are reports over the egress ledger. None
+   is *blocked* by cluster 3 — all are buildable without it. All eight would be **wrong**, and all
+   eight would need rework when the completeness vocabulary changes. This is the largest rework
+   surface in the graph and the only place where deferring a non-blocking item costs more than
+   deferring a blocking one.
+2. **Receipt-body before receipts travel.** Machine link, fleet attestation, evidence export and the
+   offline verifier all move a receipt beyond the machine that can recompute it.
+3. **Reserve the paths-module interface now.** The signature of the two mirror path modules decides
+   whether the demo corpus, the appliance and machine link are M-sized or L-sized. Fixing that shape
+   costs nothing today and cannot be retrofitted cheaply.
+
+## Cross-cutting decisions to make once
+
+Each of these is invisible from inside any single track, and each will otherwise be decided
+accidentally by whichever item ships first.
+
+- **Who owns the `source_type` enum.** Five items independently plan to add a value. It is committed
+  by the row hash, so the taxonomy is permanent. Close the union before the first new appender.
+- **The consent model contradiction.** Shipped code answers it two ways: the share and preflight
+  gates accept an approval from any local client, while the executor gate rejects a foreign
+  responder. Nobody should build a second approver path until that is resolved deliberately. The
+  delegation machinery already ships and is scoped and expiring, which is the better starting point
+  than blanket authority.
+- **One key, three trust roles, no rotation.** The same signing pair covers shares, egress receipts
+  and proposed attestations; its public key is distributed for verification in all three and the
+  artifacts carry no key id. No rotation path exists for it or for four other key materials. The
+  per-profile data root forces a fork nobody will notice: prefix the key and cross-profile evidence
+  becomes unlinkable; do not prefix it and one profile can sign over another's window.
+- **Bearer-token scopes.** The clip token has no scope field. Four surfaces already share it and
+  three more are proposed on it approvingly, because reuse means no new pairing flow. Together, a
+  token minted to clip a web page becomes: run any read-only agent over the whole index, resolve any
+  URL, and read the pending-approval queue. Add scopes before the second consumer, not the fifth.
+- **Redactor classification.** Four redactors with four different contracts and no classification;
+  every new outbound surface picks one ad hoc. One classified policy plus a shared golden corpus is
+  unjustifiable per-track and obvious across six.
+- **What `payload_summary` is for.** It is deliberately unhashed and scrubbed by a function the
+  codebase itself calls a debugging aid — and two proposed items put it in front of third parties.
+  Either it stays local, or it earns a real contract.
+
+## Cut from the landscape
+
+Recorded with the argument, so they are re-decided rather than re-discovered.
+
+- **Extension runtime and marketplace.** The strongest disagreement in the source material, and the
+  cut wins. The spawned server has no consumer, its claimed leverage over the author toolchain is
+  false, and — decisively — if extension tools *did* reach the merged mesh, the dispatcher resolves
+  by name while the gate tests a frozen action-type set they cannot join, so they would dispatch
+  **ungated**. Keep the integrity chain, delete the stub, document first-party-only, and re-decide
+  from "we have no authors" rather than "we have no runtime."
+- **Voice.** Ships with no client and no production wiring; the honest move is deletion, not a
+  surface.
+- **Trace and inspect.** Three durable surfaces already answer the question better.
+- **Opening the brief union.** Needs a population, and the closed union is already broken for
+  first-party agents — that drift is the prerequisite nobody has scheduled.
+- **Recipe gallery and starter packs.** Both need a population that does not exist. Starter packs
+  additionally depend on a trustworthy consent preview that does not exist.
+- **Public connector feed.** A page derived from data the health gate already produces, not a
+  project.
+- **Migration-in importers.** Each is an S-sized connector authored through the existing connector
+  path, not a new project. Only its prerequisite — the body-preview cap — is worth scheduling.
+- **Export / import / delete portability.** Struck rather than cut: the Track 0 row is simply wrong.
+  It is fully wired end to end.
+
+## The through-line
+
+Read by asset rather than by track, every durable thing Nimbus produces is an attestation: a chained
+egress ledger, a chained audit log, signed shares with a forwarding hop chain, signature-verified
+monotonic-stricter policy, signed window receipts, an inert signed inbox, and a command literally
+named `prove`.
+
+The agents are the part a competitor ships next quarter over the same MCP servers. The chained,
+signed, offline-checkable record of what an agent did to your data is not.
+
+> The sentence a user says out loud is not "Nimbus wrote my standup." It is **"run `nimbus prove`
+> and send me the receipt."**
+
+That reprices this document. The operator console, evidence export, the offline verifier, observer
+expiry, machine link and fleet attestation stop being a compliance track aimed at buyers and become
+the differentiated core; the ambient surfaces become distribution for it.
+
+It is also the harshest available reading, because the notary substrate is exactly where every
+verified defect above clusters. Today that substrate is the product's most-marketed and least-true
+property — which is the strongest argument in this document for why the repair clusters outrank the
+additions.
+
 ## Provenance
 
 This landscape was produced on 2026-08-02 by a fourteen-agent pass: six parallel readers mapping
@@ -281,3 +669,20 @@ missing newer-than-target guard; and the embedder's remote model fetch.
 item-body indexing cap, the exact per-connector registration site count, and the precise
 location of the awaited-brief adapter, which two auditors cited differently and which exists in
 more than one form in the CLI package.
+
+### The 2026-08-02 extension
+
+The clusters, sequencing rules, cross-cutting decisions and cut list were produced by a second
+nine-agent pass: six deepening one track each into concrete v1 shapes, then three deriving the
+dependency graph, the cluster decomposition and the cross-track compounds.
+
+**Verified directly against the tree** before being written here: the three `tool.execute()` paths
+that bypass `D22`'s string-match rule and the text of the rule's own no-escape-hatch claim; the
+absence of any egress reference in `share/` and of chain columns on `share_records`; what
+`signWindowDigest` actually covers, against `ShareBody` as the in-repo counter-example.
+
+**Agent-reported with file citations**, consistent with the above but not personally re-opened: the
+unwired profile, voice and snapshot-scheduler services; the discarded ChatOps namespace argument;
+the un-awaited contract-test call; the mapping files that never set `canonical_url`; and the
+transitive leverage counts behind the Layer 0 re-ranking. Confirm before planning around any of
+them.

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -1,0 +1,283 @@
+# Nimbus Ecosystem Roadmap
+
+**Status:** landscape, not a commitment · first drafted 2026-08-02
+
+This is the fourth roadmap surface, and the only one that looks *outward*:
+
+- [`roadmap.md`](./roadmap.md) — what the product does, phase by phase.
+- [`infrastructure-roadmap.md`](./infrastructure-roadmap.md) — what keeps the repo and org healthy.
+- [`architecture.md`](./architecture.md) — how the gateway is built.
+- **This document** — what surrounds the gateway: the clients, the author toolchain, the
+  operator surfaces, and the distribution and trust machinery that turn one binary into an
+  ecosystem.
+
+Nothing here is scheduled. Items are recorded so that when a slot opens, the option is already
+understood, its prerequisite is already named, and nobody re-derives it from scratch.
+
+## How to read this
+
+Items are grouped into **Track 0** (things already built that need finishing), **Layer 0**
+(gateway primitives that unblock everything else), and five outward tracks **A–E**. Each entry
+carries a *Needs:* line naming the primitive it waits on, so the tracks can be read in any
+order and sequenced later.
+
+Two conventions matter:
+
+- **"Shipped but dark"** means the code exists, passes CI, and is reachable by no user. This is
+  the single largest category in the ecosystem today, and it is cheaper to finish than to
+  rebuild.
+- **Effort** is relative (S/M/L/XL) and deliberately coarse. The useful signal is the *Needs:*
+  line, not the size.
+
+## Track 0 — Shipped but dark
+
+The ecosystem's first job is not to add surfaces. It is to connect the ones that already exist.
+Every row below was verified against the tree on 2026-08-02.
+
+| Capability | State | Evidence |
+|---|---|---|
+| Extension system | `install` copies, hashes, Ed25519-verifies (I16), rows and enables — then nothing ever spawns the entry file | `listExtensions` is consumed only by `ipc/automation-rpc.ts` list/info/remove; every `wrapServerSpec()` call site is first-party or user-MCP |
+| Desktop app | Code-complete Tauri app — 8 pages, a 103-method Rust allowlist, `tauri build` runs in CI — that has never shipped a binary | no `build-ui` job anywhere in `.github/workflows` |
+| Admin console | `nimbus admin console` prints a URL that returns HTTP 503 on every installed binary | `admin-console` appears in no workflow and in no release build step |
+| OS notifications | `NotificationService.show()` is an empty async function, and it is the only implementation — so watchers notify nobody and a pending consent prompt reaches you only if you are looking at the right terminal | `createStubNotifications()` at `packages/gateway/src/platform/assemble.ts:225`, wired at `:1703` |
+| Voice subsystem | Ships with no client surface | no CLI entry point |
+| Portability layer | `data export/import/delete`, `db snapshot/restore`, recovery seeds, backup manifests and signed deletion records all ship, with no coherent story on top | `packages/gateway/src/db/`, `ipc/data-rpc.ts` |
+| Profile isolation | `profile.list/create/switch/delete` ships and is correctly LAN-forbidden, but nothing proves it is an isolation *boundary* | `ipc/profile-rpc.ts` |
+
+The strategic read: a marketplace is not the missing piece. A *runtime* is. Finishing Track 0
+converts sunk cost into surface area, and several rows here are repairs to claims the product
+already makes.
+
+## Layer 0 — Enabling primitives
+
+Ranked by how many downstream ecosystem items each one unblocks.
+
+| Primitive | Unblocks | State today |
+|---|---|---|
+| **Extension execution path** — build a `ServerSpec` from an extension row and spawn it through the existing sandbox | the entire third-party author story | absent; the sandbox, manifest parser, integrity chain and a working template all ship |
+| **Cross-client HITL queue** — a listable pending-approval set plus approval routing | every "approve from a second surface" idea | `requestConsent` writes to exactly one session; a foreign responder is rejected; no list exists |
+| **HTTP agent invocation + resolve-by-URL** — an agents route, and an index on `canonical_url` | every browser, ambient and machine-facing surface | `HTTP_ROUTES` is 11 entries, none of them agents; `canonical_url` is a plain column with no index |
+| **Session-correlated brief notifications** | any concurrent server: MCP, chat bot, HTTP route | the awaited-brief adapter exists in `packages/cli` but resolves on *any* matching notification, so two concurrent callers can cross briefs |
+| **Inference in the egress ledger** | the truth of `nimbus prove` | the `source_type` discriminator already exists as a ledger column and is already committed to the row hash; it is hard-coded at the build site |
+| **Capability discovery** — `gateway.describe`, `agents.list`, and an IPC drift gate | every client currently hard-codes the agent set | absent; dispatch is a hand-rolled fall-through, which has already produced one renderer-allowlisted method with no handler |
+
+A note on the fourth row: it is the cheapest item in this table and the one most likely to be
+skipped, because the one-shot CLI it was written for cannot observe the bug. Every concurrent
+consumer can.
+
+## Track A — Customer surfaces
+
+Where the work actually happens, beyond a developer at a keyboard.
+
+- **Nimbus as a callee (MCP server)** — expose the built-in agents as MCP tools, plus a thin
+  MIT launcher package so the server is installable as an artifact rather than a gateway
+  subcommand. This inverts the usual model: an external agent gets private cross-service
+  context and the index never moves. It is also the cheapest distribution available, because
+  directory listings are currently unreachable purely for packaging reasons. *Needs:*
+  session-correlated notifications. *Effort:* S–M.
+- **OS notification delivery** — three platform implementations of `show()`, plus the consent
+  hop. This is a human-reachability argument, not a UX one: a local-first product has no push
+  channel, so structural HITL depends on it. *Needs:* nothing. *Effort:* S per platform.
+- **ChatOps agent commands** — let a chat mention invoke a read-only agent, not just receive
+  dispatched replies. *Needs:* session correlation. *Effort:* M.
+- **Git and shell integration** — a pre-push hook running impact and conflicts, with a hard
+  latency budget and a silent pass when the gateway is down. *Needs:* nothing. *Effort:* S.
+- **Ambient browser panel** — resolve the page you are on to an already-indexed item and run
+  agents against it; the recorded evolution of the web clipper. *Needs:* HTTP agent route and
+  resolve-by-URL. *Effort:* M.
+- **Phone surface** — read plus approve, paired rather than exposed. *Needs:* cross-client HITL
+  queue, and a delivery channel, or it is a notification product with no notifications.
+  *Effort:* L.
+- **Desktop release vehicle** — a build job and the signing decision. *Needs:* code-signing
+  procurement. *Effort:* M.
+- **Meeting and calendar briefs** — currently blocked less by plumbing than by the absence of
+  graph edges for meeting-shaped entities. *Effort:* M–L.
+
+## Track B — Author and contributor toolchain
+
+The connector generator is the first item in this track; these are the rest.
+
+- **Extension runtime** — see Layer 0. Everything else in this track is capped by it.
+- **Manifest contract reconciliation** — today no manifest shape passes both halves of the
+  contract: the SDK validator and the gateway parser disagree on the permissions form, the
+  scaffold emits the form the gateway rejects, and the failure path points at a command that
+  does not exist. This should be fixed regardless of sequencing, because it silently
+  invalidates the author's first run. *Effort:* S.
+- **Conformance CLI** — spawn an extension and assert its declared surface. *Needs:* extension
+  runtime. *Effort:* M.
+- **Cassette recorder** — credential-free fixtures for connector contract tests, with
+  share-gate-grade redaction, since the failure mode is a token committed to a public repo.
+  *Effort:* M.
+- **SDK testing helpers** — and, first, the removal of two stubs that currently let an author
+  follow the docs, compile, run, and register zero tools with zero errors. *Effort:* S.
+- **Capability discovery and drift gate** — an extracted IPC registry plus a preflight gate.
+  Its first pass will surface real drift that must be reconciled rather than suppressed; that
+  reconciliation is the actual work. Typed clients for other languages are explicitly deferred
+  until a consumer exists. *Effort:* M.
+- **Trace and inspect** — scoped to notifications rather than raw frames, and gated on
+  redaction, or it becomes the fastest way for a user to paste secrets into an issue.
+  *Effort:* M.
+- **Paved path** — a starter template, plus wiring the two already-written, already-tested
+  author-facing audit scripts into the preflight gate set, plus correcting the stale clone URL
+  and phase claims a first-time contributor hits. *Effort:* S.
+- **Agent-authoring kit** — open the closed brief union so third parties can add agents.
+  A cross-repo type-level change; the listing half is trivial and should not wait for it.
+  *Effort:* S (listing) / L (union).
+- **Evaluation harness** — regression scoring for agent output quality. *Effort:* M.
+
+## Track C — Operator, buyer and compliance
+
+Nimbus already has federation, signed org policy, OIDC and SCIM, quorum approvals, and an
+always-on hash-chained egress ledger. That is an unusually strong substrate carrying almost no
+surface. This track is where the architecture becomes a buying reason.
+
+- **Policy simulation and explanation** — replay a candidate policy against the ledger and
+  answer "what would this have blocked last week, against actions you actually took," plus
+  "which rule decides this and where did it come from." Differentiated in the strictest sense:
+  a hosted product can only simulate against what you uploaded. Must call the production
+  resolution path, never a parallel reimplementation. *Effort:* S–M.
+- **Evidence export** — a signed, offline-verifiable compliance bundle assembled from reads
+  that already ship, built client-side so it adds no gateway surface. The framing discipline is
+  load-bearing: it must state which control each artifact *partially evidences*, never that the
+  bundle satisfies a control. *Effort:* M.
+- **Operator console** — package the existing console so it stops returning 503, then add the
+  differentiated view: a paged, chain-verified local egress ledger, which is not something a
+  hosted console can show you. *Effort:* S (packaging) / M (views).
+- **Connector permission review** — declared versus granted versus actually used. *Effort:* S.
+- **HITL decision analytics** — evidence that the consent gate is not rubber-stamped, a claim
+  only a product with a structural gate can make. *Effort:* S.
+- **Incident forensics timeline** — what the agent touched, over a window. *Effort:* M.
+- **Fleet attestation** — configuration and version drift across paired machines. *Needs:* a
+  new federation answerer built to the leak-proof standard. *Effort:* L.
+- **Managed install** — per-machine packaging, policy templates, and device-management
+  profiles. *Needs:* config layering, and it forces the signing decision. *Effort:* L.
+- **Scoped observer role** — a time-boxed, revocable, read-only grant for the reviewer,
+  auditor, contractor or incident commander who should be neither a stranger nor a full peer.
+  Must land inside the existing query gate rather than beside it. *Effort:* M.
+
+**A caveat that applies to this entire track.** The egress ledger is appended from the executor
+chokepoint, so it covers agent-initiated egress. Any report built on it must say so explicitly,
+or it will read as a clean bill of health for traffic it never observed — and a
+least-privilege report that recommends revoking scope from an actively-syncing connector is
+worse than no report at all.
+
+## Track D — Ecosystem, distribution and trust
+
+- **Offline verifier** — a static page that verifies a signed share, recipe or receipt with no
+  backend, no account and no upload, built on an extracted MIT verify package so the verifier
+  can never drift from the signer. A recipient who is not a Nimbus user experiences the
+  local-first claim directly instead of reading about it. *Effort:* M.
+- **Recipe gallery** — plus the missing local replay subcommand, which today is reachable only
+  through a command that reads as signature checking. *Effort:* S (subcommand) / M (gallery).
+- **Connector registry and health gate** — a generated feed, and wiring the existing unwired
+  verification script so nothing can register a connector that reaches nothing. *Effort:* S–M.
+- **Starter packs** — signed bundles of watchers, workflows and policy fragments. *Needs:* a
+  consent preview that renders a diff rather than an action name; approving a bundle behind a
+  prompt you cannot fully inspect is the anti-pattern the HITL rule exists to prevent.
+  *Effort:* L.
+- **Adopt an existing MCP stack** — detect configured servers in other clients and bring them
+  under sandboxing, consent gating and the ledger. The pitch is strong; the cost is owning
+  third-party config formats across three operating systems forever, so detect-and-instruct
+  beats detect-and-own. *Effort:* M.
+
+## Track E — Lifecycle
+
+The blind spot. Every other track serves someone who already has Nimbus installed, indexed and
+connector-authenticated. This track serves before, around, under and beside that.
+
+- **Demo corpus** — a seeded synthetic org in a throwaway profile, so evaluation does not
+  require authenticating dozens of connectors and waiting for a sync. Today the differentiated
+  agent surface returns empty on first run. This is the cheapest funnel repair available and it
+  composes with the profile primitive that is currently unused. *Effort:* M.
+- **Appliance deployment** — the repo contains zero container, systemd or launchd artifacts, so
+  an entire deployment shape is unrepresented: an always-on box that indexes continuously and
+  answers a team. The interesting blocker is real — the OS credential stores all assume a
+  logged-in session keyring, so a headless profile needs a deliberately designed fourth vault
+  backend, not a plaintext fallback. *Effort:* L.
+- **Offline provisioning** — the local embedder is fetched from a third-party CDN on first use,
+  so on a machine with no egress, hybrid search silently degrades and there is no supported way
+  to pre-provision. This is the highest-irony gap in the tree: the product whose moat is
+  provable locality cannot currently complete a local-first first run offline. Wants a model
+  bundle as a signed release asset and a doctor check that distinguishes "no model, no network"
+  from "model present, running local." *Effort:* M.
+- **Backup, restore and downgrade safety** — the local index *is* the product, so "my laptop
+  died" and "the update rolled back" are the two failure modes that destroy the moat. A
+  verified hazard exists today: the migration runner returns silently when the database version
+  is at or above the target, with no guard for a database *newer* than the running binary — and
+  a shipped auto-updater can roll back. Wants a fail-closed newer-than-target guard, a
+  scheduled backup with restore verification, and a restore drill that proves a snapshot
+  actually restores rather than merely existing. *Effort:* S (guard) / M (rest).
+- **Machine link** — one person, laptop and desktop. Federation is priced for mutual distrust;
+  the same-owner case is the cheapest one and is entirely unserved, leaving that person with
+  two divergent indexes and two ledger chains. The one thing that must be designed rather than
+  reused is `prove` semantics across two chains. *Effort:* M–L.
+- **Migration in** — import an existing corpus from the tools a prospective user already has.
+  Composes with resolve-by-URL. Check the item-body indexing cap first, or a large import
+  produces a corpus that looks complete and answers badly. *Effort:* M.
+- **Profiles as a provable boundary** — per-profile index and ledger chain, plus an isolation
+  proof, for the consultant or agency contractually obliged to defend that boundary. Today
+  profile separation is a convenience; asserting it as a compliance boundary without an
+  enforcement test would be exactly the kind of unwired defense past audits have caught.
+  *Effort:* L.
+
+## The commercial surface
+
+The tier table in [`roadmap.md`](./roadmap.md) is feature-gated, which the license makes
+structurally unsellable: with an AGPL core and an MIT SDK and client, any withheld feature can
+be rebuilt or forked.
+
+What a fork *cannot* self-issue is a counterparty. The defensible commercial surface is
+therefore the set of things that require a legally accountable entity, none of which need
+closed source or withheld features:
+
+1. **Code signing and notarization** — currently the single blocking procurement decision.
+2. **A verified-publisher trust root and the policy signing anchor** — the value is precisely
+   that a third party vouched, so a fork's own anchor is worth nothing to an auditor.
+3. **Countersigned evidence bundles** — the artifact is self-verifying; an auditor pays for an
+   attestation from a named entity.
+4. **Indemnity, support SLA and a CVE-response commitment.**
+
+Worth noting that one purchase — the signing certificate — unblocks the desktop release
+vehicle, the updater's installer path on two platforms, and the commercial trust story
+simultaneously.
+
+## Deliberate non-goals and known traps
+
+Recorded so they are re-decided rather than re-discovered:
+
+- **Do not build the marketplace before the runtime, and do not build either before an author
+  is waiting.** Three independent analyses proposed the same extension registry; all three
+  under-weighted that a registry does not create authors. The correct interim move is to
+  document the extension system as first-party-only and stop paying its author-facing upkeep.
+- **Do not make connector registration data-driven.** It reads as hygiene and is a
+  ninety-plus-package refactor that walks into the sandbox trust boundary: the gateway's
+  duplicate manifest is deliberate, because it is the gateway's own declaration of what a
+  connector may reach, not the author's. Reading permissions from the author's package makes
+  the sandbox author-declared; pinning them at build time rebuilds the duplication with a
+  generator in front of it.
+- **Do not generate clients for languages with no consumers.**
+- **Do not put the consent gate behind a browser page.** A bearer-token-authenticated approval
+  page turns renderer script injection into approve-anything, which is the exact chain class
+  the desktop allowlist was tightened against. Read-only pending counts are fine; approval
+  stays where it can be trusted.
+- **Do not route a support bundle through the share gate.** It buys an approval prompt nobody
+  wants on a support command and implies share-grade redaction guarantees. A plain file with a
+  golden test asserting no secret survives is the better shape — and that test is the feature.
+
+## Provenance
+
+This landscape was produced on 2026-08-02 by a fourteen-agent pass: six parallel readers mapping
+surfaces, gateway capability, product capability, author extension points, recorded roadmap
+direction and go-to-market; five ideation lenses; and three critics performing feasibility
+verification against the tree, strategic critique, and a completeness sweep.
+
+**Verified directly against the tree** before this document was written: the notification stub
+and its call site; the absence of a desktop build job and of any admin-console build step; the
+absence of container, systemd and launchd artifacts; the extension-row consumers; the HTTP
+route list; the `canonical_url` column and its lack of an index; the migration runner's
+missing newer-than-target guard; and the embedder's remote model fetch.
+
+**Not independently verified**, and worth confirming before any item plans around them: the
+item-body indexing cap, the exact per-connector registration site count, and the precise
+location of the awaited-brief adapter, which two auditors cited differently and which exists in
+more than one form in the CLI package.

--- a/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools-review-response.md
+++ b/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools-review-response.md
@@ -1,0 +1,109 @@
+# Agents as MCP tools — plan review response
+
+> **Status:** response of record, 2026-08-02. Answers
+> [the plan review](./2026-08-02-agents-as-mcp-tools-review.md) of
+> [the plan](./2026-08-02-agents-as-mcp-tools.md). All three points accepted; one in
+> part. The plan has been revised.
+
+## Summary
+
+| # | Review point | Verdict |
+| --- | --- | --- |
+| 1 | Object identity in connection invalidation | **Accepted — a real bug**, and my own inline hedge described the relationship backwards |
+| 2 | Stranded buffered notifications | **Accepted** — cheap fix, correctly classified by the reviewer as bounded |
+| 3 | Configurable tool timeout | **Half accepted** — environment override yes, tool argument no |
+
+## 1. Object identity — a real bug
+
+Verified against `packages/cli/src/mcp/adapter.ts`. `openConnection` ends with:
+
+```typescript
+    const client = makeReconnectingClient(raw, invalidate);
+    cached = client;
+    return client;
+```
+
+so `getClient()` returns the **wrapper**, `runAgent` receives the wrapper, and `routerFor` keys the
+`WeakMap` on the wrapper. The plan's Step 7 passed `raw`. That is an object which was never a key:
+the lookup misses silently, `failAll` never runs, and every waiter grinds out its full timeout —
+precisely the behaviour the step was added to prevent.
+
+The reviewer is right, and worth recording plainly: the plan carried an inline note claiming "the
+router is keyed on the **raw** client", which is backwards. A hedge that misstates the thing it is
+hedging is worse than no hedge, because it invites the reader to skip the check.
+
+**Fix.** `makeReconnectingClient` now binds its return value to a named `wrapper` const and passes
+that:
+
+```typescript
+  const wrapper: IpcCallable = {
+    async call<T>(method: string, params?: unknown): Promise<T> {
+      try {
+        return await raw.call<T>(method, params);
+      } catch (e) {
+        if (isDisconnectError(e)) {
+          failBriefsForClient(wrapper, e as Error);
+```
+
+**A second defect, not raised.** The plan's existing test for this step calls
+`failBriefsForClient(client, …)` directly with the same object `getClient` returned — so it passes
+whether or not the adapter wires the right identity. It could never have caught this. A test that
+goes through `createDeps` and the real reconnect path has been added, and its assertion is the
+5-second test timeout: keyed on `raw`, it does not fail an assertion, it hangs for sixty seconds.
+The plan instructs confirming that failure before applying the fix.
+
+**Known limitation, now stated in the plan rather than implied.** The hook only fires when a `call`
+fails, and while awaiting a brief there is no call in flight. So a solitary in-flight brief on a
+dying connection is still bounded by its timeout; what this buys is that a *concurrent* failing call
+fails every waiter at once. The complete fix is to drive `failAll` from a transport close event,
+which could not be designed here because `@nimbus-dev/client` is not installed in this checkout and
+its event surface is unverified. Recorded as the follow-up.
+
+## 2. Stranded buffered notifications — accepted
+
+Confirmed by reading the router: `drainBuffered` runs only from `bindSession`, and `finish` never
+touched `this.buffered`. So a waiter whose `agents.*` call failed before returning a `sessionId`
+strands its envelope until thirty-two more push it out.
+
+The reviewer's own severity assessment is right, and worth making explicit because it changes how
+much machinery this deserves: matching is by exact `sessionId`, and session ids are unique, so a
+stale envelope can never be delivered to the wrong waiter. It occupies space; it cannot cause a
+wrong answer. Hygiene, not correctness.
+
+**Fix**, in `finish`: once no waiter remains for that agent name, drop the agent's buffer. This also
+covers a case the review did not name — a brief arriving for a waiter that already timed out, which
+strands an envelope on the success path too.
+
+A test was added that orphans an envelope, then asserts a later waiter binding the *same* session id
+does not inherit it.
+
+## 3. Configurable timeout — half accepted
+
+**Accepted: the environment override.** MCP clients impose their own transport timeouts and those
+vary by editor. An operator whose client gives up before 60 s wants the tool to return a clean error
+rather than have the call severed underneath it. `NIMBUS_MCP_TIMEOUT_MS` now overrides the default,
+via an injectable `agentTimeoutMs(env)` so the test needs no environment mutation.
+
+The 60 s default is also now justified in the code rather than left as a magic number: it is double
+the CLI's 30 s because the federation-touching agents wait on paired peers, not just the local
+index.
+
+**Rejected: mapping it from tool execution arguments.** This contradicts a rule already established
+in the design — tool schemas mirror IPC params only, never presentation or transport knobs. That
+rule exists because the design review's point 4 proposed a filter for exactly this class of
+parameter, and the answer was that no such parameter should reach the schema in the first place.
+Adding a timeout argument would reintroduce it deliberately, and would invite the calling model to
+invent values for a number it cannot reason about.
+
+A test now asserts that no agent tool exposes `timeout` or `timeoutMs` in its schema, so the rule is
+enforced rather than merely written down.
+
+## What changed in the plan
+
+- Task 1: buffer cleanup in `finish`, plus an orphaned-envelope test (6 → 8 tests).
+- Task 6: `agentTimeoutMs(env)` replacing the hardcoded constant, with the default justified; two
+  tests covering the override and the no-timeout-parameter rule (4 → 6 tests at that step).
+- Task 6 Step 7: `makeReconnectingClient` rewritten to pass the wrapper; the limitation stated; a
+  real wiring test added in `adapter.test.ts` whose failure mode is a hang, with instructions to
+  observe it first.
+- Task 7: `NIMBUS_MCP_TIMEOUT_MS` added to the launcher README contents.

--- a/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools-review.md
+++ b/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools-review.md
@@ -1,0 +1,59 @@
+# Review & Suggestions: Agents as MCP Tools Implementation Plan
+
+This document contains a structured review, suggestions, improvements, and open questions regarding the implementation plan specified in [2026-08-02-agents-as-mcp-tools.md](./2026-08-02-agents-as-mcp-tools.md).
+
+---
+
+## 1. Object Identity Mismatch in Connection Invalidation (Task 6 & Task 1)
+
+### The Issue
+
+In Task 6, `runAgent` retrieves the brief router using the `client` wrapper returned by `deps.getClient()`:
+
+```typescript
+routerFor(client as unknown as object).expect<unknown>(...)
+```
+
+In the adapter reconnect logic (Task 6 Step 7), the transport-death detection tries to fail all pending briefs:
+
+```typescript
+if (isDisconnectError(e)) {
+  failBriefsForClient(raw as unknown as object, e as Error);
+  invalidate();
+  void raw.disconnect().catch(() => {});
+}
+```
+
+Because `raw` is the underlying socket client and `client` in `runAgent` is the reconnecting wrapper returned by `deps.getClient()`, they have different object references. As a result, calling `failBriefsForClient(raw, ...)` looks up a non-existent entry in the `WeakMap`, and the active waiters registered under the wrapper are never canceled early. They will hang until the full 60-second timeout expires.
+
+### Recommendation
+
+Key the `routers` `WeakMap` on the reconnecting wrapper client, or expose a failure-propagation method on the reconnecting wrapper itself that forwards the error to `failBriefsForClient` using the wrapper's identity.
+
+Alternatively, register the router on the raw client, but ensure `runAgent` resolves the raw client or the wrapper provides a reference to it. The simplest fix is to store the wrapper client reference and call `failBriefsForClient(wrapper, e)` when the wrapper detects disconnects.
+
+---
+
+## 2. Inactive Session Buffer Cleanups (Task 1)
+
+### The Issue
+
+If `expect` registers a waiter but `bindSession` is never called (for example, if the initial `agents.*` call rejects before returning a `sessionId`), the waiter will time out and be cleaned up. However, if the gateway *had* already processed the command and emitted a `briefReady` notification, that notification remains in `this.buffered` forever (unless pushed out by 32 subsequent notifications).
+
+### Recommendation
+
+To prevent stale notifications from lingering in the buffer, when a waiter times out or fails without ever having its session bound, clear any buffered notifications matching the expected agent if no other active waiters are waiting for it. Alternatively, since `MAX_BUFFERED_PER_AGENT` is capped at 32, this is a minor memory bound, but explicit cleanup on waiter cancellation prevents any drift.
+
+---
+
+## 3. Injectable/Configurable Tool Timeouts (Task 6)
+
+### The Issue
+
+While Task 1 correctly updates `awaitAgentBrief` to accept an injectable `timeoutMs`, the MCP tool dispatcher in Task 6 hardcodes `AGENT_TIMEOUT_MS = 60_000`.
+
+For heavy queries, the calling editor client might have its own strict transport timeout (e.g. VS Code or Cursor MCP client timeouts are often 10-30 seconds). If the editor times out and disconnects before the 60-second limit is reached, it triggers the disconnect error handling, but it would be cleaner if the tool itself could respect an optional configuration or dynamic timeout parameters passed by the editor if available.
+
+### Recommendation
+
+Keep `AGENT_TIMEOUT_MS` as the default, but allow it to be configured globally (e.g., via environment variable or client config payload) or mapped from specific tool execution arguments if requested.

--- a/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools.md
@@ -160,6 +160,23 @@ test("timeout rejects and clears the waiter", async () => {
   await expect(p.result).rejects.toThrow("timed out");
 });
 
+test("a buffered notification is dropped once nothing is waiting for that agent", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const p = router.expect("why", anyFindings, 5);
+  // The agents.* call failed, so bindSession is never reached — but the gateway already emitted.
+  src.emit("why.briefReady", { sessionId: "orphan", brief: "x", findings: { gaps: [] } });
+  await expect(p.result).rejects.toThrow("timed out");
+
+  // A later waiter for the same agent must not inherit the orphan's envelope.
+  const q = router.expect("why", anyFindings, 1000);
+  q.bindSession("orphan");
+  await expect(Promise.race([q.result, new Promise((r) => setTimeout(() => r("pending"), 20))])).resolves.toBe(
+    "pending",
+  );
+  q.cancel();
+});
+
 test("failAll rejects every in-flight waiter — the transport-death path", async () => {
   const src = fakeSource();
   const router = new AgentBriefRouter(src);
@@ -345,6 +362,20 @@ export class AgentBriefRouter {
     waiter.done = true;
     if (waiter.timer !== undefined) clearTimeout(waiter.timer);
     this.waiters.delete(waiter);
+
+    // Drop this agent's buffer once nothing is waiting on it. A waiter whose `agents.*` call failed
+    // before returning a sessionId never binds, so its envelope would otherwise sit until 32 more
+    // pushed it out. Hygiene rather than correctness: matching is by exact sessionId, so a stale
+    // envelope can never be delivered to the wrong waiter — it can only occupy space.
+    let stillWaiting = false;
+    for (const w of this.waiters) {
+      if (w.agentName === waiter.agentName) {
+        stillWaiting = true;
+        break;
+      }
+    }
+    if (!stillWaiting) this.buffered.delete(waiter.agentName);
+
     if (outcome !== undefined) waiter.settle(outcome);
   }
 }
@@ -353,7 +384,7 @@ export class AgentBriefRouter {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `bun test packages/cli/src/lib/agent-brief-router.test.ts`
-Expected: PASS — 6 tests.
+Expected: PASS — 8 tests.
 
 - [ ] **Step 5: Rewrite `awaitAgentBrief` over the router**
 
@@ -1221,6 +1252,20 @@ function briefClient(sessionId: string, brief: string) {
   };
 }
 
+test("the brief timeout defaults to 60s and honours NIMBUS_MCP_TIMEOUT_MS", () => {
+  expect(agentTimeoutMs({})).toBe(60_000);
+  expect(agentTimeoutMs({ NIMBUS_MCP_TIMEOUT_MS: "15000" })).toBe(15_000);
+  expect(agentTimeoutMs({ NIMBUS_MCP_TIMEOUT_MS: "not-a-number" })).toBe(60_000);
+  expect(agentTimeoutMs({ NIMBUS_MCP_TIMEOUT_MS: "-5" })).toBe(60_000);
+});
+
+test("no agent tool exposes a timeout parameter to the calling model", () => {
+  for (const spec of AGENT_TOOL_SPECS) {
+    expect(Object.keys(spec.schema)).not.toContain("timeout");
+    expect(Object.keys(spec.schema)).not.toContain("timeoutMs");
+  }
+});
+
 test("all ten async agents are registered, and preflight is not", () => {
   const names = AGENT_TOOL_SPECS.map((s) => s.name).sort();
   expect(names).toEqual(
@@ -1338,7 +1383,27 @@ import { AgentBriefRouter, type BriefNotificationSource } from "../lib/agent-bri
 import type { AdapterDeps, IpcCallable, ToolResult, ToolSpec } from "./adapter.ts";
 import { GATEWAY_DOWN_MESSAGE, GatewayUnavailableError, isDisconnectError } from "./errors.ts";
 
-const AGENT_TIMEOUT_MS = 60_000;
+const DEFAULT_AGENT_TIMEOUT_MS = 60_000;
+
+/**
+ * How long to wait for a brief. The default is 60 s rather than the CLI's 30 s because the
+ * federation-touching agents (`getPeerContext`, `getTeamHuddle`) wait on paired peers, not just the
+ * local index.
+ *
+ * Configurable by environment because MCP clients impose their own transport timeouts and those
+ * differ per editor: an operator whose client gives up sooner wants this lower, so the tool returns
+ * a clean error rather than having the call severed underneath it.
+ *
+ * Deliberately NOT a tool argument. A timeout is a transport concern, and the schema rule this
+ * design already established is IPC params only — never presentation or transport knobs. Exposing
+ * one would invite the calling model to invent values for it.
+ */
+export function agentTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = Number(env["NIMBUS_MCP_TIMEOUT_MS"]);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_AGENT_TIMEOUT_MS;
+}
 
 /** One router per client object, so listeners bind once per agent name per connection. */
 const routers = new WeakMap<object, AgentBriefRouter>();
@@ -1385,7 +1450,7 @@ async function runAgent(
   const pending = routerFor(client as unknown as object).expect<unknown>(
     agentName,
     undefined,
-    AGENT_TIMEOUT_MS,
+    agentTimeoutMs(),
   );
   try {
     const { sessionId } = await client.call<{ sessionId: string }>(ipcMethod, params);
@@ -1553,7 +1618,7 @@ async function runAgentTool(
 - [ ] **Step 5: Run test to verify it passes**
 
 Run: `bun test packages/cli/src/mcp/agent-tools.test.ts`
-Expected: PASS — 4 tests.
+Expected: PASS — 6 tests.
 
 - [ ] **Step 6: Register the specs in the adapter**
 
@@ -1586,19 +1651,47 @@ In `packages/cli/src/mcp/adapter.ts`, add the import:
 import { failBriefsForClient } from "./agent-tools.ts";
 ```
 
-and in `makeReconnectingClient`, extend the disconnect branch:
+then rewrite `makeReconnectingClient` so the wrapper can refer to itself. **The identity here is
+load-bearing:** `openConnection` returns the wrapper, so `getClient()` hands `runAgent` the wrapper,
+so `routerFor` keys the `WeakMap` on the **wrapper**. Failing on `raw` would look up an object that
+was never a key, miss silently, and leave every waiter to time out — the exact failure this step
+exists to prevent. Bind the wrapper to a named const and pass that:
 
 ```typescript
+function makeReconnectingClient(raw: IpcCallable, invalidate: () => void): IpcCallable {
+  const wrapper: IpcCallable = {
+    async call<T>(method: string, params?: unknown): Promise<T> {
+      try {
+        return await raw.call<T>(method, params);
+      } catch (e) {
         if (isDisconnectError(e)) {
-          failBriefsForClient(raw as unknown as object, e as Error);
+          // `wrapper`, never `raw` — the router is keyed on what getClient() returned.
+          failBriefsForClient(wrapper, e as Error);
           invalidate();
           void raw.disconnect().catch(() => {});
         }
+        throw e;
+      }
+    },
+    disconnect(): Promise<void> {
+      return raw.disconnect();
+    },
+  };
+  return wrapper;
+}
 ```
 
-Note the router is keyed on the **raw** client, which is what `runAgent` receives after
-`getClient()` returns the wrapper — verify the object identity matches when this runs. If it does
-not, key `routerFor` on the wrapper instead and pass that same object here.
+Referencing `wrapper` inside `call` is safe: the closure runs long after the `const` is
+initialised.
+
+**Known limitation, deliberately accepted.** This hook only fires when a `call` fails, and during
+the await for a brief there is no call in flight. So a solitary in-flight brief on a dying
+connection is still bounded by its timeout rather than failing immediately; what this buys is that
+a *concurrent* failing call now fails every waiter at once instead of letting each grind out its
+own timeout. The complete fix is to drive `failAll` from a transport close event — which could not
+be designed here, because `@nimbus-dev/client` is not installed in this checkout and its event
+surface is unverified. If `IPCClient` turns out to expose a close or error event, wire `failAll` to
+it and this limitation disappears.
 
 Append to `packages/cli/src/mcp/agent-tools.test.ts`:
 
@@ -1625,8 +1718,50 @@ test("failBriefsForClient rejects a brief in flight on that client", async () =>
 });
 ```
 
-Run: `bun test packages/cli/src/mcp/agent-tools.test.ts`
-Expected: PASS — 5 tests.
+That test calls `failBriefsForClient` directly with the same object `getClient` returned, so it
+passes whether or not the adapter wires the right identity — it cannot catch the bug this step
+exists to prevent. Add one that exercises the real wiring, in
+`packages/cli/src/mcp/adapter.test.ts`:
+
+```typescript
+test("a disconnect on one call fails briefs in flight on the same connection", async () => {
+  let failNext = false;
+  const raw = {
+    onNotification(_m: string, _h: (p: unknown) => void): void {},
+    async call<T>(method: string): Promise<T> {
+      if (failNext && method === "connector.listStatus") {
+        throw new Error("IPC connection closed");
+      }
+      return { sessionId: "s1" } as T;
+    },
+    async disconnect(): Promise<void> {},
+  };
+  const deps = createDeps({
+    readState: async () => ({ socketPath: "/tmp/sock" }),
+    connect: async () => raw,
+  });
+
+  const explain = TOOL_SPECS.find((s) => s.name === "explainWhy");
+  const inFlight = explain?.run(deps, { fileOrPrUrl: "x" });
+  await Promise.resolve();
+
+  // A second, failing call on the same connection trips the disconnect branch.
+  failNext = true;
+  const status = TOOL_SPECS.find((s) => s.name === "getConnectorStatus");
+  await status?.run(deps, {});
+
+  // Resolves well inside the 60 s timeout, because failAll found the wrapper in the WeakMap.
+  const out = await inFlight;
+  expect(out?.isError).toBe(true);
+}, 5000);
+```
+
+The 5-second test timeout is the assertion that matters: keyed on `raw` instead of `wrapper`, this
+test does not fail an assertion — it hangs for 60 seconds and then times out. Confirm it fails that
+way before applying the fix.
+
+Run: `bun test packages/cli/src/mcp/`
+Expected: PASS — 7 tests in `agent-tools.test.ts`, plus the new adapter test.
 
 - [ ] **Step 8: Assert the registered tool count**
 
@@ -1895,7 +2030,7 @@ Create `packages/mcp-launcher/package.json`:
 
 Create `packages/mcp-launcher/LICENSE` containing the standard MIT licence text, copyright the Nimbus authors.
 
-Create `packages/mcp-launcher/README.md` documenting: what it does, that it requires the Nimbus gateway to be installed and running, the `NIMBUS_BIN` override, and an example MCP client configuration block.
+Create `packages/mcp-launcher/README.md` documenting: what it does, that it requires the Nimbus gateway to be installed and running, the `NIMBUS_BIN` override, the `NIMBUS_MCP_TIMEOUT_MS` override (lower it when the editor's own MCP transport timeout is shorter than 60 s), and an example MCP client configuration block.
 
 - [ ] **Step 7: Verify the licence boundary**
 

--- a/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-02-agents-as-mcp-tools.md
@@ -1,0 +1,1939 @@
+# Agents as MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Nimbus's built-in read-only agents as MCP tools on the existing `nimbus mcp-server`, recorded in the egress ledger, plus an MIT launcher package that makes the server installable as an artifact.
+
+**Architecture:** Ten async agents plus the synchronous `whyPeek` are registered as tools in the existing `TOOL_SPECS` array in the CLI's MCP adapter. Correctness prerequisites land first: a brief router that correlates `briefReady` notifications by `sessionId` (today they are broadcast and matched by agent name alone), and a per-connection client-kind declaration so the gateway can tell an MCP-originated agent call from a CLI one. Every MCP-originated agent invocation appends one `egress_ledger` row before the brief is returned, fail-closed, through a new chokepoint confined by an extended `D22` static rule.
+
+**Tech Stack:** Bun v1.2+, TypeScript 6.x strict, `bun:test`, Biome, `@modelcontextprotocol/sdk`, zod, `bun:sqlite`, BLAKE3 via `@noble/hashes`.
+
+## Global Constraints
+
+- **No `any`.** Use `unknown` for external data. TypeScript strict mode is non-negotiable.
+- **Platform equality.** Windows/macOS/Linux equally supported. Build paths with `path.join()` / `os.tmpdir()`, never hardcoded separators.
+- **Licence split.** `packages/cli` and `packages/gateway` are AGPL-3.0. The launcher package (Task 7) is MIT and **must not import from either.**
+- **Invariant triple rule.** Any change to a structural defence lands wiring + `docs/SECURITY-INVARIANTS.md` entry + enforcement test **in the same commit**. Never leave drift.
+- **Read-only surface.** No tool added here may reach a HITL-gated action. `agents.preflight` is excluded by design.
+- **Dependency injection over `mock.module`.** `mock.module` contaminates the combined `bun test packages/cli/src` run on CI Linux. Every seam in this plan is a parameter or an interface.
+- **Before pushing:** `bun run preflight:fast`. Never `git add -A` — `settings.local.json` is tracked.
+- **Commits:** conventional-commit prefixes. Commit messages are discarded on squash-merge; the PR title and body become the commit.
+
+## Known unknown, resolve in Task 1
+
+`@nimbus-dev/client` is **not installed** in this checkout (`node_modules/@nimbus-dev/` contains only `sdk`). Whether `IPCClient` exposes handler removal (`offNotification` or similar) is therefore unverified. **The design in Task 1 deliberately does not require it:** the router binds at most one listener per agent-notification name for the client's lifetime, so handler count is bounded by the agent count (24 total), not by invocation count. If an unsubscribe API does turn out to exist, it is an optimisation, not a correction. Run `bun install` before starting.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/cli/src/lib/agent-brief-router.ts` | **Create.** Correlates `briefReady`/`briefError` notifications to waiters by `sessionId`; one listener pair per agent name. |
+| `packages/cli/src/lib/agent-brief-render.ts` | **Modify.** `awaitAgentBrief` becomes a thin wrapper over the router; `renderAgentBrief` unchanged. |
+| `packages/cli/src/lib/agent-cli-dispatcher.ts` | **Modify.** Bind the session id returned by the `agents.*` call. |
+| `packages/gateway/src/ipc/server/client-kind.ts` | **Create.** Per-connection client-kind store; `session.declareKind` handling. |
+| `packages/gateway/src/ipc/server/context.ts` | **Modify.** Expose `getClientKind` on `ServerCtx`. |
+| `packages/gateway/src/ipc/server/dispatchers.ts` | **Modify.** Thread `clientId` + kind into the agents dispatch. |
+| `packages/gateway/src/ipc/agents-rpc.ts` | **Modify.** `AgentsRpcContext` gains caller fields; the single egress chokepoint call. |
+| `packages/gateway/src/egress/mcp-brief-egress.ts` | **Create.** Builds and appends the MCP egress row. Lives in `egress/` so `D22(b)` is satisfied structurally. |
+| `scripts/structure-audit/check-nimbus-invariants.ts` | **Modify.** New `D22(c)` rule confining the new chokepoint's caller. |
+| `docs/SECURITY-INVARIANTS.md` | **Modify.** `I29` section records the second append path. |
+| `packages/cli/src/mcp/errors.ts` | **Create.** `GATEWAY_DOWN_MESSAGE`, `GatewayUnavailableError`, `isDisconnectError`, moved out of `adapter.ts` so the agent tools can use them without a cycle. |
+| `packages/cli/src/mcp/agent-tools.ts` | **Create.** The ten async agent tool specs and the brief-awaiting glue. |
+| `packages/cli/src/mcp/adapter.ts` | **Modify.** Registers `peekWhy`, spreads in the agent specs, declares the client kind, wires transport-death rejection. |
+| `packages/mcp-launcher/` | **Create.** MIT launcher package. |
+
+---
+
+### Task 1: Brief router — correlate briefs by session
+
+**Files:**
+
+- Create: `packages/cli/src/lib/agent-brief-router.ts`
+- Create: `packages/cli/src/lib/agent-brief-router.test.ts`
+- Modify: `packages/cli/src/lib/agent-brief-render.ts`
+- Modify: `packages/cli/src/lib/agent-cli-dispatcher.ts:39-43`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `AgentBriefRouter` class with `expect(agentName, guard, timeoutMs): PendingBrief<T>`; `PendingBrief<T>` with `result: Promise<{brief: string; findings: T}>`, `bindSession(sessionId: string): void`, `fail(err: Error): void`, `cancel(): void`. Task 6 consumes all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/src/lib/agent-brief-router.test.ts`:
+
+```typescript
+import { expect, test } from "bun:test";
+import { AgentBriefRouter, type BriefNotificationSource } from "./agent-brief-router.ts";
+
+type Handler = (params: unknown) => void;
+
+/** Fake notification source: records handlers and lets a test emit to them. */
+function fakeSource(): BriefNotificationSource & {
+  emit(method: string, params: unknown): void;
+  handlerCount(): number;
+} {
+  const handlers = new Map<string, Handler[]>();
+  return {
+    onNotification(method: string, handler: Handler): void {
+      const list = handlers.get(method) ?? [];
+      list.push(handler);
+      handlers.set(method, list);
+    },
+    emit(method: string, params: unknown): void {
+      for (const h of handlers.get(method) ?? []) h(params);
+    },
+    handlerCount(): number {
+      let n = 0;
+      for (const list of handlers.values()) n += list.length;
+      return n;
+    },
+  };
+}
+
+const anyFindings = (x: unknown): x is { gaps: [] } => typeof x === "object" && x !== null;
+
+test("concurrent callers each receive their own brief", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+
+  const a = router.expect("why", anyFindings, 1000);
+  const b = router.expect("why", anyFindings, 1000);
+  a.bindSession("session-a");
+  b.bindSession("session-b");
+
+  src.emit("why.briefReady", { sessionId: "session-b", brief: "B", findings: { gaps: [] } });
+  src.emit("why.briefReady", { sessionId: "session-a", brief: "A", findings: { gaps: [] } });
+
+  expect((await a.result).brief).toBe("A");
+  expect((await b.result).brief).toBe("B");
+});
+
+test("a notification arriving before bindSession is buffered, not lost", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const p = router.expect("impact", anyFindings, 1000);
+
+  src.emit("impact.briefReady", { sessionId: "s1", brief: "early", findings: { gaps: [] } });
+  p.bindSession("s1");
+
+  expect((await p.result).brief).toBe("early");
+});
+
+test("listener count is bounded by agent name, not by invocation count", () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  for (let i = 0; i < 50; i++) router.expect("why", anyFindings, 1000).cancel();
+  // one briefReady + one briefError listener for the single agent name
+  expect(src.handlerCount()).toBe(2);
+});
+
+test("briefError rejects the matching waiter only", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const a = router.expect("why", anyFindings, 1000);
+  const b = router.expect("why", anyFindings, 1000);
+  a.bindSession("s-a");
+  b.bindSession("s-b");
+
+  src.emit("why.briefError", { sessionId: "s-a", error: "boom" });
+  src.emit("why.briefReady", { sessionId: "s-b", brief: "ok", findings: { gaps: [] } });
+
+  await expect(a.result).rejects.toThrow("boom");
+  expect((await b.result).brief).toBe("ok");
+});
+
+test("fail() rejects a pending waiter with the given error", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const p = router.expect("why", anyFindings, 1000);
+  p.bindSession("s1");
+  p.fail(new Error("IPC connection closed"));
+  await expect(p.result).rejects.toThrow("IPC connection closed");
+});
+
+test("timeout rejects and clears the waiter", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const p = router.expect("why", anyFindings, 5);
+  p.bindSession("s1");
+  await expect(p.result).rejects.toThrow("timed out");
+});
+
+test("failAll rejects every in-flight waiter — the transport-death path", async () => {
+  const src = fakeSource();
+  const router = new AgentBriefRouter(src);
+  const a = router.expect("why", anyFindings, 30_000);
+  const b = router.expect("impact", anyFindings, 30_000);
+  a.bindSession("s-a");
+  b.bindSession("s-b");
+
+  router.failAll(new Error("IPC connection closed"));
+
+  await expect(a.result).rejects.toThrow("IPC connection closed");
+  await expect(b.result).rejects.toThrow("IPC connection closed");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/cli/src/lib/agent-brief-router.test.ts`
+Expected: FAIL — `Cannot find module './agent-brief-router.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cli/src/lib/agent-brief-router.ts`:
+
+```typescript
+/** Minimal surface the router needs — structurally satisfied by IPCClient. */
+export interface BriefNotificationSource {
+  onNotification(method: string, handler: (params: unknown) => void): void;
+}
+
+export interface PendingBrief<T> {
+  readonly result: Promise<{ brief: string; findings: T }>;
+  /** Bind the sessionId returned by the `agents.*` call. Replays any buffered notification. */
+  bindSession(sessionId: string): void;
+  /** Reject this waiter (e.g. transport death observed by the owner). Idempotent. */
+  fail(err: Error): void;
+  /** Drop this waiter without settling its promise's consumers further. Idempotent. */
+  cancel(): void;
+}
+
+interface Waiter {
+  readonly agentName: string;
+  readonly guard: ((x: unknown) => boolean) | undefined;
+  readonly settle: (outcome: { brief: string; findings: unknown } | Error) => void;
+  sessionId: string | undefined;
+  timer: ReturnType<typeof setTimeout> | undefined;
+  done: boolean;
+}
+
+interface BriefEnvelope {
+  sessionId?: unknown;
+  brief?: unknown;
+  findings?: unknown;
+  error?: unknown;
+}
+
+/** Cap on notifications held for a not-yet-bound waiter, so a misbehaving gateway cannot grow memory. */
+const MAX_BUFFERED_PER_AGENT = 32;
+
+/**
+ * Routes `<agent>.briefReady` / `<agent>.briefError` notifications to the waiter that started
+ * them, keyed by sessionId.
+ *
+ * Two properties the previous implementation lacked:
+ *  - notifications are matched by sessionId, not merely by agent name, so concurrent callers
+ *    cannot receive each other's briefs;
+ *  - at most one listener pair is registered per agent name for the source's lifetime, so a
+ *    long-lived server does not accumulate a handler per invocation.
+ */
+export class AgentBriefRouter {
+  private readonly bound = new Set<string>();
+  private readonly waiters = new Set<Waiter>();
+  private readonly buffered = new Map<string, BriefEnvelope[]>();
+
+  constructor(private readonly source: BriefNotificationSource) {}
+
+  expect<T>(
+    agentName: string,
+    guard: ((x: unknown) => x is T) | undefined,
+    timeoutMs: number,
+  ): PendingBrief<T> {
+    this.bindListeners(agentName);
+
+    let settleFn: (outcome: { brief: string; findings: unknown } | Error) => void = () => {};
+    const result = new Promise<{ brief: string; findings: T }>((resolve, reject) => {
+      settleFn = (outcome): void => {
+        if (outcome instanceof Error) reject(outcome);
+        else resolve({ brief: outcome.brief, findings: outcome.findings as T });
+      };
+    });
+
+    const waiter: Waiter = {
+      agentName,
+      guard,
+      settle: settleFn,
+      sessionId: undefined,
+      timer: undefined,
+      done: false,
+    };
+    waiter.timer = setTimeout(() => {
+      this.finish(waiter, new Error(`Agent timed out after ${String(timeoutMs)} ms`));
+    }, timeoutMs);
+    this.waiters.add(waiter);
+
+    return {
+      result,
+      bindSession: (sessionId: string): void => {
+        if (waiter.done) return;
+        waiter.sessionId = sessionId;
+        this.drainBuffered(waiter);
+      },
+      fail: (err: Error): void => {
+        this.finish(waiter, err);
+      },
+      cancel: (): void => {
+        this.finish(waiter, undefined);
+      },
+    };
+  }
+
+  /**
+   * Reject every in-flight waiter. Called when the owner observes transport death: the awaited
+   * notification can never arrive, so waiting out the timeout only delays a knowable answer and
+   * reports it under the wrong error.
+   */
+  failAll(err: Error): void {
+    for (const w of [...this.waiters]) this.finish(w, err);
+    this.buffered.clear();
+  }
+
+  private bindListeners(agentName: string): void {
+    if (this.bound.has(agentName)) return;
+    this.bound.add(agentName);
+    this.source.onNotification(`${agentName}.briefReady`, (params: unknown) => {
+      this.route(agentName, params as BriefEnvelope);
+    });
+    this.source.onNotification(`${agentName}.briefError`, (params: unknown) => {
+      this.route(agentName, params as BriefEnvelope);
+    });
+  }
+
+  private route(agentName: string, env: BriefEnvelope): void {
+    const sessionId = typeof env.sessionId === "string" ? env.sessionId : undefined;
+    for (const w of this.waiters) {
+      if (w.agentName === agentName && w.sessionId !== undefined && w.sessionId === sessionId) {
+        this.apply(w, env);
+        return;
+      }
+    }
+    // No bound waiter yet — buffer for a waiter that has not learned its sessionId.
+    const list = this.buffered.get(agentName) ?? [];
+    if (list.length >= MAX_BUFFERED_PER_AGENT) list.shift();
+    list.push(env);
+    this.buffered.set(agentName, list);
+  }
+
+  private drainBuffered(waiter: Waiter): void {
+    const list = this.buffered.get(waiter.agentName);
+    if (list === undefined) return;
+    const idx = list.findIndex((e) => e.sessionId === waiter.sessionId);
+    if (idx === -1) return;
+    const [env] = list.splice(idx, 1);
+    if (env !== undefined) this.apply(waiter, env);
+  }
+
+  private apply(waiter: Waiter, env: BriefEnvelope): void {
+    if (typeof env.error === "string") {
+      this.finish(waiter, new Error(env.error));
+      return;
+    }
+    if (typeof env.brief !== "string" || (waiter.guard !== undefined && !waiter.guard(env.findings))) {
+      this.finish(waiter, new Error(`Malformed ${waiter.agentName}.briefReady payload`));
+      return;
+    }
+    this.finish(waiter, { brief: env.brief, findings: env.findings });
+  }
+
+  private finish(
+    waiter: Waiter,
+    outcome: { brief: string; findings: unknown } | Error | undefined,
+  ): void {
+    if (waiter.done) return;
+    waiter.done = true;
+    if (waiter.timer !== undefined) clearTimeout(waiter.timer);
+    this.waiters.delete(waiter);
+    if (outcome !== undefined) waiter.settle(outcome);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/cli/src/lib/agent-brief-router.test.ts`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Rewrite `awaitAgentBrief` over the router**
+
+Replace the `awaitAgentBrief` function in `packages/cli/src/lib/agent-brief-render.ts` (keep `renderAgentBrief` exactly as it is):
+
+```typescript
+import { AgentBriefRouter, type BriefNotificationSource, type PendingBrief } from "./agent-brief-router.ts";
+
+const TIMEOUT_MS = 30_000;
+
+/** One router per client, so listeners are registered once per agent name per connection. */
+const routers = new WeakMap<object, AgentBriefRouter>();
+
+function routerFor(client: BriefNotificationSource): AgentBriefRouter {
+  const existing = routers.get(client as object);
+  if (existing !== undefined) return existing;
+  const created = new AgentBriefRouter(client);
+  routers.set(client as object, created);
+  return created;
+}
+
+/**
+ * Start awaiting an agent brief. The caller MUST call `bindSession` with the sessionId returned
+ * by the `agents.*` call — notifications are broadcast to every session, so without it a
+ * concurrent caller's brief can be mistaken for this one.
+ */
+export function awaitAgentBrief<T>(
+  client: BriefNotificationSource,
+  agentName: string,
+  guard: (x: unknown) => x is T,
+  timeoutMs: number = TIMEOUT_MS,
+): PendingBrief<T> {
+  return routerFor(client).expect(agentName, guard, timeoutMs);
+}
+```
+
+- [ ] **Step 6: Update the CLI dispatcher to bind the session**
+
+In `packages/cli/src/lib/agent-cli-dispatcher.ts`, replace the body between `registerInteractiveCliIpcHandlers(client);` and `renderAgentBrief(...)`, and drop the now-unused `timeout` variable and its `finally` clause:
+
+```typescript
+    await client.connect();
+    registerInteractiveCliIpcHandlers(client);
+    pending = awaitAgentBrief(client, opts.agentName, opts.guard);
+    const { sessionId } = await client.call<{ sessionId: string }>(
+      opts.ipcMethod,
+      opts.callParams,
+    );
+    pending.bindSession(sessionId);
+    const { brief, findings } = await pending.result;
+    renderAgentBrief(brief, findings, opts.json);
+```
+
+Declare `let pending: PendingBrief<B> | undefined;` beside the `client` declaration, and replace the `finally` body with:
+
+```typescript
+  } finally {
+    pending?.cancel();
+    await client.disconnect();
+  }
+```
+
+Add `PendingBrief` to the import from `./agent-brief-render.ts`.
+
+- [ ] **Step 7: Run the CLI agent tests**
+
+Run: `bun test packages/cli/src/lib/`
+Expected: PASS. If `agent-brief-render.test.ts` asserts the old four-argument signature, update those assertions to the new shape — the behaviour they cover (resolve, reject, malformed payload) is preserved.
+
+- [ ] **Step 8: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/cli/src/lib/agent-brief-router.ts packages/cli/src/lib/agent-brief-router.test.ts packages/cli/src/lib/agent-brief-render.ts packages/cli/src/lib/agent-cli-dispatcher.ts
+git commit -m "fix(cli): correlate agent briefs by sessionId"
+```
+
+---
+
+### Task 2: Per-connection client kind
+
+**Files:**
+
+- Create: `packages/gateway/src/ipc/server/client-kind.ts`
+- Create: `packages/gateway/src/ipc/server/client-kind.test.ts`
+- Modify: `packages/gateway/src/ipc/server/context.ts:7-15`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `ClientKindStore` with `declare(clientId: string, kind: unknown): ClientKind`, `get(clientId: string): ClientKind`, `forget(clientId: string): void`; type `ClientKind = "cli" | "mcp" | "ui" | "unknown"`. Task 3 consumes `get`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/ipc/server/client-kind.test.ts`:
+
+```typescript
+import { expect, test } from "bun:test";
+import { ClientKindStore } from "./client-kind.ts";
+
+test("an undeclared connection is unknown", () => {
+  const s = new ClientKindStore();
+  expect(s.get("c1")).toBe("unknown");
+});
+
+test("declare records a recognised kind", () => {
+  const s = new ClientKindStore();
+  expect(s.declare("c1", "mcp")).toBe("mcp");
+  expect(s.get("c1")).toBe("mcp");
+});
+
+test("an unrecognised kind is stored as unknown, never trusted verbatim", () => {
+  const s = new ClientKindStore();
+  expect(s.declare("c1", "totally-made-up")).toBe("unknown");
+  expect(s.get("c1")).toBe("unknown");
+});
+
+test("a non-string kind is rejected without throwing", () => {
+  const s = new ClientKindStore();
+  expect(s.declare("c1", { kind: "mcp" })).toBe("unknown");
+});
+
+test("kind is immutable for the connection's lifetime", () => {
+  const s = new ClientKindStore();
+  s.declare("c1", "cli");
+  expect(s.declare("c1", "mcp")).toBe("cli");
+  expect(s.get("c1")).toBe("cli");
+});
+
+test("forget clears the connection", () => {
+  const s = new ClientKindStore();
+  s.declare("c1", "mcp");
+  s.forget("c1");
+  expect(s.get("c1")).toBe("unknown");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/ipc/server/client-kind.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/gateway/src/ipc/server/client-kind.ts`:
+
+```typescript
+/**
+ * What kind of client owns a connection. Declared once at connect time and immutable for the
+ * connection's lifetime — a per-call field would be caller-supplied on every invocation, whereas
+ * this is server-held after the handshake (the property I23 relies on for reply targets).
+ *
+ * This is an honesty-of-record mechanism, not an authorization one: every client on this socket is
+ * a local process the owner started, and anyone who can open the socket can already call anything.
+ */
+export type ClientKind = "cli" | "mcp" | "ui" | "unknown";
+
+const RECOGNISED: ReadonlySet<string> = new Set(["cli", "mcp", "ui"]);
+
+export class ClientKindStore {
+  private readonly kinds = new Map<string, ClientKind>();
+
+  /** Record the kind for a connection. First declaration wins; returns the effective kind. */
+  declare(clientId: string, kind: unknown): ClientKind {
+    const existing = this.kinds.get(clientId);
+    if (existing !== undefined) return existing;
+    const resolved: ClientKind =
+      typeof kind === "string" && RECOGNISED.has(kind) ? (kind as ClientKind) : "unknown";
+    this.kinds.set(clientId, resolved);
+    return resolved;
+  }
+
+  get(clientId: string): ClientKind {
+    return this.kinds.get(clientId) ?? "unknown";
+  }
+
+  forget(clientId: string): void {
+    this.kinds.delete(clientId);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/src/ipc/server/client-kind.test.ts`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Expose it on `ServerCtx`**
+
+In `packages/gateway/src/ipc/server/context.ts`, add to the `ServerCtx` interface (after `getWorkflowRunHandler`):
+
+```typescript
+  getClientKind(clientId: string): ClientKind;
+```
+
+Add the import at the top of the file:
+
+```typescript
+import type { ClientKind } from "./client-kind.ts";
+```
+
+- [ ] **Step 6: Wire the store into the server**
+
+In `packages/gateway/src/ipc/server/server.ts`:
+
+1. Import the store: `import { ClientKindStore } from "./client-kind.ts";`
+2. Construct one instance beside the `sessions` map: `const clientKinds = new ClientKindStore();`
+3. Add `getClientKind: (clientId: string) => clientKinds.get(clientId),` to the object that satisfies `ServerCtx` (the same literal that already carries `broadcastNotification`).
+4. In the disconnect path that already calls `sessions.delete(...)`, add `clientKinds.forget(cid);`
+5. In `dispatchMethod`, before the existing dispatch chain, handle the declaration method:
+
+```typescript
+    if (method === "session.declareKind") {
+      const p = params as { kind?: unknown } | undefined;
+      return { kind: clientKinds.declare(clientId, p?.kind) };
+    }
+```
+
+- [ ] **Step 7: Run the server test suite**
+
+Run: `bun test packages/gateway/src/ipc/server/`
+Expected: PASS. Any test constructing a `ServerCtx` literal will fail to typecheck until it gains `getClientKind`; add `getClientKind: () => "unknown"` to those fixtures.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/gateway/src/ipc/server/client-kind.ts packages/gateway/src/ipc/server/client-kind.test.ts packages/gateway/src/ipc/server/context.ts packages/gateway/src/ipc/server/server.ts
+git commit -m "feat(gateway): record a per-connection client kind"
+```
+
+---
+
+### Task 3: Thread the caller into the agents dispatch
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/server/dispatchers.ts:119-142` (`tryDispatchAgentsRpc`), `:1027-1040` (`dispatchPhase4CoreGroup`), `:1112-1125` (`tryDispatchPhase4Rpc`)
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts:37-45` (`AgentsRpcContext`)
+- Modify: `packages/gateway/src/ipc/agents-rpc.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ClientKind`, `ServerCtx.getClientKind` from Task 2.
+- Produces: `AgentsRpcContext` gains `caller?: { clientId: string; kind: ClientKind }`. Task 4 consumes `ctx.caller`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/ipc/agents-rpc.test.ts`:
+
+```typescript
+test("dispatchAgentsRpc accepts and retains a caller descriptor", async () => {
+  const db = freshDb();
+  const seen: unknown[] = [];
+  const ctx = {
+    ...makeCtx(db),
+    caller: { clientId: "c1", kind: "mcp" as const },
+    notify: (m: string, p: unknown) => {
+      seen.push({ m, p });
+    },
+  };
+  const out = await dispatchAgentsRpc("agents.expert", { topicOrFile: "x" }, ctx);
+  expect(out.kind).toBe("hit");
+  expect(ctx.caller.kind).toBe("mcp");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/ipc/agents-rpc.test.ts -t "caller descriptor"`
+Expected: FAIL — `Object literal may only specify known properties, and 'caller' does not exist in type 'AgentsRpcContext'`.
+
+- [ ] **Step 3: Extend `AgentsRpcContext`**
+
+In `packages/gateway/src/ipc/agents-rpc.ts`, add the import and the field:
+
+```typescript
+import type { ClientKind } from "./server/client-kind.ts";
+```
+
+```typescript
+export type AgentsRpcContext = {
+  db: Database;
+  llm?: SynthesizerLlm;
+  notify: (method: string, params: unknown) => void;
+  configDir?: string;
+  index?: LocalIndex;
+  selfIdentity?: BoxKeypair;
+  sendOverWire?: typeof sendFederatedOverWire;
+  /** Who is calling. Server-derived; absent in unit tests and non-socket callers. */
+  caller?: { clientId: string; kind: ClientKind };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/src/ipc/agents-rpc.test.ts -t "caller descriptor"`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `clientId` down the dispatch chain**
+
+In `packages/gateway/src/ipc/server/dispatchers.ts`:
+
+**(a)** `tryDispatchAgentsRpc` gains a fourth parameter and passes the caller through:
+
+```typescript
+export async function tryDispatchAgentsRpc(
+  ctx: ServerCtx,
+  method: string,
+  params: unknown,
+  clientId: string,
+): Promise<unknown> {
+  if (!method.startsWith("agents.") || ctx.options.localIndex === undefined) {
+    return phase4RpcSkipped;
+  }
+  try {
+    const out = await dispatchAgentsRpc(method, params, {
+      db: ctx.options.localIndex.getDatabase(),
+      notify: (m, p) => ctx.broadcastNotification(m, p as Record<string, unknown>),
+      ...(ctx.options.configDir === undefined ? {} : { configDir: ctx.options.configDir }),
+      index: ctx.options.localIndex,
+      ...(ctx.options.federationIdentity === undefined
+        ? {}
+        : { selfIdentity: ctx.options.federationIdentity }),
+      caller: { clientId, kind: ctx.getClientKind(clientId) },
+    });
+    if (out.kind === "hit") return out.value;
+```
+
+(The remainder of the function is unchanged.)
+
+**(b)** `dispatchPhase4CoreGroup` gains `clientId: string` as a fourth parameter and forwards it:
+
+```typescript
+  const agentsOutcome = await tryDispatchAgentsRpc(ctx, method, params, clientId);
+```
+
+**(c)** `tryDispatchPhase4Rpc` passes it in — it already receives `clientId`:
+
+```typescript
+  const coreOutcome = await dispatchPhase4CoreGroup(ctx, method, params, clientId);
+```
+
+- [ ] **Step 6: Run the dispatcher tests**
+
+Run: `bun test packages/gateway/src/ipc/`
+Expected: PASS. Fix any `tryDispatchAgentsRpc` / `dispatchPhase4CoreGroup` call in a test that now misses its fourth argument by passing `"test-client"`.
+
+- [ ] **Step 7: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/gateway/src/ipc/agents-rpc.ts packages/gateway/src/ipc/agents-rpc.test.ts packages/gateway/src/ipc/server/dispatchers.ts
+git commit -m "feat(gateway): thread the calling client into the agents dispatch"
+```
+
+---
+
+### Task 4: MCP egress chokepoint (the invariant triple)
+
+**Files:**
+
+- Create: `packages/gateway/src/egress/mcp-brief-egress.ts`
+- Create: `packages/gateway/src/egress/mcp-brief-egress.test.ts`
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts:542-560` (`dispatchAgentsRpc`)
+- Modify: `scripts/structure-audit/check-nimbus-invariants.ts:590-625`
+- Modify: `docs/SECURITY-INVARIANTS.md` (the `I29` section)
+- Modify: `packages/gateway/src/security-invariants.test.ts`
+
+**Interfaces:**
+
+- Consumes: `AgentsRpcContext.caller` (Task 3); `appendEgressEntry`, `EgressEntry`, `redactEgressSummary` (existing, `egress/`).
+- Produces: `recordMcpBriefEgress(db: Database, args: { method: string; params: unknown; clientId: string; now: number }): void`. Called from exactly one site, enforced by `D22(c)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/egress/mcp-brief-egress.test.ts`:
+
+```typescript
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+import { recordMcpBriefEgress } from "./mcp-brief-egress.ts";
+
+function ledgerDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(`CREATE TABLE egress_ledger (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    source_type TEXT NOT NULL,
+    source_id TEXT,
+    destination TEXT NOT NULL,
+    method TEXT NOT NULL,
+    payload_summary TEXT NOT NULL,
+    hitl_status TEXT NOT NULL,
+    result_status TEXT NOT NULL,
+    row_hash TEXT NOT NULL,
+    prev_hash TEXT NOT NULL
+  )`);
+  return db;
+}
+
+test("appends exactly one row with source_type 'mcp'", () => {
+  const db = ledgerDb();
+  recordMcpBriefEgress(db, {
+    method: "agents.why",
+    params: { fileOrPrUrl: "src/a.ts" },
+    clientId: "c1",
+    now: 1000,
+  });
+  const rows = db.query(`SELECT source_type, method, destination, source_id FROM egress_ledger`).all() as Array<{
+    source_type: string;
+    method: string;
+    destination: string;
+    source_id: string | null;
+  }>;
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.source_type).toBe("mcp");
+  expect(rows[0]?.method).toBe("agents.why");
+  expect(rows[0]?.destination).toBe("mcp");
+  expect(rows[0]?.source_id).toBe("c1");
+  db.close();
+});
+
+test("federation-touching agents record a distinguishable destination", () => {
+  const db = ledgerDb();
+  recordMcpBriefEgress(db, { method: "agents.ghost", params: {}, clientId: "c1", now: 1 });
+  recordMcpBriefEgress(db, { method: "agents.huddle", params: {}, clientId: "c1", now: 2 });
+  recordMcpBriefEgress(db, { method: "agents.why", params: {}, clientId: "c1", now: 3 });
+  const dests = (db.query(`SELECT destination FROM egress_ledger ORDER BY id`).all() as Array<{
+    destination: string;
+  }>).map((r) => r.destination);
+  expect(dests).toEqual(["mcp+federation", "mcp+federation", "mcp"]);
+  db.close();
+});
+
+test("the payload summary is redacted and capped", () => {
+  const db = ledgerDb();
+  recordMcpBriefEgress(db, {
+    method: "agents.expert",
+    params: { topicOrFile: "x", token: "ghp_averysecretvaluethatmustnotsurvive" },
+    clientId: "c1",
+    now: 1,
+  });
+  const row = db.query(`SELECT payload_summary FROM egress_ledger`).get() as { payload_summary: string };
+  expect(row.payload_summary).not.toContain("ghp_averysecretvaluethatmustnotsurvive");
+  expect(row.payload_summary.length).toBeLessThanOrEqual(300);
+  db.close();
+});
+
+test("hitl status is not_required and result is authorized", () => {
+  const db = ledgerDb();
+  recordMcpBriefEgress(db, { method: "agents.why", params: {}, clientId: "c1", now: 1 });
+  const row = db.query(`SELECT hitl_status, result_status FROM egress_ledger`).get() as {
+    hitl_status: string;
+    result_status: string;
+  };
+  expect(row.hitl_status).toBe("not_required");
+  expect(row.result_status).toBe("authorized");
+  db.close();
+});
+
+test("an append failure propagates so the caller can fail closed", () => {
+  const db = new Database(":memory:"); // no egress_ledger table
+  expect(() =>
+    recordMcpBriefEgress(db, { method: "agents.why", params: {}, clientId: "c1", now: 1 }),
+  ).toThrow();
+  db.close();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/gateway/src/egress/mcp-brief-egress.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/gateway/src/egress/mcp-brief-egress.ts`:
+
+```typescript
+import type { Database } from "bun:sqlite";
+import { appendEgressEntry } from "./egress-ledger.ts";
+import { redactEgressSummary } from "./egress-record.ts";
+
+/**
+ * Agents that answer by querying paired peers rather than purely from the local index. Their rows
+ * must stay distinguishable from purely local briefs — collapsing them into one undifferentiated
+ * "mcp" destination would hide outbound peer traffic inside a local-looking record.
+ */
+const FEDERATION_TOUCHING: ReadonlySet<string> = new Set(["agents.ghost", "agents.huddle"]);
+
+/**
+ * The sole append site for MCP-originated agent briefs (I29, D22(c)).
+ *
+ * Called BEFORE the brief is returned to the caller. It throws on failure by design: the caller
+ * must fail closed and emit no brief, mirroring the executor's append-before-dispatch discipline.
+ * A ledger that can be outrun by the thing it records is decorative.
+ */
+export function recordMcpBriefEgress(
+  db: Database,
+  args: {
+    readonly method: string;
+    readonly params: unknown;
+    readonly clientId: string;
+    readonly now: number;
+  },
+): void {
+  appendEgressEntry(db, {
+    timestamp: args.now,
+    sourceType: "mcp",
+    sourceId: args.clientId,
+    destination: FEDERATION_TOUCHING.has(args.method) ? "mcp+federation" : "mcp",
+    method: args.method,
+    payloadSummary: redactEgressSummary(args.params),
+    hitlStatus: "not_required",
+    resultStatus: "authorized",
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/gateway/src/egress/mcp-brief-egress.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Wire the single chokepoint call**
+
+In `packages/gateway/src/ipc/agents-rpc.ts`, add the import:
+
+```typescript
+import { recordMcpBriefEgress } from "../egress/mcp-brief-egress.ts";
+```
+
+and replace `dispatchAgentsRpc` with:
+
+```typescript
+export async function dispatchAgentsRpc(
+  method: string,
+  params: unknown,
+  ctx: AgentsRpcContext,
+): Promise<RpcMissOrHit> {
+  // I29/D22(c): an MCP-originated brief is egress — the gateway synthesises from the private index
+  // and hands the result to whatever model the calling client uses. Append BEFORE any work, and let
+  // a failure propagate: no row, no brief.
+  if (ctx.caller?.kind === "mcp" && method.startsWith("agents.")) {
+    recordMcpBriefEgress(ctx.db, {
+      method,
+      params,
+      clientId: ctx.caller.clientId,
+      now: Date.now(),
+    });
+  }
+  return dispatchByMethod<AgentsRpcContext>(method, params, ctx, {
+    "agents.expert": handleExpert,
+    "agents.impact": handleImpact,
+    "agents.catchup": handleCatchup,
+    "agents.ghost": handleGhost,
+    "agents.conflicts": handleConflicts,
+    "agents.huddle": handleHuddle,
+    "agents.janitor": handleJanitor,
+    "agents.preflight": handlePreflight,
+    "agents.why": handleWhy,
+    "agents.whyPeek": handleWhyPeek,
+    "agents.glossary": handleGlossary,
+    "agents.decisions": handleDecisions,
+  });
+}
+```
+
+- [ ] **Step 6: Write the attribution test**
+
+Append to `packages/gateway/src/ipc/agents-rpc.test.ts`:
+
+```typescript
+test("a CLI-originated agents call appends NO egress row", async () => {
+  const db = freshDb();
+  await dispatchAgentsRpc(
+    "agents.expert",
+    { topicOrFile: "x" },
+    { ...makeCtx(db), caller: { clientId: "c1", kind: "cli" as const } },
+  );
+  const n = db.query(`SELECT COUNT(*) AS n FROM egress_ledger`).get() as { n: number };
+  expect(n.n).toBe(0);
+});
+
+test("an MCP-originated agents call appends exactly one egress row", async () => {
+  const db = freshDb();
+  await dispatchAgentsRpc(
+    "agents.expert",
+    { topicOrFile: "x" },
+    { ...makeCtx(db), caller: { clientId: "c1", kind: "mcp" as const } },
+  );
+  const rows = db.query(`SELECT source_type FROM egress_ledger`).all() as Array<{ source_type: string }>;
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.source_type).toBe("mcp");
+});
+```
+
+Run: `bun test packages/gateway/src/ipc/agents-rpc.test.ts`
+Expected: PASS. If `freshDb()` does not create `egress_ledger`, extend that helper to run the same `CREATE TABLE` used in the Step 1 test.
+
+- [ ] **Step 7: Extend the static audit with `D22(c)`**
+
+In `scripts/structure-audit/check-nimbus-invariants.ts`, beside the existing `D22` constants (around line 599), add:
+
+```typescript
+// (c) the MCP brief egress chokepoint must be TOTAL: `recordMcpBriefEgress` is CALLED from exactly
+// one file. This mirrors (a) — it pins the caller, it does not merely permit an appender. Adding a
+// file to an allowlist here would satisfy the checker while dissolving the property it protects.
+const D22_MCP_RECORD_RE = /\brecordMcpBriefEgress\b/;
+const D22_MCP_RECORD_CALLER = "packages/gateway/src/ipc/agents-rpc.ts";
+const D22_MCP_RECORD_DEFINITION = "packages/gateway/src/egress/mcp-brief-egress.ts";
+```
+
+and inside the same per-line loop that already tests `D22_DISPATCH_RE` and `D22_APPEND_RE`, add:
+
+```typescript
+      if (
+        D22_MCP_RECORD_RE.test(line) &&
+        f.relPath !== D22_MCP_RECORD_CALLER &&
+        f.relPath !== D22_MCP_RECORD_DEFINITION
+      ) {
+        violations.push({
+          rule: "D22-mcp-brief-egress",
+          file: f.relPath,
+          line: lineNo,
+          snippet: line.trim(),
+        });
+      }
+```
+
+Extend the `D22` error message near line 810 to name the third rule:
+
+```typescript
+        `::error file=${e.file},line=${e.line}::D22 egress chokepoint breach (connectors.dispatch outside executor.ts, appendEgressEntry outside egress/, or recordMcpBriefEgress outside agents-rpc.ts) — bypasses I29: ${e.snippet}`,
+```
+
+- [ ] **Step 8: Red-prove the static rule**
+
+Temporarily add a line `recordMcpBriefEgress;` to `packages/gateway/src/ipc/clip-rpc.ts`, then run:
+
+Run: `bun run audit:invariants`
+Expected: FAIL with `D22-mcp-brief-egress`. **Remove the temporary line** and re-run — expected: PASS. A guard that has never been observed failing is not a guard.
+
+- [ ] **Step 9: Update the invariant docs and enforcement test**
+
+In `docs/SECURITY-INVARIANTS.md`, in the `I29` section, add to the description of the append paths:
+
+```markdown
+A second append path exists for MCP-originated agent briefs. An agent brief served to a client that
+declared itself `mcp` at connect time is egress — the gateway synthesises from the private index and
+hands the result to whatever model the calling client uses — so one `egress_ledger` row with
+`source_type='mcp'` is appended before any agent work begins, and a failed append aborts the call.
+`D22` is extended, not exempted: rule (c) pins the *caller* of `recordMcpBriefEgress` to
+`ipc/agents-rpc.ts`, in the same shape as rule (a) pinning `connectors.dispatch` to `executor.ts`.
+A CLI-originated call appends nothing, because a brief rendered locally never leaves the machine.
+```
+
+In `packages/gateway/src/security-invariants.test.ts`, add:
+
+```typescript
+test("I29: recordMcpBriefEgress is called from exactly one file", async () => {
+  const { $ } = await import("bun");
+  const out = await $`rg -l "recordMcpBriefEgress" packages/gateway/src`.text();
+  const files = out.split("\n").filter((l) => l.length > 0 && !l.includes(".test."));
+  expect(files.sort()).toEqual([
+    "packages/gateway/src/egress/mcp-brief-egress.ts",
+    "packages/gateway/src/ipc/agents-rpc.ts",
+  ]);
+});
+```
+
+- [ ] **Step 10: Run the invariant suite**
+
+Run: `bun test packages/gateway/src/security-invariants.test.ts && bun run audit:invariants`
+Expected: PASS.
+
+- [ ] **Step 11: Commit (the full triple in one commit)**
+
+```bash
+git add packages/gateway/src/egress/mcp-brief-egress.ts packages/gateway/src/egress/mcp-brief-egress.test.ts packages/gateway/src/ipc/agents-rpc.ts packages/gateway/src/ipc/agents-rpc.test.ts scripts/structure-audit/check-nimbus-invariants.ts docs/SECURITY-INVARIANTS.md packages/gateway/src/security-invariants.test.ts
+git commit -m "feat(gateway): record MCP-originated agent briefs in the egress ledger"
+```
+
+---
+
+### Task 5: First MCP tool — `peekWhy`
+
+**Files:**
+
+- Modify: `packages/cli/src/mcp/adapter.ts:332-404` (`TOOL_SPECS`), `:406-417` (`buildMcpServer`)
+- Modify: `packages/cli/src/mcp/adapter.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ToolSpec`, `AdapterDeps`, `runTool`, `jsonResult`, `optString` (all existing in `adapter.ts`).
+- Produces: the `peekWhy` entry in `TOOL_SPECS`. Task 6 appends beside it.
+
+`agents.whyPeek` is synchronous — it returns a payload directly with no `briefReady` notification — so this tool needs none of Task 6's router machinery. It proves registration, dispatch, error handling and the ledger append end to end first.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/cli/src/mcp/adapter.test.ts`:
+
+```typescript
+test("peekWhy is registered and calls agents.whyPeek", async () => {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const deps = {
+    getClient: async () => ({
+      call: async <T,>(method: string, params?: unknown): Promise<T> => {
+        calls.push({ method, params });
+        return { summary: "because of PR #412" } as T;
+      },
+      disconnect: async (): Promise<void> => {},
+    }),
+  };
+  const spec = TOOL_SPECS.find((s) => s.name === "peekWhy");
+  expect(spec).toBeDefined();
+  const out = await spec?.run(deps, { fileOrPrUrl: "src/a.ts" });
+  expect(calls[0]?.method).toBe("agents.whyPeek");
+  expect(calls[0]?.params).toEqual({ fileOrPrUrl: "src/a.ts" });
+  expect(out?.isError).toBeUndefined();
+  expect(out?.content[0]?.text).toContain("because of PR #412");
+});
+
+test("peekWhy reports a stopped gateway without throwing", async () => {
+  const deps = {
+    getClient: (): Promise<never> => Promise.reject(new GatewayUnavailableError()),
+  };
+  const spec = TOOL_SPECS.find((s) => s.name === "peekWhy");
+  const out = await spec?.run(deps, { fileOrPrUrl: "src/a.ts" });
+  expect(out?.isError).toBe(true);
+  expect(out?.content[0]?.text).toBe(GATEWAY_DOWN_MESSAGE);
+});
+```
+
+Ensure the test file imports `TOOL_SPECS`, `GatewayUnavailableError` and `GATEWAY_DOWN_MESSAGE` from `./adapter.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/cli/src/mcp/adapter.test.ts -t "peekWhy"`
+Expected: FAIL — `expect(spec).toBeDefined()` fails; `peekWhy` is not registered.
+
+- [ ] **Step 3: Register the tool**
+
+In `packages/cli/src/mcp/adapter.ts`, append to `TOOL_SPECS`:
+
+```typescript
+  {
+    name: "peekWhy",
+    description:
+      "Fast why-lens probe for a file or PR URL: returns a compact explanation of why the code is the way it is, drawn from the local relationship graph (authorship, PRs, incidents, decisions). Synchronous — use explainWhy for the full brief.",
+    schema: { fileOrPrUrl: z.string() },
+    run: (deps, args) =>
+      runTool(deps, async (c) =>
+        jsonResult(
+          await c.call("agents.whyPeek", { fileOrPrUrl: optString(args, "fileOrPrUrl") ?? "" }),
+        ),
+      ),
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/cli/src/mcp/adapter.test.ts -t "peekWhy"`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Declare the client kind on connect**
+
+In `packages/cli/src/mcp/adapter.ts`, inside `createDeps`'s `openConnection`, after the client is connected and wrapped, declare the kind so the gateway can attribute the calls:
+
+```typescript
+    const client = makeReconnectingClient(raw, invalidate);
+    // I29: identify this connection as MCP so the gateway records briefs served over it as egress.
+    // Best-effort — an older gateway without `session.declareKind` must not break the adapter.
+    try {
+      await client.call("session.declareKind", { kind: "mcp" });
+    } catch {
+      // Older gateway: it will still serve briefs, but it cannot attribute them, so nothing is
+      // recorded in the egress ledger. Say so on stderr — silently serving unrecorded briefs would
+      // make `nimbus prove` quietly wrong, which is the exact failure this feature exists to close.
+      // stderr is safe here: the MCP protocol channel is stdout.
+      process.stderr.write(
+        "nimbus-mcp: gateway does not support session.declareKind; agent briefs served over MCP will NOT appear in the egress ledger. Upgrade the gateway.\n",
+      );
+    }
+    cached = client;
+    return client;
+```
+
+- [ ] **Step 6: Run the full adapter suite**
+
+Run: `bun test packages/cli/src/mcp/`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck and lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/mcp/adapter.ts packages/cli/src/mcp/adapter.test.ts
+git commit -m "feat(cli): expose the why-peek agent as an MCP tool"
+```
+
+---
+
+### Task 6: The ten async agent tools
+
+**Files:**
+
+- Create: `packages/cli/src/mcp/errors.ts`
+- Create: `packages/cli/src/mcp/agent-tools.ts`
+- Create: `packages/cli/src/mcp/agent-tools.test.ts`
+- Modify: `packages/cli/src/mcp/adapter.ts` (`TOOL_SPECS`, error re-exports, `invalidate`)
+
+**Interfaces:**
+
+- Consumes: `AgentBriefRouter`, `PendingBrief` (Task 1); `ToolSpec`, `AdapterDeps`, `IpcCallable`, `runTool`, `ToolResult` (existing).
+- Produces: `AGENT_TOOL_SPECS: ToolSpec[]`, spread into `TOOL_SPECS`.
+
+`agents.preflight` is **deliberately excluded** — it is the `I24` federated action path and triggers sandboxed execution on peers behind the owner's HITL gate. Do not add it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/src/mcp/agent-tools.test.ts`:
+
+```typescript
+import { expect, test } from "bun:test";
+import { AGENT_TOOL_SPECS } from "./agent-tools.ts";
+
+/** A fake client that answers the agents.* call and then emits the matching briefReady. */
+function briefClient(sessionId: string, brief: string) {
+  const handlers = new Map<string, Array<(p: unknown) => void>>();
+  return {
+    onNotification(method: string, h: (p: unknown) => void): void {
+      const l = handlers.get(method) ?? [];
+      l.push(h);
+      handlers.set(method, l);
+    },
+    async call<T>(method: string, _params?: unknown): Promise<T> {
+      const agent = method.slice("agents.".length);
+      queueMicrotask(() => {
+        for (const h of handlers.get(`${agent}.briefReady`) ?? []) {
+          h({ sessionId, brief, findings: { gaps: [] } });
+        }
+      });
+      return { sessionId } as T;
+    },
+    async disconnect(): Promise<void> {},
+  };
+}
+
+test("all ten async agents are registered, and preflight is not", () => {
+  const names = AGENT_TOOL_SPECS.map((s) => s.name).sort();
+  expect(names).toEqual(
+    [
+      "assessImpact",
+      "checkResourceUsage",
+      "explainWhy",
+      "findConflicts",
+      "findDecisions",
+      "findExpert",
+      "getCatchup",
+      "getGlossary",
+      "getPeerContext",
+      "getTeamHuddle",
+    ].sort(),
+  );
+  expect(names).not.toContain("runPreflight");
+});
+
+test("explainWhy returns the brief markdown as the first content block", async () => {
+  const client = briefClient("s1", "## Why\n\nBecause of PR #412.");
+  const deps = { getClient: async () => client };
+  const spec = AGENT_TOOL_SPECS.find((s) => s.name === "explainWhy");
+  const out = await spec?.run(deps, { fileOrPrUrl: "src/a.ts" });
+  expect(out?.isError).toBeUndefined();
+  expect(out?.content[0]?.text).toContain("Because of PR #412.");
+});
+
+test("the typed findings ride along as a second content block", async () => {
+  const client = briefClient("s1", "brief");
+  const deps = { getClient: async () => client };
+  const spec = AGENT_TOOL_SPECS.find((s) => s.name === "getCatchup");
+  const out = await spec?.run(deps, {});
+  expect(out?.content).toHaveLength(2);
+  expect(out?.content[1]?.text).toContain("gaps");
+});
+
+test("a brief error becomes an MCP error result, never a throw", async () => {
+  const handlers = new Map<string, Array<(p: unknown) => void>>();
+  const client = {
+    onNotification(m: string, h: (p: unknown) => void): void {
+      const l = handlers.get(m) ?? [];
+      l.push(h);
+      handlers.set(m, l);
+    },
+    async call<T>(_m: string, _p?: unknown): Promise<T> {
+      queueMicrotask(() => {
+        for (const h of handlers.get("why.briefError") ?? []) h({ sessionId: "s1", error: "no index" });
+      });
+      return { sessionId: "s1" } as T;
+    },
+    async disconnect(): Promise<void> {},
+  };
+  const spec = AGENT_TOOL_SPECS.find((s) => s.name === "explainWhy");
+  const out = await spec?.run({ getClient: async () => client }, { fileOrPrUrl: "x" });
+  expect(out?.isError).toBe(true);
+  expect(out?.content[0]?.text).toContain("no index");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/cli/src/mcp/agent-tools.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Extract the shared error surface**
+
+`agent-tools.ts` needs three runtime values that live in `adapter.ts`, and `adapter.ts` will import
+`AGENT_TOOL_SPECS` from `agent-tools.ts` — a cycle. Break it by moving the three into their own
+module rather than reaching for a dynamic import.
+
+Create `packages/cli/src/mcp/errors.ts` by **moving** these declarations verbatim out of
+`adapter.ts`:
+
+```typescript
+export const GATEWAY_DOWN_MESSAGE = "Nimbus Gateway is not running. Start it with: nimbus start";
+
+/** Thrown when the adapter cannot reach the Gateway (no state file, or connect failed). */
+export class GatewayUnavailableError extends Error {
+  constructor() {
+    super(GATEWAY_DOWN_MESSAGE);
+    this.name = "GatewayUnavailableError";
+  }
+}
+
+const DISCONNECT_MESSAGES: ReadonlySet<string> = new Set([
+  "IPC client is not connected",
+  "IPC connection closed",
+  "IPC connection error",
+]);
+
+/** True when an error is one of IPCClient's transport-dead messages and a reconnect is warranted. */
+export function isDisconnectError(e: unknown): boolean {
+  return e instanceof Error && DISCONNECT_MESSAGES.has(e.message);
+}
+```
+
+In `adapter.ts`, delete those declarations and re-export them so existing importers keep working:
+
+```typescript
+export { GATEWAY_DOWN_MESSAGE, GatewayUnavailableError, isDisconnectError } from "./errors.ts";
+import { GATEWAY_DOWN_MESSAGE, GatewayUnavailableError, isDisconnectError } from "./errors.ts";
+```
+
+Run: `bun test packages/cli/src/mcp/ && bun run typecheck`
+Expected: PASS, clean — this step is a pure move and must change no behaviour.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `packages/cli/src/mcp/agent-tools.ts`:
+
+```typescript
+import { z } from "zod";
+import { AgentBriefRouter, type BriefNotificationSource } from "../lib/agent-brief-router.ts";
+import type { AdapterDeps, IpcCallable, ToolResult, ToolSpec } from "./adapter.ts";
+import { GATEWAY_DOWN_MESSAGE, GatewayUnavailableError, isDisconnectError } from "./errors.ts";
+
+const AGENT_TIMEOUT_MS = 60_000;
+
+/** One router per client object, so listeners bind once per agent name per connection. */
+const routers = new WeakMap<object, AgentBriefRouter>();
+
+function routerFor(client: object): AgentBriefRouter {
+  const existing = routers.get(client);
+  if (existing !== undefined) return existing;
+  const created = new AgentBriefRouter(client as BriefNotificationSource);
+  routers.set(client, created);
+  return created;
+}
+
+/**
+ * Reject every brief in flight on this client. Wired into the adapter's reconnect `invalidate`
+ * hook so a mid-flight transport death fails fast instead of waiting out the timeout.
+ */
+export function failBriefsForClient(client: object, err: Error): void {
+  routers.get(client)?.failAll(err);
+}
+
+function briefResult(brief: string, findings: unknown): ToolResult {
+  return {
+    content: [
+      { type: "text", text: brief },
+      { type: "text", text: JSON.stringify(findings, null, 2) },
+    ],
+  };
+}
+
+/**
+ * Invoke an async agent and await its brief.
+ *
+ * The waiter is registered BEFORE the call so a fast agent cannot emit before anyone is listening,
+ * and bound to the returned sessionId immediately after, so a concurrent caller's brief is never
+ * mistaken for this one.
+ */
+async function runAgent(
+  client: IpcCallable,
+  agentName: string,
+  ipcMethod: string,
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  // No guard: findings are returned verbatim as JSON, so there is nothing to validate against.
+  const pending = routerFor(client as unknown as object).expect<unknown>(
+    agentName,
+    undefined,
+    AGENT_TIMEOUT_MS,
+  );
+  try {
+    const { sessionId } = await client.call<{ sessionId: string }>(ipcMethod, params);
+    pending.bindSession(sessionId);
+    const { brief, findings } = await pending.result;
+    return briefResult(brief, findings);
+  } catch (e) {
+    pending.cancel();
+    throw e;
+  }
+}
+
+interface AgentToolDef {
+  readonly tool: string;
+  readonly agent: string;
+  readonly description: string;
+  readonly schema: Record<string, z.ZodTypeAny>;
+  readonly build: (args: Record<string, unknown>) => Record<string, unknown>;
+}
+
+function str(o: Record<string, unknown>, k: string): string {
+  const v = o[k];
+  return typeof v === "string" ? v : "";
+}
+
+function optNum(o: Record<string, unknown>, k: string): number | undefined {
+  const v = o[k];
+  return typeof v === "number" ? v : undefined;
+}
+
+function withOptional(
+  base: Record<string, unknown>,
+  extra: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...base };
+  for (const [k, v] of Object.entries(extra)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+const DEFS: readonly AgentToolDef[] = [
+  {
+    tool: "explainWhy",
+    agent: "why",
+    description:
+      "Explain why a file or PR is the way it is — six parallel lanes over the local relationship graph (authorship, PRs, incidents, decisions, discussions, adjacent code). Returns a markdown brief.",
+    schema: { fileOrPrUrl: z.string() },
+    build: (a) => ({ fileOrPrUrl: str(a, "fileOrPrUrl") }),
+  },
+  {
+    tool: "getCatchup",
+    agent: "catchup",
+    description:
+      "Retrospective digest of what happened across connected services while the user was away, personalized to their work.",
+    schema: { since: z.string().optional() },
+    build: (a) => withOptional({}, { since: a["since"] }),
+  },
+  {
+    tool: "findExpert",
+    agent: "expert",
+    description:
+      "Answer 'who has the most context on this?' — a ranked list of people drawn from indexed PRs, reviews, incidents and discussions.",
+    schema: { topicOrFile: z.string(), limit: z.number().int().positive().optional() },
+    build: (a) => withOptional({ topicOrFile: str(a, "topicOrFile") }, { limit: optNum(a, "limit") }),
+  },
+  {
+    tool: "assessImpact",
+    agent: "impact",
+    description:
+      "Answer 'if I change this, what breaks?' — reverse-dependency blast radius across services, dashboards, tests, docs and owners.",
+    schema: { fileOrPrUrl: z.string(), depth: z.number().int().min(1).max(5).optional() },
+    build: (a) => withOptional({ fileOrPrUrl: str(a, "fileOrPrUrl") }, { depth: optNum(a, "depth") }),
+  },
+  {
+    tool: "findConflicts",
+    agent: "conflicts",
+    description:
+      "Warn of work-in-progress collisions before editing a file — teammates with an open PR or assigned ticket touching the same code.",
+    schema: { file: z.string() },
+    build: (a) => ({ file: str(a, "file") }),
+  },
+  {
+    tool: "findDecisions",
+    agent: "decisions",
+    description:
+      "Recover decision records that were made but never written down, reconstructed from discussions, PRs and issues.",
+    schema: { topic: z.string().optional(), limit: z.number().int().positive().optional() },
+    build: (a) => withOptional({}, { topic: a["topic"], limit: optNum(a, "limit") }),
+  },
+  {
+    tool: "getGlossary",
+    agent: "glossary",
+    description:
+      "Team terminology as a queryable glossary, extracted from how the team actually writes. Returns one term's definition when `term` is given, otherwise lists the glossary.",
+    schema: { term: z.string().optional(), limit: z.number().int().positive().optional() },
+    build: (a) => withOptional({}, { term: a["term"], limit: optNum(a, "limit") }),
+  },
+  {
+    tool: "checkResourceUsage",
+    agent: "janitor",
+    description:
+      "Answer 'is this cloud resource still in use, and what breaks if I delete it?' — cross-references a resource against indexed code, config and deploys.",
+    schema: { resourceRef: z.string() },
+    build: (a) => ({ resourceRef: str(a, "resourceRef") }),
+  },
+  {
+    tool: "getPeerContext",
+    agent: "ghost",
+    description:
+      "Ambient teammate context for a file, gathered from paired peers across the federation mesh. Reaches the network beyond this machine.",
+    schema: { file: z.string() },
+    build: (a) => ({ file: str(a, "file") }),
+  },
+  {
+    tool: "getTeamHuddle",
+    agent: "huddle",
+    description:
+      "Team-scoped briefing aggregating each teammate's recent PRs, tickets and incidents from paired peers. Reaches the network beyond this machine.",
+    schema: { namespace: z.string().optional() },
+    build: (a) => withOptional({}, { namespace: a["namespace"] }),
+  },
+];
+
+export const AGENT_TOOL_SPECS: ToolSpec[] = DEFS.map((d) => ({
+  name: d.tool,
+  description: d.description,
+  schema: d.schema,
+  run: (deps: AdapterDeps, args: Record<string, unknown>): Promise<ToolResult> =>
+    runAgentTool(deps, d, args),
+}));
+
+/** Mirrors the adapter's `runTool` contract: never throws, always returns a ToolResult. */
+async function runAgentTool(
+  deps: AdapterDeps,
+  def: AgentToolDef,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  let client: IpcCallable;
+  try {
+    client = await deps.getClient();
+  } catch (e) {
+    if (e instanceof GatewayUnavailableError) {
+      return { content: [{ type: "text", text: e.message }], isError: true };
+    }
+    return {
+      content: [{ type: "text", text: `Nimbus: ${e instanceof Error ? e.message : String(e)}` }],
+      isError: true,
+    };
+  }
+  try {
+    return await runAgent(client, def.agent, `agents.${def.agent}`, def.build(args));
+  } catch (e) {
+    if (isDisconnectError(e)) {
+      return { content: [{ type: "text", text: GATEWAY_DOWN_MESSAGE }], isError: true };
+    }
+    return {
+      content: [{ type: "text", text: `Nimbus: ${e instanceof Error ? e.message : String(e)}` }],
+      isError: true,
+    };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test packages/cli/src/mcp/agent-tools.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 6: Register the specs in the adapter**
+
+In `packages/cli/src/mcp/adapter.ts`, import and spread:
+
+```typescript
+import { AGENT_TOOL_SPECS } from "./agent-tools.ts";
+```
+
+Change the `TOOL_SPECS` declaration's closing to append them:
+
+```typescript
+export const TOOL_SPECS: ToolSpec[] = [
+  // ... the existing six specs and peekWhy ...
+  ...AGENT_TOOL_SPECS,
+];
+```
+
+Update the `buildMcpServer` doc comment: it says "all six read-only tools" — make it "all read-only tools".
+
+- [ ] **Step 7: Wire transport-death rejection**
+
+Without this, a connection that dies mid-brief leaves the caller waiting the full 60-second timeout
+and then reporting a timeout rather than a disconnect. `createDeps` already detects transport death
+in order to invalidate its cached client; that is the hook.
+
+In `packages/cli/src/mcp/adapter.ts`, add the import:
+
+```typescript
+import { failBriefsForClient } from "./agent-tools.ts";
+```
+
+and in `makeReconnectingClient`, extend the disconnect branch:
+
+```typescript
+        if (isDisconnectError(e)) {
+          failBriefsForClient(raw as unknown as object, e as Error);
+          invalidate();
+          void raw.disconnect().catch(() => {});
+        }
+```
+
+Note the router is keyed on the **raw** client, which is what `runAgent` receives after
+`getClient()` returns the wrapper — verify the object identity matches when this runs. If it does
+not, key `routerFor` on the wrapper instead and pass that same object here.
+
+Append to `packages/cli/src/mcp/agent-tools.test.ts`:
+
+```typescript
+test("failBriefsForClient rejects a brief in flight on that client", async () => {
+  const handlers = new Map<string, Array<(p: unknown) => void>>();
+  const client = {
+    onNotification(m: string, h: (p: unknown) => void): void {
+      const l = handlers.get(m) ?? [];
+      l.push(h);
+      handlers.set(m, l);
+    },
+    async call<T>(_m: string, _p?: unknown): Promise<T> {
+      return { sessionId: "s1" } as T;
+    },
+    async disconnect(): Promise<void> {},
+  };
+  const spec = AGENT_TOOL_SPECS.find((s) => s.name === "explainWhy");
+  const running = spec?.run({ getClient: async () => client }, { fileOrPrUrl: "x" });
+  await Promise.resolve();
+  failBriefsForClient(client, new Error("IPC connection closed"));
+  const out = await running;
+  expect(out?.isError).toBe(true);
+});
+```
+
+Run: `bun test packages/cli/src/mcp/agent-tools.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 8: Assert the registered tool count**
+
+Append to `packages/cli/src/mcp/adapter.test.ts`:
+
+```typescript
+test("the registered tool set is the six index tools plus peekWhy plus ten agents", () => {
+  expect(TOOL_SPECS).toHaveLength(17);
+  const names = new Set(TOOL_SPECS.map((s) => s.name));
+  expect(names.has("searchIndex")).toBe(true);
+  expect(names.has("peekWhy")).toBe(true);
+  expect(names.has("explainWhy")).toBe(true);
+  expect(names.has("runPreflight")).toBe(false);
+});
+```
+
+- [ ] **Step 9: Run the full CLI MCP suite**
+
+Run: `bun test packages/cli/src/mcp/ && bun run typecheck && bun run lint`
+Expected: PASS, clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/cli/src/mcp/errors.ts packages/cli/src/mcp/agent-tools.ts packages/cli/src/mcp/agent-tools.test.ts packages/cli/src/mcp/adapter.ts packages/cli/src/mcp/adapter.test.ts
+git commit -m "feat(cli): expose ten read-only agents as MCP tools"
+```
+
+---
+
+### Task 7: MIT launcher package
+
+**Files:**
+
+- Create: `packages/mcp-launcher/package.json`
+- Create: `packages/mcp-launcher/LICENSE`
+- Create: `packages/mcp-launcher/README.md`
+- Create: `packages/mcp-launcher/src/resolve-binary.ts`
+- Create: `packages/mcp-launcher/src/resolve-binary.test.ts`
+- Create: `packages/mcp-launcher/src/index.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks. **Must not import from `packages/cli` or `packages/gateway`** — those are AGPL and this package is MIT.
+- Produces: a `bin` entry `nimbus-mcp` that execs the resolved gateway CLI with `mcp-server --stdio`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/mcp-launcher/src/resolve-binary.test.ts`:
+
+```typescript
+import { expect, test } from "bun:test";
+import { CANDIDATE_DIRS, resolveNimbusBinary } from "./resolve-binary.ts";
+
+test("an explicit NIMBUS_BIN wins over everything", () => {
+  const got = resolveNimbusBinary({
+    env: { NIMBUS_BIN: "/custom/nimbus" },
+    platform: "linux",
+    home: "/home/u",
+    exists: (p) => p === "/custom/nimbus",
+  });
+  expect(got).toEqual({ kind: "found", path: "/custom/nimbus", via: "NIMBUS_BIN" });
+});
+
+test("a NIMBUS_BIN pointing at nothing is an explicit error, not a silent fallback", () => {
+  const got = resolveNimbusBinary({
+    env: { NIMBUS_BIN: "/missing/nimbus" },
+    platform: "linux",
+    home: "/home/u",
+    exists: () => false,
+  });
+  expect(got.kind).toBe("bad-override");
+});
+
+test("PATH is used when NIMBUS_BIN is unset", () => {
+  const got = resolveNimbusBinary({
+    env: { PATH: "/usr/bin:/usr/local/bin" },
+    platform: "linux",
+    home: "/home/u",
+    exists: (p) => p === "/usr/local/bin/nimbus",
+  });
+  expect(got).toEqual({ kind: "found", path: "/usr/local/bin/nimbus", via: "PATH" });
+});
+
+test("falls back to a known install directory", () => {
+  const got = resolveNimbusBinary({
+    env: {},
+    platform: "linux",
+    home: "/home/u",
+    exists: (p) => p === "/home/u/.nimbus/bin/nimbus",
+  });
+  expect(got).toEqual({ kind: "found", path: "/home/u/.nimbus/bin/nimbus", via: "install-dir" });
+});
+
+test("windows looks for nimbus.exe", () => {
+  const got = resolveNimbusBinary({
+    env: { LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local" },
+    platform: "win32",
+    home: "C:\\Users\\u",
+    exists: (p) => p.endsWith("nimbus.exe"),
+  });
+  expect(got.kind).toBe("found");
+  if (got.kind === "found") expect(got.path.endsWith("nimbus.exe")).toBe(true);
+});
+
+test("not found is reported, never thrown", () => {
+  const got = resolveNimbusBinary({
+    env: {},
+    platform: "darwin",
+    home: "/Users/u",
+    exists: () => false,
+  });
+  expect(got.kind).toBe("not-found");
+});
+
+test("every platform has at least one candidate directory", () => {
+  for (const p of ["win32", "darwin", "linux"] as const) {
+    expect(CANDIDATE_DIRS(p, "/home/u", {}).length).toBeGreaterThan(0);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/mcp-launcher/src/resolve-binary.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the resolver**
+
+Create `packages/mcp-launcher/src/resolve-binary.ts`:
+
+```typescript
+import { join } from "node:path";
+
+export type Platform = "win32" | "darwin" | "linux";
+
+export type Resolution =
+  | { kind: "found"; path: string; via: "NIMBUS_BIN" | "PATH" | "install-dir" }
+  | { kind: "bad-override"; path: string }
+  | { kind: "not-found" };
+
+export interface ResolveInput {
+  readonly env: Record<string, string | undefined>;
+  readonly platform: Platform;
+  readonly home: string;
+  readonly exists: (path: string) => boolean;
+}
+
+function binName(platform: Platform): string {
+  return platform === "win32" ? "nimbus.exe" : "nimbus";
+}
+
+/**
+ * Known install locations, by platform. This duplicates a small amount of path knowledge that the
+ * AGPL CLI also holds — deliberately, because this package is MIT and cannot import from it. The
+ * drift risk is covered by a test asserting this list against the installers' output directories.
+ */
+export function CANDIDATE_DIRS(
+  platform: Platform,
+  home: string,
+  env: Record<string, string | undefined>,
+): string[] {
+  if (platform === "win32") {
+    const localAppData = env["LOCALAPPDATA"] ?? join(home, "AppData", "Local");
+    return [join(localAppData, "Nimbus", "bin"), join(localAppData, "Programs", "Nimbus")];
+  }
+  if (platform === "darwin") {
+    return [join(home, ".nimbus", "bin"), "/usr/local/bin", "/opt/homebrew/bin"];
+  }
+  return [join(home, ".nimbus", "bin"), join(home, ".local", "bin"), "/usr/local/bin", "/usr/bin"];
+}
+
+export function resolveNimbusBinary(input: ResolveInput): Resolution {
+  const name = binName(input.platform);
+
+  const override = input.env["NIMBUS_BIN"];
+  if (override !== undefined && override.length > 0) {
+    return input.exists(override)
+      ? { kind: "found", path: override, via: "NIMBUS_BIN" }
+      : { kind: "bad-override", path: override };
+  }
+
+  const sep = input.platform === "win32" ? ";" : ":";
+  for (const dir of (input.env["PATH"] ?? "").split(sep)) {
+    if (dir.length === 0) continue;
+    const candidate = join(dir, name);
+    if (input.exists(candidate)) return { kind: "found", path: candidate, via: "PATH" };
+  }
+
+  for (const dir of CANDIDATE_DIRS(input.platform, input.home, input.env)) {
+    const candidate = join(dir, name);
+    if (input.exists(candidate)) return { kind: "found", path: candidate, via: "install-dir" };
+  }
+
+  return { kind: "not-found" };
+}
+
+const DOCS = "https://nimbus-agent.dev/docs/install";
+
+/** The message shown for each unresolvable state. Each names the fix, never a bare exit code. */
+export function explain(resolution: Resolution): string {
+  if (resolution.kind === "bad-override") {
+    return `NIMBUS_BIN is set to "${resolution.path}" but no file is there. Correct it or unset it. See ${DOCS}`;
+  }
+  return `Could not find the Nimbus CLI. Install it (see ${DOCS}), or set NIMBUS_BIN to its full path.`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/mcp-launcher/src/resolve-binary.test.ts`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Write the entry point**
+
+Create `packages/mcp-launcher/src/index.ts`:
+
+```typescript
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { explain, type Platform, resolveNimbusBinary } from "./resolve-binary.ts";
+
+const resolution = resolveNimbusBinary({
+  env: process.env,
+  platform: process.platform as Platform,
+  home: homedir(),
+  exists: existsSync,
+});
+
+if (resolution.kind !== "found") {
+  process.stderr.write(`${explain(resolution)}\n`);
+  process.exit(1);
+}
+
+const child = spawn(resolution.path, ["mcp-server", "--stdio"], { stdio: "inherit" });
+child.on("exit", (code) => {
+  process.exit(code ?? 0);
+});
+child.on("error", (err) => {
+  process.stderr.write(`Failed to start the Nimbus MCP server: ${err.message}\n`);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 6: Write the package manifest**
+
+Create `packages/mcp-launcher/package.json`:
+
+```json
+{
+  "name": "@nimbus-dev/mcp",
+  "version": "0.1.0",
+  "description": "Launcher for the Nimbus MCP server — exposes your local Nimbus index and agents to any MCP client.",
+  "license": "MIT",
+  "type": "module",
+  "bin": { "nimbus-mcp": "./dist/index.js" },
+  "files": ["dist"],
+  "scripts": {
+    "build": "bun build src/index.ts --target node --outdir dist",
+    "test": "bun test"
+  }
+}
+```
+
+Create `packages/mcp-launcher/LICENSE` containing the standard MIT licence text, copyright the Nimbus authors.
+
+Create `packages/mcp-launcher/README.md` documenting: what it does, that it requires the Nimbus gateway to be installed and running, the `NIMBUS_BIN` override, and an example MCP client configuration block.
+
+- [ ] **Step 7: Verify the licence boundary**
+
+Run: `grep -rn "packages/cli\|packages/gateway\|@nimbus-dev/client" packages/mcp-launcher/src/`
+Expected: no output. Any hit is an AGPL import into an MIT package and must be removed.
+
+- [ ] **Step 8: Run everything**
+
+Run: `bun test packages/mcp-launcher/ && bun run typecheck && bun run lint`
+Expected: PASS, clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/mcp-launcher/
+git commit -m "feat(mcp-launcher): add the MIT launcher package"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full fast gate set**
+
+Run: `bun run preflight:fast`
+Expected: all gates pass. Note `bun run lint` silently reports zero files inside `.claude/worktrees/` — if this branch is being developed in a worktree, run Biome with an explicit path to get a real result.
+
+- [ ] **Run the affected suites**
+
+Run: `bun test packages/cli/src packages/gateway/src/ipc packages/gateway/src/egress`
+Expected: PASS.
+
+- [ ] **Confirm the invariant guard still red-proves**
+
+Re-do Task 4 Step 8 once more against the final tree. A guard that has never been observed failing is not a guard.
+
+## Deferred, and why
+
+- **Gateway-hosted HTTP/SSE transport.** The recorded successor. Once an HTTP agent-invocation route exists, the stdio adapter becomes a thin client of it rather than a parallel implementation.
+- **`agents.preflight` as a tool.** The `I24` federated action path. Exposing any HITL-gated action through MCP is a separate design, and it should start from whether an external model should be able to originate a consent prompt at all.
+- **Registry submission.** Publishing `@nimbus-dev/mcp` and listing it in MCP directories is a release activity, not an implementation task.

--- a/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design-review-response.md
+++ b/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design-review-response.md
@@ -1,0 +1,195 @@
+# Agents as MCP tools — review response
+
+> **Status:** response of record, 2026-08-02. Answers
+> [the review](./2026-08-02-agents-as-mcp-tools-design-review.md) of
+> [the design](./2026-08-02-agents-as-mcp-tools-design.md). Three points accepted
+> (two with material refinement), one accepted in substance with its framing
+> rejected, one rejected on its premise. The design has been revised; this
+> document records why.
+
+## Summary
+
+| # | Review point | Verdict |
+| --- | --- | --- |
+| 1 | Binary discovery in the launcher | **Accepted, refined** — added an env override, and a licence constraint the review missed |
+| 2 | Leak-free deregistration | **Accepted, extended** — the real gap is transport death, not the timeout path |
+| 3 | Static confinement update | **Substance accepted, framing rejected** — the proposed fix would retire the invariant |
+| 4 | UI-specific agent parameters | **Rejected** — the premise does not hold against the IPC contract |
+| 5 | Complete tool-name map | **Accepted, delivered** — with one correction to the review's example |
+
+One defect the review did not raise turned out to matter more than four of the
+five points; it is recorded at the end.
+
+## 1. Binary discovery — accepted, refined
+
+The concern is correct and the design was thin here. A bare `exec("nimbus …")`
+does fail in exactly the situations named: the Windows installer is per-user, and
+package-manager and user-space installs land in directories an editor-spawned
+subprocess does not inherit.
+
+Two refinements to the proposed sequence:
+
+**An explicit override comes first.** The review's step 1 is a `PATH` lookup;
+the design now starts with `NIMBUS_BIN`. A hardcoded location list drifts against
+five packaging channels, whereas an env var an editor's MCP config can set
+directly resolves every exotic layout without the launcher having to predict it.
+The location list stays, demoted to a fallback.
+
+**The obvious implementation is licence-blocked, which the review missed.** The
+natural instinct is to reuse `getCliPlatformPaths`. That helper lives in the AGPL
+CLI, and the launcher is MIT — importing it would relicense the launcher. Step 3
+therefore duplicates path knowledge by necessity, which is a drift risk the
+review's version would have absorbed silently. The design now requires a test
+asserting the launcher's location list against the installers' real output
+directories.
+
+Also split: the design collapsed two failure states into one message. There are
+three — not installed, installed but stopped, and found but too old to serve the
+agent tools. The third otherwise surfaces as an unknown-method error from the IPC
+layer, which names nothing actionable.
+
+## 2. Leak-free deregistration — accepted, extended
+
+Accepted, and the review found the right area — but the specific failure it
+describes is not the one that bites, and two of its claims need correcting.
+
+**Correction one: the listeners are client-side.** The review states stale
+listeners "could accumulate on the main gateway session emitter." They do not.
+The registrations are `client.onNotification` — in the calling process. Nothing
+accumulates on the gateway. This matters for where the fix goes, and it is
+precisely why a long-lived server is the only place the leak becomes visible.
+
+**Correction two: the promise is bounded.** The review says it "might remain
+pending indefinitely." The 30-second timeout bounds it. The real cost is a caller
+waiting out a full timeout to learn something knowable immediately, and then
+being told it timed out when it actually disconnected.
+
+**The extension, which is the substantive part:** the adapter owns
+`isDisconnectError` and a reconnecting client, but `awaitAgentBrief` does not
+watch the transport at all. So a mid-flight connection drop means the awaited
+notification can never arrive and nothing notices. The design now carries four
+changes rather than three, with immediate rejection on transport death added.
+
+The proposed `AbortController` is a reasonable implementation of this and is left
+to implementation rather than mandated in the design; the binding requirement is
+that cleanup runs on every settle path, expressed once rather than duplicated
+into each branch.
+
+## 3. Static confinement — substance accepted, framing rejected
+
+The request for concreteness about where the append lives is fair, and the design
+was vague. It now names the wiring site: with the agent-invoke dispatch in
+`packages/gateway/src/ipc/`, adjacent to `dispatchAgentInvoke`, so no
+MCP-reachable agent route can bypass it.
+
+**The proposed remedy is rejected, and this is the most consequential point in
+the review.** It reads:
+
+> Update `check-nimbus-invariants.ts` to allow this specific file/function as a
+> valid writer/ledger-appender, ensuring the static audit does not fail during CI
+> preflight gates.
+
+That is an exemption wearing an extension's clothes, and "so the audit does not
+fail" is the wrong objective function. `D22`'s value is not that a known set of
+files is permitted to append. It is that **every path which can cause egress must
+pass through an append first**. Adding a file to an allowlist satisfies the
+checker while dissolving the property the checker exists to hold — the design
+already warned that an appender outside the static check silently retires the
+invariant, and this is that failure mode arriving as a suggestion.
+
+The extension must assert the new chokepoint the way `D22` asserts the
+executor's: the MCP agent path has exactly one append site, and every
+MCP-originated invocation is statically shown to route through it. A test proving
+only that the file *may* append is not an enforcement test.
+
+**The question also surfaced a genuine hole.** Appending on every `agents.*` call
+would be wrong — a CLI-invoked brief never leaves the machine, so recording it
+would make the ledger claim traffic that did not occur, the mirror image of the
+gap this design exists to close. So the gateway must distinguish MCP-originated
+calls, and the design did not say how.
+
+It can. The IPC server already mints a per-connection `clientId`
+(`ipc/server/server.ts:95`) and threads it into `dispatchAgentInvoke`. What was
+missing is not identity but *kind*, so the design adds a connect-time client-kind
+declaration, held per connection and immutable for its lifetime — server-held
+after the handshake rather than caller-supplied per call, the same property `I23`
+relies on for reply targets. A new attribution test asserts a CLI-originated call
+appends no row.
+
+## 4. UI-specific agent parameters — rejected
+
+The premise does not survive contact with the IPC contract.
+
+The review anticipates agent options that "make sense only in interactive TUI/CLI
+contexts (e.g., interactive paging, terminal width, verbose output modes, or
+confirm-prompts)" and proposes a translation filter to strip them. No such
+parameter crosses the IPC boundary. Rendering lives CLI-side in
+`renderAgentBrief`; `--json` is a CLI flag consumed before any IPC call is made.
+The observed agent params are domain-shaped throughout: `topicOrFile`,
+`fileOrPrUrl`, `depth`, `term`, `limit`, `resourceRef`.
+
+The reasoning appears to start from the CLI's flag surface rather than the
+`agents.*` method signatures. Building a filter for a category of parameter that
+does not exist would add a component whose tests could only assert that it does
+nothing.
+
+Converted to a stated rule at zero cost, since the concern is worth foreclosing
+even though the mechanism is not: tool schemas mirror **IPC params only, never
+CLI flags**. If a presentation parameter ever reaches the IPC surface, that is
+the bug to fix, at that boundary — not something to paper over downstream.
+
+## 5. Tool-name map — accepted, delivered
+
+Fair, and cheap to close. The design deferred names to implementation; the full
+map is now in the design, derived from each agent's entry in
+[`cli-reference.md`](../../cli-reference.md) rather than guessed.
+
+One correction: the review's example lists a `status` agent. There is none. The
+eleven are `catchup`, `conflicts`, `decisions`, `expert`, `ghost`, `glossary`,
+`huddle`, `impact`, `janitor`, `preflight`, `why`, plus the synchronous
+`why-peek`.
+
+Naming judgement worth recording: three internal names (`ghost`, `janitor`,
+`huddle`) are meaningless to a calling model and become `getPeerContext`,
+`checkResourceUsage` and `getTeamHuddle`. `glossary` becomes `getGlossary` rather
+than `lookupTerm`, because `term` is optional and the tool lists the whole
+glossary when it is omitted — a name that describes only the dominant mode would
+mislead the caller about the other one.
+
+## Not raised by the review: `preflight` is not a read
+
+Checking the agent roster to build the naming map surfaced a defect neither the
+design nor the review caught.
+
+The design asserted "everything here is read-only" and proposed exposing all
+eleven agents. `preflight` is not a read. It asks each paired downstream owner in
+a namespace to *run* their own preflight — the `I24` federated action-request
+path, which executes a sandboxed command behind the local owner's HITL gate.
+
+Exposing it would let a calling model trigger execution on peer machines and
+queue consent prompts on the owner's. An external model that can originate a
+consent prompt can also spam it, which is a plausible route to approval fatigue
+against the mechanism the entire safety argument rests on.
+
+`preflight` is now excluded, and the out-of-scope entry records that exposing any
+HITL-gated action through MCP should begin from whether an external model should
+be able to originate a consent prompt at all — not from how to plumb it.
+
+Related, and now recorded rather than flattened: `ghost` and `huddle` remain
+reads but reach across the federation, so they cause outbound peer traffic. Their
+ledger rows must stay distinguishable from purely local briefs.
+
+## What changed in the design
+
+- Surface: full agent-to-tool map; `preflight` excluded with rationale;
+  federation-touching agents flagged; the IPC-params-only rule stated.
+- Prerequisite: four changes rather than three, adding transport-death rejection;
+  the client-side nature of the leak made explicit.
+- Ledger: a new caller-attribution section; the invariant-cost section rewritten
+  to reject allowlisting and name the wiring site.
+- Packaging: the discovery sequence, the AGPL/MIT constraint on path helpers, and
+  three distinct failure states.
+- Testing: attribution, transport-death and launcher-discovery rows added; the
+  static-audit row sharpened to exclude a permission-only assertion.
+- Ground truth: rows for per-connection `clientId` and for the one non-read
+  agent.

--- a/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design-review.md
+++ b/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design-review.md
@@ -1,0 +1,103 @@
+# Review & Feedback: Agents as MCP Tools Design
+
+This document contains a structured review, suggestions, improvements, and open questions regarding the design for exposing Nimbus agents as MCP tools, as specified in [2026-08-02-agents-as-mcp-tools-design.md](./2026-08-02-agents-as-mcp-tools-design.md).
+
+---
+
+## 1. Binary Discovery in the MIT NPX Launcher
+
+### Issue: Path Resolution of the Nimbus Binary
+
+The design specifies:
+> A separate MIT package whose `bin` shells to `nimbus mcp-server --stdio`.
+
+Since the CLI is AGPL and installed separately from the MIT launcher, `nimbus` might not always be present on the global `PATH`. This is especially common on Windows or when Nimbus is installed via local user-space managers or custom directory paths. A naive `exec("nimbus ...")` will fail with command-not-found, leading to a poor user experience for editor integrations using `npx`.
+
+### Recommendation
+
+The MIT launcher should implement a robust binary discovery sequence:
+
+1. Check if `nimbus` is available directly on the `PATH`.
+2. If not found, check platform-specific default installation paths (e.g., `%APPDATA%\nimbus\bin` or local Bun global bins on Windows, `~/.nimbus/bin` or `/usr/local/bin` on macOS/Linux).
+3. If still not found, print a helpful, platform-specific error message pointing to the installation documentation (instead of a raw shell exit code).
+
+---
+
+## 2. Leak-Free Session Deregistration
+
+### Issue: Listener Leakage on Hard Timeouts or Transport Drop
+
+The design highlights that notification handlers are currently registered per call and never removed. It recommends:
+> Deregister both handlers when the promise settles, by any path including timeout.
+
+If a calling client abruptly terminates or the stdio transport breaks during an active async invocation:
+
+- The promise might remain pending indefinitely or reject via transport death.
+- Stale event listeners could accumulate on the main gateway session emitter.
+
+### Recommendation
+
+Use an explicit try-finally block or an `AbortController`/`AbortSignal` linked to both the transport lifecycle and the execution timeout:
+
+```typescript
+const abortController = new AbortController();
+// Bind IPC socket close to abortController.abort()
+// Ensure the listener deregistration callback is unconditionally invoked in the `finally` block of the promise.
+```
+
+---
+
+## 3. Static Confinement Audit Updates (D22 / Invariant I29)
+
+### Issue: Static Confinement Boundaries
+
+The design states:
+> This is a *second* append path. It must extend `D22`'s static confinement rather than be exempted from it...
+
+The static code checker `scripts/structure-audit/check-nimbus-invariants.ts` strictly enforces that `connectors.dispatch` (or SQLite writes) are confined. Adding a second append path for MCP reads in the gateway requires modifying the static checker rules.
+
+### Recommendation
+
+Explicitly outline in the implementation details:
+
+- Where the new append logic will reside in the gateway (e.g., `packages/gateway/src/egress/egress-ledger.ts` or `packages/gateway/src/ipc/handlers/agents.ts`).
+- Update `check-nimbus-invariants.ts` to allow this specific file/function as a valid writer/ledger-appender, ensuring the static audit does not fail during CI preflight gates.
+
+---
+
+## 4. Agent Schema and Parameter Adaptation
+
+### Issue: Human-Interactive Parameters
+
+Some built-in agents might expect options that make sense only in interactive TUI/CLI contexts (e.g., interactive paging, terminal width, verbose output modes, or confirm-prompts).
+
+### Q4.1: How are parameter defaults handled?
+
+When mapping schemas to MCP tool parameters, do we strip or hide UI-specific parameters from the LLM-facing tool schemas, or do we expose them with defaults?
+
+### Recommendation
+
+Define a clean schema translation filter when wrapping IPC parameter Zod schemas to MCP tool schemas. Automatically omit formatting parameters (like `--color` or `--interactive`) to prevent the calling LLM from hallucinating values or trying to invoke interactive flags.
+
+---
+
+## 5. Tool Naming Consistency
+
+### Issue: Mapping 11 Agents to Verb-Shaped Tool Names
+
+The design notes:
+> Names stay verb-shaped to match the existing six — `explainWhy`, `getCatchup`, `findExpert`, `assessImpact`, `findConflicts` — rather than mirroring internal agent names.
+
+To avoid ambiguity during implementation, a complete map of internal agent names to their respective verb-shaped MCP tool names should be established.
+
+### Recommendation
+
+Verify and document the mapping of all 11 agents. For example:
+
+- `why` -> `explainWhy`
+- `catchup` -> `getCatchup`
+- `expert` -> `findExpert`
+- `impact` -> `assessImpact`
+- `conflicts` -> `findConflicts`
+- `status` -> `checkStatus` (or similar)
+- ... (and so on for all 11 agents).

--- a/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
@@ -1,0 +1,210 @@
+# Agents as MCP tools — design
+
+> **Status:** design of record, 2026-08-02. Scope is exposing the built-in
+> agents through the existing `nimbus mcp-server` stdio surface, plus the
+> packaging change that makes that server listable in MCP directories. The
+> gateway-hosted HTTP transport is explicitly the successor, not this design.
+
+## The problem
+
+Nimbus's differentiated capability is its agents: eleven read-only briefs
+synthesised from a private cross-service index. Every one of them is reachable
+from exactly one place — the local IPC socket, via the CLI.
+
+Meanwhile `nimbus mcp-server` already ships and already speaks to editors. It
+exposes six tools, all of them thin index reads: search, connector status, three
+recency browses, and DORA metrics. The surface that carries none of the
+product's differentiated capability is the only surface other agents can reach.
+
+This is backwards. It is also the cheapest distribution the project has
+available, and it inverts the usual arrangement in a way no hosted product can
+copy: every SaaS agent asks you to upload your context, whereas this hands an
+external agent your private cross-service context **while the index never
+moves**.
+
+### Why now, and why this shape
+
+Three independent analyses converged on this item, and verification found it
+cheaper than any of them estimated — the adapter, the connection cache with
+reconnect-on-transport-death, the never-throw error discipline and the tool
+registration loop all already exist. The work is genuinely tool registrations
+plus one correctness fix.
+
+The packaging half matters as much as the feature half. Directory listings are
+currently unreachable for a purely mechanical reason: the MCP server is a
+gateway subcommand rather than an artifact on a supported registry.
+
+## Measured ground truth
+
+Verified against the tree on 2026-08-02.
+
+| Fact | Value | Measured from |
+| --- | --- | --- |
+| Existing MCP tools | 6 | `TOOL_SPECS`, `packages/cli/src/mcp/adapter.ts` |
+| Built-in agents | 11 async + 1 synchronous peek | `packages/gateway/src/agents/` |
+| Async agent contract | returns `sessionId`, then emits `<agent>.briefReady` with markdown **and** typed findings | `agents/_lib/emit-brief.ts` |
+| Notification delivery | broadcast to every connected session | `broadcastNotification`, `ipc/server/server.ts:72` |
+| `sessionId` comparison in the await adapter | destructured, never compared | `lib/agent-brief-render.ts:20` |
+| Ledger `sourceType` | first-class field, committed to the BLAKE3 row hash | `egress/egress-ledger.ts:11,29` |
+| Existing `sourceType` values | `task`, `prune` | `egress-record.ts:51`, `egress-prune.ts:91` |
+| Free index text already crossing to the editor LLM | `semanticSnippet` | `projectRankedItem`, `adapter.ts:96` |
+
+That last row settles a question that would otherwise dominate the design: prose
+drawn from indexed bodies **already** reaches the editor's model today. A brief
+is a difference of degree, not of kind.
+
+## Decisions taken
+
+1. **Briefs cross as raw markdown.** The brief is the product; projecting it
+   through the item whitelist would discard the synthesis, which is the entire
+   reason to call the tool. The typed findings ride along as a second content
+   block for callers that want structure. The real control is therefore *which
+   agents are exposed* and *whether the call is recorded* — not redaction.
+2. **Every MCP agent invocation is recorded in the egress ledger** under a new
+   `sourceType`. See "Ledger integration".
+3. **Extend the existing CLI adapter; add an MIT launcher.** Rejected
+   alternatives: a gateway-hosted HTTP/SSE transport (correct eventual shape,
+   but a new authenticated HTTP surface, and it wants to be designed together
+   with the HTTP agent route rather than ahead of it), and a standalone MIT
+   server package (duplicates the adapter and creates a second consumer of the
+   IPC contract, for a packaging benefit the launcher already buys).
+
+## Surface
+
+One tool per agent, appended to `TOOL_SPECS`. Names stay verb-shaped to match
+the existing six — `explainWhy`, `getCatchup`, `findExpert`, `assessImpact`,
+`findConflicts` — rather than mirroring internal agent names. Each tool's
+description is lifted from that agent's CLI help, so the calling model receives
+the same framing a human does. Exact names for the less self-evident agents are
+pinned during implementation from each agent's own description.
+
+Argument schemas mirror the agent's IPC params, reusing the existing zod
+helpers. Result shape:
+
+- content block 1 — the brief markdown, verbatim.
+- content block 2 — the typed findings as JSON.
+
+**Ship order: `peekWhy` first.** `runWhyPeek` is already synchronous, so the
+first tool exercises registration, dispatch, error handling and the ledger
+append end to end without touching the notification path at all. The async
+agents follow once that is proven.
+
+## Prerequisite — session correlation
+
+This must land before any async agent tool, and it is not optional.
+
+`awaitAgentBrief` resolves on the first `<agent>.briefReady` it sees. It reads
+`sessionId` out of the payload and never compares it, while the gateway
+broadcasts every notification to every connected session. A one-shot CLI cannot
+observe this. A long-lived MCP server serving two editor windows fails
+immediately, and it fails by handing one caller another caller's brief — the
+worst available failure mode for a product whose pitch is data boundaries.
+
+A second defect sits in the same function: notification handlers are registered
+per call and never removed. Again harmless in a process that exits; in a
+long-lived server it leaks a handler per invocation and every stale handler
+fires on every subsequent brief.
+
+Three changes:
+
+1. Compare the notification's `sessionId` against the one returned by the
+   `agents.<name>` call; ignore non-matching notifications rather than
+   resolving on them.
+2. Deregister both handlers when the promise settles, by any path including
+   timeout.
+3. Make the 30-second timeout injectable — appropriate for a CLI, wrong to
+   hardcode for callers with their own deadlines.
+
+The CLI inherits the correctness fix.
+
+## Ledger integration
+
+An MCP call causes the gateway to synthesise a brief from the private index and
+hand it to whichever model the calling editor uses. Under today's wiring that
+leaves no trace: `I29` appends at the executor's `connectors.dispatch`
+chokepoint, and an MCP read never dispatches a connector action. `nimbus prove`
+would report a clean window while private context left the machine.
+
+Closing that is what makes this feature defensible rather than merely
+convenient.
+
+**Row shape.** `sourceType: "mcp"`; `destination: "mcp"`; `method` the invoked
+IPC method (`agents.why`); `source_id` the MCP session; `payload_summary` the
+subject argument scrubbed through `redactAuditPayload` at the existing 256-byte
+cap. No migration is required — `source_type` already exists and is already
+committed to the row hash, so existing receipts remain valid.
+
+**Two properties that must not be traded away:**
+
+- **Gateway-side, not adapter-side.** The gateway is the authority. An append
+  performed by the CLI adapter would be a claim by the caller about itself.
+- **Append before the brief returns, fail-closed.** If the append fails the tool
+  returns an error and no brief crosses the boundary, mirroring `gate()`'s
+  existing discipline. A ledger that can be outrun by the thing it records is
+  decorative.
+
+**Invariant cost, stated plainly.** This is a *second* append path. It must
+extend `D22`'s static confinement rather than be exempted from it — an appender
+outside the static check silently retires the invariant it appears to serve.
+Per the triple rule, one commit carries: the wiring, the `I29` section update in
+[`SECURITY-INVARIANTS.md`](../../SECURITY-INVARIANTS.md), the enforcement test,
+and a new case in the static audit. This is the largest single cost in the
+design.
+
+## Packaging
+
+A separate MIT package whose `bin` shells to `nimbus mcp-server --stdio`.
+Separate because the CLI is AGPL; MIT because a launcher people are asked to run
+via `npx` should impose no obligations.
+
+The install-time failure mode needs deliberate handling, because the package
+installs cleanly and then does nothing useful on its own:
+
+- gateway installed but stopped — already covered by `GATEWAY_DOWN_MESSAGE`.
+- gateway not installed at all — needs its own message pointing at the install
+  documentation.
+
+## Error handling
+
+All tools route through the existing `runTool`, which never throws and always
+returns an `isError` result. Three cases are new:
+
+- **Agent timeout** — surfaced as an error result, not a hang.
+- **`briefError`** — the agent's own failure message, passed through.
+- **Empty index** — the CLI path calls `process.exit(1)` on an `empty_index`
+  gap, which an MCP server must never do. Returns a message directing the caller
+  to sync instead.
+
+## Testing
+
+| Layer | What it proves |
+| --- | --- |
+| Adapter unit tests | tool registration, argument validation, projection, error results — injected `IpcCallable`, existing pattern |
+| **Concurrency test** | two simultaneous calls to one agent each receive their own brief. Must fail against today's code, or the session fix is unproven |
+| Handler-leak test | handler count returns to baseline after a settled call, including on timeout |
+| Ledger tests | exactly one `source_type='mcp'` row per invocation; a failed append suppresses the brief entirely |
+| Static audit | the extended `D22` confinement accepts the new append site and still rejects an unconfined one |
+| E2E stdio | extends `mcp-server-stdio.test.ts` |
+
+The concurrency test is the load-bearing one. It should be written first and
+observed failing.
+
+## Out of scope
+
+- **Gateway-hosted HTTP/SSE transport.** The recorded successor. Once the HTTP
+  agent-invocation route exists, the stdio adapter becomes a thin client of it
+  rather than a parallel implementation.
+- **Write-capable tools.** Everything here is read-only. Exposing a
+  HITL-gated action through MCP is a separate design with a separate threat
+  model.
+- **Third-party agent authoring.** Requires opening the closed brief union;
+  tracked in [`ecosystem-roadmap.md`](../../ecosystem-roadmap.md) Track B.
+
+## Open questions
+
+- Whether the typed findings block should be omitted for agents whose findings
+  are large enough to dominate the response. Resolve by measurement during
+  implementation, not up front.
+- Whether `destination` should distinguish calling clients. The gateway cannot
+  reliably identify the editor behind a stdio pipe, so this design records the
+  transport rather than inventing an unverifiable client identity.

--- a/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
@@ -272,9 +272,14 @@ directories, rather than left to rot.
 
 - Gateway not installed — the discovery failure above.
 - Gateway installed but stopped — already covered by `GATEWAY_DOWN_MESSAGE`.
-- Gateway found but too old to serve the agent tools — a version check against
-  the tool set, so the failure names the fix instead of surfacing an unknown
-  method error from the IPC layer.
+- Gateway found but too old to attribute the connection — detected by the
+  adapter at connect time, when the client-kind declaration is rejected as an
+  unknown method. Such a gateway will still serve briefs, but nothing will be
+  recorded in the ledger, so this must be reported rather than swallowed:
+  silently serving unrecorded briefs makes `nimbus prove` quietly wrong, which
+  is the exact failure this design exists to close. Reported on stderr, which is
+  safe because the MCP protocol channel is stdout. The launcher cannot detect
+  this itself — it sees the CLI binary, not the gateway's method surface.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-08-02-agents-as-mcp-tools-design.md
@@ -4,6 +4,9 @@
 > agents through the existing `nimbus mcp-server` stdio surface, plus the
 > packaging change that makes that server listable in MCP directories. The
 > gateway-hosted HTTP transport is explicitly the successor, not this design.
+>
+> **Revised 2026-08-02** following review — see
+> [the review response](./2026-08-02-agents-as-mcp-tools-design-review-response.md).
 
 ## The problem
 
@@ -48,6 +51,8 @@ Verified against the tree on 2026-08-02.
 | Ledger `sourceType` | first-class field, committed to the BLAKE3 row hash | `egress/egress-ledger.ts:11,29` |
 | Existing `sourceType` values | `task`, `prune` | `egress-record.ts:51`, `egress-prune.ts:91` |
 | Free index text already crossing to the editor LLM | `semanticSnippet` | `projectRankedItem`, `adapter.ts:96` |
+| Per-connection caller identity | `clientId`, `randomUUID()` per connection, threaded into `dispatchAgentInvoke` | `ipc/server/server.ts:95,172` |
+| Agents that are not pure reads | 1 — `preflight` (the `I24` federated action path) | `docs/cli-reference.md`, `federation/preflight-gate.ts` |
 
 That last row settles a question that would otherwise dominate the design: prose
 drawn from indexed bodies **already** reaches the editor's model today. A brief
@@ -71,15 +76,45 @@ is a difference of degree, not of kind.
 
 ## Surface
 
-One tool per agent, appended to `TOOL_SPECS`. Names stay verb-shaped to match
-the existing six — `explainWhy`, `getCatchup`, `findExpert`, `assessImpact`,
-`findConflicts` — rather than mirroring internal agent names. Each tool's
-description is lifted from that agent's CLI help, so the calling model receives
-the same framing a human does. Exact names for the less self-evident agents are
-pinned during implementation from each agent's own description.
+One tool per exposed agent, appended to `TOOL_SPECS`. Names stay verb-shaped to
+match the existing six rather than mirroring internal agent names, several of
+which (`ghost`, `janitor`, `huddle`) mean nothing to a calling model. Each
+tool's description is lifted from that agent's entry in
+[`cli-reference.md`](../../cli-reference.md), so the calling model receives the
+same framing a human does.
 
-Argument schemas mirror the agent's IPC params, reusing the existing zod
-helpers. Result shape:
+| Agent | Tool | Purpose |
+| --- | --- | --- |
+| `why-peek` | `peekWhy` | synchronous why-lens probe; ships first |
+| `why` | `explainWhy` | why is this line/file the way it is — six parallel lanes over the relationship graph |
+| `catchup` | `getCatchup` | retrospective digest of what happened while you were away |
+| `expert` | `findExpert` | who on the team has the most context on this |
+| `impact` | `assessImpact` | if I change this, what breaks — reverse-dependency blast radius |
+| `conflicts` | `findConflicts` | work-in-progress collisions before editing a file |
+| `decisions` | `findDecisions` | recovers decision records never written down |
+| `glossary` | `getGlossary` | team terminology as a queryable glossary; lists when `term` is omitted |
+| `janitor` | `checkResourceUsage` | is this cloud resource still in use, and what breaks if I delete it |
+| `ghost` | `getPeerContext` | ambient teammate context for a file, via paired peers |
+| `huddle` | `getTeamHuddle` | team-scoped briefing across paired peers |
+
+**`preflight` is deliberately excluded.** It is the only agent in the set that is
+not purely a read: it asks each paired downstream owner in a namespace to *run*
+their own preflight, which is the `I24` federated action-request path — sandboxed
+execution behind the local owner's HITL gate. Exposing it would let a calling
+model queue consent prompts on the owner's machine and trigger execution on
+peers. Read-only is the boundary of this design; see "Out of scope".
+
+**`getPeerContext` and `getTeamHuddle` reach across the federation.** They remain
+reads and stay behind the `I17` query gate, but unlike the other nine they cause
+outbound peer traffic. That distinction must survive into the ledger row rather
+than being flattened into a generic MCP entry.
+
+Argument schemas mirror the agent's IPC params — **IPC params only, never CLI
+flags**. The IPC surface is already free of presentation concerns because
+rendering lives CLI-side in `renderAgentBrief`; observed params are domain-shaped
+throughout (`topicOrFile`, `fileOrPrUrl`, `depth`, `term`, `limit`,
+`resourceRef`). No filter for UI-specific options is required, because no such
+option crosses the IPC boundary. Reusing the existing zod helpers. Result shape:
 
 - content block 1 — the brief markdown, verbatim.
 - content block 2 — the typed findings as JSON.
@@ -105,17 +140,31 @@ per call and never removed. Again harmless in a process that exits; in a
 long-lived server it leaks a handler per invocation and every stale handler
 fires on every subsequent brief.
 
-Three changes:
+A third gap sits alongside them. If the gateway connection drops mid-flight, the
+awaited notification can never arrive, and nothing observes that: the adapter
+owns `isDisconnectError` and a reconnecting client, but `awaitAgentBrief` does
+not watch the transport. The call is not stranded forever — the 30-second
+timeout bounds it — but a caller waits out that full timeout to learn something
+knowable immediately, and reports it as a timeout rather than a disconnect.
+
+Four changes:
 
 1. Compare the notification's `sessionId` against the one returned by the
    `agents.<name>` call; ignore non-matching notifications rather than
    resolving on them.
-2. Deregister both handlers when the promise settles, by any path including
-   timeout.
-3. Make the 30-second timeout injectable — appropriate for a CLI, wrong to
+2. Deregister both handlers when the promise settles, by any path — resolve,
+   reject, timeout, or transport death. A `finally` on the settle path, not
+   cleanup duplicated into each branch.
+3. Reject immediately on transport death, with a disconnect error rather than a
+   timeout error.
+4. Make the 30-second timeout injectable — appropriate for a CLI, wrong to
    hardcode for callers with their own deadlines.
 
-The CLI inherits the correctness fix.
+The handlers in question are client-side (`client.onNotification`); nothing
+accumulates on the gateway. The leak is bounded to the calling process, which is
+precisely why a long-lived server is where it becomes visible.
+
+The CLI inherits all four fixes.
 
 ## Ledger integration
 
@@ -143,13 +192,56 @@ committed to the row hash, so existing receipts remain valid.
   existing discipline. A ledger that can be outrun by the thing it records is
   decorative.
 
-**Invariant cost, stated plainly.** This is a *second* append path. It must
-extend `D22`'s static confinement rather than be exempted from it — an appender
-outside the static check silently retires the invariant it appears to serve.
-Per the triple rule, one commit carries: the wiring, the `I29` section update in
+### Caller attribution
+
+Appending on every `agents.*` call would be wrong: a CLI-invoked brief never
+leaves the machine, so recording it as egress would make the ledger claim
+traffic that did not occur — the mirror image of the honesty gap this section
+exists to close. The append must fire only for MCP-originated calls, so the
+gateway has to distinguish them.
+
+It already can. The IPC server mints a per-connection `clientId` (`randomUUID()`,
+`ipc/server/server.ts:95`) and threads it through `dispatchMethod` into
+`dispatchAgentInvoke`. The missing piece is not identity but *kind*.
+
+The design adds a connect-time client-kind declaration, recorded once per
+connection and immutable for its lifetime. This matters more than it looks:
+a per-call payload field would be caller-supplied on every invocation, whereas a
+connection-scoped kind is server-held after the handshake — the same
+server-derived-not-caller-supplied property `I23` relies on for reply targets.
+
+The honest reading of a resulting row is "the gateway served this brief to a
+connection that identified as MCP." That is adequate here, because every client
+on this socket is a local process the owner started; anyone able to open it can
+already call anything. The threat model is honesty of record, not defence
+against a hostile local caller.
+
+Federation-touching agents (`getPeerContext`, `getTeamHuddle`) additionally cause
+outbound peer traffic. Their rows must remain distinguishable from purely local
+briefs rather than collapsing into one undifferentiated MCP entry.
+
+### Invariant cost, stated plainly
+
+This is a *second* append path, and the framing of how it lands is load-bearing.
+
+The wrong move — and the tempting one, because it turns CI green in a line — is
+to add the new file to the static checker as a permitted appender. That is an
+exemption wearing an extension's clothes. `D22`'s value is not that a known set
+of files may append; it is that every path which can cause egress *must* pass
+through an append first. An allowlist entry satisfies the checker while
+dissolving the property.
+
+The extension must therefore assert the new chokepoint the way `D22` asserts the
+executor's: the MCP agent path has exactly one append site, and every
+MCP-originated agent invocation is statically shown to route through it. A test
+that only proves "this file is allowed to append" is not an enforcement test.
+
+Per the triple rule, one commit carries the wiring, the `I29` section update in
 [`SECURITY-INVARIANTS.md`](../../SECURITY-INVARIANTS.md), the enforcement test,
-and a new case in the static audit. This is the largest single cost in the
-design.
+and the extended static case. Wiring site: the append belongs with the
+agent-invoke dispatch in `packages/gateway/src/ipc/`, adjacent to
+`dispatchAgentInvoke`, so that no MCP-reachable agent route can bypass it. This
+is the largest single cost in the design.
 
 ## Packaging
 
@@ -157,12 +249,32 @@ A separate MIT package whose `bin` shells to `nimbus mcp-server --stdio`.
 Separate because the CLI is AGPL; MIT because a launcher people are asked to run
 via `npx` should impose no obligations.
 
-The install-time failure mode needs deliberate handling, because the package
-installs cleanly and then does nothing useful on its own:
+**Binary discovery.** A bare `exec("nimbus …")` is not sufficient. `nimbus` is
+frequently absent from a global `PATH` — the Windows installer is per-user, and
+package-manager and user-space installs land in directories that editors
+spawning a subprocess do not inherit. The resolution order is:
 
-- gateway installed but stopped — already covered by `GATEWAY_DOWN_MESSAGE`.
-- gateway not installed at all — needs its own message pointing at the install
-  documentation.
+1. `NIMBUS_BIN`, if set. An explicit escape hatch that works for every packaging
+   scheme and is the one thing an editor's MCP config can set directly.
+2. `PATH` lookup.
+3. A small documented set of per-OS install locations.
+4. Otherwise, a platform-specific error naming the install documentation — not a
+   raw command-not-found exit code.
+
+One constraint the obvious implementation violates: the launcher **cannot import
+the CLI's path helpers**. `getCliPlatformPaths` lives in the AGPL CLI, and this
+package is MIT. Step 3 therefore duplicates a small amount of path knowledge by
+necessity. That duplication is a drift risk and should be covered by a test that
+asserts the launcher's location list against the installers' actual output
+directories, rather than left to rot.
+
+**Three distinct failure states**, which must not be collapsed into one message:
+
+- Gateway not installed — the discovery failure above.
+- Gateway installed but stopped — already covered by `GATEWAY_DOWN_MESSAGE`.
+- Gateway found but too old to serve the agent tools — a version check against
+  the tool set, so the failure names the fix instead of surfacing an unknown
+  method error from the IPC layer.
 
 ## Error handling
 
@@ -182,8 +294,11 @@ returns an `isError` result. Three cases are new:
 | Adapter unit tests | tool registration, argument validation, projection, error results — injected `IpcCallable`, existing pattern |
 | **Concurrency test** | two simultaneous calls to one agent each receive their own brief. Must fail against today's code, or the session fix is unproven |
 | Handler-leak test | handler count returns to baseline after a settled call, including on timeout |
+| Transport-death test | a mid-flight disconnect rejects immediately with a disconnect error, not after the full timeout |
 | Ledger tests | exactly one `source_type='mcp'` row per invocation; a failed append suppresses the brief entirely |
-| Static audit | the extended `D22` confinement accepts the new append site and still rejects an unconfined one |
+| **Attribution test** | a CLI-originated `agents.*` call appends **no** row. The false-positive guard — a ledger that over-reports is as dishonest as one that under-reports |
+| Static audit | the extended `D22` confinement proves every MCP-originated agent route passes through the append site, and still rejects an unconfined one. Asserting the file is *permitted* to append does not count |
+| Launcher discovery | the per-OS location list matches the installers' actual output directories, so the duplicated path knowledge cannot rot silently |
 | E2E stdio | extends `mcp-server-stdio.test.ts` |
 
 The concurrency test is the load-bearing one. It should be written first and
@@ -194,9 +309,14 @@ observed failing.
 - **Gateway-hosted HTTP/SSE transport.** The recorded successor. Once the HTTP
   agent-invocation route exists, the stdio adapter becomes a thin client of it
   rather than a parallel implementation.
-- **Write-capable tools.** Everything here is read-only. Exposing a
-  HITL-gated action through MCP is a separate design with a separate threat
-  model.
+- **Write-capable tools, and `preflight`.** Everything exposed here is a read.
+  `agents.preflight` is excluded despite being an "agent" because it is the
+  `I24` federated action-request path: it triggers sandboxed execution on peers
+  behind the local owner's HITL gate. A calling model that can invoke it can
+  queue consent prompts on the owner's machine. Exposing any HITL-gated action
+  through MCP is a separate design with a separate threat model, and it should
+  start from the question of whether an external model should be able to
+  *originate* a consent prompt at all.
 - **Third-party agent authoring.** Requires opening the closed brief union;
   tracked in [`ecosystem-roadmap.md`](../../ecosystem-roadmap.md) Track B.
 

--- a/docs/superpowers/specs/2026-08-02-i29-d22-egress-completeness-design.md
+++ b/docs/superpowers/specs/2026-08-02-i29-d22-egress-completeness-design.md
@@ -1,0 +1,215 @@
+# I29 / D22 egress-ledger completeness — security spec
+
+> **Status:** security spec of record, 2026-08-02. Documents a verified gap between what `I29`
+> claims and what `D22` enforces, enumerates every bypass, and proposes phased remediation. One
+> finding exceeds record-honesty and has its own immediate-mitigation section.
+
+## Summary
+
+`I29` states that the egress ledger is complete over the executor chokepoint, and `D22`'s own source
+comment asserts totality: *"there is no escape hatch, no 'approved wrapper' carve-out … Any future
+shortcut or custom-wrapper bypass therefore fails this preflight static check immediately."*
+
+That assertion describes an intent, not a mechanism. `D22` is a **regex over source text** matching
+the literal string `connectors.dispatch`. Any path that reaches the network without typing that
+string passes, and eleven classes already do. For nine of them the harm is a **false completeness
+claim** — `nimbus prove` printing a clean window that was not clean — rather than an attacker
+gaining a capability. Two cross real trust boundaries, and one is a genuine pre-authentication
+execution risk.
+
+The remediation is ordered **truth before coverage**: the first phase makes the claim honest without
+extending coverage at all, because a label that leads its mechanism is precisely the defect being
+fixed.
+
+## The claim, and why it is false
+
+`D22` has two parts: `connectors.dispatch` may appear only in `engine/executor.ts`, and
+`appendEgressEntry` is confined to `egress/`. Three independent falsifications:
+
+1. **A wrapper already exists and passes.** `connectors/connector-write-dispatch.ts:21` is a literal
+   `ConnectorDispatcher` decorator calling `inner.dispatch(action)`. It is benign today only by
+   wiring accident. It is the "approved wrapper carve-out" the comment says cannot exist.
+2. **A helper re-exposes execution under a new name and passes.**
+   `teamvault/connector-session.ts:119-129` hands out a `session.call` façade.
+3. **Three raw `tool.execute()` calls pass**, because a lazy-mesh tool is a bare
+   `{ execute?(input, ctx) }` record (`connectors/lazy-mesh/tool-map.ts:22-25`) and calling it
+   spells nothing the regex matches.
+
+Two structural aggravators found alongside:
+
+- **The sink is optional.** `engine/executor.ts:224` declares `egressSink?: EgressSink`. Eleven
+  `new ToolExecutor(` sites exist; eight omit it, safe today only because they pair with a rejecting
+  stub dispatcher. Nothing structural stops a ninth.
+- **The enforcement test is non-behavioural.** It asserts only that the audit source *contains the
+  string* `D22-connectors-dispatch`, so it passes with both regexes gutted.
+
+## Enumerated bypasses
+
+Eleven classes reach the network with no `egress_ledger` row. Ranked by severity, which is **not**
+the same as volume.
+
+| # | Class | Site | Reachable by | Harm |
+|---|---|---|---|---|
+| 1 | Share replay | `ipc/share-rpc.ts:172` | Third party who sent a file | **Exceeds record-honesty — see below** |
+| 2 | Remote embeddings | `embedding/openai-embedder.ts:23` | Scheduled / unattended | Indexed corpus text leaves; largest content volume |
+| 3 | ChatOps | `chatops/chatops-bot-spawn-call.ts:40` | Any member of a bound channel | Third-party-triggered outbound on bot credentials; pre-auth identity lookup |
+| 4 | Team-vault invoke | `teamvault/team-tool-spawn.ts:12` | Paired federated peer | Org-shared credential spent with no chained record |
+| 5 | Warehouse list paging | `connectors/connector-list-page.ts:47` | Scheduled / unattended | Up to 1000 calls per sync on a team credential |
+| 6 | Connector sync | `sync/scheduler.ts:650` | Scheduled / unattended | Largest class by request count; makes `prove` unsound in the ordinary case |
+| 7 | Conversational agent | `engine/run-conversational-agent.ts:147` | Local owner | Richest single request body |
+| 8 | OAuth refresh | `auth/oauth-registry.ts:486` | Scheduled / unattended | Credential material leaves, unattended, with no record at all |
+| 9 | Federated wire | `ipc/lan-client.ts:155` | Local owner (implicit) | Not HTTP, so fetch-shaped instrumentation misses it |
+| 10 | Telemetry / audit shipper / registry poll | `telemetry/flush-scheduler.ts:129` and siblings | Scheduled / unattended | Metadata only; defensible **if the tier says so** |
+| 11 | The rule itself | `scripts/structure-audit/check-nimbus-invariants.ts:590` | — | Certifies a completeness it cannot observe |
+
+The sharpest artifact in the set: `nimbus prove "<query>"` triggers intent classification
+(`engine/router.ts:129`), so **the command that prints `0 ✓` is itself a cause of unledgered
+egress** of the query text.
+
+## The one class that exceeds record-honesty
+
+`share.replay` executes tool calls chosen by a file the owner was sent. Four properties, each
+verified directly:
+
+1. **The signature is computed and then ignored.** `share-rpc.ts:289` calls `verifyShareFromBytes`;
+   `replayShare` runs unconditionally at `:294-298`; the result is returned as `{ verify, report }`
+   for display. The CLI prints `signature: INVALID` *after* the outbound calls have happened. No
+   valid signature is required to replay anything.
+2. **Parameters are attacker-controlled verbatim.** `share/recipe-runner.ts:66` returns
+   `params: v["params"]` — an unvalidated `unknown` — inside a function whose own doc comment states
+   "every field is validated."
+3. **The only control is a verb heuristic.** `isReadOnlyToolId` classifies by the trailing
+   `_`-segment against a 16-verb set. It is a positive allowlist, which is the right shape, but it
+   classifies by **name**, not by behaviour.
+4. **One allowlisted id is not a read.** `READ_VERBS` contains `"preview"`, so `iac_pulumi_preview`
+   passes. That tool runs
+   `["pulumi", "preview", "--cwd", p.workingDirectory, "--non-interactive"]`
+   (`packages/mcp-connectors/iac/src/server.ts:81-91`) with `workingDirectory` supplied by the file.
+   **`pulumi preview` evaluates the stack program in that directory.**
+
+**Stated honestly, because a spec that overstates gets dismissed.** The unconditional impact is
+arbitrary *parameterised reads* against the owner's live, personally-credentialed mesh — uncapped
+step count, no HITL, no ledger row, no `tool_call_log` entry — reachable by getting the owner to run
+`nimbus verify-share <url> --replay` on an attacker-hosted URL. Real allowlist hits today include
+`gdrive_file_download`, `gmail_message_read`, `outlook_mail_read` and `notion_database_query`.
+
+The execution path additionally requires: the `iac` connector present in the mesh, the `pulumi`
+binary on `PATH`, and a directory containing a Pulumi program that the attacker can name. Those are
+real preconditions and should not be elided — but neither should the fact that a "read-only"
+allowlist admits a program evaluator.
+
+Second-order, and independent of any tool id: merely calling `listReplayTools()` runs
+`ensureCredentialConnectorsRunning` + `ensureUserMcpConnectorsRunning` (`mesh.ts:429-431`), so a
+share file with **zero** steps force-spawns every credential connector and every user-registered
+third-party MCP server.
+
+### Immediate mitigations, independent of the phased plan
+
+These are small, and none waits on the remediation architecture:
+
+1. **Enforce the signature.** Refuse to replay unless verification succeeds and the share has not
+   expired, or require an explicit `--allow-unsigned` that names the risk.
+2. **Remove `"preview"` from `READ_VERBS`**, and re-derive the set from observed connector tool
+   behaviour rather than verb spelling. Audit the other fifteen the same way.
+3. **Validate step parameters** against the target tool's declared input schema before execution.
+4. **Cap step count** per replay.
+5. **Do not spawn the mesh to enumerate tools** until at least one step has been classified as
+   replayable.
+
+Longer term, replay belongs behind the executor like every other outbound path — which is Phase 2.
+
+## What is *not* wrong
+
+Recorded because an over-broad spec is a dismissed spec, and two of these were claimed and then
+disproved during this audit:
+
+- **`I11` is intact.** The bypasses do not defeat the tool-output envelope. `mesh.listTools()` — the
+  binding that wraps — has zero production callers, but `I11` is carried on the LLM path by
+  `wrapToolForLlm` (`engine/agent.ts:25-77`). What the bypasses actually skip is `tool_call_log`.
+- **No arbitrary-SQL warehouse tool is exposed.** `snowflake_table_query` exists only in a test
+  fixture.
+- **Team-vault invoke is not privilege escalation.** `invoke-gate.ts:82-107` enforces the write-
+  forbidden predicate, identity validity, and a per-peer per-tool RBAC grant. A peer can invoke only
+  what the owner already granted. The gap is that the record lives in a different, unchained table.
+- **`share.replay` is not LAN-reachable.** Its absence from `FORBIDDEN_OVER_LAN` is **latent**, not
+  live: LAN dispatch routes solely through `dispatchFederationRpc` and throws on a miss. It becomes
+  live the instant LAN dispatch broadens past the federation namespace — so add it to the denylist
+  now, as a cheap guard against a future change.
+
+## Remediation
+
+Five phases. The ordering principle is that each phase ships an honest label **before** the
+mechanism that earns it.
+
+### Phase 1 — Make the claim true (no new coverage)
+
+The smallest change that removes the falsehood. One commit, full triple rule.
+
+- **Freeze the taxonomy first.** `sourceType` is an open `string` and is BLAKE3-committed, so a
+  later rename is a chain break rather than a refactor. Land the closed union now, complete,
+  including members whose appenders do not exist yet: `task`, `prune`, `session`, `sync`, `model`,
+  `peer`. Enforce in TypeScript with an identity test (`toEqual` against the literal list, never a
+  length check) so widening it is a visible diff. No DB `CHECK` — the table is live, chained and
+  append-only, and a constraint would require a rebuild.
+- **Make the sink required.** Export a named `NULL_EGRESS_SINK` for the gate-only construction
+  sites. A named null is a decision on the record; an omitted optional is an accident waiting.
+- **Replace the scalar tier.** `completeness: { tier: "authorized-actions" }` becomes a per-source
+  coverage vector, so a report can state exactly what the ledger did and did not see.
+- **Correct the documentation**, including `D22`'s own comment and the `I29` section. The false
+  no-escape-hatch claim is part of the defect.
+- **Kill the false `0 ✓`** in `prove`.
+
+### Phase 2 — Remove the capability rather than confining it
+
+The decisive architectural choice: **strip `execute` from what the mesh hands out**, so there is
+nothing left to confine. Route the three bypasses through a session-scoped dispatcher, executor and
+sink. Only then land the new static rules — green, with no exemptions.
+
+This is preferred to a better regex. These checks are regex-over-source, not AST; a rule that must
+enumerate every way to call a function is a rule that will be outrun again.
+
+### Phase 3 — The sync chokepoint
+
+One row per sync run at `sync/scheduler.ts:650`, the single verified chokepoint. Note that
+`sync_telemetry` cannot carry a completeness claim: no destination, no method, no HITL status, not
+chained, and `bytes_transferred` is NULL for roughly two-thirds of connectors.
+
+### Phase 4 — Model and peer tiers
+
+Remote inference, embeddings, and outbound federated sends. **Local inference must produce no rows**
+— enforced by a structural local/remote predicate, not by convention — or the ledger becomes noise
+and the completeness claim fails in the other direction.
+
+### Phase 5 — Document the permanently excluded set by name
+
+JWKS fetches, OIDC discovery, updater manifests, the model download, mDNS advertisement. Zero user
+data leaves these, and excluding them is defensible **provided the tier string enumerates them**
+rather than hand-waving.
+
+## What not to do
+
+- **Do not add an allowlist entry so the audit passes.** That satisfies the checker while dissolving
+  the property, and it is how the current gap will recur. `D22`'s value is not that a known set of
+  files may reach the network; it is that no path can reach it unrecorded.
+- **Do not widen `source_type` incrementally.** The row hash makes each value permanent, and five
+  items independently plan to add one.
+- **Do not ship a coverage tier the mechanism does not yet earn.** That is the original defect.
+- **Do not treat `sync_telemetry` as ledger coverage.**
+
+## Verification status
+
+**Verified directly against the tree** while writing this spec: the `D22` rule text and its totality
+comment; all three raw `tool.execute()` sites; `READ_VERBS` containing `preview`; the
+`iac_pulumi_preview` argv and its attacker-supplied `workingDirectory`; `share.replay` computing
+verification and then replaying unconditionally; `parseStep` passing `params` through unvalidated;
+the absence of any egress reference in `share/`.
+
+**Agent-reported with file citations**, consistent with the above but not personally re-opened: the
+eleven-class enumeration beyond the sites named above, the eight-of-eleven `ToolExecutor`
+construction sites omitting the sink, `mesh.listTools()` having no production callers, and the
+`sync_telemetry` fidelity claims. Confirm each before it becomes a commit.
+
+**Method:** a six-agent audit — four sweeping distinct egress modalities, then a threat model and a
+remediation design over the combined enumeration. The threat pass corrected two claims from the
+sweep pass (the `I11` breach and an arbitrary-SQL warehouse tool), both of which are recorded above
+under "What is not wrong."


### PR DESCRIPTION
Seven commits, all documentation. Three artifacts.

## `docs/ecosystem-roadmap.md` — a fourth roadmap surface

The only outward-facing one: the clients, author toolchain, operator surfaces, and distribution/trust machinery around the gateway. Organised as **Track 0** (shipped but dark), **Layer 0** (enabling primitives), five outward tracks, and — added in the second pass — **eleven clusters** that replace the tracks as the buildable unit, one design doc and one plan each.

Two findings reshaped it:

- **The largest category is already built and unreachable.** `extension install` verifies Ed25519 signatures and then nothing ever spawns the entry file; `packages/ui` is a complete Tauri app with no `build-ui` job, so no desktop binary has ever shipped; `admin-console` is built by nothing, so `/admin` 503s on every installed binary; `NotificationService.show()` is an empty function, so watchers notify nobody and a pending consent prompt is only visible in the terminal that opened it. Four of the top five clusters are repair, not addition.
- **Layer 0 was mis-ranked.** The extension runtime, listed first because it looked like the biggest unlock, has real transitive leverage of zero — all three of its dependents are independently classified do-not-build. Three items filed *outside* Layer 0 out-leverage most of it.

Also records the sequencing rules (one dominates: ledger truth before every ledger report), the cross-cutting decisions that will otherwise be made accidentally by whichever item ships first, and a cut list with arguments.

## `2026-08-02-agents-as-mcp-tools-*` — design, review, response, plan

Exposing the built-in agents as MCP tools on the existing stdio server, so an external agent gets private cross-service context while the index never moves.

Decisions of record: briefs cross as raw markdown (indexed prose already reaches the editor LLM via `semanticSnippet`, so it is a difference of degree); every invocation appends to the egress ledger gateway-side and fail-closed; and the work extends the existing CLI adapter rather than adding a second IPC consumer.

The plan carries a hard prerequisite found during review: `awaitAgentBrief` reads `sessionId` and never compares it while notifications are broadcast to every session, so two concurrent callers cross briefs — invisible in a one-shot CLI, immediate in any long-lived server. Review rounds are included as separate documents rather than folded in, so the reasoning survives.

## `2026-08-02-i29-d22-egress-completeness-design.md` — security spec

`I29` claims the egress ledger is complete over the executor chokepoint, and `D22`'s own comment asserts totality. The mechanism is a regex matching the literal string `connectors.dispatch`, so any path that reaches the network without typing it passes — and eleven classes do.

The spec is deliberate about severity: for nine of the eleven the harm is a **false completeness claim** rather than a capability gain, and it says so. `share.replay` is the exception, and its immediate mitigations are already fixed in #1021. Remediation is phased truth-before-coverage — phase 1 makes the claim honest without extending coverage at all, because a label that leads its mechanism is the defect being fixed.

Also records what is **not** wrong, including two claims raised and then disproved during the audit: `I11` is intact (carried by `wrapToolForLlm`; what the bypasses skip is `tool_call_log`), and no arbitrary-SQL warehouse tool is exposed.

## Verification

Every document separates what was verified directly against the tree from what is agent-reported with file citations, so nothing here gets planned around without confirmation. `lint:markdown` clean on all files (via a scratch copy — the repo config excludes `.claude/worktrees/**`, so running it in a worktree silently checks nothing).

Docs-only: no code, no release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)