### PR TITLE
feat(automation): add incident_opened and deploy_failed watcher conditions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,12 +8,17 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
-- **Watcher conditions — `incident_opened` + `deploy_failed`** (2026-08-10) — the watcher engine
+- **2026-08-10 — Watcher conditions: `incident_opened` + `deploy_failed`.** The watcher engine
   previously evaluated one condition type, `alert_fired`, which matches an item type no connector
   indexes; a watcher could be created and armed and still never fire. Both new conditions come from
   one condition-kind table that the engine and `watcher.create` share, so an unsupported
   `conditionType` is now rejected at creation rather than accepted and silently ignored.
-  `deploy_failed` covers CI-annotated deployments only. Groundwork for `nimbus pre-mortem` PR B.
+  `incident_opened` narrows to `metadata.status = 'triggered'`, since PagerDuty re-indexes an
+  incident on acknowledgement and resolution too. `deploy_failed` covers CI-annotated deployments
+  only, and its coverage limits are recorded in
+  [`docs/architecture.md` § Watchers](./architecture.md#watchers). The desktop Create Watcher
+  dialog now offers exactly these three condition types, with the graph predicate as an orthogonal
+  option rather than a fourth condition type. Groundwork for `nimbus pre-mortem` PR B.
 - **2026-08-09 — Pre-mortem recurring-blocker-theme extraction: schema + background pass (schema
   V53).** PR A of the S1 pre-mortem work — schema and a debounced background pass only.
   **THERE IS NO USER-FACING COMMAND IN THIS PR**: `nimbus pre-mortem`, the `agents.premortem`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **Watcher conditions — `incident_opened` + `deploy_failed`** (2026-08-10) — the watcher engine
+  previously evaluated one condition type, `alert_fired`, which matches an item type no connector
+  indexes; a watcher could be created and armed and still never fire. Both new conditions come from
+  one condition-kind table that the engine and `watcher.create` share, so an unsupported
+  `conditionType` is now rejected at creation rather than accepted and silently ignored.
+  `deploy_failed` covers CI-annotated deployments only. Groundwork for `nimbus pre-mortem` PR B.
 - **2026-08-09 — Pre-mortem recurring-blocker-theme extraction: schema + background pass (schema
   V53).** PR A of the S1 pre-mortem work — schema and a debounced background pass only.
   **THERE IS NO USER-FACING COMMAND IN THIS PR**: `nimbus pre-mortem`, the `agents.premortem`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,9 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   one condition-kind table that the engine and `watcher.create` share, so an unsupported
   `conditionType` is now rejected at creation rather than accepted and silently ignored.
   `incident_opened` narrows to `metadata.status = 'triggered'`, since PagerDuty re-indexes an
-  incident on acknowledgement and resolution too. `deploy_failed` covers CI-annotated deployments
+  incident on acknowledgement and resolution too — the tradeoff, recorded rather than fixed, is
+  that an incident indexed with a null status (PagerDuty omitted the field, or returned a
+  non-string) never fires this condition at all. `deploy_failed` covers CI-annotated deployments
   only, and its coverage limits are recorded in
   [`docs/architecture.md` § Watchers](./architecture.md#watchers). The desktop Create Watcher
   dialog now offers exactly these three condition types, with the graph predicate as an orthogonal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1025,8 +1025,16 @@ The watcher engine evaluates post-sync conditions and fires configured automatio
 could never evaluate cannot be created.
 
 **Coverage limits of the conditions above.** A condition being evaluable is not the same as it
-firing on every qualifying event, and three gaps are known and unclosed:
+firing on every qualifying event, and four gaps are known and unclosed:
 
+- **`incident_opened` misses an incident indexed without a status.** The predicate matches only an
+  incident whose indexed `metadata.status` is exactly `triggered`. `pagerduty-sync.ts` writes
+  `metadata.status = status ?? null`, so if PagerDuty's API omits `status` for a row, or returns a
+  non-string, the incident is indexed with `metadata.status = null` and this condition never fires
+  for it — not on open, not ever. Widening the predicate to also match a null status was
+  considered and rejected: that would re-admit the resolution-firing bug the `triggered` narrowing
+  above exists to fix, for precisely the rows whose state is unknown. Fail-closed here is
+  intentional.
 - **The freshness window is shared across connectors.** A watcher only sees items whose
   `modified_at` is newer than its own `last_checked_at`, and the engine updates `last_checked_at`
   for *every* enabled watcher after *every* successful connector sync, regardless of which service

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1015,6 +1015,15 @@ Both Phase 4 clients use the **existing JSON-RPC 2.0 IPC socket** — no new Gat
 
 The watcher engine evaluates post-sync conditions and fires configured automations. Each watcher has a `condition_type`, a `condition_json` payload (service-specific filter criteria), and an optional `graph_predicate_json` that narrows evaluation using the Phase 3 relationship graph substrate.
 
+| `condition_type` | Fires on | Coverage |
+| --- | --- | --- |
+| `alert_fired` | an indexed item of type `alert` | no connector currently indexes `alert`, so this condition cannot fire today |
+| `incident_opened` | an indexed item of type `incident` | PagerDuty |
+| `deploy_failed` | an indexed item of type `deployment` whose `metadata.conclusion` is `failure` | CI-annotated deployments (`POST /v1/deployments`) only — Vercel records its outcome under `metadata.state`, and Prefect indexes deployment definitions with no outcome |
+
+`watcher.create` rejects any other `condition_type` with `-32602`, so a watcher that the engine
+could never evaluate cannot be created.
+
 #### Graph-aware watcher example (Phase 4 §2)
 
 A watcher can additionally reference the relationship graph to narrow when it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1018,11 +1018,30 @@ The watcher engine evaluates post-sync conditions and fires configured automatio
 | `condition_type` | Fires on | Coverage |
 | --- | --- | --- |
 | `alert_fired` | an indexed item of type `alert` | no connector currently indexes `alert`, so this condition cannot fire today |
-| `incident_opened` | an indexed item of type `incident` | PagerDuty |
+| `incident_opened` | an indexed item of type `incident` whose `metadata.status` is `triggered` | PagerDuty — the status narrowing is what keeps the condition faithful to its name, because `pagerduty-sync.ts` fetches `/incidents` unfiltered and re-indexes an incident on every `updated_at` change, so an acknowledgement or a resolution otherwise looks identical to an opening |
 | `deploy_failed` | an indexed item of type `deployment` whose `metadata.conclusion` is `failure` | CI-annotated deployments (`POST /v1/deployments`) only — Vercel records its outcome under `metadata.state`, and Prefect indexes deployment definitions with no outcome |
 
 `watcher.create` rejects any other `condition_type` with `-32602`, so a watcher that the engine
 could never evaluate cannot be created.
+
+**Coverage limits of the conditions above.** A condition being evaluable is not the same as it
+firing on every qualifying event, and three gaps are known and unclosed:
+
+- **The freshness window is shared across connectors.** A watcher only sees items whose
+  `modified_at` is newer than its own `last_checked_at`, and the engine updates `last_checked_at`
+  for *every* enabled watcher after *every* successful connector sync, regardless of which service
+  the watcher filters on. With several connectors configured, an item that is indexed more than a
+  few seconds after it changed upstream can fall outside that window and never fire.
+- **`deploy_failed` reads a start-time timestamp.** It matches on `item.modified_at`, which the
+  deployment annotation path binds from `started_at_ms` and overwrites on the finishing `POST`. A
+  deploy that runs longer than one watcher tick can therefore record its failure carrying a
+  `modified_at` from when it started, which may already be behind the window above.
+- **A service-filtered `deploy_failed` watcher is effectively startup-only.** For deployments,
+  `item.service` is the annotation `provider` value (`github-actions`, `gitlab`, `jenkins`,
+  `circleci`, `bitbucket`, `other`), not a syncable service id. The engine skips a watcher whose
+  `filter.service` does not equal the id of the service that just synced, and no sync ever reports
+  those provider names — so such a watcher is only reachable via the startup catch-up pass. A
+  watcher with an empty `filter` (`{}`) is unaffected and works normally.
 
 #### Graph-aware watcher example (Phase 4 §2)
 
@@ -1031,7 +1050,7 @@ fires. For example, "alert any PagerDuty incident *owned by me*":
 
 ```json
 {
-  "condition_type": "alert_fired",
+  "condition_type": "incident_opened",
   "condition_json": { "filter": { "service": "pagerduty" } },
   "graph_predicate_json": {
     "relation": "owned_by",

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions-review-response.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions-review-response.md
@@ -1,0 +1,103 @@
+# pre-mortem PR B1 — Response to Plan Review
+
+Responds to [`2026-08-10-pre-mortem-pr-b1-watcher-conditions-review.md`](./2026-08-10-pre-mortem-pr-b1-watcher-conditions-review.md).
+
+**One finding was a genuine bug and is fixed. One question surfaced a different, real defect in the
+plan — also fixed. One suggestion is accepted as a comment. Two are already verified true and need no
+change.**
+
+---
+
+## S1 — `json_extract` on invalid/NULL metadata · **ACCEPTED — this was a real bug**
+
+The review is right, and the failure is worse than "the query fails". Verified empirically against
+`bun:sqlite` (SQLite 3.53.0) rather than reasoned about:
+
+| `metadata` value | `json_extract(metadata, '$.conclusion') = 'failure'` |
+|---|---|
+| `{"conclusion":"failure"}` | matches |
+| `NULL` | safe — yields NULL, no match, no error |
+| `'not json at all'` | **raises `malformed JSON`** |
+| `''` (empty string) | **raises `malformed JSON`** |
+
+The predicate runs inside `evaluateOneWatcher`, which is called in a loop over
+`listEnabledWatchers` from `evaluateWatchersAfterSync`, and **nothing in that path catches**. So one
+bad row would abort evaluation for **every watcher on the machine**, not merely the deploy one — a
+data-dependent, silent-until-it-happens failure introduced by a feature that is supposed to make
+watchers more reliable.
+
+**Fix.** `deploy_failed`'s predicate becomes:
+
+```sql
+AND json_valid(metadata) AND json_extract(metadata, '$.conclusion') = 'failure'
+```
+
+Verified: the guarded form returns the one matching row across all four cases above without raising.
+
+**Can such a row exist today?** No. Both production writers of `item.metadata` — `index/item-store.ts`
+and `deployment/annotate.ts` — go through `JSON.stringify`. The guard therefore protects against a
+migration or a future writer, not a present bug. It is still worth it: the cost is one cheap SQL
+function, and the blast radius of being wrong is the entire watcher subsystem.
+
+**Two additions beyond the one-line fix**, so the guard cannot be quietly dropped later:
+
+- A regression test that force-corrupts one row's metadata via raw SQL and asserts a *different*,
+  valid failed deployment still fires. (`db.run` in a test file is established practice here and is
+  not scanned by the D12/I14 static audit — many `packages/gateway/src/agents/*.test.ts` do it.)
+- The table-module test now pins `json_valid(metadata)` in `extraSql` explicitly.
+
+**Deliberately not done: wrapping the evaluation loop in try/catch.** That would convert this class
+of bug into a silent skip. An unexpected SQL error should still surface loudly; the correct fix is a
+predicate that does not raise.
+
+## Q2 — Ordering of the new check vs graph-predicate validation · **NO ORDERING ISSUE — but the question found a different real defect**
+
+**On the question as asked: there is nothing to order.** `watcher.create` does not validate
+`graphPredicateJson` at all — it does a `typeof v === "string"` check and stores the string verbatim
+(`ipc/automation-rpc.ts:115-118`). The malformed-predicate rejection test in that file
+(`automation-rpc.test.ts:103`) targets **`watcher.validateCondition`**, a different method. So the new
+membership check cannot race or reorder anything.
+
+**But checking that turned up a defect in my plan's own code block.** I had hoisted
+`requireString(rec, "conditionType")` above the `name` extraction. Since `requireString` throws on the
+first missing field it sees, that silently changed which error a caller gets when *both* `name` and
+`conditionType` are missing — a behaviour change nobody asked for, in a PR that claims to change only
+which condition types are accepted. Fixed: `name` is extracted first, preserving the existing order.
+
+Credit where due — the question was about a different thing, and asking it is what surfaced this.
+
+## S2 — Confirm the key is `conclusion`, not `result` · **VERIFIED — no change**
+
+`deployment/annotate.ts:169-174` builds the metadata object and writes `conclusion: input.status`,
+validated at line 86 against `STATUS_VALUES`, which includes `"failure"`. It is the **only**
+production writer of a deployment item carrying an outcome — the other two deployment producers
+(`vercel-deployment-mapping.ts`, `prefect-deployment-mapping.ts`) are the ones the plan already
+excludes by name. There is no `result` key anywhere on this path, and no webhook path that bypasses
+`annotate.ts`.
+
+## S3 — Biome and unbound promises in the new tests · **VERIFIED — no change**
+
+`await expect(...).rejects.toThrow(...)` is already the idiom in the file being edited
+(`automation-rpc.test.ts:105-111`), which passes lint on `main` today. The plan's rejection test now
+uses exactly that form — it previously used a `.catch()` variant, corrected during the plan's own
+self-review for a different reason (`dispatchAutomationRpc` rejects rather than returning an error
+value). Task 3 runs `bun run preflight:fast`, which covers Biome, so a lint regression is caught
+before push regardless.
+
+## Q1 — Will `extraSql` still be enough when Vercel is added? · **ACCEPTED as a comment**
+
+Short answer: yes, but with a caveat worth writing down where the next author will see it. A single
+`extraSql` string *can* express an OR across both shapes
+(`metadata.conclusion = 'failure' OR metadata.state = 'ERROR'`). It should not, for long — the moment
+a second producer shape lands, the readable move is to widen `WatcherConditionKind` to hold several
+predicates per kind rather than grow one long SQL string.
+
+Added to the module's doc comment, alongside the `json_valid` rationale, so both constraints are
+visible at the point of change rather than only in this document.
+
+---
+
+## Net effect on the plan
+
+Task 1 gains one SQL guard, one regression test, one assertion, and expanded module comments. Task 2
+gains a one-line ordering fix. Tasks and their boundaries are unchanged; no new task, no new file.

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions-review.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions-review.md
@@ -1,0 +1,22 @@
+# pre-mortem PR B1 — Watcher Conditions Plan Review & Feedback
+
+## Open Questions
+
+1. **Vercel deploy failure parsing in future:**
+   - The plan states: `deploy_failed` covers CI-annotated deployments only.
+   - *Question:* In the condition table (`watcher-condition-kinds.ts`), we write a static `extraSql: "AND json_extract(metadata, '$.conclusion') = 'failure'"`. If we ever want to support Vercel (which uses `state = 'ERROR'`), will `extraSql` be sufficient, or will we need a more expressive schema/mapping? Should we mention this limitation clearly in the table module comments to guide future developers?
+
+2. **Graph Predicates type safety:**
+   - *Question:* Since `watcher.create` now checks `isKnownWatcherConditionType`, does this validation run before or after the graph predicate validation? We should make sure the ordering of exceptions is consistent in `ipc/automation-rpc.ts`.
+
+## Suggestions & Improvements
+
+1. **Refined SQLite JSON Extract Safety:**
+   - In `deploy_failed`'s extraSql: `AND json_extract(metadata, '$.conclusion') = 'failure'`.
+   - *Suggestion:* In SQLite, `json_extract` can throw an error if `metadata` is not valid JSON or is null. If there are old rows where `metadata` is a plain string or empty/null, this might cause queries to fail. We should ensure the SQL is safe, for example: `AND json_valid(metadata) AND json_extract(metadata, '$.conclusion') = 'failure'`.
+
+2. **Verification of `deploy_failed` Metadata Field in CI:**
+   - *Suggestion:* Double check if the key is `conclusion` or `result` in all CI-annotated deployment payloads (such as GitHub Actions or general webhooks). If `deployment/annotate.ts` indeed uses `conclusion`, then `$.conclusion` is correct.
+
+3. **Pre-flight & Lint Checks for test templates:**
+   - *Suggestion:* Make sure the newly added tests don't trigger any Biome/ESLint rules for unbound promises (especially since `dispatchAutomationRpc` is async and we use `await expect(...).rejects.toThrow()`).

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -393,8 +393,10 @@ Append inside the existing `describe("watcher-engine", ...)` block in `packages/
 
 `incident` and `deployment` are both valid graph entity types (`graph/relationship-graph.ts:6-22`),
 so the predicate path applies to the new kinds exactly as it does to `alert_fired`. The predicate is
-evaluated against `r.type` / `r.external_id` after the query, so this test proves the new kinds did
-not accidentally bypass it.
+evaluated against `r.type` / `r.external_id` after the query, so this test guards against the
+predicate being skipped for a new kind. On its own it cannot prove the predicate ran — it passes
+identically if the row fetch returns nothing — so it is the sibling firing tests, which assert the
+same fixture shape *does* notify without a predicate, that establish rows are actually fetched.
 
 - [ ] **Step 6: Run the engine tests to confirm they fail**
 

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -1,0 +1,612 @@
+# pre-mortem PR B1 — Watcher Conditions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the watcher engine two condition types that can actually fire — `incident_opened` and `deploy_failed` — and stop `watcher.create` from accepting a condition type the engine will silently ignore.
+
+**Architecture:** Today `evaluateOneWatcher` hardcodes `condition_type !== "alert_fired"` and then queries `item WHERE type = 'alert'`, an item type nothing in this repository indexes. Replace that hardcode with one exported condition-kind table that maps a condition type to its item type plus an optional SQL predicate; the engine reads the table to build its query, and `watcher.create` reads the same table to reject unknown kinds. Everything downstream of the query — the service filter, the `since` window, the `LIMIT 5`, the graph predicate, the summary/snapshot shape — is untouched.
+
+**Tech Stack:** Bun v1.2+, TypeScript strict (no `any`), `bun:sqlite`, `bun:test`, Biome.
+
+## Global Constraints
+
+- **No `any`** — use `unknown` for external data. TypeScript strict is non-negotiable.
+- **I9 — bound-param SQL.** Every value goes through a bound parameter. The one interpolated SQL fragment in this plan (`kind.extraSql`) is a module-private compile-time constant, never derived from a row, a user, or an IPC parameter. It must stay that way.
+- **I14 — SQLite writes go through `dbRun`/`dbExec`/`dbStmtRun`.** This PR adds no writes, so nothing here touches that path; do not introduce one.
+- **Local error convention** — no repo-wide JSON-RPC error enum exists. Each IPC namespace has its own class over a raw integer. In `ipc/automation-rpc.ts` that is `AutomationRpcError(-32602, message)`. Do not invent an enum.
+- **Coverage floor** — every source file must hold ≥85% line and ≥80% branch. The new file in Task 1 is small; its dedicated test file must cover every branch.
+- **Branch** — work happens on `dev/asafgolombek/pre-mortem-pr-b` in the worktree at `.claude/worktrees/pre-mortem-pr-b`. Never commit to `main`.
+- **Commit messages avoid backticks** — `git commit -m` command-substitutes backticked text out of the message.
+- **Spec** — `docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md` (§ PR B1) is authoritative; `docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review-response.md` records what was deliberately excluded.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/gateway/src/automation/watcher-condition-kinds.ts` **(new)** | The SSoT: which condition types exist, what item type each matches, and any extra SQL predicate. Nothing else. |
+| `packages/gateway/src/automation/watcher-condition-kinds.test.ts` **(new)** | Table membership and lookup, including every branch of the lookup helper. |
+| `packages/gateway/src/automation/watcher-engine.ts` **(modify, lines 86-120)** | Reads the table instead of hardcoding `alert_fired` / `type = 'alert'`. |
+| `packages/gateway/src/automation/watcher-engine.test.ts` **(modify, append)** | Firing behaviour per condition, and the negative cases that pin the stated coverage limits. |
+| `packages/gateway/src/ipc/automation-rpc.ts` **(modify, `watcher.create` at line 114)** | Rejects an unknown `conditionType` with `-32602`. |
+| `packages/gateway/src/ipc/automation-rpc.test.ts` **(modify, lines ~240-320)** | Existing tests pass `conditionType: "schedule"`, a placeholder that is not a real condition type anywhere in production code. They must move to a real one, plus a new rejection test. |
+| `docs/architecture.md` **(modify, ~line 1016-1030)** | The watcher-engine section documents `alert_fired` as the condition type. Record all three. |
+
+---
+
+### Task 1: The condition-kind table, and an engine that reads it
+
+**Files:**
+- Create: `packages/gateway/src/automation/watcher-condition-kinds.ts`
+- Create: `packages/gateway/src/automation/watcher-condition-kinds.test.ts`
+- Modify: `packages/gateway/src/automation/watcher-engine.ts` (lines 86-120)
+- Test: `packages/gateway/src/automation/watcher-engine.test.ts` (append cases)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces, for Task 2 and for PR B2:
+  - `type WatcherConditionKind = { readonly conditionType: string; readonly itemType: string; readonly extraSql: string }`
+  - `const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[]`
+  - `function watcherConditionKind(conditionType: string): WatcherConditionKind | undefined`
+  - `function isKnownWatcherConditionType(conditionType: string): boolean`
+
+**Context the implementer needs.** `evaluateOneWatcher` is module-private and called from two exported entry points, `evaluateWatchersAfterSync` and `evaluateWatchersStartupCatchUp`. Both already pass through it, so changing it once covers both. The existing test at `watcher-engine.test.ts:71` (`"non-alert_fired condition does not notify"`) uses `condition_type: "custom"`; `"custom"` is absent from the new table, so that test must stay green unchanged — treat it as a regression check, not something to edit.
+
+**Why the extra predicate lives in SQL and not in a TypeScript filter after the query:** the query ends in `LIMIT 5`. Filtering afterwards would let five successful deployments hide a failed sixth, so a `deploy_failed` watcher would miss real failures whenever a service deploys often. The predicate must narrow the rows the database returns.
+
+- [ ] **Step 1: Write the failing test for the table module**
+
+Create `packages/gateway/src/automation/watcher-condition-kinds.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  isKnownWatcherConditionType,
+  WATCHER_CONDITION_KINDS,
+  watcherConditionKind,
+} from "./watcher-condition-kinds.ts";
+
+describe("watcher-condition-kinds", () => {
+  test("the table holds exactly the three supported condition types", () => {
+    expect(WATCHER_CONDITION_KINDS.map((k) => k.conditionType).sort()).toEqual([
+      "alert_fired",
+      "deploy_failed",
+      "incident_opened",
+    ]);
+  });
+
+  test("each kind names the item type it matches", () => {
+    expect(watcherConditionKind("alert_fired")?.itemType).toBe("alert");
+    expect(watcherConditionKind("incident_opened")?.itemType).toBe("incident");
+    expect(watcherConditionKind("deploy_failed")?.itemType).toBe("deployment");
+  });
+
+  test("only deploy_failed carries an extra predicate", () => {
+    expect(watcherConditionKind("alert_fired")?.extraSql).toBe("");
+    expect(watcherConditionKind("incident_opened")?.extraSql).toBe("");
+    expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("conclusion");
+  });
+
+  test("an unknown condition type resolves to undefined and is not known", () => {
+    expect(watcherConditionKind("schedule")).toBeUndefined();
+    expect(isKnownWatcherConditionType("schedule")).toBe(false);
+    expect(isKnownWatcherConditionType("incident_opened")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `bun test packages/gateway/src/automation/watcher-condition-kinds.test.ts`
+Expected: FAIL — the module does not exist ("Cannot find module ./watcher-condition-kinds.ts").
+
+- [ ] **Step 3: Write the table module**
+
+Create `packages/gateway/src/automation/watcher-condition-kinds.ts`:
+
+```ts
+/**
+ * The single source of truth for which watcher conditions the engine can evaluate.
+ *
+ * `watcher-engine.ts` builds its item query from this table, and `ipc/automation-rpc.ts`
+ * rejects a `watcher.create` whose condition type is absent from it. Keeping both readers on
+ * one table is the point: a creation path that accepted a condition the engine cannot evaluate
+ * would produce a watcher that is silently inert forever.
+ *
+ * `extraSql` is a COMPILE-TIME CONSTANT fragment ANDed into that query. It is never derived from
+ * a row, a user, or an IPC parameter, and must never become so — every value in the query is a
+ * bound parameter (I9).
+ */
+export type WatcherConditionKind = {
+  /** The value stored in `watcher.condition_type`. */
+  readonly conditionType: string;
+  /** The `item.type` this condition observes. */
+  readonly itemType: string;
+  /** Constant SQL ANDed into the item query, or "" for none. */
+  readonly extraSql: string;
+};
+
+export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
+  // Preserved as-is. NOTE: no connector indexes `item.type = 'alert'` today, so this condition
+  // cannot currently fire. That is the pre-existing state, recorded rather than silently fixed.
+  { conditionType: "alert_fired", itemType: "alert", extraSql: "" },
+  // PagerDuty indexes `type: "incident"` (connectors/pagerduty-sync.ts).
+  { conditionType: "incident_opened", itemType: "incident", extraSql: "" },
+  // CI-annotated deployments only: `deployment/annotate.ts` writes metadata.conclusion. Vercel
+  // records its outcome under metadata.state, and Prefect indexes deployment DEFINITIONS with no
+  // outcome at all, so neither matches. Keyed on the presence of the conclusion value rather than
+  // on a producer name, so a new producer that adopts the same shape works without a code change.
+  {
+    conditionType: "deploy_failed",
+    itemType: "deployment",
+    extraSql: "AND json_extract(metadata, '$.conclusion') = 'failure'",
+  },
+];
+
+export function watcherConditionKind(conditionType: string): WatcherConditionKind | undefined {
+  return WATCHER_CONDITION_KINDS.find((k) => k.conditionType === conditionType);
+}
+
+export function isKnownWatcherConditionType(conditionType: string): boolean {
+  return watcherConditionKind(conditionType) !== undefined;
+}
+```
+
+- [ ] **Step 4: Run the table test to confirm it passes**
+
+Run: `bun test packages/gateway/src/automation/watcher-condition-kinds.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Write the failing engine tests**
+
+Append inside the existing `describe("watcher-engine", ...)` block in `packages/gateway/src/automation/watcher-engine.test.ts`. `upsertIndexedItem` is already imported at the top of that file; `insertWatcher` likewise.
+
+```ts
+  test("incident_opened fires on an indexed incident", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-1",
+      title: "api-gateway 500s",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "pagerduty", t0 + 2000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("api-gateway 500s");
+  });
+
+  test("incident_opened respects the service filter", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "opsgenie",
+      type: "incident",
+      externalId: "OG-1",
+      title: "other tracker",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    let calls = 0;
+    evaluateWatchersStartupCatchUp(db, t0 + 2000, () => {
+      calls += 1;
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  test("deploy_failed fires only on a failed deployment, not a successful one", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-ok",
+      title: "checkout v2.1.0",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+      metadata: { conclusion: "success" },
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-bad",
+      title: "checkout v2.1.1",
+      modifiedAt: t0 + 2000,
+      syncedAt: t0 + 2000,
+      metadata: { conclusion: "failure" },
+    });
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("checkout v2.1.1");
+    expect(bodies[0]).not.toContain("v2.1.0");
+  });
+
+  test("deploy_failed does not match a Vercel-shaped deployment, whose outcome is in metadata.state", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "vercel" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "vercel",
+      type: "deployment",
+      externalId: "dpl_1",
+      title: "marketing-site",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+      metadata: { state: "ERROR", target: "production" },
+    });
+
+    let calls = 0;
+    evaluateWatchersAfterSync(db, "vercel", t0 + 2000, () => {
+      calls += 1;
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  test("a graph predicate still narrows a new condition kind", () => {
+    const db = makeDb();
+    const t0 = 5_200_000_000_000;
+    insertWatcher(db, {
+      name: "incidents-owned",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+      graph_predicate_json: JSON.stringify({
+        relation: "owned_by",
+        target: { type: "person", externalId: "gh:absent" },
+      }),
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-9",
+      title: "unowned incident",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    let calls = 0;
+    evaluateWatchersAfterSync(
+      db,
+      "pagerduty",
+      t0 + 2000,
+      () => {
+        calls += 1;
+      },
+      { graphConditionsEnabled: true },
+    );
+
+    expect(calls).toBe(0);
+  });
+```
+
+`incident` and `deployment` are both valid graph entity types (`graph/relationship-graph.ts:6-22`),
+so the predicate path applies to the new kinds exactly as it does to `alert_fired`. The predicate is
+evaluated against `r.type` / `r.external_id` after the query, so this test proves the new kinds did
+not accidentally bypass it.
+
+- [ ] **Step 6: Run the engine tests to confirm they fail**
+
+Run: `bun test packages/gateway/src/automation/watcher-engine.test.ts`
+Expected: the two firing tests FAIL (0 notifications, because `evaluateOneWatcher` still returns `null` for any condition other than `alert_fired`). The two negative tests PASS already, for the wrong reason — that is expected and is exactly why the firing tests exist alongside them.
+
+- [ ] **Step 7: Make the engine read the table**
+
+In `packages/gateway/src/automation/watcher-engine.ts`, add to the imports:
+
+```ts
+import { watcherConditionKind } from "./watcher-condition-kinds.ts";
+```
+
+Replace the guard at lines 86-88:
+
+```ts
+  if (w.condition_type !== "alert_fired") {
+    return null;
+  }
+```
+
+with:
+
+```ts
+  const kind = watcherConditionKind(w.condition_type);
+  if (kind === undefined) {
+    return null;
+  }
+```
+
+Then replace the query at lines 104-113 — note `type = ?` is now bound, and `kind.extraSql` is the only interpolation:
+
+```ts
+  const since = w.last_checked_at ?? w.created_at;
+  const rows = db
+    .query(
+      `SELECT id, title, service, type, external_id, modified_at FROM item
+       WHERE type = ?
+         AND modified_at > ?
+         AND (? IS NULL OR service = ?)
+         ${kind.extraSql}
+       ORDER BY modified_at DESC
+       LIMIT 5`,
+    )
+    .all(kind.itemType, since, service ?? null, service ?? null) as Array<{
+    id: string;
+    title: string;
+    service: string;
+    type: string;
+    external_id: string;
+    modified_at: number;
+  }>;
+```
+
+Everything below line 120 — the graph predicate block, the filter, the summary and snapshot — stays exactly as it is.
+
+- [ ] **Step 8: Run the whole automation suite to confirm green**
+
+Run: `bun test packages/gateway/src/automation/`
+Expected: PASS. Specifically confirm `"non-alert_fired condition does not notify"` is still green — it uses `condition_type: "custom"`, which is absent from the table, so the unknown-kind path is still covered.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/gateway/src/automation/watcher-condition-kinds.ts \
+        packages/gateway/src/automation/watcher-condition-kinds.test.ts \
+        packages/gateway/src/automation/watcher-engine.ts \
+        packages/gateway/src/automation/watcher-engine.test.ts
+git commit -m "feat(automation): add incident_opened and deploy_failed watcher conditions"
+```
+
+---
+
+### Task 2: Reject an unknown condition type at creation
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/automation-rpc.ts` (the `watcher.create` handler, line 114)
+- Test: `packages/gateway/src/ipc/automation-rpc.test.ts` (lines ~240-320)
+
+**Interfaces:**
+- Consumes: `isKnownWatcherConditionType` from Task 1.
+- Produces: nothing new for later tasks.
+
+**Context the implementer needs.** `watcher.create` currently passes `conditionType` straight into `insertWatcher` as an unvalidated string (`automation-rpc.ts:122`), so a watcher with a nonsense condition is accepted and then never fires. Three existing tests in `automation-rpc.test.ts` pass `conditionType: "schedule"` as a throwaway placeholder — `"schedule"` is not a watcher condition type anywhere in production code (the only repo matches are unrelated connector fields in `databricks-job-mapping.ts`, `dbt-job-mapping.ts` and `prefect-deployment-mapping.ts`). Those tests must move to a real condition type. **This validation applies to creation only.** Existing rows with unknown condition types are untouched and keep their current behaviour of never firing, so no migration or backfill is needed.
+
+Scope discipline: this is a membership check and nothing more. Do **not** add validation of `condition_json`, of whether the filtered service exists, or of whether any item currently matches — a watcher is a forward-looking subscription, and a service with no incidents yet is the normal case for one worth arming.
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/gateway/src/ipc/automation-rpc.test.ts`, inside `describe("watcher.create / pause / resume / delete", ...)`, add:
+
+```ts
+  test("create rejects a condition type the engine cannot evaluate", async () => {
+    const db = seededDb();
+    await expect(
+      dispatchAutomationRpc({
+        method: "watcher.create",
+        params: {
+          name: "bogus",
+          conditionType: "schedule",
+          conditionJson: "{}",
+          actionType: "notify",
+          actionJson: "{}",
+        },
+        db,
+      }),
+    ).rejects.toThrow(AutomationRpcError);
+
+    expect((db.query("SELECT COUNT(*) AS n FROM watcher").get() as { n: number }).n).toBe(0);
+  });
+
+  test("create accepts every supported condition type", async () => {
+    const db = seededDb();
+    for (const conditionType of ["alert_fired", "incident_opened", "deploy_failed"]) {
+      const out = await dispatchAutomationRpc({
+        method: "watcher.create",
+        params: {
+          name: `w-${conditionType}`,
+          conditionType,
+          conditionJson: "{}",
+          actionType: "notify",
+          actionJson: "{}",
+        },
+        db,
+      });
+      expect(out.kind).toBe("hit");
+    }
+    expect((db.query("SELECT COUNT(*) AS n FROM watcher").get() as { n: number }).n).toBe(3);
+  });
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `bun test packages/gateway/src/ipc/automation-rpc.test.ts`
+Expected: `"create rejects a condition type the engine cannot evaluate"` FAILS — the call succeeds and one row is written instead of zero.
+
+- [ ] **Step 3: Add the membership check**
+
+In `packages/gateway/src/ipc/automation-rpc.ts`, add to the imports (alongside the existing `../automation/...` imports):
+
+```ts
+import { isKnownWatcherConditionType } from "../automation/watcher-condition-kinds.ts";
+```
+
+Then in the `watcher.create` handler at line 114, insert the check before the `insertWatcher` call:
+
+```ts
+  "watcher.create": (rec, ctx) => {
+    const graphPredicateJson =
+      rec !== undefined && typeof rec["graphPredicateJson"] === "string"
+        ? rec["graphPredicateJson"]
+        : null;
+    const conditionType = requireString(rec, "conditionType");
+    if (!isKnownWatcherConditionType(conditionType)) {
+      throw new AutomationRpcError(
+        -32602,
+        `Unsupported conditionType "${conditionType}" — the watcher engine cannot evaluate it`,
+      );
+    }
+    const id = insertWatcher(ctx.db, {
+      name: requireString(rec, "name"),
+      enabled: 1,
+      condition_type: conditionType,
+      condition_json: requireString(rec, "conditionJson"),
+      action_type: requireString(rec, "actionType"),
+      action_json: requireString(rec, "actionJson"),
+      created_at: Date.now(),
+      graph_predicate_json: graphPredicateJson,
+    });
+    return { kind: "hit", value: { id } };
+  },
+```
+
+- [ ] **Step 4: Update the three placeholder tests**
+
+There are **exactly five** pre-existing occurrences of `conditionType: "schedule"` in this file, at lines **247, 270, 293, 309 and 337**. Every one is a throwaway placeholder in a test about something else (graph-predicate storage, pause/resume, delete), so change each value to `"alert_fired"` and change nothing else about those tests.
+
+Verify before moving on:
+
+```bash
+grep -c 'conditionType: "schedule"' packages/gateway/src/ipc/automation-rpc.test.ts
+```
+
+Expected: `1` — only the deliberate rejection test added in Step 1. If the count is higher, a placeholder was missed and its test will fail in Step 5.
+
+`AutomationRpcError` is already imported at line 17 of this test file, so the rejection test needs no new import.
+
+- [ ] **Step 5: Run the IPC tests to confirm they pass**
+
+Run: `bun test packages/gateway/src/ipc/automation-rpc.test.ts`
+Expected: PASS, including both new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/ipc/automation-rpc.ts packages/gateway/src/ipc/automation-rpc.test.ts
+git commit -m "feat(ipc): reject a watcher conditionType the engine cannot evaluate"
+```
+
+---
+
+### Task 3: Documentation and ship-readiness
+
+**Files:**
+- Modify: `docs/architecture.md` (watcher-engine section, ~lines 1016-1030)
+- Modify: `docs/CHANGELOG.md` (add a dated entry)
+
+**Interfaces:**
+- Consumes: the finished behaviour from Tasks 1 and 2.
+- Produces: nothing consumed by later tasks.
+
+**Context the implementer needs.** `docs/architecture.md:1016` describes the watcher engine and its example JSON at line ~1025 shows `"condition_type": "alert_fired"` as though it were the only one. The repository's triple rule is that wiring, docs and tests land together, so this is part of the work rather than a follow-up. `docs/CHANGELOG.md` is the canonical dated delivery log — connector and feature deliveries go there, **not** in the CLAUDE.md status line.
+
+- [ ] **Step 1: Document the three condition types**
+
+In `docs/architecture.md`, in the watcher-engine section, add a table immediately after the paragraph at line 1016 that introduces `condition_type`:
+
+```markdown
+| `condition_type` | Fires on | Coverage |
+| --- | --- | --- |
+| `alert_fired` | an indexed item of type `alert` | no connector currently indexes `alert`, so this condition cannot fire today |
+| `incident_opened` | an indexed item of type `incident` | PagerDuty |
+| `deploy_failed` | an indexed item of type `deployment` whose `metadata.conclusion` is `failure` | CI-annotated deployments (`POST /v1/deployments`) only — Vercel records its outcome under `metadata.state`, and Prefect indexes deployment definitions with no outcome |
+
+`watcher.create` rejects any other `condition_type` with `-32602`, so a watcher that the engine
+could never evaluate cannot be created.
+```
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+In `docs/CHANGELOG.md`, add an entry under the current unreleased/dated heading, matching the file's existing style:
+
+```markdown
+- **Watcher conditions — `incident_opened` + `deploy_failed`** (2026-08-10) — the watcher engine
+  previously evaluated one condition type, `alert_fired`, which matches an item type no connector
+  indexes; a watcher could be created and armed and still never fire. Both new conditions come from
+  one condition-kind table that the engine and `watcher.create` share, so an unsupported
+  `conditionType` is now rejected at creation rather than accepted and silently ignored.
+  `deploy_failed` covers CI-annotated deployments only. Groundwork for `nimbus pre-mortem` PR B.
+```
+
+- [ ] **Step 3: Run the full fast pre-flight**
+
+Run: `bun run preflight:fast`
+Expected: PASS. If it fails, fix it here — do not push red. Note that pre-flight fail-fasts, so an early lint failure hides every later gate; re-run to green after each fix rather than assuming the rest passed.
+
+- [ ] **Step 4: Run the gateway suites that this PR touches**
+
+Run: `bun test packages/gateway/src/automation/ packages/gateway/src/ipc/automation-rpc.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Check the coverage floor for the new file**
+
+Run: `bun run audit:coverage-floor`
+Expected: no violation for `watcher-condition-kinds.ts` or `watcher-engine.ts`. This gate is **CI-Linux-authoritative** — a Windows run reports false violations, so confirm what `git diff --name-only` actually contains before believing a failure, and reproduce through Docker if it disagrees with CI.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/architecture.md docs/CHANGELOG.md
+git commit -m "docs: record the three watcher condition types and their coverage limits"
+```
+
+---
+
+## Out of scope for B1
+
+Named so an implementer does not helpfully add them:
+
+- Any change to `watcher.validateCondition` — it validates the graph predicate and never receives a `conditionType`.
+- Validating `condition_json`, service existence, or whether any item matches today.
+- A new condition type for anything else (cycle time, review drag) — the spec deliberately proposes no watcher for risks with no watchable condition.
+- Indexing `item.type = 'alert'` so `alert_fired` can fire, or teaching `deploy_failed` about Vercel's `metadata.state`. Both are real gaps; both are separate changes.
+- Anything from PR B2: the agent, the CLI command, watcher creation from pre-mortem, `premortem_watcher_proposal` writes, and the Tauri `ALLOWED_METHODS` bump.

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -80,10 +80,13 @@ describe("watcher-condition-kinds", () => {
     expect(watcherConditionKind("deploy_failed")?.itemType).toBe("deployment");
   });
 
-  test("only deploy_failed carries an extra predicate", () => {
+  test("only deploy_failed carries an extra predicate, and it is json_valid-guarded", () => {
     expect(watcherConditionKind("alert_fired")?.extraSql).toBe("");
     expect(watcherConditionKind("incident_opened")?.extraSql).toBe("");
     expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("conclusion");
+    // Pinned deliberately: without json_valid, a single non-JSON metadata row makes json_extract
+    // raise and takes down evaluation for every watcher.
+    expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("json_valid(metadata)");
   });
 
   test("an unknown condition type resolves to undefined and is not known", () => {
@@ -135,10 +138,22 @@ export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
   // records its outcome under metadata.state, and Prefect indexes deployment DEFINITIONS with no
   // outcome at all, so neither matches. Keyed on the presence of the conclusion value rather than
   // on a producer name, so a new producer that adopts the same shape works without a code change.
+  //
+  // `json_valid(metadata)` is LOAD-BEARING, not defensive noise: SQLite's json_extract RAISES
+  // "malformed JSON" on a non-JSON TEXT value, and that exception would propagate out of
+  // evaluateOneWatcher through the whole evaluateWatchersAfterSync loop — killing evaluation for
+  // EVERY watcher, not just this one. (A NULL metadata is safe on its own; an empty string or
+  // plain text is not.) Every production writer stringifies today, so this guards a migration or a
+  // future writer, at the cost of one cheap call.
+  //
+  // Extending to Vercel later means matching a DIFFERENT key with a different vocabulary
+  // (metadata.state = 'ERROR'). A single extraSql string can express that as an OR, but the moment
+  // a second shape lands, prefer widening this type to hold several predicates per kind over
+  // growing one unreadable SQL string.
   {
     conditionType: "deploy_failed",
     itemType: "deployment",
-    extraSql: "AND json_extract(metadata, '$.conclusion') = 'failure'",
+    extraSql: "AND json_valid(metadata) AND json_extract(metadata, '$.conclusion') = 'failure'",
   },
 ];
 
@@ -289,6 +304,49 @@ Append inside the existing `describe("watcher-engine", ...)` block in `packages/
     });
 
     expect(calls).toBe(0);
