### PR TITLE
ci: stop the release guard failing on healthy releases, and capture a failure-triage bundle

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -592,12 +592,37 @@ jobs:
           fail-on-error: false
           fail-on-empty: false
 
+      # Ordering is load-bearing: this must run BEFORE the cleanup step below, which
+      # deletes the only copy of the evidence. See the script header for what the
+      # bundle can and cannot reach.
+      - name: Collect failure artifacts (triage bundle)
+        if: failure()
+        shell: bash
+        run: bash scripts/ci/collect-failure-artifacts.sh integration
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: failure-integration-${{ inputs.runner }}
+          path: failure-artifacts/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup integration test artifacts
         if: always()
         shell: bash
         run: |
-          rm -rf /tmp/nimbus-test-* 2>/dev/null || true
-          rm -rf "${TEMP:-/tmp}/nimbus-test-"* 2>/dev/null || true
+          # `nimbus-*`, not `nimbus-test-*`. The glob was mismatched to its own job:
+          # `nimbus-test-*` is produced by UNIT tests (registry-fetcher, engine-ask-stream,
+          # the CLI test-runner suite), which run in `unit-coverage` — a job with no
+          # cleanup step at all. The suites THIS job runs name their scratch dirs after
+          # themselves — `nimbus-share-e2e-`, `nimbus-bindfirst-`, `nimbus-assemble-`,
+          # `nimbus-dep-lifecycle-e2e-` — so none of them ever matched and their leftovers
+          # stayed put. Measured on a dev machine: 42,400 surviving `nimbus-*` dirs, of
+          # which 228 matched the old glob.
+          rm -rf /tmp/nimbus-* 2>/dev/null || true
+          rm -rf "${TEMP:-/tmp}/nimbus-"* 2>/dev/null || true
 
   # ── E2E Gateway tests ──────────────────────────────────────────────────────
   e2e-gateway:
@@ -672,12 +697,31 @@ jobs:
           fail-on-error: false
           fail-on-empty: false
 
+      # Highest-value job for this bundle: these are the tests that spawn a real
+      # gateway subprocess, and a Linux-only hang here currently leaves nothing to
+      # read. Must precede the cleanup step.
+      - name: Collect failure artifacts (triage bundle)
+        if: failure()
+        shell: bash
+        run: bash scripts/ci/collect-failure-artifacts.sh e2e-gateway
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: failure-e2e-gateway-${{ inputs.runner }}
+          path: failure-artifacts/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup E2E test artifacts
         if: always()
         shell: bash
         run: |
-          rm -rf /tmp/nimbus-test-* 2>/dev/null || true
-          rm -rf "${TEMP:-/tmp}/nimbus-test-"* 2>/dev/null || true
+          # See the integration job above: `nimbus-test-*` belongs to the unit suites,
+          # not to anything this job runs, so it never matched here.
+          rm -rf /tmp/nimbus-* 2>/dev/null || true
+          rm -rf "${TEMP:-/tmp}/nimbus-"* 2>/dev/null || true
 
   # ── E2E CLI tests ──────────────────────────────────────────────────────────
   e2e-cli:
@@ -742,12 +786,28 @@ jobs:
           fail-on-error: false
           fail-on-empty: false
 
+      - name: Collect failure artifacts (triage bundle)
+        if: failure()
+        shell: bash
+        run: bash scripts/ci/collect-failure-artifacts.sh e2e-cli
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: failure-e2e-cli-${{ inputs.runner }}
+          path: failure-artifacts/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Cleanup E2E test artifacts
         if: always()
         shell: bash
         run: |
-          rm -rf /tmp/nimbus-test-* 2>/dev/null || true
-          rm -rf "${TEMP:-/tmp}/nimbus-test-"* 2>/dev/null || true
+          # See the integration job above: `nimbus-test-*` belongs to the unit suites,
+          # not to anything this job runs, so it never matched here.
+          rm -rf /tmp/nimbus-* 2>/dev/null || true
+          rm -rf "${TEMP:-/tmp}/nimbus-"* 2>/dev/null || true
 
   # ── Headless bundle + Linux installers ─────────────────────────────────────
   # Runs only when explicitly enabled (currently: ubuntu-24.04 on both PR and

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,16 +80,23 @@ jobs:
         # release-please step above errored (the very failure it recovers from),
         # not just on success. Skipped only if the job is cancelled outright.
         if: ${{ always() }}
