### PR TITLE
fix(ipc): forbid the clip namespace over LAN — clip.pair opens the I30 pairing window

### DIFF
--- a/packages/gateway/src/ipc/lan-rpc.test.ts
+++ b/packages/gateway/src/ipc/lan-rpc.test.ts
@@ -229,3 +229,31 @@ describe("decisions over LAN (I5 — on-demand passes are write-class and local-
     expect(() => checkLanMethodAllowed("agents.decisions", peer)).not.toThrow();
   });
 });
+
+describe("clip over LAN (I5 / I30 — pairing must stay owner-opened)", () => {
+  test("forbids the clip namespace over LAN regardless of grant-write", () => {
+    for (const peer of [
+      { peerId: "p1", writeAllowed: true },
+      { peerId: "p1", writeAllowed: false },
+    ]) {
+      // clip.pair opens the I30 pairing window and returns the one-time code; admitting it over
+      // LAN would let a paired peer mint its own clip token without the owner ever running
+      // `nimbus clip pair`. Proven on a second method too, to show the namespace entry is doing
+      // the work rather than a coincidental single-method match.
+      expect(() => checkLanMethodAllowed("clip.pair", peer)).toThrow(LanError);
+      expect(() => checkLanMethodAllowed("clip.status", peer)).toThrow(LanError);
+    }
+  });
+
+  test("clip.pair rejection is ERR_METHOD_NOT_ALLOWED (fully forbidden, not merely write-gated)", () => {
+    let thrown: LanError | undefined;
+    try {
+      checkLanMethodAllowed("clip.pair", { peerId: "p", writeAllowed: true });
+    } catch (e) {
+      thrown = e as LanError;
+    }
+    expect(thrown).toBeInstanceOf(LanError);
+    expect(thrown?.rpcCode).toBe(-32601);
+    expect(thrown?.message).toMatch(/ERR_METHOD_NOT_ALLOWED/);
+  });
+});

