### PR TITLE
fix(quality): close two ReDoS regexes and clear 25 SonarCloud findings

### DIFF
--- a/packages/cli/src/lib/agent-brief-router.ts
+++ b/packages/cli/src/lib/agent-brief-router.ts
@@ -114,7 +114,10 @@ export class AgentBriefRouter {
    * reports it under the wrong error.
    */
   failAll(err: Error): void {
-    for (const w of [...this.waiters]) this.finish(w, err);
+    // Snapshot into an array FIRST: `finish` deletes from `this.waiters`, and
+    // mutating a Set mid-iteration is exactly the footgun a bare `for…of` over
+    // the live Set would introduce here.
+    for (const w of Array.from(this.waiters)) this.finish(w, err);
     this.buffered.clear();
   }
 

--- a/packages/cli/src/mcp/adapter.ts
+++ b/packages/cli/src/mcp/adapter.ts
@@ -12,7 +12,7 @@ import {
   supportsClose,
   supportsNotifications,
 } from "./client-surface.ts";
-import { GATEWAY_DOWN_MESSAGE, GatewayUnavailableError, isDisconnectError } from "./errors.ts";
+import { GatewayUnavailableError, isDisconnectError } from "./errors.ts";
 import {
   type AdapterDeps,
   AGENT_TOOLS_UNSUPPORTED_MESSAGE,
@@ -24,16 +24,16 @@ import {
 } from "./tool-runtime.ts";
 
 export type { ClosableClient, IpcCallable, NotifyingClient } from "./client-surface.ts";
+// `export … from`, not import-then-export: this name is a pure pass-through with no use anywhere
+// in this module, so importing it only to re-export it binds it locally for nothing (Sonar S7763).
+// The three value re-exports at the bottom of this block stay import-bound because they genuinely
+// ARE used here.
+export { GATEWAY_DOWN_MESSAGE } from "./errors.ts";
 export type { AdapterDeps, ToolResult, ToolSpec } from "./tool-runtime.ts";
 // Re-exported so existing importers (and tests) keep reaching these through `adapter.ts`. The
 // declarations themselves live in `errors.ts` / `client-surface.ts` / `tool-runtime.ts` to keep
 // `agent-tools.ts` free of a runtime import back into this module.
-export {
-  AGENT_TOOLS_UNSUPPORTED_MESSAGE,
-  GATEWAY_DOWN_MESSAGE,
-  GatewayUnavailableError,
-  isDisconnectError,
-};
+export { AGENT_TOOLS_UNSUPPORTED_MESSAGE, GatewayUnavailableError, isDisconnectError };
 
 const MCP_LIMIT_DEFAULT = 20;
 const MCP_LIMIT_MAX = 50;

--- a/packages/gateway/src/agents/ownership.test.ts
+++ b/packages/gateway/src/agents/ownership.test.ts
@@ -157,7 +157,7 @@ test("an unknown service id with zero services bound fires only the existing no-
   const relationGaps = brief.gaps.filter(
     (g) => g.category === "missing_relation_emit" && g.detail.includes("No service is bound"),
   );
-  expect(relationGaps.length).toBe(1);
+  expect(relationGaps).toHaveLength(1);
   // Not double-reported: the id-naming branch (requires servicesBound > 0)
   // must stay silent here.
   expect(brief.gaps.some((g) => g.detail.includes("nonexistent"))).toBe(false);

--- a/packages/gateway/src/connectors/bitbucket-sync.test.ts
+++ b/packages/gateway/src/connectors/bitbucket-sync.test.ts
@@ -62,65 +62,30 @@ describeWithFetchRestore("bitbucket-sync fetchOne", () => {
     expect(out).toEqual({ status: "unsupported_url" });
   });
 
-  test("reports absent for a 404", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithCreds(db, "user", "app-pass");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("nope", { status: 404 }))) as unknown as typeof fetch;
+  // Five upstream status codes, one shape: mock the status, assert the mapped
+  // result. The mapping is the whole point — a 403 must read as `unauthorized`
+  // and NOT as `absent`, or a permissions problem looks like a deleted PR.
+  // `credential` varies only to keep the expired-token narrative on the 401 row.
+  test.each([
+    [404, "app-pass", { status: "not_found", reason: "absent" }],
+    [401, "expired-app-pass", { status: "not_found", reason: "unauthorized" }],
+    [403, "app-pass", { status: "not_found", reason: "unauthorized" }],
+    [429, "app-pass", { status: "rate_limited" }],
+    [500, "app-pass", { status: "not_found", reason: "upstream_error" }],
+  ] as const)(
+    "maps upstream %i to the right fetchOne result",
+    async (code, credential, expected) => {
+      const db = createMemoryIndexDb();
+      const ctx = ctxWithCreds(db, "user", credential);
+      globalThis.fetch = ((): Promise<Response> =>
+        Promise.resolve(new Response("body", { status: code }))) as unknown as typeof fetch;
 
-    const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/999");
+      const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
+      const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/42");
 
-    expect(out).toEqual({ status: "not_found", reason: "absent" });
-  });
-
-  test("reports unauthorized for a 401", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithCreds(db, "user", "expired-app-pass");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("Unauthorized", { status: 401 }))) as unknown as typeof fetch;
-
-    const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/42");
-
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("reports unauthorized for a 403", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithCreds(db, "user", "app-pass");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("forbidden", { status: 403 }))) as unknown as typeof fetch;
-
-    const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/42");
-
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("reports rate_limited for a 429", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithCreds(db, "user", "app-pass");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("slow down", { status: 429 }))) as unknown as typeof fetch;
-
-    const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/42");
-
-    expect(out).toEqual({ status: "rate_limited" });
-  });
-
-  test("reports upstream_error for a 500", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithCreds(db, "user", "app-pass");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("boom", { status: 500 }))) as unknown as typeof fetch;
-
-    const syncable = createBitbucketSyncable({ ensureBitbucketMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://bitbucket.org/w/r/pull-requests/42");
-
-    expect(out).toEqual({ status: "not_found", reason: "upstream_error" });
-  });
+      expect(out).toEqual(expected);
+    },
+  );
 
   test("reports no_credential when credentials are missing", async () => {
     const db = createMemoryIndexDb();

--- a/packages/gateway/src/connectors/elasticsearch-sync.ts
+++ b/packages/gateway/src/connectors/elasticsearch-sync.ts
@@ -125,11 +125,7 @@ async function walkIndices(
   }
 
   // 3. Process and upsert items
-  for (let i = 0; i < validRows.length; i++) {
-    const item = validRows[i];
-    if (item === undefined) {
-      continue;
-    }
+  for (const item of validRows) {
     const { row, name } = item;
     const fields = mappingResults[name]?.fields ?? [];
 

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -59,64 +59,27 @@ describeWithFetchRestore("github-sync fetchOne", () => {
     expect(out).toEqual({ status: "unsupported_url" });
   });
 
-  test("reports not_found for a 404", async () => {
+  // Five upstream status codes, one shape: mock the status, assert the mapped
+  // result. The mapping is the whole point — a 403 must read as `unauthorized`
+  // and NOT as `absent`, or a permissions problem looks like a deleted PR, and a
+  // 429 must surface as `rate_limited` rather than as a miss. `pat` varies only
+  // to keep the expired-token narrative on the 401 row.
+  test.each([
+    [404, "pat-value", { status: "not_found", reason: "absent" }],
+    [401, "expired-pat", { status: "not_found", reason: "unauthorized" }],
+    [403, "pat-value", { status: "not_found", reason: "unauthorized" }],
+    [429, "pat-value", { status: "rate_limited" }],
+    [500, "pat-value", { status: "not_found", reason: "upstream_error" }],
+  ] as const)("maps upstream %i to the right fetchOne result", async (code, pat, expected) => {
     const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "pat-value");
+    const ctx = ctxWithPat(db, pat);
     globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("nope", { status: 404 }))) as unknown as typeof fetch;
-
-    const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://github.com/o/r/pull/999");
-
-    expect(out).toEqual({ status: "not_found", reason: "absent" });
-  });
-
-  test("a 401 reports unauthorized — the expired-PAT case", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "expired-pat");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("Bad credentials", { status: 401 }))) as unknown as typeof fetch;
-
-    const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://github.com/o/r/pull/42");
-
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("a 403 reports unauthorized", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "pat-value");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("forbidden", { status: 403 }))) as unknown as typeof fetch;
+      Promise.resolve(new Response("body", { status: code }))) as unknown as typeof fetch;
 
     const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
     const out = await syncable.fetchOne?.(ctx, "https://github.com/o/r/pull/42");
 
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("a provider 429 surfaces as rate_limited, not a miss", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "pat-value");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("slow down", { status: 429 }))) as unknown as typeof fetch;
-
-    const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://github.com/o/r/pull/42");
-
-    expect(out).toEqual({ status: "rate_limited" });
-  });
-
-  test("a 500 reports upstream_error", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "pat-value");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("boom", { status: 500 }))) as unknown as typeof fetch;
-
-    const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://github.com/o/r/pull/42");
-
-    expect(out).toEqual({ status: "not_found", reason: "upstream_error" });
+    expect(out).toEqual(expected);
   });
 
   // IMPORTANT 3: a DNS/TLS/connect failure must report not_found, not throw — the caller

