### PR TITLE
🧪 test: add test file for Tableau server.ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "nimbus",
@@ -9,6 +8,7 @@
         "@nimbus-dev/client": "^0.15.1",
         "@nimbus-dev/sdk": "^1.16.0",
         "astro": "^7.1.6",
+        "nanoid": "^6.0.1",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -3295,7 +3295,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -4414,6 +4414,8 @@
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@nimbus-dev/client": "^0.15.1",
         "@nimbus-dev/sdk": "^1.16.0",
         "astro": "^7.1.6",
-        "nanoid": "^6.0.1",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -3295,7 +3294,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -4414,8 +4413,6 @@
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "@nimbus-dev/client": "^0.15.1",
     "@nimbus-dev/sdk": "^1.16.0",
     "astro": "^7.1.6",
+    "nanoid": "^6.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -259,7 +259,6 @@
     "@nimbus-dev/client": "^0.15.1",
     "@nimbus-dev/sdk": "^1.16.0",
     "astro": "^7.1.6",
-    "nanoid": "^6.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/mcp-connectors/tableau/test/server.test.ts
+++ b/packages/mcp-connectors/tableau/test/server.test.ts
@@ -208,7 +208,7 @@ describe("tableau server", () => {
       const tools = captureTools();
       const out = parsePayload(await tool(tools, "tableau_search")({ query: "sale", limit: 10 }));
       expect(out.matches).toHaveLength(1);
-      expect(out.matches[0]).toEqual({ luid: "v1", name: "Sales" });
+      expect(out.matches![0]).toEqual({ luid: "v1", name: "Sales" });
     });
   });
 });

