### PR TITLE
ci(release): treat a created-or-updated release PR as a healthy run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -219,6 +219,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           RELEASES_CREATED: ${{ steps.release-please.outputs.releases_created }}
+          PRS_CREATED: ${{ steps.release-please.outputs.prs_created }}
           RECONCILED: ${{ steps.reconcile.outputs.reconciled }}
           UNACCOUNTED: ${{ steps.reconcile.outputs.unaccounted }}
         run: |
@@ -274,21 +275,34 @@ jobs:
             exit 0
           fi
 
-          # Three ways a run is healthy. The middle one is NOT redundant with the tag
-          # baseline above: it is the direct statement from the recovery step that it
-          # accounted for this release, and it does not depend on the tag it just created
-          # already being visible to a subsequent API read.
+          # FOUR ways a run is healthy, and the ORDER matters: every signal that comes
+          # straight back from the action is consulted before the one that re-queries the
+          # API, because a read issued seconds after a write can still miss it.
+          #
+          # `prs_created` closes a real false positive (#1134 -> v1.27.0). That run created
+          # release PR #1135 at 19:47:55 and this guard ran at 19:47:59. The PR existed and
+          # already carried `autorelease: pending`, but the `gh pr list` search index had
+          # not caught up four seconds later, so `pending` came back 0 and a completely
+          # healthy release went red. Worse, the advice below then pointed at a
+          # `Release-As:` trailer, which would have cut a SECOND version on top of the
+          # pending one. `prs_created` is the action's own return value for the PR it just
+          # opened or updated, so it cannot race with itself.
+          #
+          # The label query stays, LAST: it is the only signal here that can see a release
+          # PR left open by an EARLIER run, which no output of THIS run reports.
           pending=$(gh pr list --repo "$REPO" --state open \
                       --label "autorelease: pending" --json number --jq 'length')
           if [ "${RELEASES_CREATED:-false}" = "true" ] \
+            || [ "${PRS_CREATED:-false}" = "true" ] \
             || [ "${RECONCILED:-false}" = "true" ] \
             || [ "$pending" -gt 0 ]; then
-            echo "Healthy: releases_created=${RELEASES_CREATED:-false}, reconciled=${RECONCILED:-false}, open release PR(s)=${pending}."
+            echo "Healthy: releases_created=${RELEASES_CREATED:-false}, prs_created=${PRS_CREATED:-false}, reconciled=${RECONCILED:-false}, open release PR(s)=${pending}."
             exit 0
           fi
 
-          echo "::error::${facing} user-facing commit(s) since ${tag}, but release-please produced neither a release nor a release PR."
-          echo "::error::Most likely it could not PARSE one of them and skipped it. Open this run's release-please step and look for 'commit could not be parsed' and a 'commits: N' lower than the count above."
-          echo "::error::Unstick with a 'Release-As: X.Y.Z' trailer as the LAST line of a PR description, and keep prose with nested parens out of commit bodies."
+          echo "::error::${facing} user-facing commit(s) since ${tag}, but release-please reported no release, no release PR, and none is open."
+          echo "::error::FIRST check whether a release PR actually exists. If one does, this guard is wrong and the release is fine — do not act on the advice below."
+          echo "::error::If none exists, release-please most likely could not PARSE a commit and skipped it: open this run's release-please step and look for 'commit could not be parsed' and a 'commits: N' lower than the count above."
+          echo "::error::Only then unstick it with a 'Release-As: X.Y.Z' trailer as the LAST line of a PR description. NEVER add that trailer while a release PR is pending — it cuts a second version on top of it, and tags are immutable (see CLAUDE.md)."
           grep -E '^(feat|fix)(\([^)]*\))?!?:' <<<"$subjects" | sed 's/^/  dropped-or-unreleased: /'
           exit 1


### PR DESCRIPTION
## Summary

The release-please guard fails healthy releases. It fired on #1134 → v1.27.0 even though release-please had done exactly the right thing, and its own error advice would have made things worse.

## What happened