--- a/packages/gateway/src/connectors/gitlab-sync.test.ts
+++ b/packages/gateway/src/connectors/gitlab-sync.test.ts
@@ -125,64 +125,26 @@ describeWithFetchRestore("gitlab-sync fetchOne", () => {
     });
   });
 
-  test("reports absent for a 404", async () => {
+  // Five upstream status codes, one shape: mock the status, assert the mapped
+  // result. The mapping is the whole point — a 403 must read as `unauthorized`
+  // and NOT as `absent`, or a permissions problem looks like a deleted MR.
+  // `pat` varies only to keep the expired-token narrative on the 401 row.
+  test.each([
+    [404, "t", { status: "not_found", reason: "absent" }],
+    [401, "expired-pat", { status: "not_found", reason: "unauthorized" }],
+    [403, "t", { status: "not_found", reason: "unauthorized" }],
+    [429, "t", { status: "rate_limited" }],
+    [500, "t", { status: "not_found", reason: "upstream_error" }],
+  ] as const)("maps upstream %i to the right fetchOne result", async (code, pat, expected) => {
     const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "t");
+    const ctx = ctxWithPat(db, pat);
     globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("nope", { status: 404 }))) as unknown as typeof fetch;
-
-    const syncable = createGitlabSyncable({ ensureGitlabMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://gitlab.com/g/p/-/merge_requests/999");
-
-    expect(out).toEqual({ status: "not_found", reason: "absent" });
-  });
-
-  test("reports unauthorized for a 401", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "expired-pat");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("Unauthorized", { status: 401 }))) as unknown as typeof fetch;
+      Promise.resolve(new Response("body", { status: code }))) as unknown as typeof fetch;
 
     const syncable = createGitlabSyncable({ ensureGitlabMcpRunning: async () => {} });
     const out = await syncable.fetchOne?.(ctx, "https://gitlab.com/g/p/-/merge_requests/7");
 
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("reports unauthorized for a 403", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "t");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("forbidden", { status: 403 }))) as unknown as typeof fetch;
-
-    const syncable = createGitlabSyncable({ ensureGitlabMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://gitlab.com/g/p/-/merge_requests/7");
-
-    expect(out).toEqual({ status: "not_found", reason: "unauthorized" });
-  });
-
-  test("reports rate_limited for a 429", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "t");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("slow down", { status: 429 }))) as unknown as typeof fetch;
-
-    const syncable = createGitlabSyncable({ ensureGitlabMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://gitlab.com/g/p/-/merge_requests/7");
-
-    expect(out).toEqual({ status: "rate_limited" });
-  });
-
-  test("reports upstream_error for a 500", async () => {
-    const db = createMemoryIndexDb();
-    const ctx = ctxWithPat(db, "t");
-    globalThis.fetch = ((): Promise<Response> =>
-      Promise.resolve(new Response("boom", { status: 500 }))) as unknown as typeof fetch;
-
-    const syncable = createGitlabSyncable({ ensureGitlabMcpRunning: async () => {} });
-    const out = await syncable.fetchOne?.(ctx, "https://gitlab.com/g/p/-/merge_requests/7");
-
-    expect(out).toEqual({ status: "not_found", reason: "upstream_error" });
+    expect(out).toEqual(expected);
   });
 
   test("reports unreachable when fetch itself throws (DNS/TLS/connect failure)", async () => {

--- a/packages/gateway/src/connectors/jenkins-sync.test.ts
+++ b/packages/gateway/src/connectors/jenkins-sync.test.ts
@@ -142,15 +142,6 @@ describeWithFetchRestore("jenkins-sync fetchOne", () => {
     expect(resolveItemByUrl(db, callerUrl)).toMatchObject({ found: true, matchKind: "exact" });
   });
 
-  test("jenkins fetchOne declines a job url with no build number", async () => {
-    const ctx = ctxWithCreds(createMemoryIndexDb(), "https://ci.corp.example");
-    const syncable = createJenkinsSyncable({ ensureJenkinsMcpRunning: async () => {} });
-
-    const out = await syncable.fetchOne?.(ctx, "https://ci.corp.example/job/build/");
-
-    expect(out).toEqual({ status: "unsupported_url" });
-  });
-
   test("reports absent for a 404", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxWithCreds(db, "https://ci.corp.example");
@@ -273,20 +264,22 @@ describeWithFetchRestore("jenkins-sync fetchOne", () => {
     expect(out).toEqual({ status: "unsupported_url" });
   });
 
-  test("declines a job segment that percent-decodes to contain a slash", async () => {
+  // Every URL shape `fetchOne` must DECLINE outright, before it makes a request.
+  // Declining is the safe answer for all three: a job url with no build number
+  // identifies no single build, and a segment that decodes to a slash or is
+  // malformed percent-encoding cannot be re-encoded to a stable request path.
+  test.each([
+    ["a job url with no build number", "https://ci.corp.example/job/build/"],
+    [
+      "a job segment that percent-decodes to contain a slash",
+      "https://ci.corp.example/job/a%2Fb/12/",
+    ],
+    ["a job segment with malformed percent-encoding", "https://ci.corp.example/job/%E0%A4%A/12/"],
+  ])("declines %s", async (_case, url) => {
     const ctx = ctxWithCreds(createMemoryIndexDb(), "https://ci.corp.example");
     const syncable = createJenkinsSyncable({ ensureJenkinsMcpRunning: async () => {} });
 
-    const out = await syncable.fetchOne?.(ctx, "https://ci.corp.example/job/a%2Fb/12/");
-
-    expect(out).toEqual({ status: "unsupported_url" });
-  });
-
-  test("declines a job segment with malformed percent-encoding", async () => {
-    const ctx = ctxWithCreds(createMemoryIndexDb(), "https://ci.corp.example");
-    const syncable = createJenkinsSyncable({ ensureJenkinsMcpRunning: async () => {} });
-
-    const out = await syncable.fetchOne?.(ctx, "https://ci.corp.example/job/%E0%A4%A/12/");
+    const out = await syncable.fetchOne?.(ctx, url);
 
     expect(out).toEqual({ status: "unsupported_url" });
   });

--- a/packages/gateway/src/connectors/jira-sync.test.ts
+++ b/packages/gateway/src/connectors/jira-sync.test.ts
@@ -209,7 +209,36 @@ describeWithFetchRestore("jira-sync", () => {
     expect(capturedJql).toContain("updated >= -30d");
   });
 
-  test("cursor with wrong prefix is treated as null", async () => {
+  // Every way a stored cursor can be unusable, and the one thing they must all
+  // do: fall back to the INITIAL date range rather than to an empty or partial
+  // JQL. A cursor that silently degraded to "no floor" would re-scan nothing and
+  // look like a healthy incremental sync, so the assertion is the same for all
+  // of them and the cases differ only in how the cursor is malformed.
+  test.each([
+    [
+      "wrong prefix",
+      () =>
+        `bad-prefix:${Buffer.from(
+          JSON.stringify({ v: 1, floorJql: "2026/01/01 00:00" }),
+          "utf8",
+        ).toString("base64url")}`,
+    ],
+    [
+      "valid prefix but non-object payload",
+      () => encodeNimbusJsonCursor("nimbus-jra1:", ["array"]),
+    ],
+    [
+      "wrong v version",
+      () => encodeNimbusJsonCursor("nimbus-jra1:", { v: 2, floorJql: "2026/01/01 00:00" }),
+    ],
+    [
+      "non-string floorJql",
+      () => encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: 12345 }),
+    ],
+    // null floorJql is VALID and decodes cleanly — it simply means "no floor
+    // recorded yet", which lands on the same initial range.
+    ["null floorJql", () => encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: null })],
+  ])("cursor with %s falls back to the initial JQL range", async (_case, makeCursor) => {
     const { ctx } = credCtx();
     let capturedJql = "";
     globalThis.fetch = (async (
@@ -225,101 +254,7 @@ describeWithFetchRestore("jira-sync", () => {
     }) as unknown as typeof fetch;
 
     const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    // prefix "bad-prefix:" doesn't match "nimbus-jra1:"
-    const badCursor =
-      "bad-prefix:" +
-      Buffer.from(JSON.stringify({ v: 1, floorJql: "2026/01/01 00:00" }), "utf8").toString(
-        "base64url",
-      );
-    await sync.sync(ctx, badCursor);
-    expect(capturedJql).toContain("updated >= -30d");
-  });
-
-  test("cursor with valid prefix but non-object payload is treated as null", async () => {
-    const { ctx } = credCtx();
-    let capturedJql = "";
-    globalThis.fetch = (async (
-      _input: SyncTestFetchParams[0],
-      init?: SyncTestFetchParams[1],
-    ): Promise<Response> => {
-      const body =
-        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
-      capturedJql = typeof body.jql === "string" ? body.jql : "";
-      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
-        status: 200,
-      });
-    }) as unknown as typeof fetch;
-
-    // payload is an array, not an object → branch 38
-    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", ["array"]);
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await sync.sync(ctx, cursor);
-    expect(capturedJql).toContain("updated >= -30d");
-  });
-
-  test("cursor with wrong v version is treated as null", async () => {
-    const { ctx } = credCtx();
-    let capturedJql = "";
-    globalThis.fetch = (async (
-      _input: SyncTestFetchParams[0],
-      init?: SyncTestFetchParams[1],
-    ): Promise<Response> => {
-      const body =
-        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
-      capturedJql = typeof body.jql === "string" ? body.jql : "";
-      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
-        status: 200,
-      });
-    }) as unknown as typeof fetch;
-
-    // v: 2 → wrong version branch at line 42
-    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 2, floorJql: "2026/01/01 00:00" });
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await sync.sync(ctx, cursor);
-    expect(capturedJql).toContain("updated >= -30d");
-  });
-
-  test("cursor with non-string floorJql is treated as null", async () => {
-    const { ctx } = credCtx();
-    let capturedJql = "";
-    globalThis.fetch = (async (
-      _input: SyncTestFetchParams[0],
-      init?: SyncTestFetchParams[1],
-    ): Promise<Response> => {
-      const body =
-        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
-      capturedJql = typeof body.jql === "string" ? body.jql : "";
-      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
-        status: 200,
-      });
-    }) as unknown as typeof fetch;
-
-    // floorJql is a number → line 46 branch
-    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: 12345 });
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await sync.sync(ctx, cursor);
-    expect(capturedJql).toContain("updated >= -30d");
-  });
-
-  test("cursor with null floorJql is treated as initial sync", async () => {
-    const { ctx } = credCtx();
-    let capturedJql = "";
-    globalThis.fetch = (async (
-      _input: SyncTestFetchParams[0],
-      init?: SyncTestFetchParams[1],
-    ): Promise<Response> => {
-      const body =
-        init?.body !== undefined && typeof init.body === "string" ? JSON.parse(init.body) : {};
-      capturedJql = typeof body.jql === "string" ? body.jql : "";
-      return new Response(JSON.stringify({ issues: [], startAt: 0, maxResults: 50, total: 0 }), {
-        status: 200,
-      });
-    }) as unknown as typeof fetch;
-
-    // floorJql is null → line 49: returns { v:1, floorJql: null } → jiraJqlFromCursor uses initial range
-    const cursor = encodeNimbusJsonCursor("nimbus-jra1:", { v: 1, floorJql: null });
-    const sync = createJiraSyncable({ ensureJiraMcpRunning: async () => {} });
-    await sync.sync(ctx, cursor);
+    await sync.sync(ctx, makeCursor());
     expect(capturedJql).toContain("updated >= -30d");
   });
 

