### PR TITLE
test(elasticsearch): 🧪 add missing coverage for tools.ts

### DIFF
--- a/packages/mcp-connectors/elasticsearch/test/tools.test.ts
+++ b/packages/mcp-connectors/elasticsearch/test/tools.test.ts
@@ -212,5 +212,64 @@ describe("elasticsearch tools", () => {
         });
       });
     });
+
+    it("skips non-object or missing-index entries", async () => {
+      spyOn(globalThis, "fetch").mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify([
+              null,
+              "string",
+              123,
+              [],
+              { notIndex: "app" },
+              { index: 123 },
+              { index: "app-logs" },
+            ]),
+          ),
+      );
+
+      await withEnv(validEnv, async () => {
+        const result = await handlers["elasticsearch_search"]({ query: "app" });
+        expect(result).toEqual({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  matches: [{ index: "app-logs" }],
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        });
+      });
+    });
+
+    it("returns empty array if response is not an array", async () => {
+      spyOn(globalThis, "fetch").mockImplementation(
+        async () => new Response(JSON.stringify({ not: "an array" })),
+      );
+
+      await withEnv(validEnv, async () => {
+        const result = await handlers["elasticsearch_search"]({ query: "app" });
+        expect(result).toEqual({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  matches: [],
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The existing testing for `tools.ts` lacked coverage for non-objects in `isRecord`, missing index in `strField`, and non-array response from Elasticsearch in `indexEntries` during `elasticsearch_search` calls. 

📊 **Coverage:** What scenarios are now tested
Added missing test coverage for `indexMatches` and `indexEntries`, covering non-object, missing-index, and non-array responses. Validated that coverage is at 100%.

✨ **Result:** The improvement in test coverage
Line coverage for `packages/mcp-connectors/elasticsearch/src/tools.ts` is now 100%.

---
*PR created automatically by Jules for task [17815153842100125662](https://jules.google.com/task/17815153842100125662) started by @asafgolombek*