### PR TITLE
fix(gateway): 🔒 Prevent command injection in tar extraction

### DIFF
--- a/packages/gateway/src/extensions/install-from-local.ts
+++ b/packages/gateway/src/extensions/install-from-local.ts
@@ -261,10 +261,11 @@ function assertNoEntryEscapes(destDir: string): void {
 
 export function extractTarGzToDirectory(archivePath: string, destDir: string): void {
   const cmd = resolveSystemTarCommand();
-  const args = ["-xzf", resolve(archivePath), "-C", resolve(destDir)];
+  const args = ["-x", "-z"];
   if (process.platform === "linux") {
     args.push("--no-overwrite-dir", "--no-same-owner", "--no-same-permissions");
   }
+  args.push(`--file=${resolve(archivePath)}`, `--directory=${resolve(destDir)}`);
   const r = spawnSync(cmd, args, {
     encoding: "utf8",
     windowsHide: true,


### PR DESCRIPTION
🎯 **What:** The `extractTarGzToDirectory` function was vulnerable to command option injection, because archive paths starting with hyphens (e.g. `--checkpoint=1`) could be erroneously parsed by `tar` as command-line flags.

⚠️ **Risk:** An attacker could craft a malicious filename that, when extracted or installed, would execute arbitrary code by passing dangerous options to `tar` such as `--checkpoint-action=exec=...`, resulting in Remote Code Execution (RCE).

🛡️ **Solution:** Alter the argument structure of the `spawnSync` execution for `tar` to use the `--file=...` and `--directory=...` long options. Passing arguments directly after the equals sign guarantees `tar` evaluates them exclusively as path variables, rendering injected flags inert. Scratch files added during the investigation have been successfully purged.

---
*PR created automatically by Jules for task [21547697563473146](https://jules.google.com/task/21547697563473146) started by @asafgolombek*