--- a/packages/gateway/src/connectors/ticket-depth.ts
+++ b/packages/gateway/src/connectors/ticket-depth.ts
@@ -37,8 +37,12 @@ function lookup(
   if (raw === undefined || raw === "") {
     return "unknown";
   }
-  // An unrecognized value must NOT fall back to "todo" — that reads as "not
-  // started yet" and would quietly distort every cohort a consumer builds.
+  // An unrecognized value must NOT fall back to the not-started bucket — that
+  // reads as "has not begun yet" and would quietly distort every cohort a
+  // consumer builds. `unknown` is the honest answer.
+  //
+  // (The bucket is deliberately not named literally here: Sonar's S1135 reads
+  // the bare word as a task marker and files an INFO finding on this comment.)
   return table[raw] ?? "unknown";
 }
 

--- a/packages/gateway/src/index/migrations/runner.test.ts
+++ b/packages/gateway/src/index/migrations/runner.test.ts
@@ -877,7 +877,7 @@ test("V52 backfill leaves FTS search working for a row that existed before the m
   const hits = db
     .query("SELECT rowid FROM item_fts WHERE item_fts MATCH 'frobnicator'")
     .all() as Array<{ rowid: number }>;
-  expect(hits.length).toBe(1);
+  expect(hits).toHaveLength(1);
   db.close();
 });
 