+  });
+
+  test("a row with non-JSON metadata does not break deploy_failed evaluation", () => {
+    const db = makeDb();
+    const t0 = 5_400_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-legacy",
+      title: "legacy row",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-bad",
+      title: "checkout v3.0.0",
+      modifiedAt: t0 + 2000,
+      syncedAt: t0 + 2000,
+      metadata: { conclusion: "failure" },
+    });
+    // No production writer can produce this today — both item.metadata writers stringify — so it
+    // is forced directly. Without json_valid() in the predicate, json_extract raises
+    // "malformed JSON" here and the exception escapes the whole evaluation loop.
+    db.run("UPDATE item SET metadata = 'not json' WHERE external_id = ?", ["deploy-legacy"]);
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("checkout v3.0.0");
   });
 
   test("a graph predicate still narrows a new condition kind", () => {
@@ -488,6 +546,7 @@ Then in the `watcher.create` handler at line 114, insert the check before the `i
       rec !== undefined && typeof rec["graphPredicateJson"] === "string"
         ? rec["graphPredicateJson"]
         : null;
+    const name = requireString(rec, "name");
     const conditionType = requireString(rec, "conditionType");
     if (!isKnownWatcherConditionType(conditionType)) {
       throw new AutomationRpcError(
@@ -496,7 +555,7 @@ Then in the `watcher.create` handler at line 114, insert the check before the `i
       );
     }
     const id = insertWatcher(ctx.db, {
-      name: requireString(rec, "name"),
+      name,
       enabled: 1,
       condition_type: conditionType,
       condition_json: requireString(rec, "conditionJson"),

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -12,7 +12,7 @@
 
 - **No `any`** — use `unknown` for external data. TypeScript strict is non-negotiable.
 - **I9 — bound-param SQL.** Every value goes through a bound parameter. The one interpolated SQL fragment in this plan (`kind.extraSql`) is a module-private compile-time constant, never derived from a row, a user, or an IPC parameter. It must stay that way.
-- **I14 — SQLite writes go through `dbRun`/`dbExec`/`dbStmtRun`.** This PR adds no writes, so nothing here touches that path; do not introduce one.
+- **I14 — SQLite writes in PRODUCTION code go through `dbRun`/`dbExec`/`dbStmtRun`.** This PR adds no production writes; do not introduce one. Test files are a different matter and are deliberately outside this rule: the D12 static audit does not scan `*.test.ts`, and many existing suites (e.g. `packages/gateway/src/agents/*.test.ts`) call `db.run` directly. Task 1's corrupt-row regression test does the same, intentionally.
 - **Local error convention** — no repo-wide JSON-RPC error enum exists. Each IPC namespace has its own class over a raw integer. In `ipc/automation-rpc.ts` that is `AutomationRpcError(-32602, message)`. Do not invent an enum.
 - **Coverage floor** — every source file must hold ≥85% line and ≥80% branch. The new file in Task 1 is small; its dedicated test file must cover every branch.
 - **Branch** — work happens on `dev/asafgolombek/pre-mortem-pr-b` in the worktree at `.claude/worktrees/pre-mortem-pr-b`. Never commit to `main`.

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -36,12 +36,14 @@
 ### Task 1: The condition-kind table, and an engine that reads it
 
 **Files:**
+
 - Create: `packages/gateway/src/automation/watcher-condition-kinds.ts`
 - Create: `packages/gateway/src/automation/watcher-condition-kinds.test.ts`
 - Modify: `packages/gateway/src/automation/watcher-engine.ts` (lines 86-120)
 - Test: `packages/gateway/src/automation/watcher-engine.test.ts` (append cases)
 
 **Interfaces:**
+
 - Consumes: nothing from earlier tasks.
 - Produces, for Task 2 and for PR B2:
   - `type WatcherConditionKind = { readonly conditionType: string; readonly itemType: string; readonly extraSql: string }`
@@ -470,10 +472,12 @@ git commit -m "feat(automation): add incident_opened and deploy_failed watcher c
 ### Task 2: Reject an unknown condition type at creation
 
 **Files:**
+
 - Modify: `packages/gateway/src/ipc/automation-rpc.ts` (the `watcher.create` handler, line 114)
 - Test: `packages/gateway/src/ipc/automation-rpc.test.ts` (lines ~240-320)
 
 **Interfaces:**
+
 - Consumes: `isKnownWatcherConditionType` from Task 1.
 - Produces: nothing new for later tasks.
 
@@ -599,10 +603,12 @@ git commit -m "feat(ipc): reject a watcher conditionType the engine cannot evalu
 ### Task 3: Documentation and ship-readiness
 
 **Files:**
+
 - Modify: `docs/architecture.md` (watcher-engine section, ~lines 1016-1030)
 - Modify: `docs/CHANGELOG.md` (add a dated entry)
 
 **Interfaces:**
+
 - Consumes: the finished behaviour from Tasks 1 and 2.
 - Produces: nothing consumed by later tasks.
 

--- a/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
+++ b/docs/superpowers/plans/2026-08-10-pre-mortem-pr-b1-watcher-conditions.md
@@ -55,6 +55,15 @@
 
 **Why the extra predicate lives in SQL and not in a TypeScript filter after the query:** the query ends in `LIMIT 5`. Filtering afterwards would let five successful deployments hide a failed sixth, so a `deploy_failed` watcher would miss real failures whenever a service deploys often. The predicate must narrow the rows the database returns.
 
+> **CORRECTION (applied after the whole-branch review, 2026-08-10).** This task's code and test blocks
+> originally gave `incident_opened` an empty predicate and seeded a status-less incident. That was
+> wrong: `connectors/pagerduty-sync.ts` fetches **all** statuses and stamps `modified_at` from
+> `updated_at`, so an acknowledge or a resolve would fire a condition named "opened". The blocks below
+> carry the shipped predicate — `AND json_valid(metadata) AND json_extract(metadata, '$.status') =
+> 'triggered'` — and the fixtures set `metadata: { status: "triggered" }`. Following this task as
+> written now reproduces what merged. The trade-off it buys is recorded in `docs/architecture.md`: an
+> incident indexed with a null or absent status never fires the condition at all.
+
 - [ ] **Step 1: Write the failing test for the table module**
 
 Create `packages/gateway/src/automation/watcher-condition-kinds.test.ts`:
@@ -84,7 +93,7 @@ describe("watcher-condition-kinds", () => {
 
   test("only deploy_failed carries an extra predicate, and it is json_valid-guarded", () => {
     expect(watcherConditionKind("alert_fired")?.extraSql).toBe("");
-    expect(watcherConditionKind("incident_opened")?.extraSql).toBe("");
+    expect(watcherConditionKind("incident_opened")?.extraSql).toContain("'triggered'");
     expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("conclusion");
     // Pinned deliberately: without json_valid, a single non-JSON metadata row makes json_extract
     // raise and takes down evaluation for every watcher.
@@ -135,7 +144,15 @@ export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
   // cannot currently fire. That is the pre-existing state, recorded rather than silently fixed.
   { conditionType: "alert_fired", itemType: "alert", extraSql: "" },
   // PagerDuty indexes `type: "incident"` (connectors/pagerduty-sync.ts).
-  { conditionType: "incident_opened", itemType: "incident", extraSql: "" },
+  // Narrowed to triggered-only: pagerduty-sync.ts fetches ALL statuses and stamps modified_at
+  // from updated_at, so without this an acknowledge or resolve fires a condition named "opened".
+  // Trade-off recorded in docs/architecture.md: an incident indexed with a null/absent status
+  // (the sync writes status ?? null) never fires this condition at all.
+  {
+    conditionType: "incident_opened",
+    itemType: "incident",
+    extraSql: "AND json_valid(metadata) AND json_extract(metadata, '$.status') = 'triggered'",
+  },
   // CI-annotated deployments only: `deployment/annotate.ts` writes metadata.conclusion. Vercel
   // records its outcome under metadata.state, and Prefect indexes deployment DEFINITIONS with no
   // outcome at all, so neither matches. Keyed on the presence of the conclusion value rather than
@@ -197,6 +214,7 @@ Append inside the existing `describe("watcher-engine", ...)` block in `packages/
       title: "api-gateway 500s",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      metadata: { status: "triggered" },
     });
 
     const bodies: string[] = [];
@@ -227,6 +245,7 @@ Append inside the existing `describe("watcher-engine", ...)` block in `packages/
       title: "other tracker",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      metadata: { status: "triggered" },
     });
 
     let calls = 0;
@@ -374,6 +393,7 @@ Append inside the existing `describe("watcher-engine", ...)` block in `packages/
       title: "unowned incident",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      metadata: { status: "triggered" },
     });
 
     let calls = 0;

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review-response.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review-response.md
@@ -1,0 +1,123 @@
+# `nimbus pre-mortem` PR B — Response to Design Review
+
+Responds to [`2026-08-10-pre-mortem-pr-b-design-review.md`](./2026-08-10-pre-mortem-pr-b-design-review.md).
+Six items: **three accepted** (spec amended), **three answered from the code with no change**, one of
+those partially accepted for its documentation demand while rejecting its proposed mechanism.
+
+Every answer below was checked against the tree rather than reasoned from the design document.
+
+---
+
+## Q1 — Warn when a service's deployments are Vercel/Prefect · **ACCEPTED (scoped)**
+
+Correct, and cheap. A user whose deploys come from Vercel would otherwise see pre-mortem propose no
+`deploy_failed` watcher and have no way to learn why.
+
+**Amendment.** When the deploy-failure risk fires for a service, the brief distinguishes three states
+rather than two:
+
+| Service's deployment items | Brief says |
+|---|---|
+| carry `metadata.conclusion` | proposes the watcher normally |
+| exist, but none carry `conclusion` | *"deploy-failure watching covers CI-annotated deployments (`POST /v1/deployments`); this service's deployments are indexed from a source that records no outcome, so no watcher was proposed"* |
+| none at all | the ordinary "no deployment history" gap |
+
+Keyed on the presence of the `conclusion` key in the indexed rows — **derived, not a hardcoded list of
+producer names.** A hardcoded list would be a fourth place to drift when a producer changes shape, and
+this repository has hit exactly that failure three times with the connector body-depth table.
+
+## Q2 — Method naming, and Tauri access to refresh · **NO CHANGE (both answered from the code)**
+
+**Naming: `agents.premortem` is correct.** `ipc/agents-rpc.ts:633-638` registers `agents.ownership`,
+`agents.glossary`, `agents.decisions` — lowercase single token — and reserves camelCase for genuinely
+two-word names (`agents.whyPeek`). "premortem" is one token here, matching the `premortem/` directory
+and the existing `premortem.refresh` shipped in PR A. `agents.preMortem` would be the anomaly.
+
+**Refresh stays unexposed, and this is pinned by tests.** `gateway_bridge.rs:544` asserts
+`!is_method_allowed("ownership.refresh")` and `:530` asserts the same for `decisions.refresh`, each
+with a comment explaining that a method which re-derives an entire graph is not renderer-safe (I7).
+pre-mortem following that precedent is the consistent choice, not an oversight.
+
+To the reviewer's follow-up — *how would a Tauri user force a refresh?* They would not, exactly as
+they cannot for ownership, decisions or glossary today. The passes are debounced and post-sync, so
+the desktop UI gets fresh data without asking. If that turns out to be wrong it is a **cross-agent
+decision about all four refresh methods**, taken with the I7 rationale in view — not a change to make
+for pre-mortem alone while its three siblings stay shut.
+
+## Q3 — JSON-RPC error-code helper · **NO CHANGE (convention recorded)**
+
+There is no repo-wide error enum. Each IPC namespace defines its own error class taking a raw integer
+— `AutomationRpcError(-32602, …)` in `ipc/automation-rpc.ts`, `AgentsRpcError(-32602, …)` in
+`ipc/agents-rpc.ts:409`. B1 follows the local convention in the file it edits. Recorded in the spec so
+the implementer does not invent an enum mid-PR.
+
+## S1 — Have `watcher.validateCondition` use the condition-kind table · **PARTIALLY ACCEPTED**
+
+**Accepted: the table is the single source.** Both the engine's evaluator and `watcher.create`'s new
+membership check read the same table. That is the DRY point, and it is in the spec.
+
+**Rejected: validating target parameters through it.** Two reasons, both from the code.
+
+`watcher.validateCondition` (`automation-rpc.ts:74-87`) takes `graphPredicateJson` and `sinceMs` and
+returns a `matchCount`. It never receives a `conditionType`, so there is nothing there to route
+through the table without redefining the method's contract — which is a change to an existing IPC
+surface that pre-mortem does not need.
+
+More importantly, the suggested check — *does the filtered service exist / is it valid for that item
+type* — would be **wrong**, not merely extra. A watcher is a forward-looking subscription. A service
+with no incidents yet is the normal case for a watcher worth arming, and rejecting it would refuse
+exactly the watchers a user most wants. Validation stays a membership check on the condition kind:
+whether the engine can ever evaluate this condition, which is knowable statically, rather than whether
+it will match today, which is not a validity question at all.
+
+## S2 — The agent's write access, I2, and returning proposals instead · **PARTIALLY ACCEPTED**
+
+**Accepted — the documentation demand.** The write exception is spelled out explicitly in the Agent
+Shape Invariant amendment: which tables pre-mortem writes (`watcher` rows with `enabled = 0`, and
+`premortem_watcher_proposal`), that it writes nothing else, and why.
+
+**Rejected — the I2 framing.** I2 is HITL-gate membership over `HITL_REQUIRED_BACKING` action types in
+`engine/executor.ts`, and it governs **actions that leave the machine**. A local SQLite insert is not
+an executor action and never enters the gate: `glossary`, `decisions` and `ownership` all write local
+rows today with no HITL, as does the egress ledger itself. Applying I2 to a local row would not add
+safety; it would dilute the invariant into "any write", which is precisely the drift
+`docs/SECURITY-INVARIANTS.md` warns against. There is also no structural test asserting agents are
+read-only — it is a documented invariant in `.claude/commands/nimbus-agent-patterns.md`, which is why
+amending that document is the correct and sufficient mechanism.
+
+**Rejected — the "typically cleaner and safer" alternative, on evidence.** The proposal is that the
+agent return a payload and the client create the watcher via `watcher.create`. `watcher.create`
+hardcodes **`enabled: 1`** (`ipc/automation-rpc.ts:121`). Routing through it would produce **armed**
+watchers — and an armed watcher fires a `notify` callback whose ChatOps variant posts to a team
+channel. That is the exact outcome the paused design exists to prevent, so as stated the alternative
+is strictly *less* safe than writing a paused row directly.
+
+Making it work would mean adding a paused-creation IPC method, exposing it to clients, and moving the
+`premortem_watcher_proposal` tombstone write to the client too — otherwise "proposed" and "deleted"
+stop being distinguishable and rule 3 collapses. That is more surface, more trust in the client, and
+no safety gained over a row that is inert by construction.
+
+The safety property here is **`enabled = 0`**, not who performed the insert. `listEnabledWatchers`
+filters on `enabled === 1`, so a paused row cannot fire regardless of its author.
+
+## S3 — Name the tracker in the empty-result diagnostic · **ACCEPTED**
+
+The design's failure-mode table already returns a named gap rather than silence, but it says *"cannot
+determine services"* without saying which tracker limitation produced it. Amended so the message names
+the cause:
+
+- a Linear reference → *"pre-mortem covers Jira epics only; no Linear project items are indexed"*
+- a Jira epic with no `parent_key` children → *"this looks like a company-managed Jira project, where
+  epic membership is not indexed; pass `--service`, or re-run once child PRs land"*
+- otherwise → the existing generic gap
+
+Each names what is missing and what to do about it. Consistent with the honesty rules already in the
+2026-08-09 design.
+
+---
+
+## Net effect on the plan
+
+B1 is unchanged in scope. B2 gains one derived check (the deployment-outcome state above), two
+sharpened diagnostic messages, and a more explicit Agent Shape Invariant amendment. No new PR, no
+migration, no new IPC method.

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review.md
@@ -3,7 +3,7 @@
 ## Open Questions
 
 1. **Vercel/Prefect deploy outcome representation in UI or CLI:**
-   - The design notes that `deploy_failed` covers only CI-annotated deployments because Vercel/Prefect have different vocabularies/structures. 
+   - The design notes that `deploy_failed` covers only CI-annotated deployments because Vercel/Prefect have different vocabularies/structures.
    - *Question:* Should the CLI or agent brief actively warn the user if they query a service whose deployment mapping is Vercel/Prefect, explaining *why* a deploy-failure watcher cannot be set up? (e.g. "deploy_failed watcher is only supported for CI-annotated deployments; Vercel is not supported.")
 
 2. **Tauri Gateway Bridge Method Name:**

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design-review.md
@@ -1,0 +1,31 @@
+# `nimbus pre-mortem` PR B — Design Review & Feedback
+
+## Open Questions
+
+1. **Vercel/Prefect deploy outcome representation in UI or CLI:**
+   - The design notes that `deploy_failed` covers only CI-annotated deployments because Vercel/Prefect have different vocabularies/structures. 
+   - *Question:* Should the CLI or agent brief actively warn the user if they query a service whose deployment mapping is Vercel/Prefect, explaining *why* a deploy-failure watcher cannot be set up? (e.g. "deploy_failed watcher is only supported for CI-annotated deployments; Vercel is not supported.")
+
+2. **Tauri Gateway Bridge Method Name:**
+   - In PR B2, the design proposes adding `agents.premortem` to `gateway_bridge.rs:ALLOWED_METHODS` (I7).
+   - *Question:* Is the IPC method namespaced as `agents.premortem` or `agents.preMortem` or similar? Let's check `packages/gateway` agent naming conventions to make sure it matches.
+   - Also, does Tauri need access to `premortem.refresh` eventually? The design says: "*premortem.refresh stays unexposed*". If Tauri users need to force a refresh of the pre-mortem data, how will they do it without that method?
+
+3. **Validation Code Error Range:**
+   - For `watcher.create` unknown kinds, the design specifies rejecting with `-32602` (Invalid params in JSON-RPC).
+   - *Question:* Does the workspace have a unified helper/error enum for JSON-RPC error codes? Or are raw integers used?
+
+## Suggestions & Improvements
+
+1. **Extend `watcher.validateCondition` or condition-kind metadata:**
+   - Since we now have a `condition-kind table` mapping condition types to item types and predicates, we should ensure `watcher.validateCondition` (or a similar validation helper) leverages this table directly to validate target parameters (e.g. checking if the filtered service exists or is valid for that item type) rather than just checking if the string is in the table. This keeps the validation logic dry and robust.
+
+2. **Documenting the Agent Write-Access Exception (I2 vs Agent Shape):**
+   - Built-in agents are strictly read-only by the Agent Shape Invariant. However, the pre-mortem agent writes paused watcher rows (mutating `premortem_watcher_proposal`).
+   - *Suggestion:* Make sure we clearly define in the Agent Shape Invariant that writes to `premortem_watcher_proposal` or `watcher` (if any) are either:
+     - Gated by a specific, non-bypassable local executor / consent gate (HITL), OR
+     - The agent doesn't write directly but instead returns a *proposal payload* to the client (CLI/UI), and the client triggers the mutation via a distinct write-enabled IPC method (`watcher.create` or a new pre-mortem command) which is HITL-gated.
+     - *If the agent writes directly:* Ensure this does not violate security invariant **I2** (HITL gate) or the read-only built-in agent invariant without a specific exception. Returning proposals for the client to execute is typically cleaner and safer.
+
+3. **Linear Support Warning:**
+   - Since the extraction is Jira-only and company-managed Jira projects return zero services, the pre-mortem CLI tool should explicitly output a friendly diagnostic/info message when run on a non-supported issue tracker or company-managed Jira project: e.g. "Linear is currently not supported for pre-mortem cohort analysis." or "No affected services found (pre-mortem analysis is limited to Jira team-managed projects)." This avoids user confusion where they get empty results with no explanation.

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
@@ -137,9 +137,27 @@ existing row. Rules 1 (content-derived id = hash(epic item id, risk kind, servic
 (`premortem_watcher_proposal` as the deliberate-deletion tombstone) are unchanged.
 
 **The risk → condition mapping is concrete.** Incident coupling proposes an `incident_opened`
-watcher filtered to the service; deploy failure proposes a `deploy_failed` watcher filtered to the
-service, and the brief states the CI-annotated-only limit alongside it. Cycle time, size overrun and
-review drag still propose nothing, rather than a contrived condition.
+watcher filtered to the service. Cycle time, size overrun and review drag still propose nothing,
+rather than a contrived condition.
+
+> **BLOCKED — the deploy-failure watcher cannot be service-filtered yet (found during B1 review,
+> 2026-08-10).** B1 shipped `deploy_failed`, but it also established that a deployment item's
+> `item.service` is the **annotate provider slug** (`github-actions`, `gitlab`, `jenkins`,
+> `circleci`, `bitbucket`, `other`) written by `deployment/annotate.ts`, whereas
+> `watcher-engine.ts` skips any watcher whose `filter.service` does not equal the **syncable service
+> id**. The two vocabularies do not intersect, so a service-filtered `deploy_failed` watcher is
+> unreachable post-sync and only ever evaluated by startup catch-up. B2 must therefore NOT specify
+> one as originally written here. Three options, none silently chosen:
+>
+> 1. **Propose no deploy-failure watcher** until the identity mismatch is reconciled — consistent
+>    with this design's existing rule that a risk with no genuine watchable condition proposes
+>    nothing. Recommended.
+> 2. **Propose an unfiltered watcher** (`filter: {}`), which fires on any service's failed deploy.
+>    It works, but it is not epic-specific, and the brief would have to say so plainly.
+> 3. **Reconcile the vocabularies** — map provider slugs to syncable service ids at annotate time or
+>    at evaluation. A real fix, a separate change, and out of scope for B2.
+>
+> Whichever is taken, the brief must not imply an epic-scoped deploy alert it cannot deliver.
 
 **Jira-only, and narrower than "Jira".** Every brief states it. Discovery keys on
 `metadata.issue_type = 'Epic'`, written only by `connectors/jira-sync.ts`; `linear-sync.ts` never

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
@@ -55,6 +55,18 @@ constraint error instead of quietly doing nothing.
 `deploy_failed` therefore covers **CI-annotated deployments only**. This is stated in the condition's
 description and in every brief that proposes such a watcher — not silently absorbed.
 
+**The brief distinguishes three deployment states, not two** (design review Q1), so a Vercel user
+learns *why* no watcher was proposed instead of seeing an unexplained absence:
+
+| Service's indexed deployment items | Brief |
+|---|---|
+| carry `metadata.conclusion` | proposes the watcher |
+| exist, none carry `conclusion` | names the limit: deploy-failure watching covers CI-annotated deploys; this service's deployments record no outcome |
+| none at all | the ordinary "no deployment history" gap |
+
+Keyed on the **presence of the `conclusion` key in the indexed rows** — derived, never a hardcoded
+list of producer names, which would be a fourth surface to drift when a producer changes shape.
+
 ---
 
 ## PR B1 — two real watcher conditions
@@ -87,7 +99,17 @@ against the condition-kind table and rejects an unknown kind with `-32602`.
 
 This is deliberate scope, not creep: the table's whole purpose is to be the single answer to "which
 conditions can fire", and a creation path that bypasses it would leave that answer wrong the moment
-it shipped. Bounded to a membership check — no other change to `watcher.create` semantics.
+it shipped. Bounded to a **membership check** — no other change to `watcher.create` semantics.
+
+**Deliberately not validated: whether the filtered service currently has matching items.** A watcher
+is a forward-looking subscription; a service with no incidents *yet* is the normal case for one worth
+arming. Validation answers "can the engine ever evaluate this condition", which is statically
+knowable — not "would it match today", which is not a validity question. `watcher.validateCondition`
+is untouched: it takes `graphPredicateJson` + `sinceMs` and never receives a `conditionType`
+(`automation-rpc.ts:74-87`).
+
+**Error convention.** No repo-wide JSON-RPC error enum exists; each namespace defines its own class
+over a raw integer (`AutomationRpcError`, `AgentsRpcError`). B1 follows the file it edits.
 
 **Testing.**
 
@@ -123,8 +145,17 @@ review drag still propose nothing, rather than a contrived condition.
 `metadata.issue_type = 'Epic'`, written only by `connectors/jira-sync.ts`; `linear-sync.ts` never
 writes it and **no `linear:project` items are indexed at all**, so there is no Linear epic-shaped row
 to find. Within Jira, `metadata.parent_key` is populated only for team-managed projects, so a closed
-company-managed epic resolves to zero affected services and yields no theme — silently, by design,
-not as an error.
+company-managed epic resolves to zero affected services and yields no theme.
+
+**The empty-result diagnostic names its cause** (design review S3). The 2026-08-09 failure-mode table
+already returns a named gap rather than silence, but not *which* limitation produced it:
+
+- a Linear reference → *pre-mortem covers Jira epics only; no Linear project items are indexed*
+- a Jira epic with no `parent_key` children → *this looks like a company-managed Jira project, where
+  epic membership is not indexed; pass `--service`, or re-run once child PRs land*
+- otherwise → the existing generic gap
+
+Each names what is missing **and** what to do about it.
 
 **Surface.**
 
@@ -141,7 +172,15 @@ not as an error.
 
 - `.claude/commands/nimbus-agent-patterns.md` — its Agent Shape Invariant states that every built-in
   agent is read-only with no write tools in scope. pre-mortem writes paused watcher rows. Amend it
-  deliberately rather than leave drift for the next author.
+  deliberately rather than leave drift for the next author. The amendment is **explicit about the
+  exception's bounds** (design review S2): pre-mortem writes `watcher` rows with `enabled = 0` and
+  `premortem_watcher_proposal` rows, and nothing else. It is **not** an I2/HITL matter — I2 governs
+  `HITL_REQUIRED_BACKING` action types that leave the machine via `engine/executor.ts`, and a local
+  SQLite insert never enters that gate, exactly as `glossary`, `decisions`, `ownership` and the egress
+  ledger already write local rows without one. The safety property is `enabled = 0`, not the identity
+  of the writer: `listEnabledWatchers` filters on `enabled === 1`, so a paused row cannot fire
+  whoever inserted it. Routing the write through `watcher.create` instead would make it **less** safe
+  — that method hardcodes `enabled: 1` (`ipc/automation-rpc.ts:121`) and would arm every proposal.
 - `docs/roadmap.md` — the S1 row and the Phase 7 Wave 5 entry, which currently describe pre-mortem as
   both read-only *and* scheduling watchers.
 - `docs/cli-reference.md`, `docs/CHANGELOG.md`, `docs/architecture.md` (V53 tables + both IPC

--- a/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
+++ b/docs/superpowers/specs/2026-08-10-pre-mortem-pr-b-design.md
@@ -1,0 +1,171 @@
+# `nimbus pre-mortem` PR B — Design Delta
+
+> **Reads as an amendment to [`2026-08-09-pre-mortem-design.md`](./2026-08-09-pre-mortem-design.md)**, not a
+> replacement. That document remains canonical for the four lanes, the cohort algorithm, the five
+> structural risks, the watcher rules, the honesty rules, the failure-mode table, and everything
+> declared out of scope. This delta records only what changed after PR A shipped (#1134, squash
+> `cd1d9c2e`, released as **v1.27.0**) and after its assumptions were checked against the tree.
+
+**Date:** 2026-08-10 · **Slot:** Spine S1 (Local Brain) · **Status:** approved, plan pending
+
+---
+
+## Why a delta exists
+
+PR A shipped the substrate only: schema **V53** (`premortem_theme`, `premortem_theme_evidence`,
+`premortem_pass_state`, `premortem_watcher_proposal`), the debounced extraction pass under
+`packages/gateway/src/premortem/`, the `[premortem]` config block, and the `premortem.refresh` IPC
+method. There is no agent and no command, so today the pass mines closed epics into rows **nothing
+can read**. PR B is what makes V53 reachable.
+
+Three facts checked against the tree changed the plan. Each was previously asserted from the design
+document rather than read from the code — the failure mode that produced fifteen plan-authored
+defects in PR A.
+
+### 1. No watcher condition pre-mortem needs can fire
+
+`automation/watcher-engine.ts:86` returns `null` for every `condition_type` other than
+`alert_fired`, and that condition queries `item WHERE type = 'alert'`
+(`watcher-engine.ts:106-108`). **Nothing in the repository indexes an item of type `alert`.**
+PagerDuty indexes `type: "incident"` (`connectors/pagerduty-sync.ts:89`); deployments index
+`type: "deployment"`.
+
+So the 2026-08-09 design's premise — *"only risks with a genuine watchable condition produce a
+watcher — incident coupling and deploy failure"* — is false as written. A watcher pre-mortem
+created would never fire **even after the user armed it**, and the brief's arming command would be
+advice to do something inert. That is the same shipped-but-unreachable shape PR B exists to fix.
+
+**Resolution: PR B is split in two, and the conditions land first.**
+
+### 2. `insertWatcher` is a bare `INSERT`, not insert-if-absent
+
+`automation/watcher-store.ts:38` executes a plain `INSERT INTO watcher`. Watcher rule 2 in the
+2026-08-09 design ("insert-if-absent; never update `enabled`") therefore cannot be satisfied by
+calling it — with a content-derived id, the second `pre-mortem PROJ-120` run raises a primary-key
+constraint error instead of quietly doing nothing.
+
+### 3. Deployment status has three shapes, only one of which is a deploy outcome
+
+| Producer | Status field | Usable for `deploy_failed`? |
+|---|---|---|
+| `deployment/annotate.ts:174` (CI, `POST /v1/deployments`) | `metadata.conclusion` ∈ success / failure / cancelled / … | **yes** |
+| `connectors/vercel-deployment-mapping.ts:72` | `metadata.state` (Vercel's own vocabulary) | no — different key, different vocabulary |
+| `connectors/prefect-deployment-mapping.ts` | none | no — it indexes deployment *definitions*, not runs; there is no outcome to key on |
+
+`deploy_failed` therefore covers **CI-annotated deployments only**. This is stated in the condition's
+description and in every brief that proposes such a watcher — not silently absorbed.
+
+---
+
+## PR B1 — two real watcher conditions
+
+**Scope:** `packages/gateway/src/automation/watcher-engine.ts` plus its validation seam. Small,
+self-contained, and worth landing on its own merits: the automation subsystem advertising one
+condition type that matches an item type nothing produces is a gap independent of pre-mortem.
+
+**Shape.** Replace the hardcoded `condition_type !== "alert_fired"` guard with a **condition-kind
+table** mapping each condition type to its item type and optional extra predicate. Everything
+downstream is reused unchanged: the `service` filter, the `since = last_checked_at ?? created_at`
+window, the `LIMIT 5`, the optional graph predicate, and the summary/snapshot shape.
+
+| Condition | Matches | Coverage |
+|---|---|---|
+| `alert_fired` | `item.type = 'alert'` | unchanged. Nothing indexes `alert` today; this is the status quo being preserved, not a regression being introduced |
+| `incident_opened` | `item.type = 'incident'` | PagerDuty. Real — fires today |
+| `deploy_failed` | `item.type = 'deployment'` AND `json_extract(metadata, '$.conclusion') = 'failure'` | CI-annotated deploys only (see table above) |
+
+A table rather than an if-chain because it makes the set of firable conditions a single readable
+SSoT: "which conditions can actually fire" was unanswerable here without grepping three files, and a
+future condition should be a row, not a branch.
+
+**Validation — closing a pre-existing hole while we are here.** `watcher.create`
+(`ipc/automation-rpc.ts:122`) passes `conditionType` straight through as an unvalidated string, so a
+watcher with a nonsense condition type is accepted today and then silently never fires. Neither
+`watcher.validateCondition` (`automation-rpc.ts:74-87`, which validates the **graph predicate** only)
+nor `watcher.listCandidateRelations` (graph relations only) looks at it. B1 validates `conditionType`
+against the condition-kind table and rejects an unknown kind with `-32602`.
+
+This is deliberate scope, not creep: the table's whole purpose is to be the single answer to "which
+conditions can fire", and a creation path that bypasses it would leave that answer wrong the moment
+it shipped. Bounded to a membership check — no other change to `watcher.create` semantics.
+
+**Testing.**
+
+- One evaluator test per condition, seeding **real `item` rows**, asserting fire and no-fire.
+- An unknown `condition_type` still returns `null`.
+- The `service` filter and the graph predicate still apply to the new kinds.
+- A Vercel-shaped deployment row (status in `metadata.state`, no `conclusion`) does **not** match
+  `deploy_failed` — the stated coverage limit enforced by a test, not by a comment.
+- `watcher.create` rejects an unknown `conditionType` with `-32602`, and accepts all three known
+  kinds.
+
+**Not in B1:** no migration, no new security invariant, no HTTP route, no Tauri change, no change to
+the `watcher.*` IPC method set.
+
+---
+
+## PR B2 — the agent
+
+Everything in the 2026-08-09 design's *Request path*, *Watchers*, *Honesty rules*, *Failure modes*
+and *Testing* sections holds. The amendments:
+
+**Watcher insertion gets a store helper.** Add `insertWatcherIfAbsent` to
+`automation/watcher-store.ts`: select by id, insert only when absent, never write `enabled` on an
+existing row. Rules 1 (content-derived id = hash(epic item id, risk kind, service)) and 3
+(`premortem_watcher_proposal` as the deliberate-deletion tombstone) are unchanged.
+
+**The risk → condition mapping is concrete.** Incident coupling proposes an `incident_opened`
+watcher filtered to the service; deploy failure proposes a `deploy_failed` watcher filtered to the
+service, and the brief states the CI-annotated-only limit alongside it. Cycle time, size overrun and
+review drag still propose nothing, rather than a contrived condition.
+
+**Jira-only, and narrower than "Jira".** Every brief states it. Discovery keys on
+`metadata.issue_type = 'Epic'`, written only by `connectors/jira-sync.ts`; `linear-sync.ts` never
+writes it and **no `linear:project` items are indexed at all**, so there is no Linear epic-shaped row
+to find. Within Jira, `metadata.parent_key` is populated only for team-managed projects, so a closed
+company-managed epic resolves to zero affected services and yields no theme — silently, by design,
+not as an error.
+
+**Surface.**
+
+- `packages/gateway/src/agents/premortem.ts` — the thirteenth built-in agent (the agents directory
+  currently holds twelve standalone agents plus the `why-peek` companion).
+- `packages/cli/src/commands/pre-mortem.ts` — `nimbus pre-mortem <epic-ref> [--service <name>]…
+  [--json] [--refresh]`, unknown flags hard-rejected, matching `glossary` / `decisions` / `owners`.
+- `packages/ui/src-tauri/src/gateway_bridge.rs` — `agents.premortem` added to `ALLOWED_METHODS`,
+  **104 → 105**, with the `gateway_bridge.rs:549` count assertion updated (I7). `premortem.refresh`
+  stays unexposed.
+- No migration, no new security invariant, no HTTP write route.
+
+**Documentation, landing in the same commits as the wiring.**
+
+- `.claude/commands/nimbus-agent-patterns.md` — its Agent Shape Invariant states that every built-in
+  agent is read-only with no write tools in scope. pre-mortem writes paused watcher rows. Amend it
+  deliberately rather than leave drift for the next author.
+- `docs/roadmap.md` — the S1 row and the Phase 7 Wave 5 entry, which currently describe pre-mortem as
+  both read-only *and* scheduling watchers.
+- `docs/cli-reference.md`, `docs/CHANGELOG.md`, `docs/architecture.md` (V53 tables + both IPC
+  methods).
+
+**Testing.** Pure-function unit tests per structural calculator; cohort selection and IDF ranking;
+theme matching; the two watcher rules (id determinism across re-runs, and an armed watcher surviving
+a re-run **un-paused**) plus the suppression rule; and
+`packages/gateway/test/e2e/scenarios/premortem.e2e.test.ts` asserting the brief's sections, the
+`premortem.briefReady` notification, and zero HITL fires. Graph fixtures are seeded through the real
+`upsertGraphEntity` — never a hand-rolled `INSERT INTO graph_entity`, which hid three separate
+defects in PR A.
+
+---
+
+## Sequencing
+
+**B1 then B2.** B2's brief tells the user to arm a watcher; that instruction is only true once B1 has
+landed. Building in the other order would ship, for one release cycle, exactly the claim this delta
+exists to remove.
+
+## Unchanged from the 2026-08-09 design
+
+Out of scope remains out of scope: semantic cohort selection, a project-based fallback cohort,
+indexing Jira components/labels, indexing ticket comments, armed watchers and ChatOps routing,
+federated cross-team cohorts, a shared harness for the four extraction passes, and a deterministic
+no-LLM theme-discovery fallback.

--- a/packages/gateway/src/automation/watcher-condition-kinds.test.ts
+++ b/packages/gateway/src/automation/watcher-condition-kinds.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isKnownWatcherConditionType,
+  WATCHER_CONDITION_KINDS,
+  watcherConditionKind,
+} from "./watcher-condition-kinds.ts";
+
+describe("watcher-condition-kinds", () => {
+  test("the table holds exactly the three supported condition types", () => {
+    expect(WATCHER_CONDITION_KINDS.map((k) => k.conditionType).sort()).toEqual([
+      "alert_fired",
+      "deploy_failed",
+      "incident_opened",
+    ]);
+  });
+
+  test("each kind names the item type it matches", () => {
+    expect(watcherConditionKind("alert_fired")?.itemType).toBe("alert");
+    expect(watcherConditionKind("incident_opened")?.itemType).toBe("incident");
+    expect(watcherConditionKind("deploy_failed")?.itemType).toBe("deployment");
+  });
+
+  test("only deploy_failed carries an extra predicate, and it is json_valid-guarded", () => {
+    expect(watcherConditionKind("alert_fired")?.extraSql).toBe("");
+    expect(watcherConditionKind("incident_opened")?.extraSql).toBe("");
+    expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("conclusion");
+    // Pinned deliberately: without json_valid, a single non-JSON metadata row makes json_extract
+    // raise and takes down evaluation for every watcher.
+    expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("json_valid(metadata)");
+  });
+
+  test("an unknown condition type resolves to undefined and is not known", () => {
+    expect(watcherConditionKind("schedule")).toBeUndefined();
+    expect(isKnownWatcherConditionType("schedule")).toBe(false);
+    expect(isKnownWatcherConditionType("incident_opened")).toBe(true);
+  });
+});

--- a/packages/gateway/src/automation/watcher-condition-kinds.test.ts
+++ b/packages/gateway/src/automation/watcher-condition-kinds.test.ts
@@ -20,13 +20,32 @@ describe("watcher-condition-kinds", () => {
     expect(watcherConditionKind("deploy_failed")?.itemType).toBe("deployment");
   });
 
-  test("only deploy_failed carries an extra predicate, and it is json_valid-guarded", () => {
+  test("alert_fired carries no extra predicate", () => {
     expect(watcherConditionKind("alert_fired")?.extraSql).toBe("");
-    expect(watcherConditionKind("incident_opened")?.extraSql).toBe("");
+  });
+
+  test("incident_opened narrows to a triggered incident, and it is json_valid-guarded", () => {
+    // Without this clause the condition also fires when an incident is acknowledged or resolved:
+    // pagerduty-sync re-indexes on every `updated_at` change, not only on open.
+    expect(watcherConditionKind("incident_opened")?.extraSql).toContain(
+      "json_extract(metadata, '$.status') = 'triggered'",
+    );
+    expect(watcherConditionKind("incident_opened")?.extraSql).toContain("json_valid(metadata)");
+  });
+
+  test("deploy_failed narrows to a failed conclusion, and it is json_valid-guarded", () => {
     expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("conclusion");
     // Pinned deliberately: without json_valid, a single non-JSON metadata row makes json_extract
     // raise and takes down evaluation for every watcher.
     expect(watcherConditionKind("deploy_failed")?.extraSql).toContain("json_valid(metadata)");
+  });
+
+  test("no extraSql fragment contains a bind placeholder", () => {
+    // The engine binds exactly four positional parameters around this fragment. A `?` inside an
+    // extraSql would consume one of them and silently misbind all four.
+    for (const kind of WATCHER_CONDITION_KINDS) {
+      expect(kind.extraSql).not.toContain("?");
+    }
   });
 
   test("an unknown condition type resolves to undefined and is not known", () => {

--- a/packages/gateway/src/automation/watcher-condition-kinds.ts
+++ b/packages/gateway/src/automation/watcher-condition-kinds.ts
@@ -1,0 +1,57 @@
+/**
+ * The single source of truth for which watcher conditions the engine can evaluate.
+ *
+ * `watcher-engine.ts` builds its item query from this table, and `ipc/automation-rpc.ts`
+ * rejects a `watcher.create` whose condition type is absent from it. Keeping both readers on
+ * one table is the point: a creation path that accepted a condition the engine cannot evaluate
+ * would produce a watcher that is silently inert forever.
+ *
+ * `extraSql` is a COMPILE-TIME CONSTANT fragment ANDed into that query. It is never derived from
+ * a row, a user, or an IPC parameter, and must never become so — every value in the query is a
+ * bound parameter (I9).
+ */
+export type WatcherConditionKind = {
+  /** The value stored in `watcher.condition_type`. */
+  readonly conditionType: string;
+  /** The `item.type` this condition observes. */
+  readonly itemType: string;
+  /** Constant SQL ANDed into the item query, or "" for none. */
+  readonly extraSql: string;
+};
+
+export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
+  // Preserved as-is. NOTE: no connector indexes `item.type = 'alert'` today, so this condition
+  // cannot currently fire. That is the pre-existing state, recorded rather than silently fixed.
+  { conditionType: "alert_fired", itemType: "alert", extraSql: "" },
+  // PagerDuty indexes `type: "incident"` (connectors/pagerduty-sync.ts).
+  { conditionType: "incident_opened", itemType: "incident", extraSql: "" },
+  // CI-annotated deployments only: `deployment/annotate.ts` writes metadata.conclusion. Vercel
+  // records its outcome under metadata.state, and Prefect indexes deployment DEFINITIONS with no
+  // outcome at all, so neither matches. Keyed on the presence of the conclusion value rather than
+  // on a producer name, so a new producer that adopts the same shape works without a code change.
+  //
+  // `json_valid(metadata)` is LOAD-BEARING, not defensive noise: SQLite's json_extract RAISES
+  // "malformed JSON" on a non-JSON TEXT value, and that exception would propagate out of
+  // evaluateOneWatcher through the whole evaluateWatchersAfterSync loop — killing evaluation for
+  // EVERY watcher, not just this one. (A NULL metadata is safe on its own; an empty string or
+  // plain text is not.) Every production writer stringifies today, so this guards a migration or a
+  // future writer, at the cost of one cheap call.
+  //
+  // Extending to Vercel later means matching a DIFFERENT key with a different vocabulary
+  // (metadata.state = 'ERROR'). A single extraSql string can express that as an OR, but the moment
+  // a second shape lands, prefer widening this type to hold several predicates per kind over
+  // growing one unreadable SQL string.
+  {
+    conditionType: "deploy_failed",
+    itemType: "deployment",
+    extraSql: "AND json_valid(metadata) AND json_extract(metadata, '$.conclusion') = 'failure'",
+  },
+];
+
+export function watcherConditionKind(conditionType: string): WatcherConditionKind | undefined {
+  return WATCHER_CONDITION_KINDS.find((k) => k.conditionType === conditionType);
+}
+
+export function isKnownWatcherConditionType(conditionType: string): boolean {
+  return watcherConditionKind(conditionType) !== undefined;
+}

--- a/packages/gateway/src/automation/watcher-condition-kinds.ts
+++ b/packages/gateway/src/automation/watcher-condition-kinds.ts
@@ -19,12 +19,21 @@ export type WatcherConditionKind = {
   readonly extraSql: string;
 };
 
-export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
+export const WATCHER_CONDITION_KINDS = [
   // Preserved as-is. NOTE: no connector indexes `item.type = 'alert'` today, so this condition
   // cannot currently fire. That is the pre-existing state, recorded rather than silently fixed.
   { conditionType: "alert_fired", itemType: "alert", extraSql: "" },
-  // PagerDuty indexes `type: "incident"` (connectors/pagerduty-sync.ts).
-  { conditionType: "incident_opened", itemType: "incident", extraSql: "" },
+  // PagerDuty indexes `type: "incident"` (connectors/pagerduty-sync.ts), writing the incident's
+  // current status to `metadata.status`. The narrowing to 'triggered' is LOAD-BEARING for the name:
+  // pagerduty-sync fetches `/incidents` with no `statuses[]` filter and sets `modifiedAt` from
+  // `updated_at`, so acknowledging or resolving an incident re-indexes it with a fresh
+  // `modified_at`. Without this clause a watcher called `incident_opened` fires on resolution too.
+  {
+    conditionType: "incident_opened",
+    itemType: "incident",
+    // `json_valid(metadata)` is load-bearing here for the same reason as on `deploy_failed` below.
+    extraSql: "AND json_valid(metadata) AND json_extract(metadata, '$.status') = 'triggered'",
+  },
   // CI-annotated deployments only: `deployment/annotate.ts` writes metadata.conclusion. Vercel
   // records its outcome under metadata.state, and Prefect indexes deployment DEFINITIONS with no
   // outcome at all, so neither matches. Keyed on the presence of the conclusion value rather than
@@ -46,7 +55,11 @@ export const WATCHER_CONDITION_KINDS: readonly WatcherConditionKind[] = [
     itemType: "deployment",
     extraSql: "AND json_valid(metadata) AND json_extract(metadata, '$.conclusion') = 'failure'",
   },
-];
+  // `as const` keeps each `extraSql` a literal type rather than widening it to `string`. That
+  // matters because the engine binds exactly four positional parameters around this fragment: an
+  // `extraSql` containing a `?` would silently shift every one of them. The table test pins the
+  // absence of `?`; `satisfies` keeps the shape checked without widening.
+] as const satisfies readonly WatcherConditionKind[];
 
 export function watcherConditionKind(conditionType: string): WatcherConditionKind | undefined {
   return WATCHER_CONDITION_KINDS.find((k) => k.conditionType === conditionType);

--- a/packages/gateway/src/automation/watcher-engine.test.ts
+++ b/packages/gateway/src/automation/watcher-engine.test.ts
@@ -355,6 +355,7 @@ describe("watcher-engine", () => {
       title: "api-gateway 500s",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      metadata: { status: "triggered" },
     });
 
     const bodies: string[] = [];
@@ -385,6 +386,7 @@ describe("watcher-engine", () => {
       title: "other tracker",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      metadata: { status: "triggered" },
     });
 
     let calls = 0;
@@ -395,6 +397,96 @@ describe("watcher-engine", () => {
     expect(calls).toBe(0);
   });
 
+  test("incident_opened fires on a triggered incident but not on a resolved one", () => {
+    // pagerduty-sync fetches /incidents unfiltered and sets modifiedAt from `updated_at`, so a
+    // resolution re-indexes the incident with a fresh modified_at. Only the status distinguishes
+    // an opening from a resolution.
+    const db = makeDb();
+    const t0 = 5_600_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-RESOLVED",
+      title: "checkout latency (resolved)",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+      metadata: { status: "resolved" },
+    });
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "pagerduty", t0 + 2000, (_title, body) => {
+      bodies.push(body);
+    });
+    expect(bodies).toHaveLength(0);
+
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-TRIGGERED",
+      title: "checkout 500s",
+      modifiedAt: t0 + 3000,
+      syncedAt: t0 + 3000,
+      metadata: { status: "triggered" },
+    });
+
+    evaluateWatchersAfterSync(db, "pagerduty", t0 + 4000, (_title, body) => {
+      bodies.push(body);
+    });
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("checkout 500s");
+  });
+
+  test("a row with non-JSON metadata does not break incident_opened evaluation", () => {
+    const db = makeDb();
+    const t0 = 5_700_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-LEGACY",
+      title: "legacy row",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-NEW",
+      title: "payments down",
+      modifiedAt: t0 + 2000,
+      syncedAt: t0 + 2000,
+      metadata: { status: "triggered" },
+    });
+    // Forced directly: no production writer emits non-JSON metadata. Without json_valid() the
+    // json_extract below raises and the exception escapes the whole evaluation loop.
+    db.run("UPDATE item SET metadata = 'not json' WHERE external_id = ?", ["INC-LEGACY"]);
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "pagerduty", t0 + 3000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("payments down");
+  });
+
   test("deploy_failed fires only on a failed deployment, not a successful one", () => {
     const db = makeDb();
     const t0 = 1_700_000_000_000;
@@ -402,13 +494,13 @@ describe("watcher-engine", () => {
       name: "deploys",
       enabled: 1,
       condition_type: "deploy_failed",
-      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      condition_json: JSON.stringify({ filter: { service: "github-actions" } }),
       action_type: "notify",
       action_json: "{}",
       created_at: t0,
     });
     upsertIndexedItem(db, {
-      service: "github_actions",
+      service: "github-actions",
       type: "deployment",
       externalId: "deploy-ok",
       title: "checkout v2.1.0",
@@ -417,7 +509,7 @@ describe("watcher-engine", () => {
       metadata: { conclusion: "success" },
     });
     upsertIndexedItem(db, {
-      service: "github_actions",
+      service: "github-actions",
       type: "deployment",
       externalId: "deploy-bad",
       title: "checkout v2.1.1",
@@ -427,7 +519,7 @@ describe("watcher-engine", () => {
     });
 
     const bodies: string[] = [];
-    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+    evaluateWatchersAfterSync(db, "github-actions", t0 + 3000, (_title, body) => {
       bodies.push(body);
     });
 
@@ -473,13 +565,13 @@ describe("watcher-engine", () => {
       name: "deploys",
       enabled: 1,
       condition_type: "deploy_failed",
-      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      condition_json: JSON.stringify({ filter: { service: "github-actions" } }),
       action_type: "notify",
       action_json: "{}",
       created_at: t0,
     });
     upsertIndexedItem(db, {
-      service: "github_actions",
+      service: "github-actions",
       type: "deployment",
       externalId: "deploy-legacy",
       title: "legacy row",
@@ -487,7 +579,7 @@ describe("watcher-engine", () => {
       syncedAt: t0 + 1000,
     });
     upsertIndexedItem(db, {
-      service: "github_actions",
+      service: "github-actions",
       type: "deployment",
       externalId: "deploy-bad",
       title: "checkout v3.0.0",
@@ -501,7 +593,7 @@ describe("watcher-engine", () => {
     db.run("UPDATE item SET metadata = 'not json' WHERE external_id = ?", ["deploy-legacy"]);
 
     const bodies: string[] = [];
-    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+    evaluateWatchersAfterSync(db, "github-actions", t0 + 3000, (_title, body) => {
       bodies.push(body);
     });
 
@@ -532,6 +624,9 @@ describe("watcher-engine", () => {
       title: "unowned incident",
       modifiedAt: t0 + 1000,
       syncedAt: t0 + 1000,
+      // `status: "triggered"` so the row genuinely reaches the predicate: without it the query
+      // returns nothing and the assertion below would hold for the wrong reason.
+      metadata: { status: "triggered" },
     });
 
     let calls = 0;

--- a/packages/gateway/src/automation/watcher-engine.test.ts
+++ b/packages/gateway/src/automation/watcher-engine.test.ts
@@ -335,4 +335,216 @@ describe("watcher-engine", () => {
     );
     expect(calls).toBe(1);
   });
+
+  test("incident_opened fires on an indexed incident", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-1",
+      title: "api-gateway 500s",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "pagerduty", t0 + 2000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("api-gateway 500s");
+  });
+
+  test("incident_opened respects the service filter", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "incidents",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "opsgenie",
+      type: "incident",
+      externalId: "OG-1",
+      title: "other tracker",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    let calls = 0;
+    evaluateWatchersStartupCatchUp(db, t0 + 2000, () => {
+      calls += 1;
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  test("deploy_failed fires only on a failed deployment, not a successful one", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-ok",
+      title: "checkout v2.1.0",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+      metadata: { conclusion: "success" },
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-bad",
+      title: "checkout v2.1.1",
+      modifiedAt: t0 + 2000,
+      syncedAt: t0 + 2000,
+      metadata: { conclusion: "failure" },
+    });
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("checkout v2.1.1");
+    expect(bodies[0]).not.toContain("v2.1.0");
+  });
+
+  test("deploy_failed does not match a Vercel-shaped deployment, whose outcome is in metadata.state", () => {
+    const db = makeDb();
+    const t0 = 1_700_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "vercel" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "vercel",
+      type: "deployment",
+      externalId: "dpl_1",
+      title: "marketing-site",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+      metadata: { state: "ERROR", target: "production" },
+    });
+
+    let calls = 0;
+    evaluateWatchersAfterSync(db, "vercel", t0 + 2000, () => {
+      calls += 1;
+    });
+
+    expect(calls).toBe(0);
+  });
+
+  test("a row with non-JSON metadata does not break deploy_failed evaluation", () => {
+    const db = makeDb();
+    const t0 = 5_400_000_000_000;
+    insertWatcher(db, {
+      name: "deploys",
+      enabled: 1,
+      condition_type: "deploy_failed",
+      condition_json: JSON.stringify({ filter: { service: "github_actions" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-legacy",
+      title: "legacy row",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+    upsertIndexedItem(db, {
+      service: "github_actions",
+      type: "deployment",
+      externalId: "deploy-bad",
+      title: "checkout v3.0.0",
+      modifiedAt: t0 + 2000,
+      syncedAt: t0 + 2000,
+      metadata: { conclusion: "failure" },
+    });
+    // No production writer can produce this today — both item.metadata writers stringify — so it
+    // is forced directly. Without json_valid() in the predicate, json_extract raises
+    // "malformed JSON" here and the exception escapes the whole evaluation loop.
+    db.run("UPDATE item SET metadata = 'not json' WHERE external_id = ?", ["deploy-legacy"]);
+
+    const bodies: string[] = [];
+    evaluateWatchersAfterSync(db, "github_actions", t0 + 3000, (_title, body) => {
+      bodies.push(body);
+    });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("checkout v3.0.0");
+  });
+
+  test("a graph predicate still narrows a new condition kind", () => {
+    const db = makeDb();
+    const t0 = 5_200_000_000_000;
+    insertWatcher(db, {
+      name: "incidents-owned",
+      enabled: 1,
+      condition_type: "incident_opened",
+      condition_json: JSON.stringify({ filter: { service: "pagerduty" } }),
+      action_type: "notify",
+      action_json: "{}",
+      created_at: t0,
+      graph_predicate_json: JSON.stringify({
+        relation: "owned_by",
+        target: { type: "person", externalId: "gh:absent" },
+      }),
+    });
+    upsertIndexedItem(db, {
+      service: "pagerduty",
+      type: "incident",
+      externalId: "INC-9",
+      title: "unowned incident",
+      modifiedAt: t0 + 1000,
+      syncedAt: t0 + 1000,
+    });
+
+    let calls = 0;
+    evaluateWatchersAfterSync(
+      db,
+      "pagerduty",
+      t0 + 2000,
+      () => {
+        calls += 1;
+      },
+      { graphConditionsEnabled: true },
+    );
+
+    expect(calls).toBe(0);
+  });
 });

--- a/packages/gateway/src/automation/watcher-engine.ts
+++ b/packages/gateway/src/automation/watcher-engine.ts
@@ -6,6 +6,7 @@ import {
   itemMatchesGraphPredicate,
   parseGraphPredicate,
 } from "./graph-predicate.ts";
+import { watcherConditionKind } from "./watcher-condition-kinds.ts";
 import {
   insertWatcherEvent,
   listEnabledWatchers,
@@ -83,7 +84,8 @@ function evaluateOneWatcher(
   syncedServiceId: string | undefined,
   graphEnabled: boolean,
 ): { summary: string; snapshot: string } | null {
-  if (w.condition_type !== "alert_fired") {
+  const kind = watcherConditionKind(w.condition_type);
+  if (kind === undefined) {
     return null;
   }
   const cond = asRecord(w.condition_json);
@@ -104,13 +106,14 @@ function evaluateOneWatcher(
   const rows = db
     .query(
       `SELECT id, title, service, type, external_id, modified_at FROM item
-       WHERE type = 'alert'
+       WHERE type = ?
          AND modified_at > ?
          AND (? IS NULL OR service = ?)
+         ${kind.extraSql}
        ORDER BY modified_at DESC
        LIMIT 5`,
     )
-    .all(since, service ?? null, service ?? null) as Array<{
+    .all(kind.itemType, since, service ?? null, service ?? null) as Array<{
     id: string;
     title: string;
     service: string;

--- a/packages/gateway/src/ipc/automation-rpc.test.ts
+++ b/packages/gateway/src/ipc/automation-rpc.test.ts
@@ -244,7 +244,7 @@ describe("watcher.create / pause / resume / delete", () => {
       method: "watcher.create",
       params: {
         name: "alpha",
-        conditionType: "schedule",
+        conditionType: "alert_fired",
         conditionJson: "{}",
         actionType: "notify",
         actionJson: "{}",
@@ -267,7 +267,7 @@ describe("watcher.create / pause / resume / delete", () => {
       method: "watcher.create",
       params: {
         name: "alpha",
-        conditionType: "schedule",
+        conditionType: "alert_fired",
         conditionJson: "{}",
         actionType: "notify",
         actionJson: "{}",
@@ -290,7 +290,7 @@ describe("watcher.create / pause / resume / delete", () => {
       dispatchAutomationRpc({
         method: "watcher.create",
         params: {
-          conditionType: "schedule",
+          conditionType: "alert_fired",
           conditionJson: "{}",
           actionType: "notify",
           actionJson: "{}",
@@ -306,7 +306,7 @@ describe("watcher.create / pause / resume / delete", () => {
       method: "watcher.create",
       params: {
         name: "alpha",
-        conditionType: "schedule",
+        conditionType: "alert_fired",
         conditionJson: "{}",
         actionType: "notify",
         actionJson: "{}",
@@ -334,7 +334,7 @@ describe("watcher.create / pause / resume / delete", () => {
       method: "watcher.create",
       params: {
         name: "alpha",
-        conditionType: "schedule",
+        conditionType: "alert_fired",
         conditionJson: "{}",
         actionType: "notify",
         actionJson: "{}",
@@ -356,6 +356,44 @@ describe("watcher.create / pause / resume / delete", () => {
     await expect(
       dispatchAutomationRpc({ method: "watcher.delete", params: {}, db }),
     ).rejects.toThrow(AutomationRpcError);
+  });
+
+  test("create rejects a condition type the engine cannot evaluate", async () => {
+    const db = seededDb();
+    await expect(
+      dispatchAutomationRpc({
+        method: "watcher.create",
+        params: {
+          name: "bogus",
+          conditionType: "schedule",
+          conditionJson: "{}",
+          actionType: "notify",
+          actionJson: "{}",
+        },
+        db,
+      }),
+    ).rejects.toThrow(AutomationRpcError);
+
+    expect((db.query("SELECT COUNT(*) AS n FROM watcher").get() as { n: number }).n).toBe(0);
+  });
+
+  test("create accepts every supported condition type", async () => {
+    const db = seededDb();
+    for (const conditionType of ["alert_fired", "incident_opened", "deploy_failed"]) {
+      const out = await dispatchAutomationRpc({
+        method: "watcher.create",
+        params: {
+          name: `w-${conditionType}`,
+          conditionType,
+          conditionJson: "{}",
+          actionType: "notify",
+          actionJson: "{}",
+        },
+        db,
+      });
+      expect(out.kind).toBe("hit");
+    }
+    expect((db.query("SELECT COUNT(*) AS n FROM watcher").get() as { n: number }).n).toBe(3);
   });
 });
 

--- a/packages/gateway/src/ipc/automation-rpc.ts
+++ b/packages/gateway/src/ipc/automation-rpc.ts
@@ -12,6 +12,7 @@ import {
   listCandidateGraphRelations,
   parseGraphPredicate,
 } from "../automation/graph-predicate.ts";
+import { isKnownWatcherConditionType } from "../automation/watcher-condition-kinds.ts";
 import { listWatcherHistory } from "../automation/watcher-history.ts";
 import {
   deleteWatcher,
@@ -116,10 +117,18 @@ const AUTOMATION_HANDLERS: Readonly<Record<string, AutomationHandler>> = {
       rec !== undefined && typeof rec["graphPredicateJson"] === "string"
         ? rec["graphPredicateJson"]
         : null;
+    const name = requireString(rec, "name");
+    const conditionType = requireString(rec, "conditionType");
+    if (!isKnownWatcherConditionType(conditionType)) {
+      throw new AutomationRpcError(
+        -32602,
+        `Unsupported conditionType "${conditionType}" — the watcher engine cannot evaluate it`,
+      );
+    }
     const id = insertWatcher(ctx.db, {
-      name: requireString(rec, "name"),
+      name,
       enabled: 1,
-      condition_type: requireString(rec, "conditionType"),
+      condition_type: conditionType,
       condition_json: requireString(rec, "conditionJson"),
       action_type: requireString(rec, "actionType"),
       action_json: requireString(rec, "actionJson"),

--- a/packages/ui/src/pages/Watchers.tsx
+++ b/packages/ui/src/pages/Watchers.tsx
@@ -11,7 +11,30 @@ import type {
 } from "../ipc/types";
 import { useNimbusStore } from "../store";
 
-const NON_GRAPH_CONDITION_TYPES = ["schedule", "metric"] as const;
+/**
+ * The condition types the gateway's watcher engine can actually evaluate. `watcher.create` rejects
+ * anything else with `-32602`, so an entry here that the gateway does not know makes the dialog
+ * unusable, and a missing entry hides a working condition.
+ *
+ * MUST STAY IN SYNC with `packages/gateway/src/automation/watcher-condition-kinds.ts`, which is the
+ * source of truth. It cannot be imported: `packages/ui` reaches the gateway over IPC only and never
+ * imports gateway source (see the dependency rules in CLAUDE.md).
+ */
+const CONDITION_TYPES = ["alert_fired", "incident_opened", "deploy_failed"] as const;
+type ConditionType = (typeof CONDITION_TYPES)[number];
+
+/**
+ * `incident_opened` is the default because it is the only condition with a live indexing connector
+ * today: nothing indexes `item.type = 'alert'`, and `deploy_failed` needs CI-annotated deployments.
+ */
+const DEFAULT_CONDITION_TYPE: ConditionType = "incident_opened";
+
+/**
+ * The engine reads `condition_json.filter` and evaluates nothing when it is absent, so an empty
+ * `{}` would arm a watcher that can never fire. An empty `filter` means "any service".
+ */
+const DEFAULT_CONDITION_JSON = '{ "filter": {} }';
+
 const ACTION_TYPES = ["notify", "webhook", "workflow"] as const;
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const VALIDATE_DEBOUNCE_MS = 500;
@@ -138,8 +161,11 @@ interface CreateDialogProps {
 
 function CreateWatcherDialog({ onClose, onCreated }: Readonly<CreateDialogProps>) {
   const [name, setName] = useState("");
-  const [conditionType, setConditionType] = useState<"graph" | "schedule" | "metric">("graph");
-  const [conditionJson, setConditionJson] = useState("{}");
+  const [conditionType, setConditionType] = useState<ConditionType>(DEFAULT_CONDITION_TYPE);
+  const [conditionJson, setConditionJson] = useState(DEFAULT_CONDITION_JSON);
+  // Orthogonal to the condition type: the engine applies `graph_predicate_json` to whichever kind
+  // the watcher carries, so any of the three can be narrowed by a graph predicate.
+  const [useGraphPredicate, setUseGraphPredicate] = useState(false);
   const [graphFields, setGraphFields] = useState<GraphPredicateFields>({
     relation: "owned_by",
     targetType: "",
@@ -190,12 +216,10 @@ function CreateWatcherDialog({ onClose, onCreated }: Readonly<CreateDialogProps>
       const params: WatcherCreateParams = {
         name: name.trim(),
         conditionType,
-        conditionJson: conditionType === "graph" ? "{}" : conditionJson,
+        conditionJson,
         actionType,
         actionJson,
-        ...(conditionType === "graph"
-          ? { graphPredicateJson: buildGraphPredicateJson(graphFields) }
-          : {}),
+        ...(useGraphPredicate ? { graphPredicateJson: buildGraphPredicateJson(graphFields) } : {}),
       };
       await createIpcClient().watcherCreate(params);
       onCreated();
@@ -207,7 +231,7 @@ function CreateWatcherDialog({ onClose, onCreated }: Readonly<CreateDialogProps>
   }
 
   const graphSubmitDisabled =
-    conditionType === "graph" &&
+    useGraphPredicate &&
     (graphFields.targetType.trim() === "" || graphFields.targetId.trim() === "");
 
   return (
@@ -239,10 +263,9 @@ function CreateWatcherDialog({ onClose, onCreated }: Readonly<CreateDialogProps>
             aria-label="Condition type"
             className="border rounded px-2 py-1"
             value={conditionType}
-            onChange={(e) => setConditionType(e.target.value as "graph" | "schedule" | "metric")}
+            onChange={(e) => setConditionType(e.target.value as ConditionType)}
           >
-            <option value="graph">graph</option>
-            {NON_GRAPH_CONDITION_TYPES.map((t) => (
+            {CONDITION_TYPES.map((t) => (
               <option key={t} value={t}>
                 {t}
               </option>
@@ -250,23 +273,33 @@ function CreateWatcherDialog({ onClose, onCreated }: Readonly<CreateDialogProps>
           </select>
         </label>
 
-        {conditionType === "graph" ? (
+        <label className="flex flex-col gap-1 text-sm">
+          <span>Condition JSON</span>
+          <textarea
+            aria-label="Condition JSON"
+            className="border rounded px-2 py-1 font-mono text-xs"
+            rows={3}
+            value={conditionJson}
+            onChange={(e) => setConditionJson(e.target.value)}
+          />
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            aria-label="Narrow with a graph predicate"
+            checked={useGraphPredicate}
+            onChange={(e) => setUseGraphPredicate(e.target.checked)}
+          />
+          <span>Narrow with a graph predicate</span>
+        </label>
+
+        {useGraphPredicate && (
           <GraphConditionBuilder
             value={graphFields}
             onChange={setGraphFields}
             candidateRelations={candidateRelations}
           />
-        ) : (
-          <label className="flex flex-col gap-1 text-sm">
-            <span>Condition JSON</span>
-            <textarea
-              aria-label="Condition JSON"
-              className="border rounded px-2 py-1 font-mono text-xs"
-              rows={3}
-              value={conditionJson}
-              onChange={(e) => setConditionJson(e.target.value)}
-            />
-          </label>
         )}
 
         <label className="flex flex-col gap-1 text-sm">

--- a/packages/ui/test/pages/Watchers.condition-types.drift.test.ts
+++ b/packages/ui/test/pages/Watchers.condition-types.drift.test.ts
@@ -69,15 +69,15 @@ function extractGatewayConditionTypes(src: string): string[] {
 }
 
 function extractUiConditionTypes(src: string): string[] {
-  const arrayMatch = src.match(/const CONDITION_TYPES = \[([^\]]*)\]/);
-  if (arrayMatch === null) {
+  const arrayBody = src.match(/const CONDITION_TYPES = \[([^\]]*)\]/)?.[1];
+  if (arrayBody === undefined) {
     throw new Error(
       "Watchers condition-type drift guard could not find `const CONDITION_TYPES = [...]` in " +
         "Watchers.tsx — its shape changed and the guard's extraction regex no longer matches. " +
         "Update the regex in Watchers.condition-types.drift.test.ts, do not delete this test.",
     );
   }
-  return [...arrayMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1] as string);
+  return [...arrayBody.matchAll(/"([^"]+)"/g)].map((m) => m[1] as string);
 }
 
 describe("Watchers condition-type drift guard", () => {

--- a/packages/ui/test/pages/Watchers.condition-types.drift.test.ts
+++ b/packages/ui/test/pages/Watchers.condition-types.drift.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `packages/ui/src/pages/Watchers.tsx` duplicates the gateway's condition-type list rather than
+ * importing it: `packages/ui` may reach the Gateway over IPC only and must never import Gateway
+ * source. Nothing else detects the two lists drifting apart — a drift means the Create Watcher
+ * dialog offers a `conditionType` the gateway's `watcher.create` rejects with `-32602`, or hides
+ * one it would accept.
+ *
+ * This guard reads BOTH files as TEXT (not a source import — the dependency rule stays intact)
+ * and compares the `conditionType` literals declared in
+ * `packages/gateway/src/automation/watcher-condition-kinds.ts` against the `CONDITION_TYPES`
+ * array literal declared in `packages/ui/src/pages/Watchers.tsx`.
+ *
+ * Paths are resolved from the module's own directory, never `process.cwd()` — a CWD-relative
+ * read has previously gone ENOENT under a sharded CI runner and silently never run (see
+ * `audit:import-meta-dir` / `scripts/structure-audit/check-import-meta-dir.ts`, and the sibling
+ * guard `packages/gateway/src/embedding/embedding-body-source.guard.test.ts`, which use Bun's
+ * `import.meta.dir`). This package's tests run under vitest on Node, not Bun, so the Bun-only
+ * `import.meta.dir` is unavailable here; `import.meta.dirname` is Node's equivalent (Node
+ * >=20.11) and resolves to this file's own directory the same way — never the process CWD.
+ */
+
+const GATEWAY_CONDITION_KINDS_PATH = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "gateway",
+  "src",
+  "automation",
+  "watcher-condition-kinds.ts",
+);
+
+const UI_WATCHERS_PAGE_PATH = join(import.meta.dirname, "..", "..", "src", "pages", "Watchers.tsx");
+
+/**
+ * Reads `path` as text or fails loudly. A guard that cannot read its inputs must never silently
+ * skip or pass — that is worse than no guard at all, because it reports green while proving
+ * nothing.
+ */
+function readSourceOrFail(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Watchers condition-type drift guard could not read "${path}": ${String(err)}. This guard ` +
+        "compares packages/ui/src/pages/Watchers.tsx's CONDITION_TYPES against " +
+        "packages/gateway/src/automation/watcher-condition-kinds.ts's WATCHER_CONDITION_KINDS " +
+        "and cannot verify anything without both files. Fix the path (or restore the missing " +
+        "file) — do not delete or skip this test.",
+    );
+  }
+}
+
+function extractGatewayConditionTypes(src: string): string[] {
+  const matches = [...src.matchAll(/conditionType:\s*"([^"]+)"/g)];
+  if (matches.length === 0) {
+    throw new Error(
+      'Watchers condition-type drift guard found zero `conditionType: "..."` entries in ' +
+        "watcher-condition-kinds.ts — its shape changed and the guard's extraction regex no " +
+        "longer matches. Update the regex in Watchers.condition-types.drift.test.ts, do not " +
+        "delete this test.",
+    );
+  }
+  return matches.map((m) => m[1] as string);
+}
+
+function extractUiConditionTypes(src: string): string[] {
+  const arrayMatch = src.match(/const CONDITION_TYPES = \[([^\]]*)\]/);
+  if (arrayMatch === null) {
+    throw new Error(
+      "Watchers condition-type drift guard could not find `const CONDITION_TYPES = [...]` in " +
+        "Watchers.tsx — its shape changed and the guard's extraction regex no longer matches. " +
+        "Update the regex in Watchers.condition-types.drift.test.ts, do not delete this test.",
+    );
+  }
+  return [...arrayMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1] as string);
+}
+
+describe("Watchers condition-type drift guard", () => {
+  it("Watchers.tsx CONDITION_TYPES has exactly the gateway's WATCHER_CONDITION_KINDS conditionTypes", () => {
+    const gatewaySrc = readSourceOrFail(GATEWAY_CONDITION_KINDS_PATH);
+    const uiSrc = readSourceOrFail(UI_WATCHERS_PAGE_PATH);
+
+    const gatewayTypes = extractGatewayConditionTypes(gatewaySrc);
+    const uiTypes = extractUiConditionTypes(uiSrc);
+
+    // Compared as sets, not sequences: WATCHER_CONDITION_KINDS's order is the engine's own
+    // table order (not meaningful outside it), and CONDITION_TYPES's order is a UI presentation
+    // choice (dropdown option order) — neither file promises to match the other's ordering, only
+    // membership. Membership is what a rejected/hidden `conditionType` actually depends on.
+    const gatewaySorted = [...gatewayTypes].sort();
+    const uiSorted = [...uiTypes].sort();
+
+    if (JSON.stringify(uiSorted) !== JSON.stringify(gatewaySorted)) {
+      throw new Error(
+        `Watchers condition-type drift: packages/ui/src/pages/Watchers.tsx CONDITION_TYPES is ` +
+          `${JSON.stringify(uiTypes)} but packages/gateway/src/automation/watcher-condition-kinds.ts ` +
+          `WATCHER_CONDITION_KINDS conditionTypes are ${JSON.stringify(gatewayTypes)}. The Create ` +
+          "Watcher dialog would offer a condition watcher.create rejects, or hide one it accepts. " +
+          "Fix: update CONDITION_TYPES in Watchers.tsx to match WATCHER_CONDITION_KINDS in " +
+          "watcher-condition-kinds.ts (or fix whichever list is wrong).",
+      );
+    }
+
+    expect(uiSorted).toEqual(gatewaySorted);
+  });
+});

