### PR TITLE
fix(ci): accept repo as satisfying public_repo on WINGET_PAT, and add a scope-check script

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -281,6 +281,13 @@ first upstream workflow commit, after which **every** release fails with
 The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.
 ```
 
+**Check a candidate token before storing it** — `pwsh
+scripts/release/check-winget-pat.ps1` (prompts for the token without echoing it,
+reads `$env:WINGET_PAT` if set). It reports the granted scopes, names the missing
+one, and compares the submission fork against upstream; `-Sync` additionally
+performs the fork sync, which is both the operation that fails without `workflow`
+and the manual remediation after it has failed. Read-only otherwise.
+
 That is precisely what happened on 2026-08-04: upstream added
 `.github/workflows/missing-dependency-assist.lock.yml` hours after the v1.19.1
 publish, and the winget manifest then sat at 1.19.1 through v1.26.0 while

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -269,6 +269,16 @@ the App and remains a **classic** PAT with the **`public_repo`** *and*
 **`workflow`** scopes (<https://github.com/settings/tokens/new>). This is a
 deliberate, documented exception, not an oversight.
 
+**What GitHub actually issues.** Ticking `workflow` in the classic-PAT UI pulls
+in the whole `repo` group, so `public_repo` + `workflow` is **not an obtainable
+combination** — every real `WINGET_PAT` reports `repo, workflow`. That is the
+narrowest shape available for this job, not an over-selection, and
+`check-secret-health.ts` accepts it (`repo` subsumes `public_repo`). It does
+mean the token grants full control of every private repo its owner can reach,
+for a job that only ever touches public ones. The scope can't be narrowed; the
+only lever is **whose account it is** — a dedicated machine account reaches
+nothing private of yours. See the options discussion below.
+
 **Both scopes are load-bearing.** Before submitting, `wingetcreate` syncs its
 fork of `winget-pkgs` with upstream, and GitHub refuses any token-attributed
 write that creates or updates files under `.github/workflows/` unless the token

--- a/scripts/release/check-secret-health.test.ts
+++ b/scripts/release/check-secret-health.test.ts
@@ -46,6 +46,18 @@ describe("classifyPatProbe", () => {
     expect(classifyPatProbe(s, { status: 200, scopes: "workflow" })).toBe("insufficient");
     expect(classifyPatProbe(s, { status: 200, scopes: "" })).toBe("insufficient");
   });
+  // `repo` subsumes `public_repo` but is the only name reported, so a literal
+  // membership test would call a WORKING token insufficient. Crying wolf at a healthy
+  // credential is how the real finding gets ignored — the failure mode this file exists
+  // to prevent. The implication is one-way: it never excuses a genuinely missing scope.
+  test("scopes: a broader scope satisfies the narrower one it subsumes", () => {
+    const s = { kind: "scopes", required: ["public_repo", "workflow"] } as const;
+    expect(classifyPatProbe(s, { status: 200, scopes: "repo, workflow" })).toBe("ok");
+    expect(classifyPatProbe(s, { status: 200, scopes: "repo" })).toBe("insufficient");
+    // …and not the reverse: public_repo does NOT stand in for repo.
+    const t = { kind: "scopes", required: ["repo"] } as const;
+    expect(classifyPatProbe(t, { status: 200, scopes: "public_repo" })).toBe("insufficient");
+  });
   test("alive: 200 → ok, 401 → dead, other → indeterminate", () => {
     const s = { kind: "alive" } as const;
     expect(classifyPatProbe(s, { status: 200, scopes: null })).toBe("ok");

--- a/scripts/release/check-secret-health.ts
+++ b/scripts/release/check-secret-health.ts
@@ -15,6 +15,27 @@ export type PatStrategy =
 export type PatStatus = "ok" | "dead" | "insufficient" | "indeterminate" | "not-configured";
 export type CertStatus = "ok" | "expiring" | "expired" | "indeterminate" | "not-configured";
 
+/**
+ * Classic-PAT scope implication: `<required>` → the broader scopes that satisfy it.
+ *
+ * `repo` grants everything `public_repo` does (and private repos besides), but
+ * `x-oauth-scopes` reports only the name that was ticked — so a literal membership
+ * test calls a perfectly working `repo`-scoped token `insufficient`.
+ *
+ * This is load-bearing, not a courtesy: ticking `workflow` in the classic-PAT UI
+ * pulls in the whole `repo` group, so `public_repo` + `workflow` is not a
+ * combination GitHub will issue. Every real WINGET_PAT therefore reports
+ * `repo, workflow`, and without this map the check would reject the ONLY obtainable
+ * token — crying wolf at a healthy credential, which is how a real finding gets
+ * ignored, which is the failure this whole file exists to prevent.
+ *
+ * Widening here is safe ONLY where the broader scope genuinely subsumes the
+ * narrower one. It is not a place to record "close enough".
+ */
+const SCOPE_IMPLIED_BY: Record<string, readonly string[]> = {
+  public_repo: ["repo"],
+};
+
 export function classifyPatProbe(
   strategy: PatStrategy,
   probe: { status: number; scopes: string | null; push?: boolean },
@@ -27,7 +48,11 @@ export function classifyPatProbe(
     // `insufficient`, not `ok` — a partial grant is exactly how the winget channel
     // broke silently at v1.20.0 (see the WINGET_PAT entry below).
     const have = (probe.scopes ?? "").split(",").map((s) => s.trim());
-    return strategy.required.every((r) => have.includes(r)) ? "ok" : "insufficient";
+    return strategy.required.every(
+      (r) => have.includes(r) || (SCOPE_IMPLIED_BY[r] ?? []).some((b) => have.includes(b)),
+    )
+      ? "ok"
+      : "insufficient";
   }
   return "ok";
 }

--- a/scripts/release/check-winget-pat.ps1
+++ b/scripts/release/check-winget-pat.ps1
@@ -128,10 +128,13 @@ $failed = $false
 if ($hasPublic) {
   Write-Output "  OK    public_repo — can fork winget-pkgs and open the PR"
 } elseif ($hasRepo) {
-  Write-Output "  WARN  repo (not public_repo) — functionally sufficient, but BROADER than needed, and"
-  Write-Output "        scripts/release/check-secret-health.ts matches the literal string 'public_repo',"
-  Write-Output "        so the weekly health report will call this token 'insufficient'. Prefer re-issuing"
-  Write-Output "        with public_repo only."
+  Write-Output "  OK    repo — subsumes public_repo, so the fork + PR flow works."
+  Write-Output "  NOTE  'repo, workflow' is the NARROWEST shape GitHub will issue here: ticking"
+  Write-Output "        'workflow' in the classic-PAT UI pulls in the whole repo group, so"
+  Write-Output "        public_repo + workflow is not an obtainable combination. The scope is"
+  Write-Output "        therefore broader than the job needs — full control of every PRIVATE repo"
+  Write-Output "        this account can reach — and the only lever left is WHOSE account it is."
+  Write-Output "        A dedicated machine account reaches nothing private of yours."
 } else {
   Write-Output "  FAIL  no public_repo (nor repo) — cannot fork winget-pkgs or open the submission PR"
   $failed = $true

--- a/scripts/release/check-winget-pat.ps1
+++ b/scripts/release/check-winget-pat.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+  Verify a WINGET_PAT candidate has the scopes the winget publish path actually needs.
+
+.DESCRIPTION
+  WINGET_PAT is the one human-owned classic PAT in the release path (see
+  docs/ci-secrets.md). It must carry BOTH `public_repo` and `workflow`:
+
+    public_repo  fork microsoft/winget-pkgs, push to the fork, open the PR
+    workflow     replay upstream commits that touch .github/workflows/ when
+                 syncing the fork — GitHub refuses those writes without it
+
+  A `public_repo`-only token authenticates fine, probes healthy, and publishes
+  correctly right up until winget-pkgs next commits a workflow file, after which
+  EVERY release fails with wingetcreate's opaque "The forked repository could not
+  be synced with the upstream commits". That is what froze the published winget
+  manifest at 1.19.1 from v1.20.0 through v1.26.0 in 2026-08.
+
+  This script checks the token BEFORE you find out the hard way. It is read-only
+  unless you pass -Sync. It never prints the token and never puts it in a URL.
+
+.PARAMETER Token
+  The PAT. Omit it and the script reads $env:WINGET_PAT, or prompts (no echo).
+
+.PARAMETER Sync
+  Also sync the token owner's winget-pkgs fork with upstream — the exact
+  operation that fails when `workflow` is missing, and the manual remediation
+  when it has already failed. This is the only write this script performs.
+
+.PARAMETER Upstream
+  Upstream repo to compare/sync against (default: microsoft/winget-pkgs).
+
+.NOTES
+  Exit codes:
+    0  token authenticates and holds every required scope
+    1  token is dead, or a required scope is missing
+    2  usage error / network unreachable
+
+  Store a good token with:  gh secret set WINGET_PAT --repo nimbus-agent/Nimbus
+  (no value argument — gh prompts, keeping it out of your shell history).
+#>
+[CmdletBinding()]
+param(
+  [string]$Token = "",
+  [switch]$Sync,
+  [string]$Upstream = "microsoft/winget-pkgs"
+)
+
+$ErrorActionPreference = "Stop"
+
+# ---- Token intake (never echoed, never interpolated into a URL) -------------
+if (-not $Token) { $Token = $env:WINGET_PAT }
+if (-not $Token) {
+  $secure = Read-Host -AsSecureString "Paste the WINGET_PAT candidate"
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+  try { $Token = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr) }
+  finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
+}
+if (-not $Token) {
+  Write-Output "usage: no token supplied (-Token, `$env:WINGET_PAT, or the prompt)"
+  exit 2
+}
+
+function Invoke-GhApi {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [string]$Method = "GET",
+    [hashtable]$Body = $null
+  )
+  $params = @{
+    Uri              = "https://api.github.com$Path"
+    Method           = $Method
+    Headers          = @{
+      Authorization          = "Bearer $Token"
+      Accept                 = "application/vnd.github+json"
+      "X-GitHub-Api-Version" = "2022-11-28"
+      "User-Agent"           = "nimbus-check-winget-pat"
+    }
+    UseBasicParsing  = $true
+    ErrorAction      = "Stop"
+  }
+  if ($null -ne $Body) {
+    $params.Body = ($Body | ConvertTo-Json -Compress)
+    $params.ContentType = "application/json"
+  }
+  try {
+    $r = Invoke-WebRequest @params
+    return [pscustomobject]@{
+      Ok      = $true
+      Status  = [int]$r.StatusCode
+      Headers = $r.Headers
+      Json    = ($r.Content | ConvertFrom-Json)
+    }
+  } catch {
+    $resp = $_.Exception.Response
+    $status = if ($null -ne $resp) { [int]$resp.StatusCode } else { 0 }
+    return [pscustomobject]@{ Ok = $false; Status = $status; Headers = $null; Json = $null }
+  }
+}
+
+# ---- 1. Does it authenticate at all? ---------------------------------------
+$me = Invoke-GhApi -Path "/user"
+if (-not $me.Ok) {
+  if ($me.Status -eq 401) {
+    Write-Output "FAIL  the API rejected this token (401) — it is revoked, expired, or mistyped."
+    exit 1
+  }
+  Write-Output "ERROR could not reach api.github.com (status $($me.Status)). Network or proxy problem, token unproven."
+  exit 2
+}
+$login = $me.Json.login
+Write-Output "authenticates as: $login"
+
+# ---- 2. Scopes -------------------------------------------------------------
+# x-oauth-scopes reports what was literally ticked. `repo` SUBSUMES `public_repo`
+# but is reported as `repo` alone, so it is functionally sufficient while failing
+# a literal-membership check — called out below rather than silently accepted.
+$raw = $me.Headers["x-oauth-scopes"]
+if ($raw -is [array]) { $raw = $raw -join "," }
+$have = @($raw -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+Write-Output "scopes: $(if ($have.Count) { $have -join ', ' } else { '(none — this is a fine-grained token, not a classic PAT)' })"
+
+$hasWorkflow = $have -contains "workflow"
+$hasPublic = $have -contains "public_repo"
+$hasRepo = $have -contains "repo"
+$failed = $false
+
+if ($hasPublic) {
+  Write-Output "  OK    public_repo — can fork winget-pkgs and open the PR"
+} elseif ($hasRepo) {
+  Write-Output "  WARN  repo (not public_repo) — functionally sufficient, but BROADER than needed, and"
+  Write-Output "        scripts/release/check-secret-health.ts matches the literal string 'public_repo',"
+  Write-Output "        so the weekly health report will call this token 'insufficient'. Prefer re-issuing"
+  Write-Output "        with public_repo only."
+} else {
+  Write-Output "  FAIL  no public_repo (nor repo) — cannot fork winget-pkgs or open the submission PR"
+  $failed = $true
+}
+
+if ($hasWorkflow) {
+  Write-Output "  OK    workflow — can sync the fork across upstream .github/workflows/ commits"
+} else {
+  Write-Output "  FAIL  no workflow — THIS is the scope that broke winget publishing. The token will"
+  Write-Output "        work until winget-pkgs next commits a workflow file, then fail every release."
+  $failed = $true
+}
+
+$extra = @($have | Where-Object { $_ -notin @("public_repo", "repo", "workflow") })
+if ($extra.Count) {
+  Write-Output "  NOTE  also grants: $($extra -join ', ') — broader than this credential needs."
+}
+
+# ---- 3. Fork reachability (and, with -Sync, the real thing) -----------------
+$fork = "$login/winget-pkgs"
+$forkRes = Invoke-GhApi -Path "/repos/$fork"
+if (-not $forkRes.Ok) {
+  Write-Output "fork: none at $fork — wingetcreate creates it on the first-ever submission. Not an error."
+} else {
+  $branch = $forkRes.Json.default_branch
+  $cmp = Invoke-GhApi -Path "/repos/$Upstream/compare/master...${login}:winget-pkgs:${branch}?per_page=1"
+  if ($cmp.Ok) {
+    Write-Output "fork: $fork ($branch) is $($cmp.Json.status) — $($cmp.Json.behind_by) behind, $($cmp.Json.ahead_by) ahead of $Upstream"
+    if ($cmp.Json.ahead_by -gt 0) {
+      Write-Output "  NOTE  the fork carries commits upstream does not have; a fast-forward sync will not apply."
+    }
+  }
+  if ($Sync) {
+    $merge = Invoke-GhApi -Path "/repos/$fork/merge-upstream" -Method "POST" -Body @{ branch = $branch }
+    if ($merge.Ok) {
+      Write-Output "sync: $($merge.Json.message)"
+    } else {
+      Write-Output "sync: FAILED (status $($merge.Status)) — with 'workflow' absent this is the expected"
+      Write-Output "      outcome once the pending delta contains a .github/workflows/ change."
+      $failed = $true
+    }
+  }
+}
+
+if ($failed) {
+  Write-Output ""
+  Write-Output "VERDICT: unusable as WINGET_PAT. Re-issue a CLASSIC token with public_repo + workflow"
+  Write-Output "         at https://github.com/settings/tokens/new (see docs/ci-secrets.md)."
+  exit 1
+}
+Write-Output ""
+Write-Output "VERDICT: usable as WINGET_PAT."
+exit 0


### PR DESCRIPTION
Follow-up to #1130, which merged while this work was in flight — the second commit landed on a branch whose PR was already closed, so it never reached `main`.

## The bug #1130 introduced

#1130 made `check-secret-health.ts` require the literal strings `public_repo` **and** `workflow` on `WINGET_PAT`. That combination **cannot be issued**: ticking `workflow` in the classic-PAT UI pulls in the whole `repo` group, so every real token reports `repo, workflow` — never `public_repo, workflow`.

As merged, the weekly health run would therefore report the **only obtainable** token as `insufficient`. Crying wolf at a healthy credential is precisely how the real finding went unnoticed for six days, so this is worth fixing rather than living with.

## Changes

- **`check-secret-health.ts`** — a `SCOPE_IMPLIED_BY` map records that `repo` subsumes `public_repo`, so a `repo, workflow` token classifies `ok`. The implication is one-way and deliberately narrow: it is not a place to record "close enough", and it never excuses a genuinely absent scope. `workflow` missing is still `insufficient`, which is the case that actually broke publishing.
- **`check-winget-pat.ps1`** (new) — a maintainer script answering "is this token usable as `WINGET_PAT`?" *before* it becomes a repo secret. Authenticates it, prints and judges the granted scopes, and compares the submission fork against upstream; `-Sync` performs the fork sync — both the operation that fails without `workflow` and the manual remediation once it has. Read-only otherwise. The token comes from a no-echo prompt or `$env:WINGET_PAT`, is never printed, and never appears in a URL.
- **`docs/ci-secrets.md`** — records that `repo, workflow` is the narrowest obtainable shape, that the check accepts it, and that the residual blast radius (full control of the owner's private repos, for a job touching only public ones) cannot be narrowed by scope — the only lever is whose account owns the token. Points at the new script from the minting instructions.

## Verification

- `bun test scripts/release/check-secret-health.test.ts` — 67 pass, 0 fail. New cases: `repo, workflow` → `ok`; `repo` alone → `insufficient`; and the reverse implication is *not* granted (`public_repo` does not stand in for a required `repo`).
- `bun run preflight:fast` — PASSED.
- The script was exercised on both outcomes: a live token (`repo, workflow` → OK + the breadth NOTE, exit 0) and a bogus one (401 → FAIL, exit 1).
