### PR TITLE
🧪 test(zotero): add search filter edge case coverage

### DIFF
--- a/packages/mcp-connectors/zotero/test/search-filter.test.ts
+++ b/packages/mcp-connectors/zotero/test/search-filter.test.ts
@@ -94,18 +94,49 @@ describe("filterZoteroItems", () => {
   });
 
   test("supports creators with only firstName or only lastName", () => {
+    // @ts-expect-error Intentionally passing incomplete creator objects
     const onlyFirst = item({ data: { creators: [{ creatorType: "author", firstName: "Cher" }] } });
+    // @ts-expect-error Intentionally passing incomplete creator objects
     const onlyLast = item({ data: { creators: [{ creatorType: "author", lastName: "Prince" }] } });
 
     expect(filterZoteroItems([onlyFirst], { query: "Cher" })).toHaveLength(1);
     expect(filterZoteroItems([onlyLast], { query: "Prince" })).toHaveLength(1);
   });
 
-  test("ignores tag when it is not a string", () => {
-    // The previous item() has a baseline title of "Exponential backoff..."
-    // so if we search for "12345", it might match DOI which is "10.1145/1234567.8901234"
-    // We should clear DOI to ensure we are only testing the tag filter.
-    const badTag = item({ data: { DOI: undefined, tags: [{ tag: 12345 }] } });
-    expect(filterZoteroItems([badTag], { query: "12345" })).toHaveLength(0);
+  test("ignores creator objects that are null, primitive, or lack valid name fields", () => {
+    const edgeCaseCreators = item({
+      data: {
+        creators: [
+          // @ts-expect-error Intentionally passing invalid creator objects
+          null,
+          // @ts-expect-error Intentionally passing invalid creator objects
+          "invalid string creator",
+          // @ts-expect-error Intentionally passing invalid creator objects
+          42,
+          { creatorType: "author", firstName: "", lastName: "" }, // empty names
+          // @ts-expect-error Intentionally passing invalid creator objects
+          { creatorType: "author", name: "" }, // empty name
+          // @ts-expect-error Intentionally passing invalid creator objects
+          { creatorType: "author" }, // no name fields at all
+        ]
+      }
+    });
+    // Ensure it doesn't crash and correctly parses missing info
+    expect(filterZoteroItems([edgeCaseCreators], { query: "exponential backoff" })).toHaveLength(1);
+  });
+
+  test("ignores tags when tag property is missing or not a string", () => {
+    // Clear DOI to prevent false positives from default data
+    const badTags = item({
+      data: {
+        DOI: undefined,
+        // @ts-expect-error Intentionally passing invalid tag shape
+        tags: [{ tag: 12345 }, { notTag: "hello" }, null, "string_instead_of_object"]
+      }
+    });
+    // None of these should be indexed
+    expect(filterZoteroItems([badTags], { query: "12345" })).toHaveLength(0);
+    expect(filterZoteroItems([badTags], { query: "hello" })).toHaveLength(0);
+    expect(filterZoteroItems([badTags], { query: "string_instead_of_object" })).toHaveLength(0);
   });
 });

--- a/packages/mcp-connectors/zotero/test/search-filter.test.ts
+++ b/packages/mcp-connectors/zotero/test/search-filter.test.ts
@@ -118,8 +118,8 @@ describe("filterZoteroItems", () => {
           { creatorType: "author", name: "" }, // empty name
           // @ts-expect-error Intentionally passing invalid creator objects
           { creatorType: "author" }, // no name fields at all
-        ]
-      }
+        ],
+      },
     });
     // Ensure it doesn't crash and correctly parses missing info
     expect(filterZoteroItems([edgeCaseCreators], { query: "exponential backoff" })).toHaveLength(1);
@@ -131,8 +131,8 @@ describe("filterZoteroItems", () => {
       data: {
         DOI: undefined,
         // @ts-expect-error Intentionally passing invalid tag shape
-        tags: [{ tag: 12345 }, { notTag: "hello" }, null, "string_instead_of_object"]
-      }
+        tags: [{ tag: 12345 }, { notTag: "hello" }, null, "string_instead_of_object"],
+      },
     });
     // None of these should be indexed
     expect(filterZoteroItems([badTags], { query: "12345" })).toHaveLength(0);

--- a/packages/mcp-connectors/zotero/test/search-filter.test.ts
+++ b/packages/mcp-connectors/zotero/test/search-filter.test.ts
@@ -92,4 +92,20 @@ describe("filterZoteroItems", () => {
     const many = Array.from({ length: 10 }, (_, i) => item({ key: `K${String(i)}` }));
     expect(filterZoteroItems(many, { query: "exponential backoff", limit: 3 })).toHaveLength(3);
   });
+
+  test("supports creators with only firstName or only lastName", () => {
+    const onlyFirst = item({ data: { creators: [{ creatorType: "author", firstName: "Cher" }] } });
+    const onlyLast = item({ data: { creators: [{ creatorType: "author", lastName: "Prince" }] } });
+
+    expect(filterZoteroItems([onlyFirst], { query: "Cher" })).toHaveLength(1);
+    expect(filterZoteroItems([onlyLast], { query: "Prince" })).toHaveLength(1);
+  });
+
+  test("ignores tag when it is not a string", () => {
+    // The previous item() has a baseline title of "Exponential backoff..."
+    // so if we search for "12345", it might match DOI which is "10.1145/1234567.8901234"
+    // We should clear DOI to ensure we are only testing the tag filter.
+    const badTag = item({ data: { DOI: undefined, tags: [{ tag: 12345 }] } });
+    expect(filterZoteroItems([badTag], { query: "12345" })).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added tests to cover edge cases for partial creators and invalid tags in `search-filter.ts` for the Zotero connector.
📊 **Coverage:** Covered `creatorNames` processing creators missing either `firstName` or `lastName`, and covered `tagNames` skipping over non-string tag entries.
✨ **Result:** Improved test coverage for `filterZoteroItems` API and ensured correct handling of malformed records.

---
*PR created automatically by Jules for task [3400155881408885207](https://jules.google.com/task/3400155881408885207) started by @asafgolombek*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for creator-based search when only a first or last name is available.
  * Added coverage to ensure numeric tag values do not affect search filtering.
  * These checks improve confidence in accurate Zotero search results across common metadata variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->