### PR TITLE
test(mcp-connectors/tableau): 🧪 expand coverage for search-filter edge cases

### DIFF
--- a/packages/mcp-connectors/tableau/test/search-filter.test.ts
+++ b/packages/mcp-connectors/tableau/test/search-filter.test.ts
@@ -25,13 +25,23 @@ describe("filterTableauViews", () => {
   });
 
   test("skips non-object entries", () => {
-    expect(filterTableauViews([null, 42, "x", view({})], { query: "sales" })).toHaveLength(1);
+    expect(filterTableauViews([null, 42, "x", [], [1, 2], view({})], { query: "sales" })).toHaveLength(1);
   });
 
   test("tolerates a missing name without throwing", () => {
     const noName = { luid: "ghi-789" };
     expect(filterTableauViews([noName], { query: "ghi-789" })).toHaveLength(1);
     expect(filterTableauViews([noName], { query: "rollup" })).toHaveLength(0);
+  });
+
+  test("handles non-string values gracefully", () => {
+    const nonString = { name: 123, luid: true };
+    // Should skip since they aren't matched as strings
+    expect(filterTableauViews([nonString], { query: "123" })).toHaveLength(0);
+    expect(filterTableauViews([nonString], { query: "true" })).toHaveLength(0);
+
+    // An empty query will match empty strings which is what the non-string values become
+    expect(filterTableauViews([nonString], { query: "" })).toHaveLength(1);
   });
 
   test("honors the limit cap", () => {

--- a/packages/mcp-connectors/tableau/test/search-filter.test.ts
+++ b/packages/mcp-connectors/tableau/test/search-filter.test.ts
@@ -25,7 +25,9 @@ describe("filterTableauViews", () => {
   });
 
   test("skips non-object entries", () => {
-    expect(filterTableauViews([null, 42, "x", [], [1, 2], view({})], { query: "sales" })).toHaveLength(1);
+    expect(
+      filterTableauViews([null, 42, "x", [], [1, 2], view({})], { query: "sales" }),
+    ).toHaveLength(1);
   });
 
   test("tolerates a missing name without throwing", () => {


### PR DESCRIPTION
🎯 **What:** Expanded test coverage for `packages/mcp-connectors/tableau/src/search-filter.ts` module handling unexpected field types and array inputs. The file was reported as missing, but since it already existed, tests were expanded to address edge cases.
📊 **Coverage:** Added coverage for arrays appearing as properties and scenarios where non-string values are provided for `name` and `luid`. 
✨ **Result:** Improved test reliability in the tableau connector search filter against incorrectly structured data gracefully.

---
*PR created automatically by Jules for task [9658946063906962304](https://jules.google.com/task/9658946063906962304) started by @asafgolombek*