--- a/packages/ui/test/pages/Watchers.test.tsx
+++ b/packages/ui/test/pages/Watchers.test.tsx
@@ -40,7 +40,7 @@ const WATCHER_1 = {
   id: "w1",
   name: "PR opened",
   enabled: 1,
-  condition_type: "graph",
+  condition_type: "incident_opened",
   condition_json: "{}",
   action_type: "notify",
   action_json: "{}",
@@ -54,7 +54,7 @@ const WATCHER_2 = {
   id: "w2",
   name: "Daily digest",
   enabled: 0,
-  condition_type: "schedule",
+  condition_type: "deploy_failed",
   condition_json: "{}",
   action_type: "webhook",
   action_json: "{}",
@@ -178,18 +178,96 @@ describe("Watchers page — list", () => {
   });
 });
 
+/** The condition types the gateway engine can evaluate — see watcher-condition-kinds.ts. */
+const REAL_CONDITION_TYPES = ["alert_fired", "incident_opened", "deploy_failed"];
+
 async function openDialog() {
   stubWatcherList([]);
   renderPage();
   await waitFor(() => expect(callMock).toHaveBeenCalled());
   await userEvent.click(screen.getByRole("button", { name: /new watcher/i }));
   expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  expect(await screen.findByLabelText("Condition type")).toBeInTheDocument();
+}
+
+/** The graph predicate is orthogonal to the condition type — it lives behind its own checkbox. */
+async function enableGraphPredicate() {
+  await userEvent.click(screen.getByLabelText("Narrow with a graph predicate"));
   expect(await screen.findByLabelText("Graph relation")).toBeInTheDocument();
 }
 
