### PR TITLE
ci(release): alert when a channel publish fails, and check channel drift daily

### DIFF
--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -220,26 +220,10 @@ jobs:
       - name: Audit the bypass-actor attestation
         run: bun scripts/structure-audit/check-bypass-attestation.ts --strict
 
-  release-staleness:
-    name: release-staleness
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - name: Checkout Nimbus
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
-      # No App token: every read (Nimbus releases + manifest, the channel repos,
-      # microsoft/winget-pkgs) is PUBLIC. The default github.token authenticates
-      # gh at 5000 req/hr, far above this job's handful of reads + one search.
-      - name: Audit release-train staleness
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: bun scripts/structure-audit/check-release-staleness.ts --strict
+  # release-staleness moved to `release-channel-drift.yml` on 2026-08-09 — weekly
+  # was too slow for a download channel (winget sat at 1.19.1 for six days across
+  # seven releases), and a red job in a big sweep is not a signal anyone reads.
+  # It now runs DAILY and files a release-health issue naming the findings.
 
   pin-freshness:
     name: pin-freshness

--- a/.github/workflows/publish-package-managers.yml
+++ b/.github/workflows/publish-package-managers.yml
@@ -292,3 +292,88 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "wingetcreate submit failed. If this is the first release, $id may not yet exist in winget-pkgs — bootstrap it once with 'wingetcreate new' (see docs/install.md)."
           }
