### PR TITLE
refactor(agents): route expert through the shared brief emitter

### DIFF
--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { AgentCoordinator, type SubTask } from "../engine/coordinator.ts";
+import { emitBriefWithSynthesis } from "./_lib/emit-brief.ts";
 import type { Evidence, ExpertBrief, ExpertFinding, GapNote } from "./_lib/findings.ts";
 import {
   detectEmptyIndex,
@@ -8,7 +9,7 @@ import {
   detectMissingRelationEmit,
   detectMissingRelationToEntityType,
 } from "./_lib/gap-notes.ts";
-import { type SynthesizerLlm, synthesize } from "./_lib/synthesize.ts";
+import type { SynthesizerLlm } from "./_lib/synthesize.ts";
 
 export type ExpertInput = {
   topicOrFile: string;
@@ -150,25 +151,18 @@ export async function runExpert(input: ExpertInput, ctx: ExpertContext): Promise
   return brief;
 }
 
-export async function emitExpertBrief(
+export function emitExpertBrief(
   input: ExpertInput,
   ctx: ExpertContext,
 ): Promise<{ sessionId: string }> {
-  void (async () => {
-    const brief = await runExpert(input, ctx);
-    const markdown = await synthesize(brief, ctx.llm === undefined ? {} : { llm: ctx.llm });
-    ctx.notify("expert.briefReady", {
-      sessionId: ctx.sessionId,
-      brief: markdown,
-      findings: brief,
-    });
-  })().catch((err: unknown) => {
-    ctx.notify("expert.briefError", {
-      sessionId: ctx.sessionId,
-      error: err instanceof Error ? err.message : String(err),
-    });
+  return emitBriefWithSynthesis({
+    sessionId: ctx.sessionId,
+    briefReadyMethod: "expert.briefReady",
+    briefErrorMethod: "expert.briefError",
+    notify: ctx.notify,
+    ...(ctx.llm === undefined ? {} : { llm: ctx.llm }),
+    buildBrief: () => runExpert(input, ctx),
   });
-  return { sessionId: ctx.sessionId };
 }
 
 async function subBlame(db: Database, input: string): Promise<SubAgentResult> {


### PR DESCRIPTION
Closes the last of the follow-ups from the maintenance sweep (#1049).

`emitExpertBrief` hand-rolled the exact body of `emitBriefWithSynthesis` with `"expert."` substituted for the method prefix — the same fire-and-forget `void (async () => …)()` wrapper, the same `synthesize` call with the same `llm`-spread, the same `briefReady` payload shape, and the same `.catch` emitting `briefError`.

`ExpertBrief` is already a member of the helper's `AnyBrief` union, so expert was always intended to use it. It was **the last of the eleven built-in agents still not doing so**, and SonarCloud measured the file at **8.0% duplication** — the highest of any gateway agent.

## No behaviour change

Same notification methods (`expert.briefReady` / `expert.briefError`), same payload keys (`sessionId` / `brief` / `findings`), same `err instanceof Error ? err.message : String(err)` coercion, and it still returns `Promise<{ sessionId }>` **without awaiting the work** — the helper preserves the fire-and-forget contract that the `briefReady` IPC notification depends on.

The typed `runExpert` builder is untouched and stays in the agent module, which is exactly what the helper's own docstring prescribes.

`synthesize` is no longer imported directly, so that import narrows to a type-only import of `SynthesizerLlm`.

## Verification

`bun run typecheck` clean, `bun run lint` clean, and the full agents suite passes: **269 tests, 0 fail** across 25 files.
