### PR TITLE
test(mcp-connectors): 🧪 add tests for encodeZoomMeetingPathSegment

### DIFF
--- a/packages/mcp-connectors/zoom/test/encode-meeting-path.test.ts
+++ b/packages/mcp-connectors/zoom/test/encode-meeting-path.test.ts
@@ -22,4 +22,20 @@ describe("encodeZoomMeetingPathSegment", () => {
       encodeURIComponent(encodeURIComponent("ab//cd")),
     );
   });
+
+  it("single-encodes a UUID that contains a single / not at the beginning", () => {
+    expect(encodeZoomMeetingPathSegment("ab/cd")).toBe(
+      encodeURIComponent("ab/cd"),
+    );
+  });
+
+  it("handles empty string correctly", () => {
+    expect(encodeZoomMeetingPathSegment("")).toBe("");
+  });
+
+  it("single-encodes other special characters", () => {
+    expect(encodeZoomMeetingPathSegment("abc?def&ghi")).toBe(
+      encodeURIComponent("abc?def&ghi"),
+    );
+  });
 });

--- a/packages/mcp-connectors/zoom/test/encode-meeting-path.test.ts
+++ b/packages/mcp-connectors/zoom/test/encode-meeting-path.test.ts
@@ -24,9 +24,7 @@ describe("encodeZoomMeetingPathSegment", () => {
   });
 
   it("single-encodes a UUID that contains a single / not at the beginning", () => {
-    expect(encodeZoomMeetingPathSegment("ab/cd")).toBe(
-      encodeURIComponent("ab/cd"),
-    );
+    expect(encodeZoomMeetingPathSegment("ab/cd")).toBe(encodeURIComponent("ab/cd"));
   });
 
   it("handles empty string correctly", () => {
@@ -34,8 +32,6 @@ describe("encodeZoomMeetingPathSegment", () => {
   });
 
   it("single-encodes other special characters", () => {
-    expect(encodeZoomMeetingPathSegment("abc?def&ghi")).toBe(
-      encodeURIComponent("abc?def&ghi"),
-    );
+    expect(encodeZoomMeetingPathSegment("abc?def&ghi")).toBe(encodeURIComponent("abc?def&ghi"));
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that although the test file existed, it missed edge cases for when strings shouldn't be double-encoded.
📊 **Coverage:** Single slashes not at the beginning, empty strings, and standard URL-safe special characters are now tested.
✨ **Result:** Test coverage for `encodeZoomMeetingPathSegment` in `packages/mcp-connectors/zoom/src/encode-meeting-path.ts` is more complete.

---
*PR created automatically by Jules for task [15419051465715345510](https://jules.google.com/task/15419051465715345510) started by @asafgolombek*