### PR TITLE
fix(gateway): log why the process exits instead of dying silently

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,29 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-10 — Gateway lifecycle diagnostics: the silent-exit blind spot.** The gateway could end
+  without writing a single line: its only process-level hooks were `SIGTERM`/`SIGINT`, and the only
+  code that logged anything about termination was the `shutdown()` path those two signals reach.
+  On Windows neither signal is deliverable — `process.kill(pid, "SIGTERM")`, which is exactly what
+  `nimbus stop` issues, is `TerminateProcess(handle, 1)`: measured on Windows 11, the `SIGTERM`
+  handler does not run, an `exit` handler does not run either, and the process ends with code 1 and
+  no output. So a deliberate `nimbus stop` and an unexplained death left byte-identical evidence:
+  nothing. `platform/exit-diagnostics.ts` now arms on the first statement of `main()` and writes
+  pino-shaped records with `appendFileSync` (the daily logger is `pino.destination({ sync: false })`,
+  whose buffered final write is precisely the one an abrupt exit loses): `boot`, a `heartbeat`
+  carrying uptime/rss/heap/in-flight-syncs/embedding state, `before_exit` (the event-loop-drain
+  discriminator), `process_exit` with the code and a `drained` flag, and `uncaught_exception` /
+  `unhandled_rejection` with full stacks — the last two preserving exit code 1 rather than
+  swallowing the failure. Because no in-process handler can observe `TerminateProcess`, the
+  **absence** of a `process_exit` record is itself the diagnosis: the process was killed from
+  outside, and the last heartbeat bounds when. Heartbeat interval via `NIMBUS_HEARTBEAT_MS`
+  (default 60 s, `0` disables); it is `unref`'d so it cannot mask the drain it exists to detect.
+  Two silent-failure sites found alongside and fixed: the Windows named-pipe server's only `error`
+  listener called `reject()` on an already-resolved promise, so every post-listen pipe fault was a
+  no-op that still counted as a handler; and the embedding worker had no `onerror`, so a dying
+  worker (verified: an uncaught throw in a Bun `Worker` neither crashes the parent nor prints
+  anything) left semantic search reading as `warming` for the full 600 s init window instead of
+  `unavailable`.
 - **2026-08-10 — Watcher conditions: `incident_opened` + `deploy_failed`.** The watcher engine
   previously evaluated one condition type, `alert_fired`, which matches an item type no connector
   indexes; a watcher could be created and armed and still never fire. Both new conditions come from

