### PR TITLE
🧪 Add test for FORBIDDEN_RESULT_KEYS constant in gx-parse.ts

### DIFF
--- a/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
+++ b/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
@@ -4,9 +4,22 @@ import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import {
   assertWithinResultsDir,
+  FORBIDDEN_RESULT_KEYS,
   listAllExpectations,
   parseValidationResult,
 } from "../src/gx-parse.ts";
+
+describe("FORBIDDEN_RESULT_KEYS", () => {
+  it("contains the exact set of keys that must be stripped to prevent row-data leaks", () => {
+    expect([...FORBIDDEN_RESULT_KEYS]).toEqual([
+      "unexpected_list",
+      "partial_unexpected_list",
+      "partial_unexpected_index_list",
+      "unexpected_index_list",
+      "partial_unexpected_counts",
+    ]);
+  });
+});
 
 /**
  * Unit coverage for the pure parser surface in gx-parse.ts. The no-row-data


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `FORBIDDEN_RESULT_KEYS` in `gx-parse.ts` to protect against accidental removal of keys that prevent row-data leaks.
📊 **Coverage:** The test ensures that the set contains exactly the keys expected to be stripped (`unexpected_list`, `partial_unexpected_list`, etc.).
✨ **Result:** Improved test coverage and reliability for the parser's stripping contract.

---
*PR created automatically by Jules for task [4724834116050644690](https://jules.google.com/task/4724834116050644690) started by @asafgolombek*