--- a/packages/mcp-connectors/tableau/test/server.test.ts
+++ b/packages/mcp-connectors/tableau/test/server.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { McpListResult, ZodObjectSchema } from "../../shared/mcp-tool-kit.ts";
+import { registerTableauTools } from "../src/server.ts";
+
+type Handler = (args: unknown) => Promise<McpListResult>;
+
+function captureTools(): Map<string, Handler> {
+  const tools = new Map<string, Handler>();
+  registerTableauTools(
+    <T>(
+      name: string,
+      _desc: string,
+      _schema: ZodObjectSchema<T>,
+      handler: (args: T) => Promise<McpListResult>,
+    ) => {
+      tools.set(name, handler as Handler);
+    },
+  );
+  return tools;
+}
+
+function tool(tools: Map<string, Handler>, name: string): Handler {
+  const handler = tools.get(name);
+  if (handler === undefined) throw new Error(`tool not registered: ${name}`);
+  return handler;
+}
+
+function parsePayload(res: McpListResult): {
+  items?: unknown[];
+  nextCursor?: string | null;
+  luid?: string;
+  name?: string;
+  matches?: unknown[];
+} {
+  return JSON.parse((res.content[0] as { text: string }).text) as {
+    items?: unknown[];
+    nextCursor?: string | null;
+    luid?: string;
+    name?: string;
+    matches?: unknown[];
+  };
+}
+
+describe("tableau server", () => {
+  const origFetch = globalThis.fetch;
+  let _calls: { url: string; method: string }[] = [];
+
+  beforeEach(() => {
+    _calls = [];
+    process.env["TABLEAU_URL"] = "https://tab.example.com";
+    process.env["TABLEAU_PAT_NAME"] = "pat";
+    process.env["TABLEAU_PAT_SECRET"] = "secret";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    delete process.env["TABLEAU_URL"];
+    delete process.env["TABLEAU_PAT_NAME"];
+    delete process.env["TABLEAU_PAT_SECRET"];
+  });
+
+  describe("environment variable validation", () => {
+    it("throws if TABLEAU_URL is missing", async () => {
+      delete process.env["TABLEAU_URL"];
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
+        "TABLEAU_URL is not set",
+      );
+    });
+
+    it("throws if TABLEAU_PAT_NAME is missing", async () => {
+      delete process.env["TABLEAU_PAT_NAME"];
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
+        "TABLEAU_PAT_NAME is not set",
+      );
+    });
+
+    it("throws if TABLEAU_PAT_SECRET is missing", async () => {
+      delete process.env["TABLEAU_PAT_SECRET"];
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
+        "TABLEAU_PAT_SECRET is not set",
+      );
+    });
+  });
+
+  describe("signin errors", () => {
+    it("throws on non-ok signin response", async () => {
+      globalThis.fetch = (async (_url: string) => {
+        return new Response("Unauthorized", { status: 401 });
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow("Tableau signin 401");
+    });
+
+    it("throws on missing token or site id", async () => {
+      globalThis.fetch = (async (_url: string) => {
+        return new Response(JSON.stringify({ credentials: { site: { id: "site-1" } } }), {
+          status: 200,
+        }); // missing token
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
+        "missing credentials.token or credentials.site.id",
+      );
+    });
+  });
+
+  describe("tableau_get", () => {
+    it("returns view successfully by luid", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response(
+            JSON.stringify({ views: { view: [{ luid: "view-123", name: "My View" }] } }),
+            { status: 200 },
+          );
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      const out = parsePayload(await tool(tools, "tableau_get")({ id: "view-123" }));
+      expect(out).toEqual({ luid: "view-123", name: "My View" });
+    });
+
+    it("throws if view not found", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response(
+            JSON.stringify({ views: { view: [{ luid: "view-123", name: "My View" }] } }),
+            { status: 200 },
+          );
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "non-existent" })).rejects.toThrow(
+        "Tableau view not found: non-existent",
+      );
+    });
+
+    it("throws on non-ok views response", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_get")({ id: "view-123" })).rejects.toThrow(
+        "Tableau views 400",
+      );
+    });
+  });
+
+  describe("tableau_search", () => {
+    it("returns matched views successfully", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response(
+            JSON.stringify({
+              views: {
+                view: [
+                  { luid: "v1", name: "Sales" },
+                  { luid: "v2", name: "Marketing" },
+                ],
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      const out = parsePayload(await tool(tools, "tableau_search")({ query: "sale", limit: 10 }));
+      expect(out.matches).toHaveLength(1);
+      expect(out.matches[0]).toEqual({ luid: "v1", name: "Sales" });
+    });
+  });
+});

--- a/packages/mcp-connectors/tableau/test/server.test.ts
+++ b/packages/mcp-connectors/tableau/test/server.test.ts
@@ -43,10 +43,8 @@ function parsePayload(res: McpListResult): {
 
 describe("tableau server", () => {
   const origFetch = globalThis.fetch;
-  let _calls: { url: string; method: string }[] = [];
 
   beforeEach(() => {
-    _calls = [];
     process.env["TABLEAU_URL"] = "https://tab.example.com";
     process.env["TABLEAU_PAT_NAME"] = "pat";
     process.env["TABLEAU_PAT_SECRET"] = "secret";


### PR DESCRIPTION
🎯 **What:** The `tableau_get` and `tableau_search` tools in the Tableau MCP connector's `server.ts`, as well as environment variable and generic sign-in logic, were lacking a dedicated test file. This PR adds a `server.test.ts` to bridge the gap.
📊 **Coverage:** The new test file covers:
- Environment variable validation (`TABLEAU_URL`, `TABLEAU_PAT_NAME`, `TABLEAU_PAT_SECRET`).
- Authentication logic errors (failed sign-in status, missing tokens/site ids in the response).
- The `tableau_get` tool (retrieving a view by id, throwing an error if the view is not found, and throwing on a bad status response).
- The `tableau_search` tool (ensuring the `filterTableauViews` mapping returns successful view search results).
✨ **Result:** Test coverage for the core public API functionality exposed by `registerTableauTools` is greatly improved, strengthening the module's safety net.

---
*PR created automatically by Jules for task [16900623180390857264](https://jules.google.com/task/16900623180390857264) started by @asafgolombek*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Tableau server integrations.
  * Verified tool registration, request parsing, credential validation, sign-in failures, view retrieval, missing views, unsuccessful responses, and search filtering.
  * Added checks for successful results and expected error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->