-describe("Watchers page — graph condition builder", () => {
-  it("graph condition type shows relation dropdown with candidate relations", async () => {
+describe("Watchers page — condition type", () => {
+  it("offers exactly the condition types the gateway engine can evaluate", async () => {
     await openDialog();
+    const select = screen.getByLabelText("Condition type");
+    const values = Array.from(select.querySelectorAll("option")).map((o) => o.value);
+    expect(values).toEqual(REAL_CONDITION_TYPES);
+  });
+
+  it("does not offer the condition types watcher.create rejects with -32602", async () => {
+    await openDialog();
+    const select = screen.getByLabelText("Condition type");
+    const values = Array.from(select.querySelectorAll("option")).map((o) => o.value);
+    expect(values).not.toContain("graph");
+    expect(values).not.toContain("schedule");
+    expect(values).not.toContain("metric");
+  });
+
+  it.each(REAL_CONDITION_TYPES)(
+    "sends %s verbatim as conditionType, so watcher.create accepts it",
+    async (conditionType) => {
+      // The IPC client is a fake here and cannot catch a contract mismatch, so this asserts the
+      // EXACT value crossing the boundary against the gateway's condition-kind table.
+      watcherCreateMock.mockResolvedValue({ id: "w-new" });
+      await openDialog();
+
+      await userEvent.type(screen.getByLabelText("Watcher name"), `Watch ${conditionType}`);
+      await userEvent.selectOptions(screen.getByLabelText("Condition type"), conditionType);
+      await userEvent.click(screen.getByRole("button", { name: /create/i }));
+
+      expect(watcherCreateMock).toHaveBeenCalledTimes(1);
+      const params = watcherCreateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(params["conditionType"]).toBe(conditionType);
+      expect(REAL_CONDITION_TYPES).toContain(params["conditionType"]);
+    },
+  );
+
+  it("defaults conditionJson to a filter object the engine actually evaluates", async () => {
+    // The engine returns early when `condition_json.filter` is absent, so a bare `{}` would arm a
+    // watcher that can never fire.
+    watcherCreateMock.mockResolvedValue({ id: "w-new" });
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Watcher name"), "Default filter");
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    const params = watcherCreateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(JSON.parse(String(params["conditionJson"]))).toEqual({ filter: {} });
+  });
+
+  it("omits graphPredicateJson when the graph predicate is not enabled", async () => {
+    watcherCreateMock.mockResolvedValue({ id: "w-new" });
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Watcher name"), "No predicate");
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    const params = watcherCreateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params).not.toHaveProperty("graphPredicateJson");
+  });
+});
+
+describe("Watchers page — graph condition builder", () => {
+  it("the graph builder is hidden until the graph predicate is enabled", async () => {
+    await openDialog();
+    expect(screen.queryByLabelText("Graph relation")).not.toBeInTheDocument();
+    await enableGraphPredicate();
+    expect(screen.getByLabelText("Graph relation")).toBeInTheDocument();
+  });
+
+  it("graph predicate shows relation dropdown with candidate relations", async () => {
+    await openDialog();
+    await enableGraphPredicate();
     const select = screen.getByLabelText("Graph relation");
     expect(select).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "owned_by" })).toBeInTheDocument();
@@ -199,20 +277,22 @@ describe("Watchers page — graph condition builder", () => {
 
   it("shows target type and target ID inputs", async () => {
     await openDialog();
+    await enableGraphPredicate();
     expect(screen.getByLabelText("Target entity type")).toBeInTheDocument();
     expect(screen.getByLabelText("Target entity ID")).toBeInTheDocument();
   });
 
-  it("switching to non-graph condition type shows raw textarea", async () => {
+  it("the condition JSON textarea stays available alongside a graph predicate", async () => {
     await openDialog();
-    await userEvent.selectOptions(screen.getByLabelText("Condition type"), "schedule");
     expect(screen.getByLabelText("Condition JSON")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Graph relation")).not.toBeInTheDocument();
+    await enableGraphPredicate();
+    expect(screen.getByLabelText("Condition JSON")).toBeInTheDocument();
   });
 
   it("validation fires after debounce and shows match count", async () => {
     watcherValidateConditionMock.mockResolvedValue({ matchCount: 7 });
     await openDialog();
+    await enableGraphPredicate();
 
     await userEvent.type(screen.getByLabelText("Target entity type"), "person");
     await userEvent.type(screen.getByLabelText("Target entity ID"), "user-42");
@@ -238,6 +318,7 @@ describe("Watchers page — graph condition builder", () => {
   it("validation shows error message on failure", async () => {
     watcherValidateConditionMock.mockRejectedValue(new Error("invalid predicate"));
     await openDialog();
+    await enableGraphPredicate();
 
     await userEvent.type(screen.getByLabelText("Target entity type"), "repo");
     await userEvent.type(screen.getByLabelText("Target entity ID"), "my-repo");
@@ -251,11 +332,13 @@ describe("Watchers page — graph condition builder", () => {
     );
   });
 
-  it("watcherCreate is called with graphPredicateJson for graph condition type", async () => {
+  it("watcherCreate carries graphPredicateJson alongside a real condition type", async () => {
     watcherCreateMock.mockResolvedValue({ id: "w-new" });
     await openDialog();
 
     await userEvent.type(screen.getByLabelText("Watcher name"), "My Graph Watcher");
+    await userEvent.selectOptions(screen.getByLabelText("Condition type"), "deploy_failed");
+    await enableGraphPredicate();
     await userEvent.type(screen.getByLabelText("Target entity type"), "person");
     await userEvent.type(screen.getByLabelText("Target entity ID"), "user-99");
     await userEvent.click(screen.getByRole("button", { name: /create/i }));
@@ -263,8 +346,7 @@ describe("Watchers page — graph condition builder", () => {
     expect(watcherCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "My Graph Watcher",
-        conditionType: "graph",
-        conditionJson: "{}",
+        conditionType: "deploy_failed",
         graphPredicateJson: JSON.stringify({
           relation: "owned_by",
           target: { type: "person", externalId: "user-99" },
@@ -276,6 +358,7 @@ describe("Watchers page — graph condition builder", () => {
   it("Create button is disabled when graph fields are incomplete", async () => {
     await openDialog();
     await userEvent.type(screen.getByLabelText("Watcher name"), "Incomplete");
+    await enableGraphPredicate();
     expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Why

The watcher engine evaluated exactly one condition type, `alert_fired`, and that condition matched `item.type = 'alert'` — an item type **no connector in this repository indexes**. A user could create a watcher, arm it, and it would never fire, with nothing anywhere saying so. `watcher.create` compounded it by accepting any string as `conditionType`, so a watcher the engine could never evaluate was accepted silently.

This came out of planning `nimbus pre-mortem` PR B, which proposes watchers off the back of a brief. Proposing a watcher that cannot fire, and printing the command to arm it, would have shipped a claim the engine could not honour.

## What changed

- **`automation/watcher-condition-kinds.ts` (new)** — one table mapping each condition type to the `item.type` it observes plus an optional constant SQL predicate. Both the engine and `watcher.create` read it, so "which conditions can actually fire" has one answer.
- **`automation/watcher-engine.ts`** — `evaluateOneWatcher` builds its query from the table instead of hardcoding `alert_fired` / `type = 'alert'`. The service filter, the `since` window, the `LIMIT 5` and the graph-predicate block are untouched; `type = 'alert'` became a bound `type = ?`.
- **`ipc/automation-rpc.ts`** — `watcher.create` rejects a condition type absent from the table with `-32602`. Membership check only: no validation of `condition_json`, of service existence, or of whether anything matches today, because a watcher is a forward-looking subscription.
- **`ui/src/pages/Watchers.tsx`** — the Create Watcher dialog offered `graph` / `schedule` / `metric`, none of which the engine has ever been able to evaluate, so every watcher it created was already inert. It now offers the three real condition types, with the graph predicate as an orthogonal option rather than a fake fourth condition type, and its condition JSON default is `{ "filter": {} }` (a bare `{}` makes the engine return `null`).

| `condition_type` | Fires on | Coverage |
| --- | --- | --- |
| `alert_fired` | item of type `alert` | **cannot fire today** — nothing indexes `alert`. Pre-existing state, recorded rather than quietly fixed |
| `incident_opened` | item of type `incident` with `metadata.status = 'triggered'` | PagerDuty. Narrowed to `triggered` because the sync fetches all statuses and stamps `modified_at` from `updated_at`, so acknowledging or resolving would otherwise fire a condition named "opened" |
| `deploy_failed` | item of type `deployment` with `metadata.conclusion = 'failure'` | CI-annotated deploys only — Vercel records its outcome under `metadata.state`, Prefect indexes deployment *definitions* with no outcome |

## Two details worth the reviewer's attention

**`json_valid(metadata)` in the predicates is load-bearing, not defensive noise.** SQLite's `json_extract` *raises* `malformed JSON` on a non-JSON TEXT value — `NULL` is safe, but the empty string and plain text are not. The predicate runs inside a loop over every enabled watcher with nothing catching, so one bad row would abort evaluation for the whole machine. No current writer can produce such a row (both `item.metadata` writers stringify), so this guards a future one. A regression test force-corrupts a row and was verified to fail without the guard.

**The predicate is in SQL rather than a TypeScript filter after the query.** The query ends in `LIMIT 5`; post-filtering would let five successful deployments hide a failed sixth on a busy service.

## Coverage limits, documented in `docs/architecture.md`

Every limit below was verified against the connectors, not assumed:

- A watcher only sees items whose `modified_at` is newer than its `last_checked_at`, and that timestamp advances for *every* enabled watcher on *every* successful sync, regardless of service filter — so a late-indexed item can fall outside the window.
- `deploy_failed` reads `item.modified_at`, which `deployment/annotate.ts` binds from `started_at_ms` and overwrites on the finishing POST, so a long deploy can record its failure with a start-time stamp.
- `deploy_failed`'s `item.service` is the annotate provider slug (`github-actions`, `gitlab`, …), not a syncable service id, so a service-filtered watcher of that kind is only reachable via startup catch-up. Unfiltered watchers work normally.
- `incident_opened` never fires for an incident indexed without a status — the sync writes `null` when the API omits the field. Fail-closed, and stated rather than discovered later.

## Not in scope

Indexing `item.type = 'alert'` so `alert_fired` can fire; teaching `deploy_failed` about Vercel's `metadata.state`; reconciling the annotate provider and syncable-service vocabularies; and a `watcher.listConditionTypes` IPC read that would remove the UI's duplicated list (a drift test guards it instead).

## Testing

Gateway automation + `automation-rpc` suites and the UI `Watchers` suite all pass. Full `preflight` is green except `audit:coverage-floor`, which fails on this Windows machine for two files this branch does not touch (`platform/linux.ts`, `ipc/server/socket-listeners.ts`) — `exclusions.ts` documents `platform/linux.ts` as deliberately non-exempt because it is the *active* arm on a Linux runner, which is why that gate is CI-Linux-authoritative. This branch's own files measure 100.0/100.0, 95.4/94.8 and 92.9/81.6 (line/branch) against the 85/80 floor.

Groundwork for `nimbus pre-mortem` PR B2; design and plan documents for it are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watcher conditions for opened incidents and failed deployments.
  * Watcher creation now offers three supported condition types: alerts, incidents, and deployment failures.
  * Graph predicates are optional and can refine any supported condition.

* **Bug Fixes**
  * Unsupported watcher conditions are rejected before creation.
  * Improved handling of malformed deployment metadata.

* **Documentation**
  * Added architecture guidance, changelog updates, design reviews, and implementation plans for watcher conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->