--- a/packages/gateway/src/index/resolve-by-url.test.ts
+++ b/packages/gateway/src/index/resolve-by-url.test.ts
@@ -15,24 +15,32 @@ function dbWith(rows: Array<{ id: string; key: string | null; type?: string }>):
   return db;
 }
 
-test("rung 1 — exact key matches", () => {
-  const db = dbWith([{ id: "a", key: "https://github.com/o/r/pull/1" }]);
-  const out = resolveItemByUrl(db, "https://github.com/o/r/pull/1#note");
-  expect(out).toMatchObject({ found: true, matchKind: "exact" });
-  db.close();
-});
-
-test("rung 2 — all query params dropped", () => {
-  const db = dbWith([{ id: "a", key: "https://github.com/o/r/pull/1" }]);
-  const out = resolveItemByUrl(db, "https://github.com/o/r/pull/1?tab=files");
-  expect(out).toMatchObject({ found: true, matchKind: "query_stripped" });
-  db.close();
-});
-
-test("rung 3 — trailing path segments trimmed", () => {
-  const db = dbWith([{ id: "a", key: "https://bitbucket.org/o/r/pull-requests/42" }]);
-  const out = resolveItemByUrl(db, "https://bitbucket.org/o/r/pull-requests/42/diff");
-  expect(out).toMatchObject({ found: true, matchKind: "path_trimmed" });
+// The three MATCHING rungs of the ladder share one shape: seed a key, ask with a
+// URL that only that rung can reduce to it, assert which rung answered. The
+// declining cases below stay separate — they assert a different outcome.
+test.each([
+  [
+    "1 — exact key matches",
+    "https://github.com/o/r/pull/1",
+    "https://github.com/o/r/pull/1#note",
+    "exact",
+  ],
+  [
+    "2 — all query params dropped",
+    "https://github.com/o/r/pull/1",
+    "https://github.com/o/r/pull/1?tab=files",
+    "query_stripped",
+  ],
+  [
+    "3 — trailing path segments trimmed",
+    "https://bitbucket.org/o/r/pull-requests/42",
+    "https://bitbucket.org/o/r/pull-requests/42/diff",
+    "path_trimmed",
+  ],
+])("rung %s", (_label, seededKey, askedUrl, matchKind) => {
+  const db = dbWith([{ id: "a", key: seededKey }]);
+  const out = resolveItemByUrl(db, askedUrl);
+  expect(out).toMatchObject({ found: true, matchKind });
   db.close();
 });
 

--- a/packages/gateway/src/ipc/agents-rpc.ts
+++ b/packages/gateway/src/ipc/agents-rpc.ts
@@ -31,6 +31,7 @@ import { KnownNamespaceStore } from "../index/known-namespace-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
 import { buildServiceIdentityResolver } from "../metrics/service-identity.ts";
 import { ownershipRoots } from "../ownership/ownership-target.ts";
+import { codeUnitCompare } from "../util/code-unit-compare.ts";
 import {
   dispatchByMethod,
   type RpcMethodHandlerMap,
@@ -813,12 +814,15 @@ export const HTTP_AGENT_NAMES: readonly string[] = Object.freeze(
   Object.keys(AGENTS_RPC_HANDLERS)
     .filter((m) => !HTTP_EXCLUDED_AGENT_METHODS.has(m))
     .map((m) => m.slice(AGENTS_METHOD_PREFIX.length))
+    // The SHARED `codeUnitCompare` (`util/code-unit-compare.ts`), not an inline
+    // `(a, b) => a < b ? -1 : a > b ? 1 : 0` — that nested ternary was S3358, and the same ordering
+    // rule already had one home, used by the share canonicalizer.
     // Explicit code-unit comparator, NOT `localeCompare` (which S2871's message suggests) and not a
     // bare `.sort()` (whose implicit string coercion is what S2871 flags). This array is a WIRE
     // RESPONSE: `localeCompare` is locale-sensitive, so two gateways under different locales could
     // publish the same eleven agents in different orders. The names are ASCII identifiers, so a
     // code-unit comparison is total, stable and identical on every machine.
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+    .sort(codeUnitCompare),
 );
 
 /**

--- a/packages/gateway/src/ipc/clip-rpc.ts
+++ b/packages/gateway/src/ipc/clip-rpc.ts
@@ -148,12 +148,12 @@ function resolveClipIdsToDelete(db: Database, rec: Record<string, unknown>): str
 function readScopes(v: unknown): readonly ApiScope[] {
   if (v === undefined) return LEGACY_SCOPES;
   if (!Array.isArray(v)) {
-    throw new Error(`scopes must be an array of: ${API_SCOPES.join(", ")}`);
+    throw new TypeError(`scopes must be an array of: ${API_SCOPES.join(", ")}`);
   }
   const invalid = v.filter((s) => !isApiScope(s));
   if (invalid.length > 0) {
     throw new Error(
-      `unknown scope(s): ${invalid.map((s) => String(s)).join(", ")} — valid scopes are: ${API_SCOPES.join(", ")}`,
+      `unknown scope(s): ${invalid.map(String).join(", ")} — valid scopes are: ${API_SCOPES.join(", ")}`,
     );
   }
   if (v.length === 0) {

--- a/packages/gateway/src/ipc/http-route-auth.test.ts
+++ b/packages/gateway/src/ipc/http-route-auth.test.ts
@@ -171,7 +171,7 @@ describe("http-route-auth", () => {
     // `RE.exec(...)` IS used (BRIEF_GET_RE). Pin the count so a SECOND regex-matched route has to
     // be added to REGEX_ROUTED_GET deliberately rather than joining the surface unguarded.
     const execMatches = [...src.matchAll(/\w+_RE\.exec\(/g)];
-    expect(execMatches.length).toBe(REGEX_ROUTED_GET.size);
+    expect(execMatches).toHaveLength(REGEX_ROUTED_GET.size);
   });
 
   test("the agent invoke route requires the agents scope", () => {

--- a/packages/gateway/src/ipc/http-route-auth.ts
+++ b/packages/gateway/src/ipc/http-route-auth.ts
@@ -119,7 +119,7 @@ function hasScope(granted: readonly ApiScope[], required: ApiScope): boolean {
  */
 export function clipScopeFor(routeKey: string): ApiScope | null {
   const auth = HTTP_ROUTE_AUTH[routeKey];
-  return auth !== undefined && auth.kind === "clip" ? auth.scope : null;
+  return auth?.kind === "clip" ? auth.scope : null;
 }
 
 export function insufficientScopeBody(

--- a/packages/gateway/src/ownership/repo-remote.test.ts
+++ b/packages/gateway/src/ownership/repo-remote.test.ts
@@ -160,3 +160,24 @@ describe("resolveRepoRemote", () => {
     await expect(resolveRepoRemote("/r", throwingSpawn)).resolves.toBeNull();
   });
 });
+
+/**
+ * Sonar `typescript:S8786`: the trailing-slash strip was `/\/+$/`, retried from
+ * every start offset. Remote URLs come from `git remote -v` in a repository the
+ * user may not control.
+ *
+ * Time-bounded for the same reason as the theme-label case: the regex produced
+ * the right answer, so no correctness test could distinguish it.
+ */
+test("parseRemoteUrl stays linear on a degenerate slash run", () => {
+  // THE SLASH RUN MUST BE INTERIOR. The old code stripped LEADING slashes first
+  // (`^\/+`, linear and anchored), so a leading or trailing run never reached
+  // the quadratic `\/+$` — both measured at ~0.1 ms against the old code, i.e.
+  // tests that cannot fail. A run between two path segments does reach it:
+  // 9.1 s against the old regex, ~1 ms against the current linear scan.
+  const hostile = `https://github.com/a${"/".repeat(200_000)}x`;
+  const started = performance.now();
+  // Empty segments drop out, so this still parses as the repo `a/x`.
+  expect(parseRemoteUrl(hostile)).toEqual({ service: "github", ownerName: "a/x" });
+  expect(performance.now() - started).toBeLessThan(1000);
+});

--- a/packages/gateway/src/ownership/repo-remote.ts
+++ b/packages/gateway/src/ownership/repo-remote.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../extensions/spawn-env.ts";
+import { stripAffixChars } from "../util/strip-affixes.ts";
 
 export type RemoteRef = { readonly service: string; readonly ownerName: string };
 export type RemoteSpawn = typeof Bun.spawn;
@@ -59,7 +60,11 @@ export function parseRemoteUrl(url: string): RemoteRef | null {
   const service = HOST_TO_SERVICE.get(host.toLowerCase());
   if (service === undefined) return null;
 
-  let p = path.replace(/^\/+/, "").replace(/\/+$/, "");
+  // A linear scan, not `.replace(/\/+$/, "")`: that trailing-anchored form is
+  // retried from every start offset, so a long run of slashes that does not
+  // reach the end backtracks quadratically (Sonar `typescript:S8786`). Remote
+  // URLs come from `git remote -v` in a repo the user may not control.
+  let p = stripAffixChars(path, "/");
   if (p.toLowerCase().endsWith(".git")) p = p.slice(0, -4);
   const parts = p.split("/").filter((s) => s !== "");
   if (parts.length !== 2) return null;

--- a/packages/gateway/src/premortem/epic-services.ts
+++ b/packages/gateway/src/premortem/epic-services.ts
@@ -126,7 +126,7 @@ export function affectedServicesForEpics(
     const services = result.get(r.epicItemId) ?? [];
     // DISTINCT per epic: rows arrive service-sorted, so a plain de-dupe
     // preserves the same sorted order the single-epic function returns.
-    if (services[services.length - 1] !== r.service) {
+    if (services.at(-1) !== r.service) {
       services.push(r.service);
     }
     result.set(r.epicItemId, services);

--- a/packages/gateway/src/premortem/premortem-pass.ts
+++ b/packages/gateway/src/premortem/premortem-pass.ts
@@ -169,7 +169,7 @@ export async function runPremortemPass(
       }
     }
 
-    const last = batch[batch.length - 1];
+    const last = batch.at(-1);
     if (last === undefined) break;
     watermarkMs = last.modifiedAt;
     watermarkId = last.itemId;

--- a/packages/gateway/src/premortem/theme-identity.test.ts
+++ b/packages/gateway/src/premortem/theme-identity.test.ts
@@ -61,3 +61,26 @@ test("a digit-only service and label cannot collide across the boundary", () => 
   // to fifteen '1' characters. The ":" terminator closes that class.
   expect(themeId("1", "1".repeat(11))).not.toBe(themeId("1".repeat(11), "1"));
 });
+
+/**
+ * Sonar `typescript:S8786`: the edge-trim was a regex whose `[…]+$` alternative
+ * backtracks quadratically. Theme labels are LLM output over indexed
+ * third-party text, so the input is attacker-adjacent.
+ *
+ * Time-bounded on purpose. The regex version returned the CORRECT string — only
+ * slowly — so every correctness assertion in this file passed against it, and
+ * would pass again if someone reintroduced it. A clock is the only detector.
+ */
+test("normalizeThemeLabel stays linear on a degenerate punctuation run", () => {
+  // THE LEADING "a" IS THE WHOLE TEST. Without it the run is at the start, the
+  // old regex's `^[…]+` alternative swallows it in one step, and the quadratic
+  // `[…]+$` alternative is never reached — measured at 0.3 ms against the old
+  // code, i.e. a test that cannot fail. With the leading non-edge character the
+  // `^` alternative fails and `[…]+$` is retried from all 200k offsets: 20.2 s
+  // against the old regex, ~1 ms against the current linear scan.
+  const hostile = `a${".".repeat(200_000)}x`;
+  const started = performance.now();
+  // Nothing trims: neither end is an edge character. The output is the input.
+  expect(normalizeThemeLabel(hostile)).toHaveLength(hostile.length);
+  expect(performance.now() - started).toBeLessThan(1000);
+});

--- a/packages/gateway/src/premortem/theme-identity.ts
+++ b/packages/gateway/src/premortem/theme-identity.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import { stripAffixWhere } from "../util/strip-affixes.ts";
+
 /**
  * Identity and confidence for a recurring blocker theme.
  *
@@ -8,12 +10,31 @@ import { createHash } from "node:crypto";
  * "latency", destroying exactly the distinction a reader needs.
  */
 
-/** Matched at either end only, so internal punctuation ("2xx/5xx") survives. */
-const EDGE_PUNCTUATION =
-  /^[\s"'\u201c\u201d\u2018\u2019.,;:!?()[\]-]+|[\s"'\u201c\u201d\u2018\u2019.,;:!?()[\]-]+$/g;
+/**
+ * Trimmed at either end only, so internal punctuation ("2xx/5xx") survives.
+ *
+ * This was a regex \u2014 `/^[\s\u2026]+|[\s\u2026]+$/g` \u2014 until Sonar flagged it as
+ * super-linear (`typescript:S8786`), correctly: the `[\u2026]+$` alternative is
+ * retried from every start offset, so a long run of trimmable characters that
+ * does not reach the end backtracks quadratically. Theme labels come from LLM
+ * output over indexed third-party text, which is exactly the attacker-adjacent
+ * input where that matters.
+ *
+ * Whitespace stays in the edge set even though `split(/\s+/).filter(Boolean)`
+ * below would drop leading/trailing blanks anyway. It is load-bearing for
+ * INTERLEAVED edges: in `"  (hello)"` the first character is a space, so a
+ * punctuation-only trim would stop there and leave the `(` in place.
+ */
+const EDGE_PUNCTUATION_CHARS = "\"'\u201c\u201d\u2018\u2019.,;:!?()[]-";
+
+function isEdgeChar(ch: string): boolean {
+  // Single-character test \u2014 constant time, no backtracking possible. `\s` rather
+  // than a literal list so NBSP and the unicode space run trim like a space.
+  return EDGE_PUNCTUATION_CHARS.includes(ch) || /^\s$/.test(ch);
+}
 
 export function normalizeThemeLabel(raw: string): string {
-  return raw.replace(EDGE_PUNCTUATION, "").toLowerCase().split(/\s+/).filter(Boolean).join(" ");
+  return stripAffixWhere(raw, isEdgeChar).toLowerCase().split(/\s+/).filter(Boolean).join(" ");
 }
 
 /**

--- a/packages/gateway/src/util/strip-affixes.test.ts
+++ b/packages/gateway/src/util/strip-affixes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { stripAffixChars, stripTrailingChars } from "./strip-affixes.ts";
+import { stripAffixChars, stripAffixWhere, stripTrailingChars } from "./strip-affixes.ts";
 
 describe("stripTrailingChars", () => {
   it("removes a maximal trailing run of the given chars", () => {
@@ -39,5 +39,42 @@ describe("stripAffixChars", () => {
     expect(stripAffixChars("-".repeat(200000), "-")).toBe("");
     const padded = `${"-".repeat(100000)}mid${"-".repeat(100000)}`;
     expect(stripAffixChars(padded, "-")).toBe("mid");
+  });
+});
+
+describe("stripAffixWhere", () => {
+  const isSpaceOrDash = (ch: string) => ch === "-" || /^\s$/.test(ch);
+
+  it("trims by predicate at both ends and keeps the interior", () => {
+    expect(stripAffixWhere(" -a-b- ", isSpaceOrDash)).toBe("a-b");
+    expect(stripAffixWhere("abc", isSpaceOrDash)).toBe("abc");
+    expect(stripAffixWhere("", isSpaceOrDash)).toBe("");
+  });
+
+  it("returns empty when the predicate matches everything", () => {
+    expect(stripAffixWhere(" - - ", isSpaceOrDash)).toBe("");
+  });
+
+  it("reaches whitespace a literal char list would miss", () => {
+    // NBSP, line separator, paragraph separator, ideographic space. These are
+    // exactly the characters a hand-written " \t\n\r" list drops, which is why
+    // the predicate form exists at all.
+    expect(stripAffixWhere("  x 　", isSpaceOrDash)).toBe("x");
+  });
+
+  /**
+   * The regression this whole module is shaped around, and the one a
+   * correctness test cannot see: the regex spellings produce the RIGHT answer,
+   * just quadratically. Only a clock catches it.
+   *
+   * 400k trimmable characters followed by a non-matching tail is the worst case
+   * for `/[x]+$/` — every start offset scans to the end and fails. Linear code
+   * finishes in single-digit milliseconds; the regex form takes minutes.
+   */
+  it("stays linear on a degenerate input a trailing-anchored regex would blow up on", () => {
+    const hostile = `${"-".repeat(400000)}x`;
+    const started = performance.now();
+    expect(stripAffixWhere(hostile, isSpaceOrDash)).toBe(hostile.slice(400000));
+    expect(performance.now() - started).toBeLessThan(1000);
   });
 });

--- a/packages/gateway/src/util/strip-affixes.ts
+++ b/packages/gateway/src/util/strip-affixes.ts
@@ -1,13 +1,43 @@
+/**
+ * Edge-trimming helpers.
+ *
+ * These exist as loops rather than as regexes on purpose. The obvious spellings
+ * — `s.replace(/[chars]+$/, "")` and `s.replace(/^[chars]+|[chars]+$/g, "")` —
+ * are super-linear: an `[X]+$` alternative is retried from every start offset,
+ * so a long run of `X` that does NOT reach the end costs O(n²) backtracking.
+ * That is a denial-of-service shape on any attacker-influenced string, and a
+ * correctness test can never catch it — the output is right, only the time is
+ * wrong. Every trim below is a single linear scan from each end.
+ *
+ * If you add a variant here, add a time-bounded test alongside the correctness
+ * ones (`strip-affixes.test.ts`), not instead of them.
+ */
+
+/** Drop every trailing character that appears in `chars`. */
 export function stripTrailingChars(s: string, chars: string): string {
   let end = s.length;
   while (end > 0 && chars.includes(s.charAt(end - 1))) end--;
   return s.slice(0, end);
 }
 
+/** Drop every leading AND trailing character that appears in `chars`. */
 export function stripAffixChars(s: string, chars: string): string {
+  return stripAffixWhere(s, (ch) => chars.includes(ch));
+}
+
+/**
+ * `stripAffixChars` for edge sets a literal character list cannot express —
+ * chiefly "any whitespace", where a hand-written list silently misses NBSP,
+ * line/paragraph separators and the unicode space run.
+ *
+ * `isAffix` is called on ONE character at a time, so a regex inside it (e.g.
+ * `/^\s$/.test(ch)`) stays constant-time and cannot reintroduce the
+ * backtracking this module exists to avoid.
+ */
+export function stripAffixWhere(s: string, isAffix: (ch: string) => boolean): string {
   let start = 0;
   let end = s.length;
-  while (start < end && chars.includes(s.charAt(start))) start++;
-  while (end > start && chars.includes(s.charAt(end - 1))) end--;
+  while (start < end && isAffix(s.charAt(start))) start++;
+  while (end > start && isAffix(s.charAt(end - 1))) end--;
   return s.slice(start, end);
 }

--- a/packages/mcp-connectors/flagsmith/src/search-filter.test.ts
+++ b/packages/mcp-connectors/flagsmith/src/search-filter.test.ts
@@ -10,22 +10,17 @@ describe("filterFlagsmithFeatures", () => {
     "not-an-object",
   ];
 
-  test("matches by name", () => {
-    const result = filterFlagsmithFeatures(features, { query: "feature_one" });
+  // One assertion shape over the fields the filter searches. Named per case so a
+  // failure still says WHICH field stopped matching, which is the only thing the
+  // separate copies bought.
+  test.each([
+    ["name", "feature_one", "feature_one"],
+    ["description", "second", "feature_two"],
+    ["string tags", "frontend", "feature_one"],
+  ])("matches by %s", (_field, query, expected) => {
+    const result = filterFlagsmithFeatures(features, { query });
     expect(result).toHaveLength(1);
-    expect((result[0] as { name?: string }).name).toBe("feature_one");
-  });
-
-  test("matches by description", () => {
-    const result = filterFlagsmithFeatures(features, { query: "second" });
-    expect(result).toHaveLength(1);
-    expect((result[0] as { name?: string }).name).toBe("feature_two");
-  });
-
-  test("matches by string tags", () => {
-    const result = filterFlagsmithFeatures(features, { query: "frontend" });
-    expect(result).toHaveLength(1);
-    expect((result[0] as { name?: string }).name).toBe("feature_one");
+    expect((result[0] as { name?: string }).name).toBe(expected);
   });
 
   test("matches by number tags", () => {

--- a/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
+++ b/packages/mcp-connectors/great-expectations/test/gx-parse.test.ts
@@ -530,34 +530,36 @@ describe("listAllExpectations — filesystem walk", () => {
     expect(rows[0]?.suiteName).toBe("normal");
   });
 
-  it("gracefully handles unreadable directories during walk", async () => {
-    if (process.platform === "win32") {
-      // chmod 000 does not block directory reading for administrators/owners on Windows
-      return;
-    }
-    const sub = join(dir, "unreadable");
-    await mkdir(sub, { recursive: true });
+  // `skipIf`, not an early `return`: a bare return reports the test as PASSED on
+  // Windows, so a run there claims coverage it never had. Skipped is the truth.
+  // chmod 000 does not block directory reading for administrators/owners on Windows.
+  it.skipIf(process.platform === "win32")(
+    "gracefully handles unreadable directories during walk",
+    async () => {
+      const sub = join(dir, "unreadable");
+      await mkdir(sub, { recursive: true });
 
-    // Write a dummy JSON expectation file inside the sub-directory first
-    const doc = {
-      meta: { expectation_suite_name: "unreadable-dummy" },
-      results: [
-        { success: true, expectation_config: { expectation_type: "t", kwargs: {} }, result: {} },
-      ],
-    };
-    await writeFile(join(sub, "dummy.json"), JSON.stringify(doc), "utf8");
+      // Write a dummy JSON expectation file inside the sub-directory first
+      const doc = {
+        meta: { expectation_suite_name: "unreadable-dummy" },
+        results: [
+          { success: true, expectation_config: { expectation_type: "t", kwargs: {} }, result: {} },
+        ],
+      };
+      await writeFile(join(sub, "dummy.json"), JSON.stringify(doc), "utf8");
 
-    // This will cause readdir to fail on this directory
-    await import("node:fs/promises").then((fs) => fs.chmod(sub, 0o000));
+      // This will cause readdir to fail on this directory
+      await import("node:fs/promises").then((fs) => fs.chmod(sub, 0o000));
 
-    try {
-      const rows = await listAllExpectations();
-      expect(rows).toEqual([]);
-    } finally {
-      // Restore permissions so cleanup works
-      await import("node:fs/promises").then((fs) => fs.chmod(sub, 0o755));
-    }
-  });
+      try {
+        const rows = await listAllExpectations();
+        expect(rows).toEqual([]);
+      } finally {
+        // Restore permissions so cleanup works
+        await import("node:fs/promises").then((fs) => fs.chmod(sub, 0o755));
+      }
+    },
+  );
 
   it("throws when GREAT_EXPECTATIONS_RESULTS_DIR is unset", async () => {
     delete process.env["GREAT_EXPECTATIONS_RESULTS_DIR"];

--- a/packages/mcp-connectors/tableau/test/server.test.ts
+++ b/packages/mcp-connectors/tableau/test/server.test.ts
@@ -58,29 +58,19 @@ describe("tableau server", () => {
   });
 
   describe("environment variable validation", () => {
-    it("throws if TABLEAU_URL is missing", async () => {
-      delete process.env["TABLEAU_URL"];
-      const tools = captureTools();
-      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
-        "TABLEAU_URL is not set",
-      );
-    });
-
-    it("throws if TABLEAU_PAT_NAME is missing", async () => {
-      delete process.env["TABLEAU_PAT_NAME"];
-      const tools = captureTools();
-      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
-        "TABLEAU_PAT_NAME is not set",
-      );
-    });
-
-    it("throws if TABLEAU_PAT_SECRET is missing", async () => {
-      delete process.env["TABLEAU_PAT_SECRET"];
-      const tools = captureTools();
-      await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
-        "TABLEAU_PAT_SECRET is not set",
-      );
-    });
+    // Each required variable, dropped one at a time. The error must NAME the
+    // missing variable — a generic "not configured" would leave an operator
+    // guessing which of the three they forgot.
+    it.each(["TABLEAU_URL", "TABLEAU_PAT_NAME", "TABLEAU_PAT_SECRET"])(
+      "throws if %s is missing",
+      async (varName) => {
+        delete process.env[varName];
+        const tools = captureTools();
+        await expect(tool(tools, "tableau_get")({ id: "1" })).rejects.toThrow(
+          `${varName} is not set`,
+        );
+      },
+    );
   });
 
   describe("signin errors", () => {


### PR DESCRIPTION
First tranche of the quality sweep: **25 of the 36 open SonarCloud issues**, including the only two with real security impact. The remaining 11 are all `typescript:S3776` cognitive-complexity refactors and are deliberately left for a follow-up — they change control flow in `assemble.ts`, `ownership-pass.ts` (complexity 55) and `premortem-pass.ts` (45), and do not belong in the same diff as mechanical cleanups.

## Two genuine ReDoS, and a measurement worth recording

`typescript:S8786` fired on two regexes. Both turned out to be **really quadratic**, not false positives — but proving it took the right hostile input, and my first attempt at both got it wrong in a way that would have shipped a test that could never fail.

| regex | site | hostile input | old | new |
|---|---|---|---|---|
| `/^[\s…]+\|[\s…]+$/g` | `premortem/theme-identity.ts` | `"a" + "."×200k + "x"` | **20.2 s** | ~1 ms |
| `/\/+$/` | `ownership/repo-remote.ts` | `"a" + "/"×200k + "x"` | **9.1 s** | ~1 ms |

The shape is everything. My first hostile strings put the trimmable run at the **start**, where the `^[…]+` alternative swallows it in one step — measured at **0.3 ms** against the old code. The `/\/+$/` case was worse: the old code ran `.replace(/^\/+/, "")` *first*, so a leading **or** trailing run never reached the quadratic branch at all — **0.1 ms**. Both of my initial tests would have passed against the unfixed code. The committed tests use interior/leading-guarded runs that do reach it, and both carry a comment saying exactly why that shape is load-bearing.

Both call sites now use linear scans from `util/strip-affixes.ts`, which already existed for precisely this reason. It gains one function, `stripAffixWhere`, for edge sets a literal character list cannot express — the theme trim needs "any whitespace", and a hand-written `" \t\n\r"` silently misses NBSP and the unicode space run.

These inputs are attacker-adjacent: theme labels are LLM output over indexed third-party text, and remote URLs come from `git remote -v` in a repo the user may not control.

## Nine duplicated test groups parameterized (S5976)

`bitbucket`/`github`/`gitlab-sync` each had five byte-identical HTTP-status tests; `jira-sync` had five cursor-corruption variants; `jenkins-sync` had three `unsupported_url` declines; plus `flagsmith`, `tableau`, `resolve-by-url`. Net **−189 lines**, with each table carrying the invariant the group exists to prove — e.g. that a 403 maps to `unauthorized` and *not* `absent`, or a permissions problem reads as a deleted PR.

**`as const` on those tables is load-bearing.** Without it the tuple widens to `string`, `{status: string}` stops satisfying `FetchOneResult`, and `tsc` fails — while `bun test` passes. I hit exactly that: 3,330 tests green, `typecheck` red.

## Fourteen smaller findings

`S7755` `.at(-1)` ×2 · `S4138` for-of · `S5906` `toHaveLength` ×3 · `S3358` nested ternary (now the shared `codeUnitCompare`, which already had one home) · `S7786` `TypeError` · `S7770` bare `String` · `S6582` optional chain · `S7747` needless array copy · `S7763` `export … from` · `S8968` `it.skipIf`.

Two are worth calling out:

- **`S8968` was hiding a false pass.** The great-expectations walk test `return`ed early on Windows, which reports the test as **PASSED** — a Windows run claimed coverage it never had. `it.skipIf` reports it as skipped, which is the truth; the suite now shows `1 skip` there.
- **`S1135` on `ticket-depth.ts` is a false positive.** The rule matched the *status value* `"todo"` inside a comment, not a task marker. Rather than suppress the rule I reworded the comment to name the bucket instead of quoting it, and said so inline — the finding is INFO-level and the rule is worth keeping armed.

## Verification

- `bun run preflight:fast` — PASSED (all 29 gates)
- `bun test packages/gateway/src/connectors packages/gateway/src/index` — 3,330 pass, 0 fail
- `bun test` across the touched mcp-connectors — 3,425 pass, 3 skip, 0 fail
- `bun run typecheck` — 0 errors

## Not in this PR

- 11 × `S3776` cognitive complexity — follow-up
- Duplication 0.3% → ≤0.2% — follow-up (this PR already removes ~189 duplicated test lines)
- Coverage 94.5% → ≥95% — follow-up (needs 422 more covered lines+conditions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
