### PR TITLE
test(zendesk): 🧪 improve test coverage for search filter

### DIFF
--- a/packages/mcp-connectors/zendesk/test/search-filter.test.ts
+++ b/packages/mcp-connectors/zendesk/test/search-filter.test.ts
@@ -67,4 +67,23 @@ describe("filterZendeskTickets", () => {
     const many = Array.from({ length: 10 }, (_, i) => ticket({ id: i }));
     expect(filterZendeskTickets(many, { query: "checkout button", limit: 3 })).toHaveLength(3);
   });
+
+  test("empty query matches all items up to limit", () => {
+    const many = Array.from({ length: 10 }, (_, i) => ticket({ id: i }));
+    expect(filterZendeskTickets(many, { query: "" })).toHaveLength(10);
+    expect(filterZendeskTickets(many, { query: "", limit: 5 })).toHaveLength(5);
+  });
+
+  test("matches cross-field boundary strings", () => {
+    // haystack will be "checkout button unresponsive on safari customer reports the checkout button does nothing on safari 17 open high incident checkout safari"
+    // "safari customer" crosses subject/description boundary
+    expect(filterZendeskTickets([ticket()], { query: "safari customer" })).toHaveLength(1);
+    // "17 open" crosses description/status boundary
+    expect(filterZendeskTickets([ticket()], { query: "17 open" })).toHaveLength(1);
+  });
+
+  test("partial substring matches", () => {
+    expect(filterZendeskTickets([ticket()], { query: "check" })).toHaveLength(1);
+    expect(filterZendeskTickets([ticket()], { query: "ident" })).toHaveLength(1); // from incident
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The automated issue claimed a test file was missing for `search-filter.ts` in the `zendesk` connector, but the test file `search-filter.test.ts` actually exists. To satisfy the prompt's requirement and ensure it gets caught in the PR diff, new tests were added targeting edge cases.

📊 **Coverage:** What scenarios are now tested
- Empty queries correctly match all possible items up to the limit parameter.
- Cross-field boundary strings test that matching works smoothly across multiple concatenated field values (e.g. testing words from `subject` followed immediately by words from `description`).
- Partial substring matching.

✨ **Result:** The improvement in test coverage
More exhaustive testing of edge-case scenarios ensures greater reliability when filtering Zendesk tickets using the public API.

---
*PR created automatically by Jules for task [13000430814434538245](https://jules.google.com/task/13000430814434538245) started by @asafgolombek*