--- a/packages/gateway/src/ipc/lan-rpc.ts
+++ b/packages/gateway/src/ipc/lan-rpc.ts
@@ -93,6 +93,20 @@ const FORBIDDEN_OVER_LAN = new Set([
   "scim.setToken",
   "scim.listUsers",
   "scim.deprovision",
+  // Web clipper (I30): clip.pair opens the owner-only PairingWindowController window and returns
+  // the one-time code in its RPC response. Admitting it over LAN (the denylist is default-allow)
+  // would let an already-paired LAN peer call clip.pair itself, read the code back, then POST it
+  // to /v1/clips/pair/confirm and mint its own Vault-stored bearer token — never routing through
+  // the owner running `nimbus clip pair`, which defeats I30's owner-opened-window requirement.
+  // The whole namespace is forbidden (not just clip.pair): clip.status/list/delete are local-CLI
+  // surfaces too (the browser extension talks to the bearer-authed HTTP surface, never LAN
+  // JSON-RPC), so forbidding the namespace costs no legitimate caller anything.
+  "clip",
+  // NOTE: egress.prune is deliberately NOT forbidden here — like federation.purge above, it is
+  // HITL-gated inside its own handler (handlePrune in egress-rpc.ts calls
+  // ctx.requestPruneApproval(beforeTs) and returns { approved: false, prunedCount: 0 } on denial),
+  // so a LAN caller only ever triggers an owner consent prompt and can never prune unilaterally.
+  // Listing it here would be redundant, not a fix — don't "fix" it by adding it to this set.
 ]);
 
 const WRITE_METHODS = new Set([

--- a/packages/gateway/src/security-invariants.test.ts
+++ b/packages/gateway/src/security-invariants.test.ts
@@ -173,6 +173,17 @@ describe("I5 — LAN method allowlist is intrinsic to LanServer", () => {
       expect(() => checkLanMethodAllowed(m, peer)).toThrow(/not callable over LAN/);
     }
   });
+
+  test("FORBIDDEN_OVER_LAN blocks the clip namespace (I30 — pairing must stay owner-opened)", async () => {
+    const { checkLanMethodAllowed } = await import("./ipc/lan-rpc.ts");
+    const peer = { peerId: "peer:x", writeAllowed: true };
+    // clip.pair opens the I30 pairing window and returns the one-time code in its response; a
+    // paired LAN peer must never be able to call it and mint its own token without the owner
+    // running `nimbus clip pair`. Checked on two methods to prove the namespace entry, not a
+    // single-method coincidence.
+    expect(() => checkLanMethodAllowed("clip.pair", peer)).toThrow(/not callable over LAN/);
+    expect(() => checkLanMethodAllowed("clip.status", peer)).toThrow(/not callable over LAN/);
+  });
 });
 
 describe("I6 — LAN bind defaults to loopback", () => {


### PR DESCRIPTION
## What

A paired LAN peer could mint a web-clipper bearer token without the machine owner ever running `nimbus clip pair`, defeating invariant **I30**'s fail-closed guarantee. Found during unrelated work; live on `main` today.

Three-line data change plus tests — no logic altered.

## The chain

**I30** states that clip token minting is fail-closed behind an **owner-opened** pairing window, opened via `nimbus clip pair`.

1. `ipc/lan-rpc.ts` — `checkLanMethodAllowed` is a **denylist**: it throws only when the method or its namespace appears in `FORBIDDEN_OVER_LAN`, then checks `WRITE_METHODS` for write permission. Anything in neither list is callable by any paired LAN peer.
2. The `clip` namespace and every `clip.*` method were in **neither** list.
3. `ipc/clip-rpc.ts` `handleClipPair` calls `deps.pairing.open(label)` and **returns the pairing `code` in the RPC response**.

So: peer calls `clip.pair` → reads `code` from the response → `POST /v1/clips/pair/confirm` → receives a Vault-stored bearer token with clip-write access.

The HTTP confirm route correctly requires a live window to exist. Nothing constrained **who may open one**. That is the gap: I30 gates minting on a window existing, and assumed only the owner could create one.

## Severity — deliberately not overstated

**Low-to-moderate.** It requires an already-paired LAN peer, and LAN is off by default (`I6` binds `127.0.0.1`), so there is no remote unauthenticated path. What makes it worth fixing promptly is that it defeats a *documented* invariant: I30 promises owner-gated minting and did not deliver it over this path.

## The fix

`"clip"` added to `FORBIDDEN_OVER_LAN`. The gate already supports namespace entries (`FORBIDDEN_OVER_LAN.has(ns)`), so one entry covers `clip.pair`, `clip.status`, `clip.revoke`, `clip.list` and `clip.delete`.

**Verified nothing legitimate breaks:** the only caller of `clip.*` is `packages/cli/src/commands/clip.ts`, which goes through `IPCClient(state.socketPath)` — the local socket, not LAN. The browser extension only uses the bearer-authed HTTP surface (`POST /v1/clips`, `/v1/clips/pair/confirm`). Forbidding the namespace costs nothing.

## Also documented: why `egress.prune` stays out

`egress.prune` is likewise absent from both lists, and that is **correct**. `ipc/egress-rpc.ts:94` calls `ctx.requestPruneApproval(beforeTs)` and returns `{approved: false, prunedCount: 0}` on denial, so a LAN caller only triggers an owner consent prompt — the same reasoning already recorded in-file for `federation.purge`.

A comment now states this at the LAN-list site, so the next auditor neither re-derives it nor "fixes" it by listing the method and breaking a legitimate flow.

## Tests

Added to `ipc/lan-rpc.test.ts` and to the **I5 block** in `security-invariants.test.ts` — asserting both `clip.pair` and `clip.status` throw over LAN, so the namespace entry is proven rather than a single method name.

**Red-proved:** commenting out the `"clip"` entry makes both tests fail with `Received function did not throw`; restoring it makes them pass. A test that passed either way would document an intention rather than enforce it — which is exactly the gap this PR closes.

## Verification

typecheck ✅ · `audit:invariants` ✅ · `packages/gateway/src/ipc/` 1,415 pass / 0 fail ✅ · `security-invariants.test.ts` 96 pass / 0 fail ✅

`docs/SECURITY-INVARIANTS.md` is intentionally unchanged: this closes a second path into the already-documented I30 rather than adding a new defence. A cross-reference there is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted LAN access to local clip-management actions, including pairing and status checks.
  * Prevented remote peers from opening pairing windows or minting clip tokens.
  * Confirmed unauthorized requests return the appropriate “method not allowed” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->