### PR TITLE
test(snowflake): 🧪 add edge case tests for search-filter

### DIFF
--- a/packages/mcp-connectors/snowflake/test/search-filter.test.ts
+++ b/packages/mcp-connectors/snowflake/test/search-filter.test.ts
@@ -48,6 +48,34 @@ describe("filterSnowflakeTables", () => {
     expect(filterSnowflakeTables([noSchema], { query: "missing" })).toHaveLength(0);
   });
 
+  test("returns empty when item list is empty", () => {
+    expect(filterSnowflakeTables([], { query: "orders" })).toHaveLength(0);
+  });
+
+  test("handles non-string field values gracefully", () => {
+    const mixedFields = {
+      database_name: 123,
+      schema_name: true,
+      table_name: null,
+      other_field: "match_this",
+    };
+    expect(filterSnowflakeTables([mixedFields], { query: "123" })).toHaveLength(0);
+    expect(filterSnowflakeTables([mixedFields], { query: "true" })).toHaveLength(0);
+    expect(filterSnowflakeTables([mixedFields], { query: "null" })).toHaveLength(0);
+  });
+
+  test("matches queries that span across multiple fields", () => {
+    const row = table({
+      database_name: "PROD_DB",
+      schema_name: "ANALYTICS",
+      table_name: "ORDERS",
+    });
+    // The query filter lowercases both haystack and needle, and splits the extracted fields with space.
+    // e.g. "orders analytics prod_db"
+    expect(filterSnowflakeTables([row], { query: "orders analytics" })).toHaveLength(1);
+    expect(filterSnowflakeTables([row], { query: "analytics prod" })).toHaveLength(1);
+  });
+
   test("honors the limit cap", () => {
     const many = Array.from({ length: 10 }, (_, i) => table({ table_name: `table_${String(i)}` }));
     expect(filterSnowflakeTables(many, { query: "table_", limit: 3 })).toHaveLength(3);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The issue highlighted a missing test file, but `search-filter.test.ts` existed. To fulfill the testing improvement, I added tests for important edge cases that were missing, such as handling empty item lists, ignoring non-string field values (e.g. numbers, booleans) gracefully, and matching a single search query against multiple properties.

📊 **Coverage:** What scenarios are now tested
- Returns empty array when `items` is empty.
- Successfully ignores non-string values like `null`, `123`, or `true` on row fields.
- Correctly matches complex multi-field queries.

✨ **Result:** The improvement in test coverage
Test suite now confidently validates the behavior of `filterSnowflakeTables` and its underlying helper logic on tricky inputs, enhancing reliability for edge cases.

---
*PR created automatically by Jules for task [10598767778754406266](https://jules.google.com/task/10598767778754406266) started by @asafgolombek*