+        id: reconcile
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Published as the `reconciled` output and read by the guard step below. Without
+          # it the two steps CONTRADICT each other: reconciling a phantom REMOVES the
+          # `autorelease: pending` label, which is one of the two signals the guard reads
+          # as "a release happened" — so every successful recovery failed the job.
+          reconciled=false
           pending=$(gh pr list --repo "$REPO" --state merged --label "autorelease: pending" \
                       --json number,mergeCommit --jq '.[] | [.number, .mergeCommit.oid] | @tsv')
           if [ -z "$pending" ]; then
             echo "No untagged, merged release PRs — nothing to reconcile."
+            echo "reconciled=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           while IFS=$'\t' read -r num sha; do
@@ -154,7 +161,13 @@ jobs:
             gh pr edit "$num" --repo "$REPO" \
               --add-label "autorelease: tagged" --remove-label "autorelease: pending"
             echo "Relabelled PR #${num}: autorelease: pending → tagged."
+            # Reached only on the two branches that end with the release ACCOUNTED FOR:
+            # the tag was just created, or it already pointed at this merge commit. The
+            # `continue` paths above (unreadable manifest, tag pointing elsewhere) leave
+            # this false, so a run that needed a human still reaches the guard.
+            reconciled=true
           done <<< "$pending"
+          echo "reconciled=${reconciled}" >> "$GITHUB_OUTPUT"
 
       # Silent-drop guard. DISTINCT from the phantom-release step above: that one recovers a
       # release PR that merged without a tag. This one catches the opposite failure — no
@@ -176,30 +189,50 @@ jobs:
       # This is structural, not bad luck: squash-merge puts the ENTIRE PR description into the
       # commit body (see CLAUDE.md), so any prose token the grammar dislikes can silently cost
       # a release. The invariant below is the one thing that cannot be true on a healthy run:
-      # a user-facing commit exists since the last release, yet there is neither a new release
-      # nor an open release PR.
+      # a user-facing commit exists since the last release TAG, yet none of the three ways a
+      # release can be accounted for happened — release-please cut it, the step above
+      # reconciled it, or a release PR is open waiting to be merged.
+      #
+      # That third arm is why this step must know about the reconcile step. Reconciling a
+      # phantom CLEARS the `autorelease: pending` label by design, so before the `reconciled`
+      # output existed this guard failed on every single release-PR merge (runs 31068750817,
+      # 31074863757, 31165486901 — v1.21.0, v1.22.0, v1.23.0) while the release itself shipped
+      # correctly. A guard that fires on the healthy path teaches people to ignore it.
       - name: Guard — a user-facing commit must produce a release or a release PR
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           RELEASES_CREATED: ${{ steps.release-please.outputs.releases_created }}
+          RECONCILED: ${{ steps.reconcile.outputs.reconciled }}
         run: |
           set -euo pipefail
 
-          # No release yet => nothing to compare against; the first release is not this step's
-          # business. Any other read failure is fatal rather than silently "clean".
+          # Baseline off the newest `vX.Y.Z` TAG, not `releases/latest`. The tag is what marks
+          # a version as cut; the GitHub Release is produced afterwards by the tag-driven
+          # release.yml build, so `releases/latest` still names the PREVIOUS version for the
+          # whole length of that build. Any push to main landing in that window compared
+          # against a stale baseline and fired this guard on a perfectly healthy release.
+          # (A release build that fails AFTER its tag exists goes red loudly in release.yml
+          # and is abandoned, never retagged — see CLAUDE.md; it is not this step's business.)
+          # No tag yet => nothing to compare against; the first release is not this step's
+          # business either. Any other read failure is fatal rather than silently "clean".
           set +e
-          tag=$(gh api "repos/${REPO}/releases/latest" --jq .tag_name 2>&1)
+          refs=$(gh api "repos/${REPO}/git/matching-refs/tags/v" --paginate --jq '.[].ref' 2>&1)
           rc=$?
           set -e
           if [ "$rc" -ne 0 ]; then
