### PR TITLE
test(cloudwatch): 🧪 add test for cloudwatch tools registration

### DIFF
--- a/packages/mcp-connectors/cloudwatch/test/tools.test.ts
+++ b/packages/mcp-connectors/cloudwatch/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { registerCloudwatchTools, CLOUDWATCH_TOOL_NAMES } from "../src/tools.ts";
+import { CLOUDWATCH_TOOL_NAMES, registerCloudwatchTools } from "../src/tools.ts";
 
 /**
  * Minimal stub MCP server that captures registered tool handlers keyed by name.

--- a/packages/mcp-connectors/cloudwatch/test/tools.test.ts
+++ b/packages/mcp-connectors/cloudwatch/test/tools.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { registerCloudwatchTools, CLOUDWATCH_TOOL_NAMES } from "../src/tools.ts";
+
+/**
+ * Minimal stub MCP server that captures registered tool handlers keyed by name.
+ */
+function stubServer() {
+  const tools: Record<string, (input: unknown) => Promise<unknown>> = {};
+  return {
+    server: (
+      name: string,
+      _desc: string,
+      _schema: unknown,
+      cb: (i: unknown) => Promise<unknown>,
+    ) => {
+      tools[name] = cb;
+    },
+    tools,
+  };
+}
+
+describe("registerCloudwatchTools", () => {
+  it("registers all expected cloudwatch tools", () => {
+    const { server, tools } = stubServer();
+
+    registerCloudwatchTools(server as never);
+
+    for (const name of CLOUDWATCH_TOOL_NAMES) {
+      expect(typeof tools[name]).toBe("function");
+    }
+    expect(Object.keys(tools)).toHaveLength(CLOUDWATCH_TOOL_NAMES.length);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing test file for `packages/mcp-connectors/cloudwatch/src/tools.ts` to verify the registration of the CloudWatch tools.

📊 **Coverage:** What scenarios are now tested
- Verifies that all expected tools (`cloudwatch_list`, `cloudwatch_get`, `cloudwatch_search`) are properly registered onto the MCP server.
- Verifies that no additional, unexpected tools are registered.

✨ **Result:** The improvement in test coverage
The public API of the CloudWatch connector tool registration is now verified against its expected surface, catching regressions if tools are accidentally dropped or renamed.

---
*PR created automatically by Jules for task [9391533403909821714](https://jules.google.com/task/9391533403909821714) started by @asafgolombek*