### PR TITLE
test(tableau): 🧪 add missing tests for tableau_list

### DIFF
--- a/packages/mcp-connectors/tableau/test/server.test.ts
+++ b/packages/mcp-connectors/tableau/test/server.test.ts
@@ -177,6 +177,57 @@ describe("tableau server", () => {
     });
   });
 
+  describe("tableau_list", () => {
+    it("returns views successfully", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response(
+            JSON.stringify({
+              views: { view: [{ luid: "view-123", name: "My View" }] },
+              pagination: { totalAvailable: 1 },
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      const out = parsePayload(await tool(tools, "tableau_list")({ cursor: null, limit: 10 }));
+      expect(out.items).toHaveLength(1);
+      expect(out.items![0]).toEqual({ luid: "view-123", name: "My View" });
+      expect(out.nextCursor).toBeNull();
+    });
+
+    it("throws on non-ok views response", async () => {
+      globalThis.fetch = (async (url: string) => {
+        const u = String(url);
+        if (u.includes("/auth/signin")) {
+          return new Response(
+            JSON.stringify({ credentials: { token: "tok", site: { id: "site-1" } } }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/views")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+        throw new Error("unexpected url");
+      }) as unknown as typeof fetch;
+
+      const tools = captureTools();
+      await expect(tool(tools, "tableau_list")({ cursor: null, limit: 10 })).rejects.toThrow(
+        "Tableau views 400",
+      );
+    });
+  });
+
   describe("tableau_search", () => {
     it("returns matched views successfully", async () => {
       globalThis.fetch = (async (url: string) => {


### PR DESCRIPTION
🎯 **What:** Added a `tableau_list` test block to `packages/mcp-connectors/tableau/test/server.test.ts`.
📊 **Coverage:** Covered the successful views fetch and the pagination simulation logic when `cursor: null` and the error condition on a non-200 views response.
✨ **Result:** Improved test coverage for `tableau_list` tool in `server.ts`.

---
*PR created automatically by Jules for task [3517487519443803581](https://jules.google.com/task/3517487519443803581) started by @asafgolombek*