-            if grep -qE '\(HTTP 404\)' <<<"$tag"; then
-              echo "No published release yet — nothing to compare against."
-              exit 0
-            fi
-            echo "::error::could not read the latest release, refusing to guess: ${tag}"
+            echo "::error::could not list release tags, refusing to guess: ${refs}"
             exit 1
+          fi
+          # `matching-refs/tags/v` is a PREFIX match, so it also returns `vscode-v*`; the
+          # pattern keeps only bare vX.Y.Z. `grep` is braced so a no-match (exit 1) cannot
+          # kill the pipeline under `pipefail`. `sort -V` orders v1.9.0 before v1.20.0.
+          tag=$(sed 's#^refs/tags/##' <<<"$refs" \
+                  | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
+          if [ -z "$tag" ]; then
+            echo "No release tag yet — nothing to compare against."
+            exit 0
           fi
 
           # Subjects only: a body line can look like a conventional header and would inflate
@@ -214,10 +247,16 @@ jobs:
             exit 0
           fi
 
+          # Three ways a run is healthy. The middle one is NOT redundant with the tag
+          # baseline above: it is the direct statement from the recovery step that it
+          # accounted for this release, and it does not depend on the tag it just created
+          # already being visible to a subsequent API read.
           pending=$(gh pr list --repo "$REPO" --state open \
                       --label "autorelease: pending" --json number --jq 'length')
-          if [ "${RELEASES_CREATED:-false}" = "true" ] || [ "$pending" -gt 0 ]; then
-            echo "Healthy: releases_created=${RELEASES_CREATED:-false}, open release PR(s)=${pending}."
+          if [ "${RELEASES_CREATED:-false}" = "true" ] \
+            || [ "${RECONCILED:-false}" = "true" ] \
+            || [ "$pending" -gt 0 ]; then
+            echo "Healthy: releases_created=${RELEASES_CREATED:-false}, reconciled=${RECONCILED:-false}, open release PR(s)=${pending}."
             exit 0
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,11 +92,21 @@ jobs:
           # `autorelease: pending` label, which is one of the two signals the guard reads
           # as "a release happened" — so every successful recovery failed the job.
           reconciled=false
+          # Counted SEPARATELY from `reconciled`, because the two are not opposites and the
+          # loop can produce both in one run. `pending` holds every merged release PR still
+          # labelled `autorelease: pending`, which is usually one — but is exactly TWO when
+          # an earlier run left one stuck. Reconciling the healthy one would then flip
+          # `reconciled=true` and, on its own, vouch for a run that still has a stuck
+          # release in it. The guard fails on `unaccounted > 0` regardless of `reconciled`.
+          unaccounted=0
           pending=$(gh pr list --repo "$REPO" --state merged --label "autorelease: pending" \
                       --json number,mergeCommit --jq '.[] | [.number, .mergeCommit.oid] | @tsv')
           if [ -z "$pending" ]; then
             echo "No untagged, merged release PRs — nothing to reconcile."
-            echo "reconciled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "reconciled=false"
+              echo "unaccounted=0"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           while IFS=$'\t' read -r num sha; do
@@ -105,6 +115,7 @@ jobs:
                     --jq '.content' | tr -d '\n' | base64 -d | jq -r '."."')
             if [ -z "$ver" ] || [ "$ver" = "null" ]; then
               echo "::warning::could not read manifest version for PR #${num} at ${sha}; skipping"
+              unaccounted=$((unaccounted + 1))
               continue
             fi
             tag="v${ver}"
@@ -154,6 +165,7 @@ jobs:
               # Tag name exists but points elsewhere — do NOT relabel, or we would mark the
               # PR released against the wrong tree. Surface it for a human instead.
               echo "::warning::${tag} exists but points at ${existing}, not PR #${num}'s merge commit ${sha}; not relabelling — needs manual review."
+              unaccounted=$((unaccounted + 1))
               continue
             else
               echo "${tag} already points at ${sha} — relabelling PR #${num} only."
@@ -167,7 +179,10 @@ jobs:
             # this false, so a run that needed a human still reaches the guard.
             reconciled=true
           done <<< "$pending"
