### PR TITLE
test(zoom): 🧪 add edge case tests for recordings window validation

### DIFF
--- a/packages/mcp-connectors/zoom/test/recordings-window.test.ts
+++ b/packages/mcp-connectors/zoom/test/recordings-window.test.ts
@@ -47,4 +47,33 @@ describe("validateZoomRecordingsWindow", () => {
       /Invalid 'to'/,
     );
   });
+
+  it("rejects empty string `from`", () => {
+    expect(() => validateZoomRecordingsWindow("", "2026-05-31T00:00:00Z")).toThrow(
+      /Invalid 'from'/,
+    );
+  });
+
+  it("rejects empty string `to`", () => {
+    expect(() => validateZoomRecordingsWindow("2026-05-01T00:00:00Z", "")).toThrow(
+      /Invalid 'to'/,
+    );
+  });
+
+  it("accepts exactly 31 days boundary", () => {
+    // 31 days = 31 * 24 * 60 * 60 * 1000 = 2678400000 ms
+    const from = new Date("2026-05-01T00:00:00.000Z");
+    const to = new Date(from.getTime() + 2678400000);
+    expect(() =>
+      validateZoomRecordingsWindow(from.toISOString(), to.toISOString()),
+    ).not.toThrow();
+  });
+
+  it("rejects exactly 31 days + 1 millisecond boundary", () => {
+    const from = new Date("2026-05-01T00:00:00.000Z");
+    const to = new Date(from.getTime() + 2678400000 + 1);
+    expect(() =>
+      validateZoomRecordingsWindow(from.toISOString(), to.toISOString()),
+    ).toThrow(/<= 1 month/);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added tests for empty strings and exact millisecond boundaries for the 31-day limit in `validateZoomRecordingsWindow`.

📊 **Coverage:** Now testing boundary conditions for the exact 31 days limit and edge cases with empty strings.

✨ **Result:** Improved test coverage and reliability for Zoom recordings window validation API.

---
*PR created automatically by Jules for task [3780916582915309764](https://jules.google.com/task/3780916582915309764) started by @asafgolombek*