### PR TITLE
ci(release): require the workflow scope on WINGET_PAT and sync the winget fork explicitly

### DIFF
--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -179,16 +179,54 @@ jobs:
       # Fail fast with an actionable message if the winget submission PAT is missing.
       # wingetcreate must fork microsoft/winget-pkgs + open a cross-repo PR, which the
       # fine-grained PACKAGE_MANAGER_PAT (scoped to our own channel repos) cannot do —
-      # this needs a classic PAT with the `public_repo` scope.
+      # this needs a classic PAT with the `public_repo` AND `workflow` scopes (see the
+      # sync step below for why `workflow` is not optional).
       - name: Require WINGET_PAT
         shell: pwsh
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
         run: |
           if ([string]::IsNullOrEmpty($env:WINGET_PAT)) {
-            Write-Output "::error::WINGET_PAT is not set. Add a classic PAT with the 'public_repo' scope so wingetcreate can fork microsoft/winget-pkgs, push to the fork, and open a PR (the fine-grained PACKAGE_MANAGER_PAT cannot). Repo Settings -> Secrets -> Actions."
+            Write-Output "::error::WINGET_PAT is not set. Add a classic PAT with the 'public_repo' AND 'workflow' scopes so wingetcreate can fork microsoft/winget-pkgs, sync + push to the fork, and open a PR (the fine-grained PACKAGE_MANAGER_PAT cannot). Repo Settings -> Secrets -> Actions."
             exit 1
           }
+
+      # wingetcreate syncs its fork of winget-pkgs before submitting, and when that sync
+      # fails it reports only "The forked repository could not be synced with the upstream
+      # commits" — naming no cause. The cause is normally scope: GitHub refuses a
+      # token-attributed write that creates or updates files under `.github/workflows/`
+      # unless the PAT carries `workflow`, and winget-pkgs commits workflow files
+      # regularly. A `public_repo`-only PAT therefore publishes fine until the first such
+      # upstream commit, then fails EVERY release — winget sat at 1.19.1 from v1.20.0
+      # through v1.26.0 exactly this way, while brew/scoop in this same workflow stayed
+      # current, so the run was red but the symptom was one stale channel.
+      #
+      # Doing the sync here, explicitly, means the failure names its own cause. Idempotent:
+      # a fork already level with upstream is a no-op, and a not-yet-existing fork is not
+      # an error (wingetcreate creates it on the first-ever submission).
+      - name: Sync the winget-pkgs fork with upstream
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PAT }}
+        run: |
+          $login = gh api user --jq .login
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::error::WINGET_PAT was rejected by the GitHub API — it is revoked or expired. Re-issue it (classic PAT, 'public_repo' + 'workflow')."
+            exit 1
+          }
+          $fork = "$login/winget-pkgs"
+          $branch = gh api "repos/$fork" --jq .default_branch 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "No $fork yet — wingetcreate will create it on submit."
+            exit 0
+          }
+          $out = gh api -X POST "repos/$fork/merge-upstream" -f "branch=$branch" 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output $out
+            Write-Output "::error::Could not sync $fork ($branch) with microsoft/winget-pkgs. The usual cause is a WINGET_PAT missing the 'workflow' scope: upstream commits touch .github/workflows/, and GitHub refuses to replay those without it. Re-issue the classic PAT with BOTH 'public_repo' and 'workflow' (https://github.com/settings/tokens), or sync the fork by hand and re-run this workflow."
+            exit 1
+          }
+          Write-Output $out
 
       - name: Download the released .msi + SHA256SUMS
         shell: pwsh

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -68,7 +68,7 @@ at repository scope.
 | `APPLE_DEVELOPER_ID_INSTALLER` | macOS installer signing identity | Cert common-name | `release.yml` |
 | `APPLE_NOTARY_ID` | Apple notarization | Apple ID e-mail | `release.yml` |
 | `APPLE_NOTARY_PASSWORD` | Apple notarization | App-specific password | `release.yml` |