-          echo "reconciled=${reconciled}" >> "$GITHUB_OUTPUT"
+          {
+            echo "reconciled=${reconciled}"
+            echo "unaccounted=${unaccounted}"
+          } >> "$GITHUB_OUTPUT"
 
       # Silent-drop guard. DISTINCT from the phantom-release step above: that one recovers a
       # release PR that merged without a tag. This one catches the opposite failure — no
@@ -205,8 +220,20 @@ jobs:
           REPO: ${{ github.repository }}
           RELEASES_CREATED: ${{ steps.release-please.outputs.releases_created }}
           RECONCILED: ${{ steps.reconcile.outputs.reconciled }}
+          UNACCOUNTED: ${{ steps.reconcile.outputs.unaccounted }}
         run: |
           set -euo pipefail
+
+          # Checked BEFORE the commit comparison, and independently of it. A merged release
+          # PR the recovery step could not account for — manifest unreadable, or its tag name
+          # already pointing at a different tree — is a stuck release that no commit-range
+          # check can see: the newest tag has moved on, so `compare` comes back empty and
+          # every other signal reads healthy. It was a `::warning::` before, which is to say
+          # invisible. A release needing a human is a red job.
+          if [ "${UNACCOUNTED:-0}" -gt 0 ]; then
+            echo "::error::${UNACCOUNTED} merged release PR(s) left unaccounted for by the reconcile step above — read its warnings. A tag pointing at the wrong tree must be resolved by hand; tags are immutable (see CLAUDE.md), so the fix is to cut the next version, never to move the tag."
+            exit 1
+          fi
 
           # Baseline off the newest `vX.Y.Z` TAG, not `releases/latest`. The tag is what marks
           # a version as cut; the GitHub Release is produced afterwards by the tag-driven