Timeline from the run, to the second:

| time | event |
|---|---|
| 19:47:21 | #1134 squash-merged to `main` (`feat(gateway): …`) |
| 19:47:44 | release-please runs, reports `commits: 2` |
| 19:47:55 | release-please **creates release PR #1135**, labelled `autorelease: pending` |
| 19:47:59 | the guard runs, queries `gh pr list --label "autorelease: pending"`, gets **0**, fails the job |

Nothing was wrong. #1135 existed, carried the right label, bumped 1.26.1 → 1.27.0, and listed the feat commit. GitHub's PR-list index simply had not caught up **four seconds** after the write.

## Why the guard missed it

Of the three signals it consulted, two come straight back from the action and one is a fresh API read:

```
releases_created   ← action output      (false here: a PR was opened, not a release)
reconciled         ← recovery step      (false here: nothing to recover)
pending            ← gh pr list         (0 here: the read raced the write)
```

The one signal that would have been decisive was never consulted: **`prs_created`**. Per the pinned action's own README (`45996ed1` / v5.0.0):

> `prs_created` — `true` if any pull request was created **or updated**

It is the action's own return value for the PR it just opened, so it cannot race with itself. And "or updated" matters as much as "created": a `feat` merged while a release PR is already open produces an *update*, which also leaves `releases_created` false.

## The fix

Add `prs_created` as a healthy signal, ordered so action-supplied outputs are all consulted **before** the one that re-queries the API:

```
releases_created  →  prs_created  →  reconciled  →  pending (gh pr list)
```

The label query stays, but last. It is still the only signal that can see a release PR left open by an **earlier** run, which no output of *this* run reports.

## The error advice was also actively dangerous

On failure the guard said:

> Most likely it could not PARSE one of them… Unstick with a `Release-As: X.Y.Z` trailer

Both halves were wrong here. Its own log showed `commits: 2` and no `commit could not be parsed` line, so nothing was skipped. And following that advice with #1135 already pending would have cut a **second** version on top of it — and per `CLAUDE.md`, release tags are immutable, so that is not undoable, only superseded.

The message now tells the reader to check whether a release PR exists **first**, says plainly that the guard is wrong if one does, and warns never to add the trailer while a release PR is pending.

## Type of Change

- [x] CI / tooling
- [x] Bug fix (non-breaking change that fixes an issue)

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome)
- [x] All existing tests pass
- [x] New behaviour is covered by tests — n/a; this is a workflow-only change with no test harness for GitHub Actions in this repo. Validated as described under Testing.
- [x] No `any` types introduced — n/a
- [x] No credentials, tokens, or secret values in logs, IPC, config or fixtures — the new `PRS_CREATED` env carries a boolean from a step output
- [x] Platform-specific code behind `PlatformServices` — n/a
- [x] The HITL consent gate has not been weakened — untouched
- [x] Does not touch `docs/README.md`

## Testing

- `bun run preflight:fast` — PASSED, all 29 gates.
- `bun run audit:workflow-lint` — OK, 24 workflows and 181 bash bodies parsed, so the edited shell body is syntactically valid.
- `bun run audit:action-sha-pins` — clean; no action reference changed.
- YAML re-parsed independently to confirm the job structure is intact.
- `prs_created` verified against the **pinned SHA's** own README rather than assumed from a newer version — the action declares outputs dynamically via `core.setOutput`, so there is no `outputs:` block in `action.yml` to check.

## Notes for Reviewers

- This is deliberately additive: no existing healthy condition was removed, so the change can only turn red runs green, never the reverse.
- The ordering is the substantive part, not just style. Any future signal that comes back from the action belongs **above** the `gh pr list` call, for the same reason `prs_created` does.
- Worth knowing when reading the guard: `releases_created` and `prs_created` are near-mutually-exclusive in practice — release-please either opens/updates a release PR (`prs_created`) or, when that PR merges, cuts the release (`releases_created`). A guard that checks only the second is blind to the entire first half of every release cycle.