-| `WINGET_PAT` | winget submission PR | **Classic** PAT — `public_repo` scope | `publish-package-managers.yml` |
+| `WINGET_PAT` | winget submission PR | **Classic** PAT — `public_repo` + `workflow` scopes | `publish-package-managers.yml` |
 | `VSCE_PAT` | VS Code Marketplace publish | Azure DevOps PAT — Marketplace (Manage) | `publish-vscode.yml` |
 | `OVSX_PAT` | Open VSX publish | Open VSX token | `publish-vscode.yml` |
 | `SONAR_TOKEN` | SonarCloud quality gate (optional) | SonarCloud token | `ci.yml`, `_test-suite.yml`, `release.yml` |
@@ -265,9 +265,27 @@ carries the whole commit as one base64 request body, which cannot fit a
 GitHub App installed on the `nimbus-agent` org can only mint tokens for repos
 *inside* that org's installation — it has no way to authenticate against an
 external org's repo or fork it. So this one credential cannot be migrated to
-the App and remains a **classic** PAT with the **`public_repo`** scope
-(<https://github.com/settings/tokens/new>). This is a deliberate, documented
-exception, not an oversight.
+the App and remains a **classic** PAT with the **`public_repo`** *and*
+**`workflow`** scopes (<https://github.com/settings/tokens/new>). This is a
+deliberate, documented exception, not an oversight.
+
+**Both scopes are load-bearing.** Before submitting, `wingetcreate` syncs its
+fork of `winget-pkgs` with upstream, and GitHub refuses any token-attributed
+write that creates or updates files under `.github/workflows/` unless the token
+carries `workflow`. `winget-pkgs` commits workflow files regularly, so a
+`public_repo`-only PAT probes healthy and publishes fine — right up until the
+first upstream workflow commit, after which **every** release fails with
+`wingetcreate`'s opaque
+
+```text
+The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.
+```
+
+That is precisely what happened on 2026-08-04: upstream added
+`.github/workflows/missing-dependency-assist.lock.yml` hours after the v1.19.1
+publish, and the winget manifest then sat at 1.19.1 through v1.26.0 while
+brew/scoop stayed current. `check-secret-health.ts` now requires **both**
+scopes, so a partial grant reports `insufficient` instead of `ok`.
 
 ---
 
@@ -382,6 +400,11 @@ specifically:
   PAT is at least present (it does not prove the token is unexpired — a
   valid-but-expired token still passes the guard and fails later at the
   API call).
+- The **`Sync the winget-pkgs fork with upstream`** step that follows it does
+  reach the API, so it *is* an authentication check: a revoked/expired PAT and
+  a fork the token may not sync both fail there, each with a message naming
+  the cause. A missing fork is deliberately **not** a failure — the first-ever
+  submission has none yet.
 
 ---
 

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -31,10 +31,20 @@ describe("classifyPatProbe", () => {
     expect(classifyPatProbe(s, { status: 500, scopes: null })).toBe("indeterminate");
   });
   test("scopes: required present → ok, absent → insufficient", () => {
-    const s = { kind: "scopes", required: "public_repo" } as const;
+    const s = { kind: "scopes", required: ["public_repo"] } as const;
     expect(classifyPatProbe(s, { status: 200, scopes: "public_repo, gist" })).toBe("ok");
     expect(classifyPatProbe(s, { status: 200, scopes: "gist" })).toBe("insufficient");
     expect(classifyPatProbe(s, { status: 401, scopes: null })).toBe("dead");
+  });
+  // The WINGET_PAT shape: a PARTIAL grant must not read as healthy. A `public_repo`-only
+  // classic PAT probes 200 and looks fine, but cannot sync a fork across an upstream
+  // `.github/workflows/` commit — the failure that froze winget at 1.19.1.
+  test("scopes: ALL required must be present, a partial grant → insufficient", () => {
+    const s = { kind: "scopes", required: ["public_repo", "workflow"] } as const;
+    expect(classifyPatProbe(s, { status: 200, scopes: "public_repo, workflow, gist" })).toBe("ok");
+    expect(classifyPatProbe(s, { status: 200, scopes: "public_repo" })).toBe("insufficient");
+    expect(classifyPatProbe(s, { status: 200, scopes: "workflow" })).toBe("insufficient");
+    expect(classifyPatProbe(s, { status: 200, scopes: "" })).toBe("insufficient");
   });
   test("alive: 200 → ok, 401 → dead, other → indeterminate", () => {
     const s = { kind: "alive" } as const;
@@ -836,6 +846,6 @@ describe("describePatOutcome", () => {
   });
 
   test("a healthy PAT keeps the original strategy-kind detail", () => {
-    expect(describePatOutcome("ok", { kind: "scopes", required: "public_repo" })).toBe("scopes");
+    expect(describePatOutcome("ok", { kind: "scopes", required: ["public_repo"] })).toBe("scopes");
   });
 });

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -10,7 +10,7 @@ import { closeHealthIssue, openOrUpdateHealthIssue } from "./open-health-issue.t
 
 export type PatStrategy =
   | { readonly kind: "repo-write"; readonly targetRepos: readonly string[] }
-  | { readonly kind: "scopes"; readonly required: string }
+  | { readonly kind: "scopes"; readonly required: readonly string[] }
   | { readonly kind: "alive" };
 export type PatStatus = "ok" | "dead" | "insufficient" | "indeterminate" | "not-configured";
 export type CertStatus = "ok" | "expiring" | "expired" | "indeterminate" | "not-configured";
@@ -23,8 +23,11 @@ export function classifyPatProbe(
   if (probe.status !== 200) return "indeterminate";
   if (strategy.kind === "repo-write") return probe.push === true ? "ok" : "insufficient";
   if (strategy.kind === "scopes") {
+    // EVERY required scope must be present. A PAT holding only some of them is
+    // `insufficient`, not `ok` — a partial grant is exactly how the winget channel
+    // broke silently at v1.20.0 (see the WINGET_PAT entry below).
     const have = (probe.scopes ?? "").split(",").map((s) => s.trim());
-    return have.includes(strategy.required) ? "ok" : "insufficient";
+    return strategy.required.every((r) => have.includes(r)) ? "ok" : "insufficient";
   }
   return "ok";
 }
@@ -628,7 +631,15 @@ if (import.meta.main) {
     {
       env: "WINGET_PAT",
       token: process.env["WINGET_PAT"],
-      strategy: { kind: "scopes", required: "public_repo" } as PatStrategy,
+      // `public_repo` alone is NOT enough. wingetcreate syncs its fork of
+      // microsoft/winget-pkgs before submitting, and GitHub refuses a token-attributed
+      // write that creates or updates files under `.github/workflows/` unless the token
+      // also carries `workflow`. winget-pkgs commits workflow files regularly, so a
+      // `public_repo`-only PAT works until the first such upstream commit and then fails
+      // every release with wingetcreate's opaque "The forked repository could not be
+      // synced with the upstream commits" — which is what froze the winget manifest at
+      // 1.19.1 from 2026-08-04 (v1.20.0) until 2026-08-09.
+      strategy: { kind: "scopes", required: ["public_repo", "workflow"] } as PatStrategy,
     },
     {
       env: "NIMBUS_CHECKS_TOKEN",

--- a/scripts/release/credential-registry.ts
+++ b/scripts/release/credential-registry.ts
@@ -266,7 +266,7 @@ export const CREDENTIAL_REGISTRY: readonly CredentialEntry[] = [
     ],
     maxAgeDays: 90,
     hardDeadline: null,
-    note: "Stays a PAT: it must fork microsoft/winget-pkgs, which the App cannot reach.",
+    note: "Stays a PAT: it must fork microsoft/winget-pkgs, which the App cannot reach. Classic PAT, scopes `public_repo` AND `workflow` — `workflow` is not optional: syncing the fork replays upstream commits that touch `.github/workflows/`, which GitHub refuses without it (winget froze at 1.19.1 for five days in 2026-08 on exactly this).",
   },
 
   // --- Nimbus: signing material ---


### PR DESCRIPTION
## What broke

The winget manifest for `NimbusAgent.Nimbus` has been frozen at **1.19.1** since 2026-08-03. Every release since (v1.20.0 → v1.26.0) failed to publish: the `winget` job of `publish-package-managers.yml` has failed **9 consecutive times**, always at `wingetcreate … --submit` with

```text
The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.
```

The `brew`/`scoop` job in the same workflow succeeded every time, so both those channels are current at 1.26.0 — only winget lagged, which is why a red workflow read as background noise.

## Root cause

The submission fork was **2326 commits behind, 0 ahead** — strictly behind, so a fast-forward was always available. What blocked it was scope:

- The first upstream commit after the fork's frozen head (`b0a5348a`, 2026-08-03T22:19) added `.github/workflows/missing-dependency-assist.lock.yml`; four more workflow-touching commits followed on 08-04 through 08-06.
- GitHub refuses a token-attributed write that creates or updates files under `.github/workflows/` unless the token carries the **`workflow`** scope. `WINGET_PAT` was provisioned — and asserted healthy — as `public_repo` only.

So the PAT worked until upstream first touched a workflow file, then failed every release after. `wingetcreate`'s message names none of this, and the health check reported the PAT `ok`, because it only ever asked for `public_repo`.

The fork has been synced by hand, so the current release can publish; this PR is about the recurrence.

## Changes

- **`check-secret-health.ts`** — the `scopes` strategy takes a **list** and requires **all** of it (`required: readonly string[]`, `every`). `WINGET_PAT` now requires `["public_repo", "workflow"]`, so a partial grant reports `insufficient` instead of `ok`.
- **`publish-package-managers.yml`** — a new `Sync the winget-pkgs fork with upstream` step performs the sync explicitly, before `wingetcreate`, so the failure names its own cause instead of surfacing as the opaque wingetcreate line. Idempotent: an already-level fork is a no-op, and a not-yet-existing fork is deliberately **not** an error (the first-ever submission has none). A revoked/expired PAT now also fails here, with a message saying so.
- **`credential-registry.ts` / `docs/ci-secrets.md`** — record that both scopes are load-bearing, and why `workflow` is not optional.

## Verification

- `bun test scripts/release/check-secret-health.test.ts` — 66 pass, 0 fail. Adds a test that a `public_repo`-only grant against the two-scope requirement classifies `insufficient` — i.e. red-proving the gate that was silent here.
- `bun run preflight:fast` — PASSED (29 gates, including `audit:workflow-lint`, `audit:secret-inventory`, `audit:consumed-by`).

## Still needs a human

The PAT itself: re-issue `WINGET_PAT` as a classic PAT with **both** `public_repo` and `workflow` (<https://github.com/settings/tokens>) and update the repo secret. Until then the new health check will report it `insufficient` — which is the point.

## Detection note (not changed here)

`audit:release-staleness` does cover winget, but it runs only in `org-drift-sweep.yml` on `cron: 0 7 * * 1`. The break started Tuesday 08-04, one day after the last sweep, so the next scheduled detection was six days out. Nine consecutive red publish runs alerted nobody in between.


## Follow-up commit: `scripts/release/check-winget-pat.ps1`

A maintainer script that answers "is this token actually usable as `WINGET_PAT`?" before it becomes a repo secret — the question nothing could answer when the scope shortfall went in.

It authenticates the token, prints the granted scopes, and names what's missing; compares the submission fork against upstream; and with `-Sync` performs the fork sync itself — both the operation that fails without `workflow` and the manual remediation once it has. Read-only by default. The token is read from a no-echo prompt or `$env:WINGET_PAT`, never printed and never placed in a URL.

It also reports the `repo`-instead-of-`public_repo` case explicitly: functionally sufficient, but `check-secret-health.ts` matches the literal string, so such a token would read `insufficient` in the weekly report.

Exercised on both paths before commit: a live token (correctly WARNs on `repo`, passes `workflow`, exit 0) and a bogus one (401 → FAIL, exit 1).