--- a/scripts/ci/collect-failure-artifacts.sh
+++ b/scripts/ci/collect-failure-artifacts.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Collect a triage bundle from a test job that has ALREADY FAILED, before the
+# job's cleanup step deletes the evidence.
+#
+# Why this exists: the dominant CI pain in this repo is a Linux-only failure that
+# does not reproduce on Windows/macOS (see CLAUDE.md "CI-Linux-only failures").
+# The JUnit XML says WHICH test failed; it never says what the spawned gateway
+# printed or what ended up in its SQLite index. `verify:docker` exists largely to
+# re-obtain, locally, output the CI runner already had and threw away.
+#
+# What it can and cannot reach — be precise, because a bundle that looks empty is
+# worse than no bundle:
+#   * JUnit XML — always present. Today it is only RENDERED into the Checks UI by
+#     dorny/test-reporter, which runs with `fail-on-error: false`, so a reporter
+#     hiccup loses it with no trace. A downloadable copy costs nothing.
+#   * Gateway working directories — the e2e tests `rmSync` their own `mkdtemp`
+#     directory from a `finally` block, so after an ORDINARY assertion failure
+#     nothing survives and this bundle will legitimately contain no dirs. What
+#     DOES survive is exactly the class with no other evidence: a hang killed by
+#     the job timeout, a segfault, an early `process.exit` that skips the
+#     `finally`. Preserving a directory across an ordinary assertion failure
+#     needs harness cooperation at 43 bespoke `Bun.spawn` sites across 14 files;
+#     that is a separate change, not a widening of this one.
+#
+# Not `set -e`: this runs only when the job is already red. It must never mask the
+# real failure, and a missing directory is an expected outcome, not an error.
+set -uo pipefail
+
+label="${1:?usage: collect-failure-artifacts.sh <label>}"
+out="failure-artifacts"
+manifest="${out}/MANIFEST.txt"
+
+# Per-file and total ceilings. A test index can grow large, and an artifact upload
+# that takes longer than the test run helps nobody.
+max_file_bytes=$((25 * 1024 * 1024))
+max_total_bytes=$((200 * 1024 * 1024))
+
+mkdir -p "$out"
+{
+  echo "job label : ${label}"
+  echo "os        : $(uname -s 2>/dev/null || echo unknown) $(uname -m 2>/dev/null || echo '')"
+  echo "bun       : $(bun --version 2>/dev/null || echo 'not on PATH')"
+  echo "collected : the bundle below is what SURVIVED the failure, not everything the run touched."
+  echo
+} > "$manifest"
+
+# Git Bash on the Windows runner receives Windows-shaped paths in RUNNER_TEMP /
+# TEMP (`D:\a\_temp`), which `find` cannot walk. Convert when cygpath is present.
+to_unix() {
+  if command -v cygpath > /dev/null 2>&1; then
+    cygpath -u "$1" 2> /dev/null || printf '%s\n' "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+# ── 1. JUnit XML ────────────────────────────────────────────────────────────
+if [ -d junit-reports ]; then
+  mkdir -p "${out}/junit"
+  cp junit-reports/*.xml "${out}/junit/" 2> /dev/null
+  echo "junit: $(find "${out}/junit" -name '*.xml' 2> /dev/null | wc -l | tr -d ' ') report(s)" >> "$manifest"
+else
+  echo "junit: none (junit-reports/ absent)" >> "$manifest"
+fi
+
+# ── 2. Surviving gateway working directories ────────────────────────────────
+# Every e2e/integration temp dir is `mkdtemp(join(tmpdir(), "nimbus-<suite>-"))`,
+# so `nimbus-*` is the correct net. (The pre-existing cleanup steps matched
+# `nimbus-test-*`, which no suite has ever produced — they were decorative.)
+roots=""
+for candidate in "${RUNNER_TEMP:-}" "${TMPDIR:-}" "${TEMP:-}" /tmp; do
+  [ -n "$candidate" ] || continue
+  unix_root="$(to_unix "$candidate")"
+  [ -d "$unix_root" ] || continue
+  case " ${roots} " in
+    *" ${unix_root} "*) continue ;; # already scanned (TMPDIR often == /tmp)
+  esac
+  roots="${roots} ${unix_root}"
+done
+echo "temp roots scanned:${roots:- none}" >> "$manifest"
+
+# Allow-list, not deny-list. This repository is public and workflow artifacts are
+# downloadable by anyone who can read it, so the filter has to fail CLOSED: a file
+# type nobody vetted must be skipped by default rather than uploaded because no
+# rule happened to name it. `.log` is the gateway's own output; the SQLite index
+# holds connector FIXTURE data, and Non-Negotiable #3 keeps real credentials in
+# the OS Vault and out of the DB entirely. The `vault/` prune below is belt and
+# braces on top of that guarantee, not a substitute for it.
+copied=0
+skipped_big=0
+skipped_total=0
+total_bytes=0
+
+# Enumerate the suite directories FIRST, then descend only into those. Walking a
+# whole temp root and filtering by `-path '*nimbus-*'` reads every unrelated file
+# in it. Two bounds, both learned the hard way on a developer machine where /tmp is
+# the user's real temp directory:
+#
+#   -mmin  : only directories touched recently can belong to THIS run. Without it
+#            the scan found 42,400 historical `nimbus-*` directories and descended
+#            into every one — the collector ran past two minutes and would have
+#            become the reason a job hit its 30-minute timeout. `-mmin` is in both
+#            GNU and BSD find, so it holds on the macOS runner too.
+#   max_dirs: a hard backstop if a suite somehow creates thousands inside the
+#            window. Anything dropped is NAMED in the manifest — a bundle that
+#            silently truncates reads as "this is everything" when it is not.
+max_age_min=240
+max_dirs=100
+
+suite_dirs=""
+for root in $roots; do
+  while IFS= read -r dir; do
+    [ -n "$dir" ] && suite_dirs="${suite_dirs}${dir}"$'\n'
+  done << EOF
+$(find "$root" -maxdepth 1 -type d -name 'nimbus-*' -mmin "-${max_age_min}" 2> /dev/null)
+EOF
+done
+
+found_dirs=$(printf '%s' "$suite_dirs" | grep -c . || true)
+if [ "$found_dirs" -gt "$max_dirs" ]; then
+  echo "suite dirs found: ${found_dirs} (modified in the last ${max_age_min} min) — CAPPED at ${max_dirs}, $((found_dirs - max_dirs)) NOT collected" >> "$manifest"
+  suite_dirs=$(printf '%s' "$suite_dirs" | head -n "$max_dirs")
+else
+  echo "suite dirs found: ${found_dirs} (modified in the last ${max_age_min} min)" >> "$manifest"
+fi
+
+while IFS= read -r dir; do
+  [ -n "$dir" ] || continue
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    size=$(wc -c < "$file" 2> /dev/null | tr -d ' ')
+    [ -n "$size" ] || continue
+    if [ "$size" -gt "$max_file_bytes" ]; then
+      skipped_big=$((skipped_big + 1))
+      echo "  SKIPPED (too large, ${size} B): ${file}" >> "$manifest"
+      continue
+    fi
+    if [ $((total_bytes + size)) -gt "$max_total_bytes" ]; then
+      skipped_total=$((skipped_total + 1))
+      continue
+    fi
+    dest="${out}/workdirs/$(echo "$file" | sed 's#^/##; s#[:\\]#_#g')"
+    mkdir -p "$(dirname "$dest")" 2> /dev/null
+    if cp "$file" "$dest" 2> /dev/null; then
+      copied=$((copied + 1))
+      total_bytes=$((total_bytes + size))
+    fi
+  done << EOF
+$(find "$dir" -maxdepth 5 -type d -name vault -prune -o \
+  -type f \( -name '*.log' -o -name '*.db' -o -name '*.db-wal' -o -name '*.db-shm' \
+  -o -name '*.sqlite' -o -name '*.sqlite3' \) -print 2> /dev/null)
+EOF
+done << EOF
+${suite_dirs}
+EOF
+
+{
+  echo
+  echo "workdir files copied : ${copied} (${total_bytes} B)"
+  echo "skipped, over ${max_file_bytes} B per file : ${skipped_big}"
+  echo "skipped, bundle hit ${max_total_bytes} B  : ${skipped_total}"
+  if [ "$copied" -eq 0 ]; then
+    echo
+    echo "No working directories survived. For an ordinary assertion failure that is"
+    echo "EXPECTED — the suite deletes its own mkdtemp dir in a finally block. Read the"
+    echo "JUnit report above. A surviving directory means the process died without"
+    echo "unwinding (timeout kill, segfault, early exit)."
+  fi
+} >> "$manifest"
+
+cat "$manifest"
+exit 0


### PR DESCRIPTION
Two CI changes. The first is the reason the PR exists; the second was added on request rather than split out.

---

# 1. The release guard fails on every healthy release

The `release-please` job has gone red on **every** release-PR merge since the silent-drop guard landed in #1052 — while the release itself shipped correctly each time. Latest: [run 31165486901](https://github.com/nimbus-agent/Nimbus/actions/runs/31165486901) on the merge of #1066 (v1.23.0), preceded by 31074863757 (v1.22.0) and 31068750817 (v1.21.0).

## Root cause: two steps in the same job contradict each other

1. `release-please-action` merges the manifest bump but never creates the tag — the phantom this workflow already documents. `releases_created=false`.
2. **Reconcile phantom release** recovers it: creates `refs/tags/v1.23.0` at the merge commit and flips PR #1066 `autorelease: pending` → `autorelease: tagged`. This worked — the tag exists and [release.yml built it](https://github.com/nimbus-agent/Nimbus/actions/runs/31165721279).
3. **Guard** reads `releases_created == true || open PRs labelled "autorelease: pending" > 0`. Both are false — *because step 2 removed that label one step earlier*, which is what recovery means. It then compares against `releases/latest`, still `v1.22.0` while release.yml is mid-build, sees four `feat`/`fix` commits that are **already in 1.23.0**, and fails.

The guard fires precisely when recovery works — the normal path in this repo. A guard that cries wolf on the healthy path is one people learn to ignore, which would cost us the real silent drop it was built to catch (#1047 / v1.20.0).

## Fix — three arms

**a. The reconcile step publishes what it did.** `id: reconcile` plus a `reconciled` output, set `true` only on the branches that end with the release *accounted for*. The guard adds `reconciled == true` as a third healthy state.

**b. The guard baselines off the newest `vX.Y.Z` tag, not `releases/latest`.** The tag marks a version as cut; the Release appears later, at the end of the tag-driven build. Any push to `main` inside that window compared against a stale baseline. `matching-refs/tags/v` is a prefix match, so `vscode-v*` and `v0.1.0-rc*` are filtered by pattern; `sort -V` orders `v1.9.0` before `v1.20.0`; the `grep` is braced so a no-match can't kill the pipeline under `pipefail`.

**c. An unaccounted-for release PR is now red, not a warning** — see the CodeRabbit thread below.

A release build that fails *after* its tag exists is unaffected: it goes red loudly in release.yml and is abandoned rather than retagged (per CLAUDE.md).

## Verification

Both `run:` blocks were extracted and `bash -n`-checked, then the guard was executed against the live repo in three states — including a **red-prove**, since a guard that can't be shown to fail hasn't been shown to work:

| case | inputs | result |
| --- | --- | --- |
| A — the failing run's exact state | `reconciled=false` | `Since v1.23.0: 0 user-facing` → **exit 0** (was exit 1) |
| B — genuine silent drop (`v1.23.0` hidden, baseline falls back to `v1.22.0`) | `reconciled=false` | still **exit 1**, listing all four dropped commits |
| C — same commits, recovery ran | `reconciled=true` | `Healthy: … reconciled=true` → **exit 0** |

---

# 2. Failure-triage bundle for the integration and E2E jobs

The dominant CI pain here is a Linux-only failure that doesn't reproduce on Windows/macOS. The JUnit report says *which* test failed; it never says what the spawned gateway printed or what landed in its SQLite index. `verify:docker` exists largely to re-obtain, locally, output the runner already had and deleted.

`scripts/ci/collect-failure-artifacts.sh` runs `if: failure()` in the `integration`, `e2e-gateway` and `e2e-cli` jobs, **before** the cleanup step that deletes the evidence, and uploads a bundle (7-day retention).

**What it reaches, stated honestly.** The e2e suites `rmSync` their own `mkdtemp` dir from a `finally`, so after an ordinary assertion failure nothing survives and the bundle will legitimately contain only JUnit — the manifest says so in as many words rather than looking empty. What *does* survive is the class with no other evidence: a hang killed by the job timeout, a segfault, an early `process.exit`. Preserving a directory across an ordinary assertion failure needs harness cooperation at 43 bespoke `Bun.spawn` sites across 14 files; that's a separate change, not a widening of this one.

**Security.** The repo is public and artifacts are downloadable by anyone who can read it, so the filter is an **allow-list** (`.log`, `.db`, `.db-wal`, `.db-shm`, `.sqlite`, `.sqlite3`) — a deny-list fails open the first time a new secret filename ships. `vault/` is pruned on top of that, and Non-Negotiable #3 already keeps real credentials out of the DB.

**Bounds.** Both were learned by running it: a first version walked whole temp roots and hit 42,400 historical `nimbus-*` directories on a dev machine, running past two minutes — a triage step must never become why a job times out. It now filters `-mmin -240` (both GNU and BSD find, so macOS holds) and caps at 100 directories, **naming in the manifest anything dropped** rather than silently truncating.

## Also: the cleanup glob never matched its own job

The three cleanup steps ran `rm -rf /tmp/nimbus-test-*`. That prefix belongs to the **unit** suites (`registry-fetcher`, `engine-ask-stream`, the CLI test-runner), which run in `unit-coverage` — a job with no cleanup step. The suites these three jobs run name their dirs after themselves (`nimbus-share-e2e-`, `nimbus-bindfirst-`, `nimbus-assemble-`, `nimbus-dep-lifecycle-e2e-`). Measured on a dev machine: 42,400 surviving `nimbus-*` dirs, of which 228 matched the old glob. Widened to `nimbus-*`.

## Verification

`bun run preflight:fast` — 29/29 gates pass, including `audit:workflow-lint` and `audit:action-sha-pins`.

The collector was run against a fabricated tree containing a gateway log, a SQLite DB, an oversized log, a non-allow-listed `.txt`, and a `vault/` holding three files with known secret strings:

| assertion | result |
| --- | --- |
| files in the bundle with `vault` in the path | **0** |
| bundle files containing the secret fixture strings | **0** |
| control — those strings *are* present in the scanned tree | **3** (so the scan saw them and excluded them) |
| bundle files outside the allow-listed extensions | **0** |
| wall-clock with the bounds active | 20s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