--- a/packages/gateway/src/embedding/worker-bridge.test.ts
+++ b/packages/gateway/src/embedding/worker-bridge.test.ts
@@ -19,6 +19,7 @@ interface PostedMessage {
 
 interface FakeWorkerHandle {
   fire: (data: unknown, origin?: string) => void;
+  fireError: (init: { message: string; filename?: string; lineno?: number }) => void;
   posted: () => readonly PostedMessage[];
   terminated: () => boolean;
 }
@@ -28,6 +29,7 @@ const handles: FakeWorkerHandle[] = [];
 function installFakeWorker(opts: { throwOnConstruct?: boolean } = {}): void {
   class FakeWorker {
     public onmessage: ((ev: MessageEvent) => void) | null = null;
+    public onerror: ((ev: ErrorEvent) => void) | null = null;
     private readonly _posted: PostedMessage[] = [];
     private _terminated = false;
     constructor(_url: string) {
@@ -43,6 +45,13 @@ function installFakeWorker(opts: { throwOnConstruct?: boolean } = {}): void {
             data,
             origin: origin ?? "",
           } as MessageEvent);
+        },
+        fireError: (init): void => {
+          this.onerror?.({
+            message: init.message,
+            filename: init.filename ?? "",
+            lineno: init.lineno ?? 0,
+          } as ErrorEvent);
         },
         posted: (): readonly PostedMessage[] => this._posted,
         terminated: (): boolean => this._terminated,
@@ -106,6 +115,59 @@ describe("tryCreateEmbeddingWorkerBridge", () => {
       logger,
     );
     expect(bridge).toBeNull();
+  });
+
+  test("a worker error flips readiness from 'warming' to 'unavailable' with the reason", () => {
+    // Without an onerror handler a dying Bun worker is COMPLETELY silent — the parent neither
+    // crashes nor logs — so readiness would sit at 'warming' for the full 600 s init window and
+    // read as "still downloading the model" rather than "dead".
+    installFakeWorker();
+    const bridge = makeBridge();
+    try {
+      expect(bridge.getReadiness().state).toBe("warming");
+      currentHandle().fireError({ message: "onnxruntime failed to load" });
+      const r = bridge.getReadiness();
+      expect(r.state).toBe("unavailable");
+      expect(r.reason).toBe("onnxruntime failed to load");
+    } finally {
+      bridge.terminate();
+    }
+  });
+
+  test("a worker error settles the init gate instead of leaving it pending forever", async () => {
+    installFakeWorker();
+    const bridge = makeBridge();
+    try {
+      currentHandle().fireError({ message: "worker died" });
+      // embedQuery must stop throwing EmbeddingWarmingError once the worker is known dead.
+      await expect(bridge.embedQuery("hello")).resolves.toBeNull();
+    } finally {
+      bridge.terminate();
+    }
+  });
+
+  test("an empty worker error message still yields a usable reason", () => {
+    installFakeWorker();
+    const bridge = makeBridge();
+    try {
+      currentHandle().fireError({ message: "" });
+      expect(bridge.getReadiness().reason).toBe("embedding worker errored");
+    } finally {
+      bridge.terminate();
+    }
+  });
+
+  test("a worker error AFTER ready does not un-ready a working runtime", () => {
+    installFakeWorker();
+    const bridge = makeBridge();
+    try {
+      currentHandle().fire({ type: "ready" });
+      expect(bridge.getReadiness().state).toBe("ready");
+      currentHandle().fireError({ message: "late blip" });
+      expect(bridge.getReadiness().state).toBe("ready");
+    } finally {
+      bridge.terminate();
+    }
   });
 
   test("posts init message synchronously to the worker", () => {

--- a/packages/gateway/src/embedding/worker-bridge.ts
+++ b/packages/gateway/src/embedding/worker-bridge.ts
@@ -118,6 +118,19 @@ class EmbeddingWorkerBridge implements EmbeddingRuntime {
       this.handleMessage(ev.data);
     };
 
+    // Without this the worker dies COMPLETELY silently: an uncaught throw inside a Bun Worker
+    // neither crashes the parent nor prints anything, so semantic search would sit in `warming`
+    // until the 600 s init timeout and read as "still downloading the model" rather than "dead".
+    this.worker.onerror = (ev: ErrorEvent): void => {
+      const reason = ev.message === "" ? "embedding worker errored" : ev.message;
+      this.logger.warn(
+        { msg: "embedding_worker_error", filename: ev.filename, lineno: ev.lineno },
+        `embedding worker error: ${reason}`,
+      );
+      this.markUnavailable(reason);
+      this.settleGate(false, new Error(reason));
+    };
+
     this.worker.postMessage({
       type: "init",
       dbPath,

--- a/packages/gateway/src/gateway-main.ts
+++ b/packages/gateway/src/gateway-main.ts
@@ -8,6 +8,7 @@ import { makeEgressSink } from "./egress/egress-ledger.ts";
 import type { EmbeddingReadiness } from "./embedding/embedding-readiness.ts";
 import { createNimbusEngineAgent } from "./engine/agent.ts";
 import { runAsk } from "./engine/run-ask.ts";
+import { armGatewayLifecycleDiagnostics } from "./platform/exit-diagnostics.ts";
 import { removeGatewayStateFile, writeGatewayStateFile } from "./platform/gateway-state-file.ts";
 import { createPlatformServices } from "./platform/index.ts";
 import type { SandboxRunner } from "./platform/sandbox/sandbox-runner.ts";
@@ -38,8 +39,28 @@ function emitSandboxPostureBannerIfDegraded(runner: SandboxRunner): void {
 }
 
 export async function main(): Promise<void> {
+  // FIRST statement in main(), before any assembly work: from here on, every in-process exit —
+  // drain, process.exit(), uncaught error — leaves a record in the daily log. A death that leaves
+  // NO record was terminated from outside, which is itself the diagnosis. The scheduler does not
+  // exist yet, so the heartbeat's activity provider is resolved lazily through this box.
+  let syncActivity: (() => readonly string[]) | undefined;
+  let heartbeatExtras: (() => Readonly<Record<string, unknown>>) | undefined;
+  const lifecycle = armGatewayLifecycleDiagnostics(
+    GATEWAY_VERSION,
+    () => syncActivity?.() ?? [],
+    () => heartbeatExtras?.() ?? {},
+  );
+
   process.stdout.write("[gateway] initializing platform services\n");
   const platform = await createPlatformServices();
+  syncActivity = (): readonly string[] =>
+    platform.syncScheduler
+      .getStatus()
+      .filter((s) => s.status === "syncing")
+      .map((s) => s.serviceId);
+  heartbeatExtras = (): Readonly<Record<string, unknown>> => ({
+    embeddings: platform.embeddingReadiness().state,
+  });
   process.stdout.write("[gateway] platform services ready; wiring engine\n");
   const mcp = platform.connectorMesh;
   const dispatcherClient: McpToolListingClient = {
@@ -130,6 +151,7 @@ export async function main(): Promise<void> {
 
   const shutdown = async (signal: string): Promise<void> => {
     process.stdout.write(`[gateway] ${signal} — shutting down\n`);
+    lifecycle.stop();
     try {
       platform.disposeSidecars?.();
     } catch {

--- a/packages/gateway/src/ipc/server/server.ts
+++ b/packages/gateway/src/ipc/server/server.ts
@@ -70,6 +70,7 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
   let bunListener: ReturnType<typeof Bun.listen<BunSessionData>> | undefined;
   let netServer: net.Server | undefined;
   let winSockets: Set<net.Socket> = new Set();
+  let markExpectedClose: (() => void) | undefined;
 
   function broadcastNotification(method: string, params: Record<string, unknown>): void {
     for (const session of sessions.values()) {
@@ -219,9 +220,25 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
     },
     async start(): Promise<void> {
       if (platform() === "win32") {
-        const handle = await startWin32NetServer(options.listenPath, attachSession);
+        const handle = await startWin32NetServer(options.listenPath, attachSession, (fault) => {
+          // stderr is redirected into the daily gateway log by `spawnGateway`, so this reaches the
+          // same file the reader is already looking at. Pino's shape keeps existing greps working.
+          process.stderr.write(
+            `${JSON.stringify({
+              level: 50,
+              time: Date.now(),
+              pid: process.pid,
+              name: "ipc-pipe",
+              event: `pipe_server_${fault.event}`,
+              listenPath: options.listenPath,
+              err: fault.error === undefined ? null : String(fault.error.stack ?? fault.error),
+              msg: `IPC named-pipe server ${fault.event} after listen — clients will see ENOENT`,
+            })}\n`,
+          );
+        });
         netServer = handle.netServer;
         winSockets = handle.winSockets;
+        markExpectedClose = handle.markExpectedClose;
         return;
       }
 
@@ -235,6 +252,8 @@ export function createIpcServer(options: CreateIpcServerOptions): IPCServer {
       if (netServer !== undefined) {
         const s = netServer;
         netServer = undefined;
+        markExpectedClose?.();
+        markExpectedClose = undefined;
         for (const sock of winSockets) {
           sock.destroy();
         }

--- a/packages/gateway/src/ipc/server/socket-listeners.test.ts
+++ b/packages/gateway/src/ipc/server/socket-listeners.test.ts
@@ -225,6 +225,81 @@ describe("startWin32NetServer (cross-platform via unix socket on POSIX)", () => 
   );
 });
 
+describe("startWin32NetServer post-listen faults", () => {
+  const paths: string[] = [];
+  let tmpDir: string | undefined;
+
+  // Runs on EVERY platform: the win32 path is the one that regressed, so it must not be skipped
+  // on the only OS where it is the production code path.
+  function listenPath(): string {
+    if (platform() === "win32") {
+      const p = `\\\\.\\pipe\\nimbus-fault-${crypto.randomUUID()}`;
+      paths.push(p);
+      return p;
+    }
+    tmpDir ??= mkdtempSync(join(tmpdir(), "nimbus-fault-"));
+    return join(tmpDir, `${crypto.randomUUID()}.sock`);
+  }
+
+  afterEach(() => {
+    if (tmpDir !== undefined) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+      tmpDir = undefined;
+    }
+  });
+
+  const attach = (): ClientSession => makeStubSession(makeStubState(), () => {});
+
+  test("an 'error' emitted AFTER listen reaches onFault instead of being swallowed", async () => {
+    // Regression: the startup listener used to stay attached, so every later error was a call to
+    // an already-resolved reject() — a no-op that still registered as an 'error' handler.
+    const faults: Array<{ event: string; message?: string }> = [];
+    const handle = await startWin32NetServer(listenPath(), attach, (f) => {
+      faults.push({
+        event: f.event,
+        ...(f.error === undefined ? {} : { message: f.error.message }),
+      });
+    });
+    try {
+      handle.netServer.emit("error", new Error("pipe went away"));
+      expect(faults).toEqual([{ event: "error", message: "pipe went away" }]);
+    } finally {
+      handle.markExpectedClose();
+      await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
+    }
+  });
+
+  test("an unrequested 'close' is reported as a fault", async () => {
+    const faults: string[] = [];
+    const handle = await startWin32NetServer(listenPath(), attach, (f) => faults.push(f.event));
+    await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
+    expect(faults).toEqual(["close"]);
+  });
+
+  test("markExpectedClose() suppresses the fault for a deliberate stop()", async () => {
+    const faults: string[] = [];
+    const handle = await startWin32NetServer(listenPath(), attach, (f) => faults.push(f.event));
+    handle.markExpectedClose();
+    await new Promise<void>((resolve) => handle.netServer.close(() => resolve()));
+    expect(faults).toEqual([]);
+  });
+
+  test("a bind failure still rejects start() (the startup listener is not lost)", async () => {
+    const p = listenPath();
+    const first = await startWin32NetServer(p, attach);
+    try {
+      await expect(startWin32NetServer(p, attach)).rejects.toThrow();
+    } finally {
+      first.markExpectedClose();
+      await new Promise<void>((resolve) => first.netServer.close(() => resolve()));
+    }
+  });
+});
+
 describe("startBunUnixListener (POSIX-only)", () => {
   let tmpDir: string;
   let socketPath: string;

--- a/packages/gateway/src/ipc/server/socket-listeners.ts
+++ b/packages/gateway/src/ipc/server/socket-listeners.ts
@@ -29,6 +29,8 @@ export type AttachSessionFn = (write: SessionWrite) => ClientSession;
 export type Win32ListenerHandle = {
   netServer: net.Server;
   winSockets: Set<net.Socket>;
+  /** Call before a deliberate `close()` so the resulting 'close' is not reported as a fault. */
+  markExpectedClose: () => void;
 };
 
 function attachWin32Socket(
@@ -56,21 +58,51 @@ function attachWin32Socket(
   });
 }
 
+/** A named-pipe server fault that happens AFTER the listen succeeded. */
+export type Win32ServerFault = { readonly event: "error" | "close"; readonly error?: Error };
+
 export async function startWin32NetServer(
   listenPath: string,
   attachSession: AttachSessionFn,
+  onFault?: (fault: Win32ServerFault) => void,
 ): Promise<Win32ListenerHandle> {
   const winSockets = new Set<net.Socket>();
   const netServer = await new Promise<net.Server>((resolve, reject) => {
     const server = net.createServer((sock) => attachWin32Socket(attachSession, winSockets, sock));
+    const emitter = server as unknown as EventEmitter;
+    // Scoped to the bind: this listener exists only to fail `start()`. Leaving it attached after
+    // the promise settles made every LATER pipe error a call to an already-resolved `reject` —
+    // a silent no-op that still counted as an 'error' handler, so the fault vanished entirely.
+    const onStartupError = (err: Error): void => {
+      reject(err);
+    };
+    emitter.once("error", onStartupError);
     server.listen(listenPath, () => {
+      emitter.off("error", onStartupError);
       resolve(server);
     });
-    (server as unknown as EventEmitter).on("error", (err: Error) => {
-      reject(err);
-    });
   });
-  return { netServer, winSockets };
+
+  // A live pipe server is what the gateway's whole IPC surface rests on; if it errors or closes
+  // out from under us, clients see ENOENT with nothing in the log to say why.
+  let expectedClose = false;
+  const emitter = netServer as unknown as EventEmitter;
+  emitter.on("error", (err: Error) => {
+    onFault?.({ event: "error", error: err });
+  });
+  emitter.on("close", () => {
+    // `stop()` closes the server on purpose; only an unrequested close is a fault.
+    if (!expectedClose) {
+      onFault?.({ event: "close" });
+    }
+  });
+  return {
+    netServer,
+    winSockets,
+    markExpectedClose: (): void => {
+      expectedClose = true;
+    },
+  };
 }
 
 export function startBunUnixListener(

--- a/packages/gateway/src/platform/exit-diagnostics.integration.test.ts
+++ b/packages/gateway/src/platform/exit-diagnostics.integration.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * The unit tests drive a fake `process`. These drive the REAL one, in a real subprocess, because
+ * the property that matters is not "the handler was registered" but "the record is on disk after
+ * the process is gone" — which only a real exit can demonstrate.
+ */
+
+const MODULE_URL = pathToFileURL(join(import.meta.dir, "exit-diagnostics.ts")).href;
+
+type Run = { code: number; records: Array<Record<string, unknown>>; stderr: string };
+
+async function runFixture(body: string, env: Record<string, string> = {}): Promise<Run> {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-lifecycle-e2e-"));
+  const logPath = join(dir, "gateway-daily.log");
+  const script = join(dir, "fixture.ts");
+  writeFileSync(
+    script,
+    `import { armGatewayLifecycleDiagnostics } from ${JSON.stringify(MODULE_URL)};\n${body}\n`,
+    "utf8",
+  );
+  try {
+    const proc = Bun.spawn(["bun", "run", script], {
+      env: { ...process.env, NIMBUS_GATEWAY_LOG_PATH: logPath, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    let raw = "";
+    try {
+      raw = readFileSync(logPath, "utf8");
+    } catch {
+      raw = "";
+    }
+    const records = raw
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    return { code, records, stderr };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("gateway lifecycle diagnostics against the real process", () => {
+  test("an event-loop drain — the silent exit-0 mode — is recorded on disk", async () => {
+    // This is the shape of the reported failure: no error, no signal, no shutdown path. Before
+    // this module it produced a log that simply stopped mid-line.
+    const run = await runFixture(`
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      setTimeout(() => {}, 10);
+    `);
+    expect(run.code).toBe(0);
+    const events = run.records.map((r) => r["event"]);
+    expect(events).toContain("boot");
+    expect(events).toContain("before_exit");
+    expect(events).toContain("process_exit");
+    const exit = run.records.find((r) => r["event"] === "process_exit");
+    expect(exit?.["code"]).toBe(0);
+    expect(exit?.["drained"]).toBe(true);
+  }, 30_000);
+
+  test("an explicit process.exit is recorded and is NOT mislabelled as a drain", async () => {
+    const run = await runFixture(`
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      process.exit(7);
+    `);
+    expect(run.code).toBe(7);
+    const exit = run.records.find((r) => r["event"] === "process_exit");
+    expect(exit?.["code"]).toBe(7);
+    expect(exit?.["drained"]).toBe(false);
+  }, 30_000);
+
+  test("an uncaught exception lands in the log with its stack, and still exits 1", async () => {
+    const run = await runFixture(`
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      setTimeout(() => { throw new Error("BOOM-e2e"); }, 5);
+      setInterval(() => {}, 60000);
+    `);
+    expect(run.code).toBe(1);
+    const rec = run.records.find((r) => r["event"] === "uncaught_exception");
+    expect(rec?.["level"]).toBe(60);
+    expect(String(rec?.["stack"])).toContain("BOOM-e2e");
+  }, 30_000);
+
+  test("an unhandled rejection lands in the log, and still exits 1", async () => {
+    const run = await runFixture(`
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      setTimeout(() => { void Promise.reject(new Error("REJECT-e2e")); }, 5);
+      setInterval(() => {}, 60000);
+    `);
+    expect(run.code).toBe(1);
+    const rec = run.records.find((r) => r["event"] === "unhandled_rejection");
+    expect(rec?.["level"]).toBe(60);
+    expect(String(rec?.["reason"])).toContain("REJECT-e2e");
+  }, 30_000);
+
+  test("the heartbeat does not by itself keep an otherwise-idle process alive", async () => {
+    // A ref'd heartbeat would hang here forever instead of draining.
+    const run = await runFixture(
+      `
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      setTimeout(() => {}, 10);
+    `,
+      { NIMBUS_HEARTBEAT_MS: "50" },
+    );
+    expect(run.code).toBe(0);
+    expect(run.records.some((r) => r["event"] === "before_exit")).toBe(true);
+  }, 30_000);
+
+  test("a heartbeat is written while the process is alive, carrying rss", async () => {
+    const run = await runFixture(
+      `
+      armGatewayLifecycleDiagnostics("test-version", () => [], () => ({}));
+      setTimeout(() => {}, 350);
+    `,
+      { NIMBUS_HEARTBEAT_MS: "60" },
+    );
+    const hb = run.records.filter((r) => r["event"] === "heartbeat");
+    expect(hb.length).toBeGreaterThanOrEqual(1);
+    expect(typeof hb[0]?.["rssMb"]).toBe("number");
+  }, 30_000);
+});

--- a/packages/gateway/src/platform/exit-diagnostics.test.ts
+++ b/packages/gateway/src/platform/exit-diagnostics.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { processEnvDelete, processEnvSet } from "./env-access.ts";
+import {
+  createLifecycleWriter,
+  DEFAULT_HEARTBEAT_MS,
+  formatLifecycleLine,
+  installGatewayLifecycleDiagnostics,
+  LIFECYCLE_LOGGER_NAME,
+  type ProcessLifecycleHost,
+  resolveHeartbeatMs,
+  resolveLifecycleLogPath,
+  type TimerHandle,
+} from "./exit-diagnostics.ts";
+
+type Listener = (...args: never[]) => void;
+
+/** A `process` stand-in that records handler registrations and exit calls. */
+function makeHost(): {
+  host: ProcessLifecycleHost;
+  listeners: Map<string, Listener[]>;
+  exits: number[];
+  emit: (event: string, ...args: unknown[]) => void;
+} {
+  const listeners = new Map<string, Listener[]>();
+  const exits: number[] = [];
+  const host: ProcessLifecycleHost = {
+    pid: 4242,
+    on(event: string, listener: Listener): void {
+      const cur = listeners.get(event) ?? [];
+      cur.push(listener);
+      listeners.set(event, cur);
+    },
+    memoryUsage() {
+      return { rss: 100 * 1024 * 1024, heapUsed: 40 * 1024 * 1024, external: 5 * 1024 * 1024 };
+    },
+    exit(code: number): never {
+      exits.push(code);
+      // Deliberately does NOT throw: the real `process.exit` never returns, but a fake that
+      // threw would mask whether the handler wrote its record BEFORE asking to exit.
+      return undefined as never;
+    },
+  };
+  const emit = (event: string, ...args: unknown[]): void => {
+    for (const l of listeners.get(event) ?? []) {
+      (l as (...a: unknown[]) => void)(...args);
+    }
+  };
+  return { host, listeners, exits, emit };
+}
+
+type Harness = ReturnType<typeof makeHost> & {
+  lines: string[];
+  records: () => Array<Record<string, unknown>>;
+  timers: Array<{ ms: number; fn: () => void; unrefCalls: number; cleared: boolean }>;
+  stop: () => void;
+};
+
+function install(opts?: {
+  heartbeatMs?: number;
+  activity?: () => readonly string[];
+  extras?: () => Readonly<Record<string, unknown>>;
+}): Harness {
+  const h = makeHost();
+  const lines: string[] = [];
+  const timers: Harness["timers"] = [];
+  const handles = new Map<TimerHandle, Harness["timers"][number]>();
+  const handle = installGatewayLifecycleDiagnostics({
+    host: h.host,
+    write: (line) => lines.push(line),
+    hostname: "testbox",
+    version: "9.9.9",
+    now: () => 1_700_000_000_000,
+    heartbeatMs: opts?.heartbeatMs ?? 60_000,
+    ...(opts?.activity === undefined ? {} : { activity: opts.activity }),
+    ...(opts?.extras === undefined ? {} : { extras: opts.extras }),
+    setIntervalFn: (fn: () => void, ms: number): TimerHandle => {
+      const rec = { ms, fn, unrefCalls: 0, cleared: false };
+      timers.push(rec);
+      const handle: TimerHandle = {
+        unref(): void {
+          rec.unrefCalls += 1;
+        },
+      };
+      handles.set(handle, rec);
+      return handle;
+    },
+    // Resolved by handle identity, so `stop()` clearing the WRONG timer would fail the test.
+    clearIntervalFn: (t: TimerHandle): void => {
+      const rec = handles.get(t);
+      if (rec !== undefined) {
+        rec.cleared = true;
+      }
+    },
+  });
+  return {
+    ...h,
+    lines,
+    timers,
+    stop: handle.stop,
+    records: () => lines.map((l) => JSON.parse(l) as Record<string, unknown>),
+  };
+}
+
+describe("formatLifecycleLine", () => {
+  test("emits one pino-shaped JSON line so existing log greps still match", () => {
+    const line = formatLifecycleLine(
+      { pid: 7, hostname: "box", now: () => 1234 },
+      60,
+      "process_exit",
+      "gateway process exiting",
+      { code: 0 },
+    );
+    expect(line.endsWith("\n")).toBe(true);
+    expect(line.indexOf("\n")).toBe(line.length - 1);
+    const rec = JSON.parse(line) as Record<string, unknown>;
+    expect(rec).toMatchObject({
+      level: 60,
+      time: 1234,
+      pid: 7,
+      hostname: "box",
+      name: LIFECYCLE_LOGGER_NAME,
+      event: "process_exit",
+      code: 0,
+      msg: "gateway process exiting",
+    });
+  });
+
+  test("a multi-line value stays on one line (JSON-escaped), so the log stays parseable", () => {
+    const line = formatLifecycleLine(
+      { pid: 7, hostname: "box", now: () => 1 },
+      60,
+      "uncaught_exception",
+      "boom",
+      { stack: "Error: x\n  at a\n  at b" },
+    );
+    expect(line.indexOf("\n")).toBe(line.length - 1);
+    expect((JSON.parse(line) as { stack: string }).stack).toContain("\n  at a");
+  });
+});
+
+describe("installGatewayLifecycleDiagnostics — exit paths", () => {
+  test("writes a boot record naming the pid and version", () => {
+    const h = install();
+    const boot = h.records()[0];
+    expect(boot).toMatchObject({ event: "boot", pid: 4242, version: "9.9.9" });
+  });
+
+  test("process 'exit' writes a record carrying the exit code", () => {
+    const h = install();
+    h.emit("exit", 0);
+    const rec = h.records().find((r) => r["event"] === "process_exit");
+    expect(rec).toBeDefined();
+    expect(rec?.["code"]).toBe(0);
+  });
+
+  test("'beforeExit' is recorded and marks the later exit as an event-loop drain", () => {
+    const h = install();
+    h.emit("beforeExit", 0);
+    h.emit("exit", 0);
+    const before = h.records().find((r) => r["event"] === "before_exit");
+    expect(before).toBeDefined();
+    // The discriminator: drained loop vs. an explicit process.exit().
+    expect(h.records().find((r) => r["event"] === "process_exit")?.["drained"]).toBe(true);
+  });
+
+  test("an exit with no preceding 'beforeExit' is NOT reported as a drain", () => {
+    const h = install();
+    h.emit("exit", 1);
+    expect(h.records().find((r) => r["event"] === "process_exit")?.["drained"]).toBe(false);
+  });
+
+  test("uncaughtException is written at fatal level with the stack, then exits 1", () => {
+    const h = install();
+    h.emit("uncaughtException", new Error("kaboom"), "uncaughtException");
+    const rec = h.records().find((r) => r["event"] === "uncaught_exception");
+    expect(rec?.["level"]).toBe(60);
+    expect(String(rec?.["stack"])).toContain("kaboom");
+    expect(h.exits).toEqual([1]);
+  });
+
+  test("unhandledRejection is written at fatal level, then exits 1", () => {
+    const h = install();
+    h.emit("unhandledRejection", new Error("nope"));
+    const rec = h.records().find((r) => r["event"] === "unhandled_rejection");
+    expect(rec?.["level"]).toBe(60);
+    expect(String(rec?.["reason"])).toContain("nope");
+    expect(h.exits).toEqual([1]);
+  });
+
+  test("a non-Error rejection reason is still recorded rather than dropped", () => {
+    const h = install();
+    h.emit("unhandledRejection", "plain string reason");
+    expect(
+      String(h.records().find((r) => r["event"] === "unhandled_rejection")?.["reason"]),
+    ).toContain("plain string reason");
+  });
+
+  test("a non-numeric exit code is recorded as null rather than a bogus number", () => {
+    // Bun/Node pass the code positionally; a future runtime that omits it must not produce
+    // `"code": undefined` (dropped by JSON.stringify) and silently lose the field.
+    const h = install();
+    h.emit("beforeExit");
+    h.emit("exit");
+    expect(h.records().find((r) => r["event"] === "before_exit")?.["code"]).toBeNull();
+    expect(h.records().find((r) => r["event"] === "process_exit")?.["code"]).toBeNull();
+  });
+
+  test("a missing uncaughtException origin is recorded as null", () => {
+    const h = install();
+    h.emit("uncaughtException", new Error("no-origin"));
+    expect(h.records().find((r) => r["event"] === "uncaught_exception")?.["origin"]).toBeNull();
+  });
+
+  test("an Error with no stack still records its name and message", () => {
+    const h = install();
+    const err = new Error("stackless");
+    Reflect.deleteProperty(err, "stack");
+    h.emit("uncaughtException", err);
+    const rec = h.records().find((r) => r["event"] === "uncaught_exception");
+    expect(rec?.["reason"]).toBe("Error: stackless");
+    expect(rec?.["stack"]).toBeUndefined();
+  });
+
+  test("registers exactly one listener per lifecycle event", () => {
+    const h = install();
+    for (const ev of ["exit", "beforeExit", "uncaughtException", "unhandledRejection"]) {
+      expect(h.listeners.get(ev)?.length).toBe(1);
+    }
+  });
+});
+
+describe("installGatewayLifecycleDiagnostics — heartbeat", () => {
+  test("the heartbeat timer is unref'd so it cannot itself keep the loop alive", () => {
+    // Load-bearing: a ref'd heartbeat would prevent the very event-loop drain the
+    // 'beforeExit' record exists to detect, turning a silent exit into a silent hang.
+    const h = install();
+    expect(h.timers).toHaveLength(1);
+    expect(h.timers[0]?.unrefCalls).toBe(1);
+  });
+
+  test("a heartbeat records uptime, rss and the in-flight sync services", () => {
+    const h = install({ activity: () => ["blame", "filesystem"] });
+    h.timers[0]?.fn();
+    const hb = h.records().find((r) => r["event"] === "heartbeat");
+    expect(hb).toBeDefined();
+    expect(hb?.["rssMb"]).toBe(100);
+    expect(hb?.["syncing"]).toEqual(["blame", "filesystem"]);
+  });
+
+  test("extras are merged into the heartbeat (embedding runtime state)", () => {
+    const h = install({ extras: () => ({ embeddings: "warming" }) });
+    h.timers[0]?.fn();
+    expect(h.records().find((r) => r["event"] === "heartbeat")?.["embeddings"]).toBe("warming");
+  });
+
+  test("an extras provider that throws does not break the heartbeat", () => {
+    const h = install({
+      extras: () => {
+        throw new Error("embedding runtime gone");
+      },
+    });
+    expect(() => h.timers[0]?.fn()).not.toThrow();
+    expect(h.records().find((r) => r["event"] === "heartbeat")).toBeDefined();
+  });
+
+  test("an activity provider that throws does not break the heartbeat", () => {
+    const h = install({
+      activity: () => {
+        throw new Error("scheduler gone");
+      },
+    });
+    expect(() => h.timers[0]?.fn()).not.toThrow();
+    expect(h.records().find((r) => r["event"] === "heartbeat")).toBeDefined();
+  });
+
+  test("heartbeatMs <= 0 disables the heartbeat entirely", () => {
+    const h = install({ heartbeatMs: 0 });
+    expect(h.timers).toHaveLength(0);
+  });
+
+  test("stop() clears the heartbeat timer", () => {
+    const h = install();
+    h.stop();
+    expect(h.timers[0]?.cleared).toBe(true);
+  });
+});
+
+describe("resolveLifecycleLogPath", () => {
+  const KEY = "NIMBUS_GATEWAY_LOG_PATH";
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      processEnvDelete(KEY);
+    } else {
+      processEnvSet(KEY, original);
+    }
+  });
+
+  test("prefers NIMBUS_GATEWAY_LOG_PATH — the exact file the CLI wrote the spawn banner to", () => {
+    const p = join(tmpdir(), "explicit-gateway.log");
+    processEnvSet(KEY, p);
+    expect(resolveLifecycleLogPath()).toBe(p);
+  });
+
+  test("falls back to the platform daily log when the env var is empty", () => {
+    processEnvSet(KEY, "");
+    const resolved = resolveLifecycleLogPath();
+    expect(resolved).not.toBe("");
+    expect(resolved).toContain("gateway-");
+  });
+
+  test("falls back to the platform daily log when the env var is unset", () => {
+    processEnvDelete(KEY);
+    expect(resolveLifecycleLogPath()).toContain("gateway-");
+  });
+});
+
+describe("resolveHeartbeatMs", () => {
+  const KEY = "NIMBUS_HEARTBEAT_MS";
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      processEnvDelete(KEY);
+    } else {
+      processEnvSet(KEY, original);
+    }
+  });
+
+  test("defaults when unset", () => {
+    processEnvDelete(KEY);
+    expect(resolveHeartbeatMs()).toBe(DEFAULT_HEARTBEAT_MS);
+  });
+
+  test("defaults when empty", () => {
+    processEnvSet(KEY, "");
+    expect(resolveHeartbeatMs()).toBe(DEFAULT_HEARTBEAT_MS);
+  });
+
+  test("defaults on a non-numeric value rather than disabling the heartbeat", () => {
+    processEnvSet(KEY, "not-a-number");
+    expect(resolveHeartbeatMs()).toBe(DEFAULT_HEARTBEAT_MS);
+  });
+
+  test("honours an explicit interval", () => {
+    processEnvSet(KEY, "5000");
+    expect(resolveHeartbeatMs()).toBe(5000);
+  });
+
+  test("honours 0 as an explicit opt-out", () => {
+    processEnvSet(KEY, "0");
+    expect(resolveHeartbeatMs()).toBe(0);
+  });
+});
+
+describe("createLifecycleWriter", () => {
+  test("appends synchronously so the final record survives an abrupt exit", () => {
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-lifecycle-"));
+    try {
+      const p = join(dir, "gateway.log");
+      const write = createLifecycleWriter(p);
+      write('{"a":1}\n');
+      write('{"a":2}\n');
+      // Read immediately, with no flush/tick in between — proves the write is synchronous.
+      expect(readFileSync(p, "utf8")).toBe('{"a":1}\n{"a":2}\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a failing write is swallowed — diagnostics must never take the gateway down", () => {
+    const write = createLifecycleWriter(join(tmpdir(), "no-such-dir-nimbus-xyz", "a.log"));
+    expect(() => write("{}\n")).not.toThrow();
+  });
+});

--- a/packages/gateway/src/platform/exit-diagnostics.ts
+++ b/packages/gateway/src/platform/exit-diagnostics.ts
@@ -1,0 +1,282 @@
+import { appendFileSync } from "node:fs";
+import { hostname as osHostname } from "node:os";
+
+import { processEnvGet } from "./env-access.ts";
+import { platformDailyLogPath } from "./gateway-log-file.ts";
+
+/**
+ * Why this module exists
+ * ----------------------
+ * Before it, the gateway's ONLY process-level hooks were SIGTERM and SIGINT, and the only code
+ * that logged anything about termination was the `shutdown()` path those two signals reach. On
+ * Windows neither signal is deliverable to the detached, console-less gateway that `nimbus start`
+ * spawns, so in practice NOTHING was ever logged about why the process ended — the daily log just
+ * stopped mid-line and the next line was a fresh spawn banner.
+ *
+ * Every record here is written with `appendFileSync`. The daily pino logger uses
+ * `pino.destination({ sync: false })`, whose buffered final write is exactly the one lost when a
+ * process dies abruptly — i.e. precisely the record that matters. Diagnostics must not share that
+ * fate, so they bypass pino and write straight to the same file, in pino's own line shape.
+ */
+
+export const LIFECYCLE_LOGGER_NAME = "gateway-lifecycle";
+
+export type LifecycleEvent =
+  | "boot"
+  | "heartbeat"
+  | "before_exit"
+  | "process_exit"
+  | "uncaught_exception"
+  | "unhandled_rejection";
+
+export type LifecycleWriter = (line: string) => void;
+
+export type LifecycleContext = {
+  readonly pid: number;
+  readonly hostname: string;
+  readonly now: () => number;
+};
+
+/**
+ * One pino-shaped JSON line. Keeping pino's field names (`level`/`time`/`pid`/`hostname`/`msg`)
+ * means the greps already used against this log — `'"level":(50|60)'` and friends — match these
+ * records too, instead of needing a second, differently-shaped thing to search for.
+ */
+export function formatLifecycleLine(
+  ctx: LifecycleContext,
+  level: number,
+  event: LifecycleEvent,
+  msg: string,
+  extra?: Readonly<Record<string, unknown>>,
+): string {
+  const rec: Record<string, unknown> = {
+    level,
+    time: ctx.now(),
+    pid: ctx.pid,
+    hostname: ctx.hostname,
+    name: LIFECYCLE_LOGGER_NAME,
+    event,
+    ...extra,
+    msg,
+  };
+  // JSON.stringify escapes embedded newlines, so a stack trace stays on one line.
+  return `${JSON.stringify(rec)}\n`;
+}
+
+/** A synchronous appender. Never throws: a diagnostics failure must not end the gateway. */
+export function createLifecycleWriter(logPath: string): LifecycleWriter {
+  return (line: string): void => {
+    try {
+      appendFileSync(logPath, line, "utf8");
+    } catch {
+      /* best-effort — a log we cannot write is not a reason to die */
+    }
+  };
+}
+
+/**
+ * The daily log the CLI is already appending its spawn banner to. `NIMBUS_GATEWAY_LOG_PATH` is set
+ * by `spawnGateway()` and is authoritative when present, so the lifecycle records land in the exact
+ * file the banner did; otherwise fall back to the platform's own daily-log path.
+ */
+export function resolveLifecycleLogPath(): string | null {
+  const fromEnv = processEnvGet("NIMBUS_GATEWAY_LOG_PATH");
+  if (fromEnv !== undefined && fromEnv !== "") {
+    return fromEnv;
+  }
+  return platformDailyLogPath();
+}
+
+export type ProcessLifecycleHost = {
+  readonly pid: number;
+  on(event: string, listener: (...args: never[]) => void): unknown;
+  memoryUsage(): { rss: number; heapUsed: number; external: number };
+  exit(code: number): never;
+};
+
+export type TimerHandle = { unref(): void };
+export type SetIntervalFn = (fn: () => void, ms: number) => TimerHandle;
+export type ClearIntervalFn = (handle: TimerHandle) => void;
+
+export type GatewayLifecycleDiagnosticsOptions = {
+  readonly host: ProcessLifecycleHost;
+  readonly write: LifecycleWriter;
+  readonly hostname: string;
+  readonly version: string;
+  readonly now: () => number;
+  /** `<= 0` disables the heartbeat. */
+  readonly heartbeatMs: number;
+  readonly setIntervalFn: SetIntervalFn;
+  readonly clearIntervalFn: ClearIntervalFn;
+  /** Service ids currently mid-sync, for correlating a death with sync activity. */
+  readonly activity?: () => readonly string[];
+  /**
+   * Extra per-heartbeat fields. Carries the embedding runtime's state: a native crash inside the
+   * embedding worker thread takes the whole process down with no JS handler able to run, so the
+   * last heartbeat before the gap is the only place that can say what it was doing.
+   */
+  readonly extras?: () => Readonly<Record<string, unknown>>;
+};
+
+const MB = 1024 * 1024;
+
+function toMb(bytes: number): number {
+  return Math.round(bytes / MB);
+}
+
+function describeReason(reason: unknown): { reason: string; stack?: string } {
+  if (reason instanceof Error) {
+    const out: { reason: string; stack?: string } = { reason: `${reason.name}: ${reason.message}` };
+    if (reason.stack !== undefined) {
+      out.stack = reason.stack;
+    }
+    return out;
+  }
+  return { reason: String(reason) };
+}
+
+export function installGatewayLifecycleDiagnostics(opts: GatewayLifecycleDiagnosticsOptions): {
+  stop: () => void;
+} {
+  const { host, write, now } = opts;
+  const ctx: LifecycleContext = { pid: host.pid, hostname: opts.hostname, now };
+  const startedAtMs = now();
+  const emit = (
+    level: number,
+    event: LifecycleEvent,
+    msg: string,
+    extra?: Readonly<Record<string, unknown>>,
+  ): void => {
+    write(formatLifecycleLine(ctx, level, event, msg, extra));
+  };
+  const uptimeSec = (): number => Math.round((now() - startedAtMs) / 1000);
+
+  emit(30, "boot", "gateway lifecycle diagnostics armed", {
+    version: opts.version,
+    heartbeatMs: opts.heartbeatMs,
+  });
+
+  // `beforeExit` fires ONLY when the event loop has drained — it does not fire for an explicit
+  // process.exit(), a fatal error, or an external kill. That makes it the discriminator between
+  // "the gateway ran out of work and returned to the OS" and "something ended it".
+  let drained = false;
+  host.on("beforeExit", (...args: never[]): void => {
+    drained = true;
+    emit(60, "before_exit", "gateway event loop drained — no work left to keep the process alive", {
+      code: typeof args[0] === "number" ? args[0] : null,
+      uptimeSec: uptimeSec(),
+    });
+  });
+
+  // The catch-all. This fires for EVERY in-process exit — drain, process.exit(), fatal error.
+  // If a future death leaves no `process_exit` record at all, the process did not exit itself:
+  // it was terminated from outside (TerminateProcess / job-object kill / native abort), which no
+  // in-process handler can observe. That absence is itself the diagnosis.
+  host.on("exit", (...args: never[]): void => {
+    const mem = host.memoryUsage();
+    emit(60, "process_exit", "gateway process exiting", {
+      code: typeof args[0] === "number" ? args[0] : null,
+      drained,
+      uptimeSec: uptimeSec(),
+      rssMb: toMb(mem.rss),
+      heapUsedMb: toMb(mem.heapUsed),
+    });
+  });
+
+  // Registering these two suppresses Bun's own stderr dump, so the record below must carry the
+  // full stack. Exit code 1 is preserved deliberately: this makes the death LOGGED, not survivable
+  // — turning a fatal error into a swallowed one is a separate decision, not an observability fix.
+  host.on("uncaughtException", (...args: never[]): void => {
+    const d = describeReason(args[0]);
+    emit(60, "uncaught_exception", "uncaught exception — gateway is exiting", {
+      ...d,
+      origin: typeof args[1] === "string" ? args[1] : null,
+      uptimeSec: uptimeSec(),
+    });
+    host.exit(1);
+  });
+
+  host.on("unhandledRejection", (...args: never[]): void => {
+    const d = describeReason(args[0]);
+    emit(60, "unhandled_rejection", "unhandled promise rejection — gateway is exiting", {
+      ...d,
+      uptimeSec: uptimeSec(),
+    });
+    host.exit(1);
+  });
+
+  if (opts.heartbeatMs <= 0) {
+    return { stop: (): void => {} };
+  }
+
+  // The ONLY evidence available when the process is killed from outside: a timestamped
+  // "last seen alive" plus the memory trend leading up to it.
+  const timer = opts.setIntervalFn(() => {
+    const mem = host.memoryUsage();
+    let syncing: readonly string[] = [];
+    let extras: Readonly<Record<string, unknown>> = {};
+    try {
+      syncing = opts.activity?.() ?? [];
+      extras = opts.extras?.() ?? {};
+    } catch {
+      /* neither the scheduler nor the embedding runtime is a dependency the heartbeat may fail on */
+    }
+    emit(30, "heartbeat", "gateway alive", {
+      uptimeSec: uptimeSec(),
+      rssMb: toMb(mem.rss),
+      heapUsedMb: toMb(mem.heapUsed),
+      externalMb: toMb(mem.external),
+      syncing,
+      ...extras,
+    });
+  }, opts.heartbeatMs);
+  // Load-bearing: a ref'd interval would keep the event loop alive by itself, masking the very
+  // drain that `beforeExit` exists to detect.
+  timer.unref();
+
+  return {
+    stop: (): void => {
+      opts.clearIntervalFn(timer);
+    },
+  };
+}
+
+export const DEFAULT_HEARTBEAT_MS = 60_000;
+
+export function resolveHeartbeatMs(): number {
+  const raw = processEnvGet("NIMBUS_HEARTBEAT_MS");
+  if (raw === undefined || raw === "") {
+    return DEFAULT_HEARTBEAT_MS;
+  }
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : DEFAULT_HEARTBEAT_MS;
+}
+
+/**
+ * Production wiring: resolve the daily log, then arm the diagnostics against the real `process`.
+ * Returns a no-op stopper when no log path can be resolved.
+ */
+export function armGatewayLifecycleDiagnostics(
+  version: string,
+  activity: () => readonly string[],
+  extras: () => Readonly<Record<string, unknown>>,
+): { stop: () => void } {
+  const logPath = resolveLifecycleLogPath();
+  if (logPath === null) {
+    return { stop: (): void => {} };
+  }
+  return installGatewayLifecycleDiagnostics({
+    host: process as unknown as ProcessLifecycleHost,
+    write: createLifecycleWriter(logPath),
+    hostname: osHostname(),
+    version,
+    now: () => Date.now(),
+    heartbeatMs: resolveHeartbeatMs(),
+    setIntervalFn: (fn, ms) => setInterval(fn, ms),
+    clearIntervalFn: (t) => {
+      clearInterval(t as unknown as ReturnType<typeof setInterval>);
+    },
+    activity,
+    extras,
+  });
+}

--- a/packages/gateway/src/platform/gateway-log-file.ts
+++ b/packages/gateway/src/platform/gateway-log-file.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { platform } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Logger } from "pino";
 import pino from "pino";
 
@@ -17,6 +17,24 @@ export function gatewayLogBasename(): string {
 
 export function gatewayDailyLogPath(logDir: string): string {
   return join(logDir, gatewayLogBasename());
+}
+
+/**
+ * Today's daily-log path for the host OS, or `null` on an unsupported platform. The single
+ * per-OS resolution used by both the emergency logger and the lifecycle diagnostics — the
+ * platform branching lives here, in the one file already sanctioned for it.
+ */
+export function platformDailyLogPath(): string | null {
+  switch (platform()) {
+    case "win32":
+      return gatewayDailyLogPath(createWindowsPaths().logDir);
+    case "darwin":
+      return gatewayDailyLogPath(createDarwinPaths().logDir);
+    case "linux":
+      return gatewayDailyLogPath(createLinuxPaths().logDir);
+    default:
+      return null;
+  }
 }
 
 const PINO_REDACT_PATHS: readonly string[] = [
@@ -181,23 +199,11 @@ export function createGatewayPinoLoggerForStream(
 
 export function emergencyGatewayLog(err: unknown): void {
   try {
-    const p = platform();
-    let logDir: string;
-    switch (p) {
-      case "win32":
-        logDir = createWindowsPaths().logDir;
-        break;
-      case "darwin":
-        logDir = createDarwinPaths().logDir;
-        break;
-      case "linux":
-        logDir = createLinuxPaths().logDir;
-        break;
-      default:
-        return;
+    const path = platformDailyLogPath();
+    if (path === null) {
+      return;
     }
-    mkdirSync(logDir, { recursive: true });
-    const path = gatewayDailyLogPath(logDir);
+    mkdirSync(dirname(path), { recursive: true });
     const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
     appendFileSync(path, `[${new Date().toISOString()}] [gateway] fatal: ${msg}\n`, "utf8");
   } catch {


### PR DESCRIPTION
The gateway died silently twice during a working session on Windows, each time leaving nothing in the log: no `level:50`/`60` lines, no shutdown message, no crash dialog, no WER event. It was investigated as a crash. It is not one.

## Root cause

**The gateway is being killed, not crashing.** A death was reproduced under a watcher that captured the exit status: **exit code 1, zero bytes on stderr, memory flat at 232 MB one second before it ended.**

That is conclusive because every other death mode was measured first, on the same machine and Bun (1.3.14, Windows 11), with output redirected to a file exactly the way `spawn-gateway.ts` does it (`stdio: ["ignore", logFd, logFd]`):

| mode | exit code | stderr |
| --- | --- | --- |
| uncaught exception | 1 | **full stack trace** |
| unhandled rejection | 1 | **full stack trace** |
| event-loop drain | 0 | empty |
| observed death | **1** | **empty** |

An uncaught exception or unhandled rejection would have written a stack into the daily log, because stderr *is* redirected there. Nothing did, all day. Both are ruled out. A drained event loop exits 0, not 1 — also ruled out, and independently implausible given the many ref'd `setInterval` sidecars.

## Why nothing was logged

Before this PR the gateway's only process-level hooks were `SIGTERM` and `SIGINT`, and the only code that logs anything about termination is the `shutdown()` path those two signals reach.

**On Windows that path is unreachable.** `process.kill(pid, "SIGTERM")` — exactly what `nimbus stop` issues — is `TerminateProcess(handle, 1)`. Measured directly: the `SIGTERM` handler does not run, **an `exit` handler does not run either**, and the process ends with code 1 and no output.

So a deliberate `nimbus stop` and an unexplained death left byte-identical evidence: nothing. The absence of a shutdown line was never a clue — it is the normal state of affairs on this platform.

## What this PR changes

`platform/exit-diagnostics.ts`, armed on the **first statement** of `main()` so it covers assembly too. Records are written with `appendFileSync`, deliberately bypassing the daily pino logger — that logger is `pino.destination({ sync: false })`, whose buffered final write is precisely the one an abrupt exit loses, i.e. the record that matters most. They keep pino's field names (`level`/`time`/`pid`/`msg`), so greps already used against this log match them.

| event | what it tells you |
| --- | --- |
| `boot` | pid + version, tying a death to its spawn banner |
| `heartbeat` | uptime, rss, heap, in-flight sync services, embedding-runtime state |
| `before_exit` | the event loop drained — the discriminator for a clean exit-0 |
| `process_exit` | exit code + a `drained` flag |
| `uncaught_exception` / `unhandled_rejection` | full stack, **still exiting 1** |

Because no in-process handler can observe `TerminateProcess`, **the absence of a `process_exit` record is itself the diagnosis** — the process was killed from outside — and the last heartbeat bounds when, with the memory trend and what it was doing. Interval via `NIMBUS_HEARTBEAT_MS` (default 60 s, `0` disables).

The heartbeat timer is `unref`'d: a ref'd one would keep the loop alive and mask the very drain `before_exit` exists to detect. That is asserted by a test that hangs if it regresses.

The two uncaught arms deliberately preserve exit code 1. This makes a fatal error **logged**, not survivable — turning it into a swallowed error is a separate decision, not an observability fix.

### Two silent-failure sites found alongside

- **`ipc/server/socket-listeners.ts`** — the win32 named-pipe server's only `error` listener called `reject()` on a promise that had already resolved. Every post-listen pipe fault was a no-op that nonetheless counted as an `error` handler, so the fault vanished entirely. The startup listener is now scoped to the bind, and real faults are reported. A deliberate `stop()` is not reported as one (`markExpectedClose`).
- **`embedding/worker-bridge.ts`** — no `onerror`. Verified: an uncaught throw inside a Bun `Worker` neither crashes the parent nor prints anything. It cannot kill the gateway, but it left semantic search reading `warming` for the full 600 s init window instead of `unavailable`.

`gateway-log-file.ts` gains `platformDailyLogPath()`, collapsing the per-OS switch that `emergencyGatewayLog` already had rather than adding a second copy.

## What this PR does *not* do

It does not stop the killing — it makes the next death identify its own cause.

**Who** terminates the process is undetermined. The reproduction ran as a child of a tool-spawned shell, so its killer is plausibly that harness's task lifetime; it corroborates the *signature*, not the *agent*.

Leading hypothesis, explicitly unproven: `detached: true` on Windows sets only `DETACHED_PROCESS` — Node/libuv never sets `CREATE_BREAKAWAY_FROM_JOB` and does not expose it — so the gateway stays in the job object of the shell that launched it, and a terminal or VS Code window closing/reloading kills it with exactly this signature. Against it: a detached grandchild *did* survive its parent's death in a plain pwsh here. No spawn flag can fix that case; it needs a different launch strategy, which is a design change not taken here.

Also ruled out with evidence, and left alone: **memory** (30 min of 3-second sampling — peak 312 MB, settled ~232 MB, handles flat ~275; the 209 s blame sync is 400 sequential `git blame` spawns via `MAX_BLAME_FILES`, not a leak) and **timing** (lifetimes of 9.5 h / 2 h / 83 s / ~6 min / 30 min correlate with neither sync activity nor idle).

One latent bug was noticed and **not** fixed, as it is outside this change's scope: `connectors/blame-index-sync.ts` `runGit` awaits `proc.exited` *before* draining stdout, which can block on a full pipe buffer until the 30 s abort — `git blame --line-porcelain` output exceeds it easily. It inflates blame duration and silently yields empty blame.

## Verification

- `bun run preflight:fast` — PASSED
- 2125 tests pass, 0 fail across `platform` + `ipc` + `embedding`
- New file: 89.4% lines / 92.9% branches (istanbul preload), above both floors
- Every load-bearing assertion red-proven by breaking the implementation and confirming the test fails
- Six end-to-end tests drive the **real** `process` in real subprocesses, because the property that matters is "the record is on disk after the process is gone", which only a real exit can show

Not run: `audit:coverage-floor` under Docker (it is Linux-authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
