### PR TITLE
fix(bitbucket): 🧹 correct itemsUpserted overcount

### DIFF
--- a/packages/gateway/src/connectors/bitbucket-sync.ts
+++ b/packages/gateway/src/connectors/bitbucket-sync.ts
@@ -128,10 +128,10 @@ function upsertFromPullRequest(
    * are byte-identical to before this fix.
    */
   webUrl?: string,
-): void {
+): boolean {
   const id = numberField(pr, "id");
   if (id === undefined) {
-    return;
+    return false;
   }
   const title = stringField(pr, "title") ?? `PR #${String(id)}`;
   const desc = stringField(pr, "description") ?? "";
@@ -172,6 +172,7 @@ function upsertFromPullRequest(
     pinned: false,
     syncedAt: now,
   });
+  return true;
 }
 
 function parseRepositoryFullNames(body: unknown): string[] {
@@ -225,8 +226,9 @@ function ingestBitbucketPullRequestPage(
     if (uo !== undefined) {
       maxUpdated = maxIso(maxUpdated, uo);
     }
-    upsertFromPullRequest(ctx, repoFull, pr, now);
-    upsertedDelta += 1;
+    if (upsertFromPullRequest(ctx, repoFull, pr, now)) {
+      upsertedDelta += 1;
+    }
   }
   const next = stringFieldFromBody(json, "next");
   const nextPrUrl = next !== undefined && next !== "" ? next : null;

--- a/packages/gateway/test/unit/connectors/bitbucket-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/bitbucket-sync.test.ts
@@ -342,7 +342,7 @@ describe("bitbucket-sync — indexing skip paths", () => {
     expect(rows[0].external_id).toBe("acme/app#1");
     expect(res.hasMore).toBe(false);
 
-    expect(res.itemsUpserted).toBe(2);
+    expect(res.itemsUpserted).toBe(1);
   });
 
   test("pull request with malformed full_name (no slash) is filtered out at workspace parse", async () => {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was `itemsUpserted` overcounting when a PR was skipped due to a missing `id` field in the `bitbucket-sync` connector.
💡 **Why:** This improves metrics accuracy and resolves a known bug documented in `known-todos.md`. Correct counts provide better operational observability for connector syncing.
✅ **Verification:** Verified by updating and successfully running `bun test packages/gateway/test/unit/connectors/bitbucket-sync.test.ts`. 45 of 45 tests pass.
✨ **Result:** The `itemsUpserted` variable correctly reflects the number of records actually upserted into the store.

---
*PR created automatically by Jules for task [12064685251787481813](https://jules.google.com/task/12064685251787481813) started by @asafgolombek*