### PR TITLE
test(mcp-connectors): 🧪 add test coverage for resultsDir in gx-parse.ts

### DIFF
--- a/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
+++ b/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
@@ -7,6 +7,7 @@ import {
   FORBIDDEN_RESULT_KEYS,
   listAllExpectations,
   parseValidationResult,
+  resultsDir,
 } from "../src/gx-parse.ts";
 
 describe("FORBIDDEN_RESULT_KEYS", () => {
@@ -427,5 +428,32 @@ describe("listAllExpectations — filesystem walk", () => {
   it("throws when GREAT_EXPECTATIONS_RESULTS_DIR is unset", async () => {
     delete process.env["GREAT_EXPECTATIONS_RESULTS_DIR"];
     await expect(listAllExpectations()).rejects.toThrow(/GREAT_EXPECTATIONS_RESULTS_DIR/);
+  });
+});
+
+describe("resultsDir", () => {
+  const originalEnv = process.env["GREAT_EXPECTATIONS_RESULTS_DIR"];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["GREAT_EXPECTATIONS_RESULTS_DIR"];
+    } else {
+      process.env["GREAT_EXPECTATIONS_RESULTS_DIR"] = originalEnv;
+    }
+  });
+
+  it("returns the resolved path when GREAT_EXPECTATIONS_RESULTS_DIR is set", () => {
+    process.env["GREAT_EXPECTATIONS_RESULTS_DIR"] = "/tmp/gx-results";
+    expect(resultsDir()).toBe(resolve("/tmp/gx-results"));
+  });
+
+  it("throws an error when GREAT_EXPECTATIONS_RESULTS_DIR is not set", () => {
+    delete process.env["GREAT_EXPECTATIONS_RESULTS_DIR"];
+    expect(() => resultsDir()).toThrow("GREAT_EXPECTATIONS_RESULTS_DIR is not set");
+  });
+
+  it("throws an error when GREAT_EXPECTATIONS_RESULTS_DIR is an empty string", () => {
+    process.env["GREAT_EXPECTATIONS_RESULTS_DIR"] = "   ";
+    expect(() => resultsDir()).toThrow("GREAT_EXPECTATIONS_RESULTS_DIR is not set");
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `resultsDir()` function in `packages/mcp-connectors/great-expectations/src/gx-parse.ts`. This function is responsible for retrieving and resolving the path to the Great Expectations results directory from the `GREAT_EXPECTATIONS_RESULTS_DIR` environment variable.

📊 **Coverage:** The following scenarios are now tested:
- Happy path: the environment variable is properly set, and the function correctly resolves and returns the directory path.
- Error path (missing): the environment variable is not set, and the function correctly throws an error.
- Error path (empty): the environment variable is set to a string containing only whitespace (which gets trimmed to an empty string), and the function correctly throws an error.

✨ **Result:** Test coverage for the `resultsDir` public API is now complete. The environment variable is also properly managed (saved and restored) during testing to avoid cross-contamination of test suites, improving test reliability.

---
*PR created automatically by Jules for task [15809628314147787657](https://jules.google.com/task/15809628314147787657) started by @asafgolombek*