+
+  # A failure here used to alert NOBODY. This workflow runs on `workflow_run`, so
+  # nothing blocks on it, no PR turns red, and the only notification goes to the
+  # actor of the upstream run. The winget job failed nine consecutive times across
+  # v1.20.0 → v1.26.0 while brew and scoop kept publishing, so even the run list
+  # looked half-healthy; the stale channel was found by hand, six days late.
+  #
+  # `release.yml` has filed a release-health issue on failure since it shipped —
+  # this is the same mechanism, one workflow later, where the assets actually
+  # reach users.
+  #
+  # ONE issue per key, not one per tag: this failure mode recurs every release
+  # until someone fixes the cause, and nine issues for one root cause is the kind
+  # of noise people learn to filter. The state hash still comments on each new
+  # tag, so a recurrence is visible without spawning a new thread.
+  alert-on-failure:
+    name: Alert on publish failure
+    needs:
+      - generate-and-publish
+      - winget
+    # failure() fires when a needed job FAILED; a skipped job is neutral, so the
+    # by-design skips (sdk-*/client-* tags) never trip this. Not always() — that
+    # would fire on success too.
+    if: ${{ failure() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: ./.github/actions/setup-nimbus-ci
+        with:
+          verify-lock: "false"
+      - name: File a release-health issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEALTH_KEY: publish-package-managers
+          HEALTH_TITLE: "🚨 Package-manager publish is failing"
+          HEALTH_BODY: "Publishing `${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}` to the package managers failed — brew/scoop: `${{ needs.generate-and-publish.result }}`, winget: `${{ needs.winget.result }}`. Users of the failed channel stay on the previous version, and nothing else blocks on this workflow, so this issue is the only signal. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: bun scripts/release/open-health-issue.ts
+
+  # The other half: an alert that never clears is one people stop reading. A fully
+  # successful publish closes the issue the failure opened.
+  resolve-alert:
+    name: Resolve publish alert
+    needs:
+      - generate-and-publish
+      - winget
+    if: ${{ success() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Bun
+        uses: ./.github/actions/setup-nimbus-ci
+        with:
+          verify-lock: "false"
+      - name: Close the release-health issue, if any
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEALTH_KEY: publish-package-managers
+          HEALTH_RESOLVE: "1"
+          HEALTH_BODY: "Resolved: `${{ github.event.workflow_run.head_branch || github.event.inputs.tag_name }}` published to every package-manager channel. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: bun scripts/release/open-health-issue.ts

--- a/.github/workflows/release-channel-drift.yml
+++ b/.github/workflows/release-channel-drift.yml
@@ -1,0 +1,103 @@
+name: Release channel drift
+
+# Does every download channel actually serve the version we published?
+#
+# This ran weekly inside `org-drift-sweep.yml` until 2026-08-09. That cadence was
+# how winget sat at 1.19.1 for six days across seven releases: the break began on
+# a Tuesday, one day after the last sweep, and the next scheduled look was six
+# days out. `publish-package-managers.yml` now files an issue the moment a publish
+# FAILS, which is faster than any poll — but it cannot see the other half of the
+# problem, where our publish job goes green and the channel still does not serve
+# the version. A winget PR that Microsoft's validation closes unmerged looks
+# exactly like success from here. That is what this daily read catches.
+#
+# Every read is public (our releases + manifest, the channel repos,
+# microsoft/winget-pkgs), so `github.token` suffices — no App token, no PAT.
+on:
+  schedule:
+    # 07:00 UTC daily — a break is at most ~24h old when it surfaces, not ~7d.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: release-channel-drift
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  staleness:
+    name: release-staleness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Nimbus
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # `continue-on-error` is NOT swallowing the failure — the findings are
+      # captured and become the issue body below, and the job still ends red via
+      # the final gate step. A bare red job is precisely the signal that went
+      # unread nine times; the issue is what a human actually sees.
+      - name: Audit release-train staleness
+        id: audit
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          bun scripts/structure-audit/check-release-staleness.ts --strict > findings.txt 2>&1
+          echo "code=$?" >> "$GITHUB_OUTPUT"
+          cat findings.txt
+
+      - name: File a release-health issue
+        if: ${{ steps.audit.outputs.code != '0' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEALTH_KEY: release-channel-drift
+          HEALTH_TITLE: "🚨 A release channel is not serving the published version"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "\`audit:release-staleness\` found a channel behind the published version. Until it clears, users of that channel install an older Nimbus than the release notes claim."
+            echo
+            echo '```'
+            cat findings.txt
+            echo '```'
+            echo
+            echo "Run: $RUN_URL"
+          } > body.md
+          HEALTH_BODY="$(cat body.md)" bun scripts/release/open-health-issue.ts
+
+      - name: Close the release-health issue, if any
+        if: ${{ steps.audit.outputs.code == '0' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEALTH_KEY: release-channel-drift
+          HEALTH_RESOLVE: "1"
+          HEALTH_BODY: "Resolved: every channel now serves the published version. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: bun scripts/release/open-health-issue.ts
+
+      # The audit's own verdict decides the job's colour, after the issue exists.
+      - name: Fail if the audit found drift
+        if: ${{ steps.audit.outputs.code != '0' }}
+        run: |
+          echo "::error::release-staleness reported drift — see the release-health issue"
+          exit 1

--- a/docs/infrastructure-roadmap.md
+++ b/docs/infrastructure-roadmap.md
@@ -311,6 +311,15 @@ moves to P6).
   file, or winget dir-or-open-PR) — and emits a per-edge verdict. A new
   `release-staleness` job runs it `--strict` on the weekly `org-drift-sweep`
   cron. Public reads only, so no App token is minted.
+  **Superseded 2026-08-09:** that job now lives in its own
+  `release-channel-drift.yml` on a **daily** cron and files a `release-health`
+  issue naming the findings (closing it again when they clear). Weekly proved
+  too slow and too quiet: winget served 1.19.1 for six days across seven
+  releases, the break landed one day after a sweep, and the sweep's own
+  `release-staleness` job was already red on an unrelated edge — a red job
+  inside a large sweep is not a signal anyone reads. The publish side got the
+  complementary fix in `publish-package-managers.yml`, which now files the same
+  kind of issue the moment a channel publish fails.
 - **Design decisions that matter:** the phantom edge gates on the *bump
   commit's* age, not the release's, so a normal build window is never red;
   winget counts as caught-up on a merged dir **or** an open PR, so the gate

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -146,7 +146,7 @@ export const CI_ONLY_GATES: readonly string[] = [
   "audit:pin-freshness", // needs network + gh (release + tag reads per pinned action); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:ci-latency", // needs network + gh (Actions API across 9 repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:ci-latency:update-baseline", // explicit human action that rewrites the committed baseline; never a gate
-  "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
+  "audit:release-staleness", // needs network + gh (public reads across release + channel repos); runs DAILY in release-channel-drift.yml with --strict (moved out of the weekly org-drift-sweep 2026-08-09), never the local FAST tier
   "audit:actions-allowlist", // needs network + gh (reads each repo's Actions permissions); runs only in org-drift-sweep.yml with --strict, never the local FAST tier
   "audit:advisories", // needs network (npm registry via `bun audit`); runs beside `bun audit` in security.yml, never the local FAST tier
   "audit:bypass-actors", // needs an OWNER gh token (admin:org) — the CI App token cannot read bypass_actors; an explicit human action, never a gate

--- a/scripts/release/open-health-issue.ts
+++ b/scripts/release/open-health-issue.ts
@@ -63,16 +63,26 @@ if (import.meta.main) {
   const key = process.env["HEALTH_KEY"];
   const title = process.env["HEALTH_TITLE"];
   const body = process.env["HEALTH_BODY"];
-  if (!repo || !token || !key || !title || !body) {
+  // `HEALTH_RESOLVE` closes the issue this key owns instead of opening one. A
+  // recurring-failure alert needs BOTH halves: without a resolve path, a stable
+  // key leaves an issue open after the fault clears, and an alert that stays red
+  // once fixed is one people learn to scroll past — the disease, not the cure.
+  // No open issue for the key is success, not an error: nothing to close.
+  const resolve = (process.env["HEALTH_RESOLVE"] ?? "") !== "";
+  if (!repo || !token || !key || !body) {
     console.error(
-      "open-health-issue: GITHUB_REPOSITORY, GITHUB_TOKEN, HEALTH_KEY, HEALTH_TITLE, HEALTH_BODY required",
+      "open-health-issue: GITHUB_REPOSITORY, GITHUB_TOKEN, HEALTH_KEY, HEALTH_BODY required",
     );
     process.exit(2);
   }
-  await openOrUpdateHealthIssue(createGitHubApi({ token, repo }), {
-    key,
-    title,
-    body,
-    state: body,
-  });
+  const api = createGitHubApi({ token, repo });
+  if (resolve) {
+    await closeHealthIssue(api, key, body);
+  } else {
+    if (!title) {
+      console.error("open-health-issue: HEALTH_TITLE required unless HEALTH_RESOLVE is set");
+      process.exit(2);
+    }
+    await openOrUpdateHealthIssue(api, { key, title, body, state: body });
+  }
 }


### PR DESCRIPTION
Closes the detection gap behind the winget outage: the winget job failed **nine consecutive times** across v1.20.0 → v1.26.0 and alerted nobody for six days.

## Why nothing fired

Two independent holes, and each needs its own fix:

1. **`publish-package-managers.yml` runs on `workflow_run`.** Nothing blocks on it, no PR turns red, and the only notification goes to the upstream run's actor. brew/scoop kept succeeding in the same run, so even the run list looked half-healthy. `release.yml` has filed a release-health issue on failure since it shipped — this workflow, one step closer to users, had no such thing.
2. **`audit:release-staleness` ran weekly**, inside `org-drift-sweep.yml`. The break landed on a Tuesday, one day after the sweep, so the next scheduled look was six days out — and that job was *already red* on an unrelated edge, so a new finding would have been invisible anyway. A red job inside a large sweep is not a signal anyone reads.

## Changes

**Alert at the source** — `publish-package-managers.yml` gains `alert-on-failure` (on `failure()`) and `resolve-alert` (on `success()`), mirroring `release.yml`'s proven `alert-on-failure` block. One issue per key rather than per tag: this failure mode recurs every release until someone fixes the cause, and nine issues for one root cause is noise people filter. The state hash still comments on each new tag, so a recurrence stays visible without a new thread.

**Detect independently** — `release-staleness` moves out of the weekly sweep into `release-channel-drift.yml` on a **daily** cron, filing a `release-health` issue whose body carries the actual findings and closing it when they clear. This catches what an alert on failure cannot: our publish going green while the channel still doesn't serve the version — a winget PR that Microsoft's validation closes unmerged looks exactly like success from here.

**`open-health-issue.ts`** — the CLI entry point gains `HEALTH_RESOLVE`, exposing the already-exported `closeHealthIssue` so an alert can clear itself. An alert that stays red once fixed is the disease, not the cure. No open issue for the key is success, not an error.

Public reads only in both workflows; `github.token` with `issues: write`, no App token and no PAT.

## Verification

- `bun run preflight:fast` — PASSED, including `audit:workflow-lint`, `audit:action-sha-pins` and `audit:consumed-by` over the new workflow.
- `bun test scripts/release/open-health-issue.test.ts` — 6 pass, 0 fail.
- Both new CLI paths exercised live against this repo: `HEALTH_RESOLVE=1` with a key owning no issue → clean no-op, exit 0; omitting `HEALTH_TITLE` without `HEALTH_RESOLVE` → exit 2 with the reason.
- The capture step was simulated locally against the real audit: exit 1, findings redirected to `findings.txt`, and the composed issue body renders them in a fenced block.

## Heads-up: this alert starts red, for a real reason

The audit's one current finding is pre-existing and unrelated to winget:

```
::error::sdk:nimbus-vscode: 1.10.0 < npm 1.16.0 and no bump PR open
```

`nimbus-vscode`'s lockfile resolves `@nimbus-dev/sdk` 1.10.0 while npm `@latest` is 1.16.0. It has been red in the weekly sweep since at least 2026-08-03 with nobody acting — which is the strongest evidence for this PR's premise. Once this merges, the first daily run files an issue for it. That is correct behaviour, but it means the new channel is red on day one, and fixing it needs a PR in `nimbus-vscode`, not here.
