### PR TITLE
test: stop CI hiding a Windows hang and two silently-skipped suites

### DIFF
--- a/packages/gateway/src/db/query-guard.test.ts
+++ b/packages/gateway/src/db/query-guard.test.ts
@@ -14,8 +14,11 @@ afterEach(() => {
     if (dir !== undefined) {
       // Best-effort: a just-terminated worker may still hold the sqlite file open
       // on Windows (EBUSY); a leftover temp dir is harmless, a failed cleanup is not.
+      // maxRetries: 0 / retryDelay: 0 — fail FAST rather than block the hook's timeout
+      // budget; the leaked dir is the accepted trade-off (#972, #973). Do NOT turn this
+      // back into a blocking retry.
       try {
-        rmSync(dir, { recursive: true, force: true });
+        rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
       } catch {
         /* worker still releasing the db handle — leave the temp dir for the OS to reap */
       }

--- a/packages/gateway/src/embedding/create-embedding-runtime.test.ts
+++ b/packages/gateway/src/embedding/create-embedding-runtime.test.ts
@@ -64,7 +64,10 @@ function makeHarness(opts: { migrateTo: number; setOpenaiKey?: boolean }): Harne
     cleanup: () => {
       db.close();
       try {
-        rmSync(dir, { recursive: true, force: true });
+        // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+        // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+        // #973). Do NOT turn this back into a blocking retry.
+        rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
       } catch {
         /* Windows handle race; harmless */
       }

--- a/packages/gateway/src/embedding/create-routing-runtime.test.ts
+++ b/packages/gateway/src/embedding/create-routing-runtime.test.ts
@@ -114,7 +114,10 @@ function makeHarness(opts: { migrateTo: number; setApiKey: boolean }): Harness {
     cleanup: () => {
       db.close();
       try {
-        rmSync(dir, { recursive: true, force: true });
+        // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+        // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+        // #973). Do NOT turn this back into a blocking retry.
+        rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
       } catch {
         /* Windows file-handle race; harmless */
       }

--- a/packages/gateway/src/embedding/lazy-scheduler.test.ts
+++ b/packages/gateway/src/embedding/lazy-scheduler.test.ts
@@ -52,7 +52,10 @@ function makeHarness(opts: { migrateTo: number }): Harness {
     cleanup: () => {
       db.close();
       try {
-        rmSync(dir, { recursive: true, force: true });
+        // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+        // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+        // #973). Do NOT turn this back into a blocking retry.
+        rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
       } catch {
         /* Windows file-handle race */
       }

--- a/packages/gateway/src/index/migrations/runner-v30.test.ts
+++ b/packages/gateway/src/index/migrations/runner-v30.test.ts
@@ -1,7 +1,19 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { tryLoadSqliteVec } from "../sqlite-vec-load.ts";
+import { isVecLoaded, tryLoadSqliteVec } from "../sqlite-vec-load.ts";
 import { runIndexedSchemaMigrations } from "./runner.ts";
+
+function vecAvailable(): boolean {
+  const db = new Database(":memory:");
+  tryLoadSqliteVec(db);
+  const ok = isVecLoaded(db);
+  db.close();
+  return ok;
+}
+// sqlite-vec genuinely does not load on macOS CI (#1029). An in-body early
+// return on load failure registers as a PASS, not a skip, so a green run there
+// was indistinguishable from a fully-exercised one — skipIf makes it honest.
+const VEC_AVAILABLE = vecAvailable();
 
 describe("V30 migration — vec_items_1536 + dim-aware triggers", () => {
   test("running migrations on a fresh DB advances user_version to 30", () => {
@@ -27,62 +39,70 @@ describe("V30 migration — vec_items_1536 + dim-aware triggers", () => {
     expect(row?.applied_at).toBeGreaterThan(0);
   });
 
-  test("with sqlite-vec, vec_items_1536 exists and dim-aware triggers are wired", () => {
-    const db = new Database(":memory:");
-    if (!tryLoadSqliteVec(db)) {
-      return;
-    }
-    runIndexedSchemaMigrations(db, 30);
-    const tables = db
-      .query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'vec_items_1536'`)
-      .all() as Array<{ name: string }>;
-    expect(tables).toHaveLength(1);
-    const triggers = db
-      .query(
-        `SELECT name, sql FROM sqlite_master WHERE type = 'trigger'
+  test.skipIf(!VEC_AVAILABLE)(
+    "with sqlite-vec, vec_items_1536 exists and dim-aware triggers are wired",
+    () => {
+      const db = new Database(":memory:");
+      tryLoadSqliteVec(db);
+      runIndexedSchemaMigrations(db, 30);
+      const tables = db
+        .query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'vec_items_1536'`)
+        .all() as Array<{ name: string }>;
+      expect(tables).toHaveLength(1);
+      const triggers = db
+        .query(
+          `SELECT name, sql FROM sqlite_master WHERE type = 'trigger'
          AND name IN ('embedding_chunk_ad_delete_vec384', 'embedding_chunk_ad_delete_vec1536')`,
-      )
-      .all() as Array<{ name: string; sql: string }>;
-    expect(triggers).toHaveLength(2);
-    const t384 = triggers.find((t) => t.name === "embedding_chunk_ad_delete_vec384");
-    const t1536 = triggers.find((t) => t.name === "embedding_chunk_ad_delete_vec1536");
-    expect(t384?.sql).toContain("WHEN OLD.dims = 384");
-    expect(t1536?.sql).toContain("WHEN OLD.dims = 1536");
-  });
+        )
+        .all() as Array<{ name: string; sql: string }>;
+      expect(triggers).toHaveLength(2);
+      const t384 = triggers.find((t) => t.name === "embedding_chunk_ad_delete_vec384");
+      const t1536 = triggers.find((t) => t.name === "embedding_chunk_ad_delete_vec1536");
+      expect(t384?.sql).toContain("WHEN OLD.dims = 384");
+      expect(t1536?.sql).toContain("WHEN OLD.dims = 1536");
+    },
+  );
 
-  test("delete via embedding_chunk fans out to the matching vec table only", () => {
-    const db = new Database(":memory:");
-    if (!tryLoadSqliteVec(db)) {
-      return;
-    }
-    runIndexedSchemaMigrations(db, 30);
-    db.run(
-      `INSERT INTO item (id, service, type, external_id, title, body_preview,
+  test.skipIf(!VEC_AVAILABLE)(
+    "delete via embedding_chunk fans out to the matching vec table only",
+    () => {
+      const db = new Database(":memory:");
+      tryLoadSqliteVec(db);
+      runIndexedSchemaMigrations(db, 30);
+      db.run(
+        `INSERT INTO item (id, service, type, external_id, title, body_preview,
           modified_at, synced_at) VALUES (?, 's', 't', 'e', 'T', NULL, ?, ?)`,
-      ["s:e", Date.now(), Date.now()],
-    );
-    db.run(`INSERT INTO vec_items_384  (rowid, embedding) VALUES (1, vec_f32(?))`, [
-      new Float32Array(384),
-    ]);
-    db.run(`INSERT INTO vec_items_1536 (rowid, embedding) VALUES (1, vec_f32(?))`, [
-      new Float32Array(1536),
-    ]);
-    db.run(
-      `INSERT INTO embedding_chunk (item_id, chunk_index, chunk_text, vec_rowid, model, dims, embedded_at)
+        ["s:e", Date.now(), Date.now()],
+      );
+      db.run(`INSERT INTO vec_items_384  (rowid, embedding) VALUES (1, vec_f32(?))`, [
+        new Float32Array(384),
+      ]);
+      db.run(`INSERT INTO vec_items_1536 (rowid, embedding) VALUES (1, vec_f32(?))`, [
+        new Float32Array(1536),
+      ]);
+      db.run(
+        `INSERT INTO embedding_chunk (item_id, chunk_index, chunk_text, vec_rowid, model, dims, embedded_at)
        VALUES (?, 0, 't', 1, 'm384', 384, ?)`,
-      ["s:e", Date.now()],
-    );
-    db.run(
-      `INSERT INTO embedding_chunk (item_id, chunk_index, chunk_text, vec_rowid, model, dims, embedded_at)
+        ["s:e", Date.now()],
+      );
+      db.run(
+        `INSERT INTO embedding_chunk (item_id, chunk_index, chunk_text, vec_rowid, model, dims, embedded_at)
        VALUES (?, 1, 't', 1, 'm1536', 1536, ?)`,
-      ["s:e", Date.now()],
-    );
+        ["s:e", Date.now()],
+      );
 
-    db.run(`DELETE FROM embedding_chunk WHERE chunk_index = 0`);
-    expect((db.query(`SELECT count(*) AS c FROM vec_items_384 `).get() as { c: number }).c).toBe(0);
-    expect((db.query(`SELECT count(*) AS c FROM vec_items_1536`).get() as { c: number }).c).toBe(1);
+      db.run(`DELETE FROM embedding_chunk WHERE chunk_index = 0`);
+      expect((db.query(`SELECT count(*) AS c FROM vec_items_384 `).get() as { c: number }).c).toBe(
+        0,
+      );
+      expect((db.query(`SELECT count(*) AS c FROM vec_items_1536`).get() as { c: number }).c).toBe(
+        1,
+      );
 
-    db.run(`DELETE FROM embedding_chunk WHERE chunk_index = 1`);
-    expect((db.query(`SELECT count(*) AS c FROM vec_items_1536`).get() as { c: number }).c).toBe(0);
-  });
+      db.run(`DELETE FROM embedding_chunk WHERE chunk_index = 1`);
+      expect((db.query(`SELECT count(*) AS c FROM vec_items_1536`).get() as { c: number }).c).toBe(
+        0,
+      );
+    },
+  );
 });

--- a/packages/gateway/src/ipc/diagnostics-rpc.test.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.test.ts
@@ -59,7 +59,11 @@ function makeCtxWithIndex(dataDir: string): {
 
 function rmTmp(dir: string): void {
   try {
-    rmSync(dir, { recursive: true, force: true });
+    // maxRetries: 0 / retryDelay: 0 — a pinned handle (e.g. from makeCtxWithIndex's
+    // Database) must fail FAST rather than block the hook's timeout budget; a leaked
+    // temp dir is the accepted trade-off (#972, #973). Do NOT turn this back into a
+    // blocking retry.
+    rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
   } catch {
     /* best-effort */
   }

--- a/packages/gateway/src/perf/perf-fixture.test.ts
+++ b/packages/gateway/src/perf/perf-fixture.test.ts
@@ -19,7 +19,10 @@ describe("buildSyntheticIndex", () => {
       db.close();
       expect(row.n).toBe(FIXTURE_TIER_SIZES.small);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     }
   });
 
@@ -34,7 +37,10 @@ describe("buildSyntheticIndex", () => {
       expect(contentA).toHaveLength(contentB.length);
       expect(contentA.equals(contentB)).toBe(true);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — fail FAST rather than block the hook's timeout
+      // budget; a leaked temp dir is the accepted trade-off (#972, #973). Do NOT turn
+      // this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     }
   });
 
@@ -49,7 +55,10 @@ describe("buildSyntheticIndex", () => {
       expect(path).toBe(path2);
       expect(mtime2).toBe(mtime1);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — fail FAST rather than block the hook's timeout
+      // budget; a leaked temp dir is the accepted trade-off (#972, #973). Do NOT turn
+      // this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     }
   });
 });

--- a/packages/gateway/test/e2e/scenarios/deploy-annotate.e2e.test.ts
+++ b/packages/gateway/test/e2e/scenarios/deploy-annotate.e2e.test.ts
@@ -23,7 +23,10 @@ describe("E2E (in-process): nimbus deploy annotate", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle (unfinalized statement) must fail
+      // FAST rather than block the hook's timeout budget; a leaked temp dir is the accepted
+      // trade-off (#972, #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
+++ b/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
@@ -24,7 +24,11 @@ describe("E2E (in-process): deploy.preflight", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — an unfinalized statement can make db.close() a
+      // silent no-op that pins the file open, and Windows will otherwise burn the hook's
+      // timeout budget retrying the delete. Fail fast and leak the temp dir instead: it's
+      // the accepted trade-off (#972, #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/integration/db/disk-full-propagation.test.ts
+++ b/packages/gateway/test/integration/db/disk-full-propagation.test.ts
@@ -148,7 +148,10 @@ function makeTinyDb(): { db: Database; cleanup: () => void; cap: () => void } {
     cleanup: () => {
       db.close();
       try {
-        rmSync(dir, { recursive: true, force: true });
+        // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+        // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+        // #973). Do NOT turn this back into a blocking retry.
+        rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
       } catch {
         /* Windows file-handle race; harmless */
       }

--- a/packages/gateway/test/integration/http/metrics-dora-route.test.ts
+++ b/packages/gateway/test/integration/http/metrics-dora-route.test.ts
@@ -40,7 +40,10 @@ pagerduty_services = ["P12ABCD"]
   afterEach(() => {
     handle?.stop();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/integration/http/preflight-deploy-route.test.ts
+++ b/packages/gateway/test/integration/http/preflight-deploy-route.test.ts
@@ -40,7 +40,10 @@ pagerduty_services = ["P12ABCD"]
   afterEach(() => {
     handle?.stop();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/integration/index/migration-v27.test.ts
+++ b/packages/gateway/test/integration/index/migration-v27.test.ts
@@ -12,7 +12,10 @@ describe("V27 migration — merged_as graph_relation_type", () => {
   });
   afterEach(() => {
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/integration/metrics/dora-deployment-source.test.ts
+++ b/packages/gateway/test/integration/metrics/dora-deployment-source.test.ts
@@ -33,7 +33,10 @@ describe("dora.deploymentFrequency — source preference", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* Windows EBUSY — OS cleans temp dir on reboot */
     }

--- a/packages/gateway/test/integration/metrics/dora-real-db.test.ts
+++ b/packages/gateway/test/integration/metrics/dora-real-db.test.ts
@@ -33,7 +33,10 @@ describe("DORA real-db integration", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* Windows EBUSY — OS cleans temp dir on reboot */
     }

--- a/packages/gateway/test/integration/preflight/preflight-real-db.test.ts
+++ b/packages/gateway/test/integration/preflight/preflight-real-db.test.ts
@@ -21,7 +21,10 @@ describe("preflight integration: payment-service fixture (real SQLite)", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/unit/db/statement-finalization.test.ts
+++ b/packages/gateway/test/unit/db/statement-finalization.test.ts
@@ -37,7 +37,10 @@ describe("db statement finalization (#969)", () => {
 
   afterEach(() => {
     for (const dir of dirs.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — if a regression ever re-pins a handle here, this
+      // must fail FAST rather than block the hook's timeout budget. A leaked temp dir is
+      // the accepted trade-off (#972, #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     }
   });
 

--- a/packages/gateway/test/unit/ipc/metrics-rpc.test.ts
+++ b/packages/gateway/test/unit/ipc/metrics-rpc.test.ts
@@ -21,7 +21,10 @@ describe("metrics-rpc", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/unit/ipc/preflight-rpc.test.ts
+++ b/packages/gateway/test/unit/ipc/preflight-rpc.test.ts
@@ -21,7 +21,10 @@ describe("preflight-rpc: deploy.preflight", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }

--- a/packages/gateway/test/unit/metrics/dora.test.ts
+++ b/packages/gateway/test/unit/metrics/dora.test.ts
@@ -123,7 +123,10 @@ describe("DORA metrics calculators", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* Windows EBUSY — OS cleans temp dir on reboot */
     }

--- a/packages/gateway/test/unit/preflight/preflight.test.ts
+++ b/packages/gateway/test/unit/preflight/preflight.test.ts
@@ -143,7 +143,10 @@ describe("computeDeployPreflight: verdict + envelope", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }
@@ -185,7 +188,10 @@ describe("computeDeployPreflight: active_p1_incidents check", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }
@@ -378,7 +384,10 @@ describe("computeDeployPreflight: failing_ci_runs check", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }
@@ -480,7 +489,10 @@ describe("computeDeployPreflight: merge_conflicts check", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }
@@ -563,7 +575,10 @@ describe("computeDeployPreflight: max_findings", () => {
   afterEach(() => {
     db.close();
     try {
-      rmSync(dir, { recursive: true, force: true });
+      // maxRetries: 0 / retryDelay: 0 — a pinned handle must fail FAST rather than block
+      // the hook's timeout budget; a leaked temp dir is the accepted trade-off (#972,
+      // #973). Do NOT turn this back into a blocking retry.
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
     } catch {
       /* non-fatal */
     }


### PR DESCRIPTION
## What

Two fixes for the same underlying defect: **CI reporting something it did not verify.** One hides a hang behind a timeout; the other hides skipped tests behind a passing count. Neither is a logic bug — the reporting is what's wrong.

## Fix 1 — a Windows hook timeout that intermittently reds `main`

`preflight-deploy.e2e.test.ts` fails on `windows-2025` with `a beforeEach/afterEach hook timed out for this test` at ~11.7s. It is a flake: the commit it failed on changed only version strings, and the commit before it — which changed the schema — passed.

The mechanism is already documented in this repo (`test/unit/db/statement-finalization.test.ts`, issue #969): `runIndexedSchemaMigrations` leaves prepared statements alive → an unfinalized `db.prepare()` makes `db.close()` a **silent no-op** → the database file stays pinned → Windows' recursive `rmSync` retries internally on `EBUSY` and burns the hook's ~5s budget.

Note the `rmSync` was *already* inside a try/catch, so this is a **block, not a throw** — widening the catch would not have helped.

**Fix:** `maxRetries: 0, retryDelay: 0` so cleanup fails fast instead of consuming the budget. A leaked temp directory is the accepted status quo (#972/#973 track ~536 per full gateway run), so this trades a leaked dir for a hook that cannot hang. Commented at each site citing those issues, so it isn't "fixed" back into a blocking call.

Applied to **26 call sites across 20 files** sharing the vulnerable `db.close()` + `rmSync(dir, …)` shape.

**Three sibling-looking files were deliberately left alone**, with reasons recorded: `db/writable-pragmas.test.ts`, `extensions/verify-extensions.test.ts`, `ipc/share-rpc.test.ts` — in-memory-only databases, or a missing try/catch where adding one would change failure semantics.

This does **not** fix the underlying statement-finalization problem (#969) — that is a much larger change across the migration runner.

## Fix 2 — tests that reported as PASSING when they never ran

Two sites in `index/migrations/runner-v30.test.ts` used:

```ts
if (!tryLoadSqliteVec(db)) { return; }
```

An early return registers as a **pass**, not a skip. The test count is identical whether the code ran or not, so a green run is indistinguishable from a fully-exercised one. This matters because `sqlite-vec` genuinely does not load on macOS CI (#1029) — these "passed" there having verified nothing.

Converted to `test.skipIf(!VEC_AVAILABLE)`, matching the existing convention in `connectors/reindex-vector-erasure.test.ts` and the `search/*.test.ts` files.

**Proven, not assumed:** forcing `VEC_AVAILABLE = false` moves the file from `5 pass` to `3 pass / 2 skip`, confirming the two tests now report as skipped rather than silently passing.

A third site named in the brief — `embedding/pipeline.test.ts:145` — turned out to be **already correctly `describe.skipIf`-wrapped** and was left untouched (verified against `origin/main`).

## Verification

typecheck ✅ exit 0 · `bunx biome check --error-on-warnings` ✅ 2,674 files clean · combined 22-file run ✅ 269 pass / 0 fail

Related: #1029 (macOS `sqlite-vec` — 54 vec-dependent sites silently skip there), #969 (statement finalization), #972/#973 (leaked temp dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Test cleanup now fails fast when temporary files remain in use, preventing teardown from blocking.
  - Cleanup errors remain non-fatal where applicable.
  - SQLite vector-dependent tests now skip gracefully when the required capability is unavailable.
  - Migration and trigger coverage retains explicit validation when SQLite vector support is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->