### PR TITLE
refactor(quality): collapse the four largest duplication clusters

### DIFF
--- a/packages/gateway/src/agent-runs/agent-test-server.ts
+++ b/packages/gateway/src/agent-runs/agent-test-server.ts
@@ -16,6 +16,7 @@ import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
 import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
 import type { ReadOnlyHttpServerHandle } from "../ipc/http-server.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
+import { createSeededTokenVault } from "../ipc/test-token-vault.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import { buildAgentHttpInvoker } from "./agent-http-invoke.ts";
 import { AgentRunController, MAX_CONCURRENT_AGENT_RUNS } from "./agent-run-store.ts";
@@ -24,30 +25,15 @@ const KNOWN_TOKEN = "agent-test-token-0123456789abcdef0123456789abcd";
 const KNOWN_LABEL = "agent-test-harness";
 
 function makeInMemoryVault(tokensJson?: string): NimbusVault {
-  const store = new Map<string, string>();
-  store.set(
-    "http_api.web_clipper_tokens",
-    // The scoped form WITH `agents`, unlike the briefs harness's legacy default: every agents route
-    // is agents-scoped, so a legacy seed would 403 the positive tests for the wrong reason. The
-    // override exists so the legacy and narrow-scope cases can still be exercised explicitly.
+  // The scoped form WITH `agents`, unlike the briefs harness's legacy default: every agents route
+  // is agents-scoped, so a legacy seed would 403 the positive tests for the wrong reason. The
+  // override exists so the legacy and narrow-scope cases can still be exercised explicitly.
+  return createSeededTokenVault(
     tokensJson ??
       JSON.stringify({
         [KNOWN_LABEL]: { token: KNOWN_TOKEN, scopes: ["clip", "briefs", "agents"] },
       }),
   );
-  return {
-    get: async (k: string) => store.get(k) ?? null,
-    set: async (k: string, v: string) => {
-      store.set(k, v);
-    },
-    delete: async (k: string) => {
-      store.delete(k);
-    },
-    listKeys: async (prefix?: string) => {
-      const keys = [...store.keys()];
-      return prefix === undefined ? keys : keys.filter((k) => k.startsWith(prefix));
-    },
-  };
 }
 
 export type AgentTestServer = {

--- a/packages/gateway/src/agents/_lib/sub-agent.test.ts
+++ b/packages/gateway/src/agents/_lib/sub-agent.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import { decode, subAgent } from "./sub-agent.ts";
+
+describe("subAgent", () => {
+  test("presents a local function as a zero-cost SubTask", async () => {
+    const task = subAgent(() => ({ hits: 3 }));
+    expect(task.taskType).toBe("agent_step");
+    // Empty prompt and zero tokens are the contract, not an oversight: a lane
+    // that never calls the model must contribute nothing to an agent's reported
+    // usage, or the brief overstates what it spent.
+    expect(task.prompt).toBe("");
+    const out = await task.execute();
+    expect(out.tokensIn).toBe(0);
+    expect(out.tokensOut).toBe(0);
+    expect(out.text).toBe(JSON.stringify({ hits: 3 }));
+  });
+
+  test("round-trips through decode", async () => {
+    const value = { owners: ["a", "b"], total: 2 };
+    const out = await subAgent(() => value).execute();
+    // Fallback typed as the same shape so `decode`'s generic resolves to it —
+    // a `null` fallback would infer `T = null` and reject the comparison.
+    expect(decode(out.text, { owners: [] as string[], total: 0 })).toEqual(value);
+  });
+
+  test("the function runs at execute() time, not at construction", async () => {
+    // The coordinator builds every lane up front and runs them on its own
+    // schedule; a subAgent that evaluated eagerly would do the SQL work even for
+    // a lane the coordinator later drops.
+    let calls = 0;
+    const task = subAgent(() => {
+      calls += 1;
+      return calls;
+    });
+    expect(calls).toBe(0);
+    await task.execute();
+    expect(calls).toBe(1);
+  });
+});
+
+describe("decode", () => {
+  test("parses valid JSON", () => {
+    expect(decode('{"a":1}', { a: 0 })).toEqual({ a: 1 });
+  });
+
+  test("undefined text yields the fallback", () => {
+    // A lane the coordinator never ran returns no text at all.
+    expect(decode(undefined, { a: 9 })).toEqual({ a: 9 });
+  });
+
+  test("unparseable text yields the fallback rather than throwing", () => {
+    // The load-bearing case: one malformed lane must not fail the whole
+    // fan-out. The brief renders what it has and reports the gap.
+    expect(decode("not json", { a: 9 })).toEqual({ a: 9 });
+    expect(() => decode("{", null)).not.toThrow();
+  });
+
+  test("preserves a falsy parsed value instead of falling back to it", () => {
+    // `0`, `false` and `""` are legitimate lane results. A `??`-style
+    // implementation would silently swap them for the fallback.
+    expect(decode("0", 42)).toBe(0);
+    expect(decode("false", true)).toBe(false);
+    expect(decode('""', "fallback")).toBe("");
+  });
+});

--- a/packages/gateway/src/agents/_lib/sub-agent.ts
+++ b/packages/gateway/src/agents/_lib/sub-agent.ts
@@ -1,0 +1,44 @@
+import type { SubTask } from "../../engine/coordinator.ts";
+
+/**
+ * A `SubTask` that runs a LOCAL function instead of calling the model.
+ *
+ * The `AgentCoordinator` fan-out machinery is uniform over `SubTask`, so a lane
+ * that is pure local computation (a SQL read, a graph walk) still has to present
+ * as one. `prompt: ""` and zero token counts are what say "this lane spent
+ * nothing" — an agent's reported token usage stays truthful because these lanes
+ * contribute zero rather than an estimate.
+ *
+ * The result is JSON round-tripped through `text` because that is the only
+ * channel `SubTask.execute` offers; `decode` is its inverse.
+ *
+ * Byte-identical copies of this and `decode` lived in `agents/decisions.ts`,
+ * `agents/glossary.ts` and `agents/ownership.ts` — the three agents that fan out
+ * over locally-computed lanes. A fourth agent written by copying one of them
+ * would have carried a fourth copy.
+ */
+export function subAgent(fn: () => unknown): SubTask {
+  return {
+    taskType: "agent_step",
+    prompt: "",
+    execute: async () => ({ text: JSON.stringify(fn()), tokensIn: 0, tokensOut: 0 }),
+  };
+}
+
+/**
+ * Inverse of `subAgent`'s JSON encoding, falling back rather than throwing.
+ *
+ * A lane that produced no text (cancelled, or a coordinator slot that never
+ * ran) and a lane that produced unparseable text are treated the same way: the
+ * caller's `fallback` stands in. That is deliberate — a brief renders what it
+ * has and reports the gap, rather than failing the whole fan-out because one
+ * lane came back empty.
+ */
+export function decode<T>(text: string | undefined, fallback: T): T {
+  if (text === undefined) return fallback;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/gateway/src/agents/decisions.ts
+++ b/packages/gateway/src/agents/decisions.ts
@@ -9,6 +9,7 @@ import { AgentCoordinator, type SubTask } from "../engine/coordinator.ts";
 import type { DecisionsBrief, DecisionsEntry, DecisionsInput } from "./_lib/decisions-types.ts";
 import { emitBriefWithSynthesis } from "./_lib/emit-brief.ts";
 import type { GapNote } from "./_lib/findings.ts";
+import { decode, subAgent } from "./_lib/sub-agent.ts";
 import type { SynthesizerLlm } from "./_lib/synthesize.ts";
 
 export type DecisionsContext = {
@@ -27,23 +28,6 @@ export type DecisionsContext = {
 
 const DEFAULT_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 const DEFAULT_LIMIT = 50;
-
-function subAgent(fn: () => unknown): SubTask {
-  return {
-    taskType: "agent_step",
-    prompt: "",
-    execute: async () => ({ text: JSON.stringify(fn()), tokensIn: 0, tokensOut: 0 }),
-  };
-}
-
-function decode<T>(text: string | undefined, fallback: T): T {
-  if (text === undefined) return fallback;
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    return fallback;
-  }
-}
 
 function serviceTypeOf(db: Database, itemId: string): string {
   const r = db.query("SELECT service, type FROM item WHERE id = ?").get(itemId) as {

--- a/packages/gateway/src/agents/glossary.ts
+++ b/packages/gateway/src/agents/glossary.ts
@@ -21,6 +21,7 @@ import type {
   GlossaryInput,
   GlossaryMatchedVia,
 } from "./_lib/glossary-types.ts";
+import { decode, subAgent } from "./_lib/sub-agent.ts";
 import type { SynthesizerLlm } from "./_lib/synthesize.ts";
 
 export type GlossaryContext = {
@@ -48,23 +49,6 @@ function toEntry(t: GlossaryTerm): GlossaryEntry {
     synonyms: t.synonyms,
     nearMisses: t.nearMisses,
   };
-}
-
-function subAgent(fn: () => unknown): SubTask {
-  return {
-    taskType: "agent_step",
-    prompt: "",
-    execute: async () => ({ text: JSON.stringify(fn()), tokensIn: 0, tokensOut: 0 }),
-  };
-}
-
-function decode<T>(text: string | undefined, fallback: T): T {
-  if (text === undefined) return fallback;
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    return fallback;
-  }
 }
 
 /**

--- a/packages/gateway/src/agents/ownership.ts
+++ b/packages/gateway/src/agents/ownership.ts
@@ -21,6 +21,7 @@ import type {
   OwnershipInput,
   OwnershipTargetView,
 } from "./_lib/ownership-types.ts";
+import { decode, subAgent } from "./_lib/sub-agent.ts";
 import type { SynthesizerLlm } from "./_lib/synthesize.ts";
 
 export type OwnershipContext = {
@@ -31,23 +32,6 @@ export type OwnershipContext = {
   sessionId: string;
   llm?: SynthesizerLlm;
 };
-
-function subAgent(fn: () => unknown): SubTask {
-  return {
-    taskType: "agent_step",
-    prompt: "",
-    execute: async () => ({ text: JSON.stringify(fn()), tokensIn: 0, tokensOut: 0 }),
-  };
-}
-
-function decode<T>(text: string | undefined, fallback: T): T {
-  if (text === undefined) return fallback;
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    return fallback;
-  }
-}
 
 function toView(
   db: Database,

--- a/packages/gateway/src/briefs/brief-test-server.ts
+++ b/packages/gateway/src/briefs/brief-test-server.ts
@@ -18,6 +18,7 @@ import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
 import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
 import type { ReadOnlyHttpServerHandle } from "../ipc/http-server.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
+import { createSeededTokenVault } from "../ipc/test-token-vault.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import { buildRegistry } from "./brief-registry.ts";
 import { BriefRunController } from "./brief-run-store.ts";
@@ -29,26 +30,11 @@ const KNOWN_TOKEN = "brief-test-token-0123456789abcdef0123456789abcdef";
 const KNOWN_LABEL = "brief-test-harness";
 
 function makeInMemoryVault(tokensJson?: string): NimbusVault {
-  const store = new Map<string, string>();
-  store.set(
-    "http_api.web_clipper_tokens",
-    // Default stays the LEGACY bare-string shape on purpose: every existing test that uses this
-    // harness then proves, for free, that a pre-scopes token still works.
+  // Default stays the LEGACY bare-string shape on purpose: every existing test that uses this
+  // harness then proves, for free, that a pre-scopes token still works.
+  return createSeededTokenVault(
     tokensJson ?? JSON.stringify({ [KNOWN_LABEL]: KNOWN_TOKEN } satisfies Record<string, string>),
   );
-  return {
-    get: async (k: string) => store.get(k) ?? null,
-    set: async (k: string, v: string) => {
-      store.set(k, v);
-    },
-    delete: async (k: string) => {
-      store.delete(k);
-    },
-    listKeys: async (prefix?: string) => {
-      const keys = [...store.keys()];
-      return prefix === undefined ? keys : keys.filter((k) => k.startsWith(prefix));
-    },
-  };
 }
 
 /** Kicks off synthesis fire-and-forget — same contract as `BriefsWriteSurface.startRun`. */

--- a/packages/gateway/src/connectors/lazy-mesh/phase3-config.ts
+++ b/packages/gateway/src/connectors/lazy-mesh/phase3-config.ts
@@ -814,26 +814,71 @@ export async function phase3AddDbtMcp(
   );
 }
 
+/**
+ * The url-plus-one-secret connector shape, registered once.
+ *
+ * Five connectors — metabase, databricks, mlflow, dependencytrack,
+ * elasticsearch — had byte-identical bodies differing only in the service id,
+ * which vault keys hold the URL and credential, and the two env-var names. They
+ * were the single largest duplication cluster in the gateway (70 lines across 5
+ * blocks).
+ *
+ * Consolidating STRENGTHENS invariant I15 rather than weakening it. D10's static
+ * check is file-scoped — a lazy-mesh file mentioning `Record<string, ServerSpec>`
+ * must also contain `wrapServerSpec(` — so this file still satisfies it. More to
+ * the point, the intent of I15 is that no `ServerSpec` reaches the mesh
+ * unsandboxed, and a shared registrar makes that structural for this whole
+ * family: a sixth url+secret connector added through it CANNOT forget the wrap,
+ * whereas a sixth hand-written copy could.
+ *
+ * The blank-credential early return is preserved exactly: an unconfigured
+ * connector registers NO server rather than a server that would fail at spawn.
+ */
+async function addUrlAndSecretMcp<S extends ConnectorServiceId>(
+  vault: NimbusVault,
+  servers: Record<string, ServerSpec>,
+  sandboxCwd: string,
+  // Generic over the service id so `urlSecretKey`/`credentialSecretKey` stay
+  // checked against THAT service's own key union — `service: string` would
+  // typecheck a vault key that does not exist for the connector being wired.
+  cfg: {
+    service: S;
+    urlSecretKey: ConnectorSecretKeyOf<S>;
+    credentialSecretKey: ConnectorSecretKeyOf<S>;
+    urlEnvVar: string;
+    credentialEnvVar: string;
+  },
+): Promise<void> {
+  const url = (await readConnectorSecret(vault, cfg.service, cfg.urlSecretKey))?.trim() ?? "";
+  const credential =
+    (await readConnectorSecret(vault, cfg.service, cfg.credentialSecretKey))?.trim() ?? "";
+  if (url === "" || credential === "") {
+    return;
+  }
+  const host = hostnameFromUrl(url);
+  const manifest = manifestWithExtraNetworkHosts(cfg.service, host === null ? [] : [host]);
+  servers[cfg.service] = wrapServerSpec(
+    {
+      ...connectorSpawn(cfg.service),
+      env: extensionProcessEnv({ [cfg.urlEnvVar]: url, [cfg.credentialEnvVar]: credential }),
+    },
+    manifest,
+    sandboxCwd,
+  );
+}
+
 export async function phase3AddMetabaseMcp(
   vault: NimbusVault,
   servers: Record<string, ServerSpec>,
   sandboxCwd: string,
 ): Promise<void> {
-  const url = (await readConnectorSecret(vault, "metabase", "url"))?.trim() ?? "";
-  const apiKey = (await readConnectorSecret(vault, "metabase", "api_key"))?.trim() ?? "";
-  if (url === "" || apiKey === "") {
-    return;
-  }
-  const host = hostnameFromUrl(url);
-  const manifest = manifestWithExtraNetworkHosts("metabase", host === null ? [] : [host]);
-  servers["metabase"] = wrapServerSpec(
-    {
-      ...connectorSpawn("metabase"),
-      env: extensionProcessEnv({ METABASE_URL: url, METABASE_API_KEY: apiKey }),
-    },
-    manifest,
-    sandboxCwd,
-  );
+  await addUrlAndSecretMcp(vault, servers, sandboxCwd, {
+    service: "metabase",
+    urlSecretKey: "url",
+    credentialSecretKey: "api_key",
+    urlEnvVar: "METABASE_URL",
+    credentialEnvVar: "METABASE_API_KEY",
+  });
 }
 
 export async function phase3AddSnowflakeMcp(
@@ -982,21 +1027,13 @@ export async function phase3AddDatabricksMcp(
   servers: Record<string, ServerSpec>,
   sandboxCwd: string,
 ): Promise<void> {
-  const hostUrl = (await readConnectorSecret(vault, "databricks", "host"))?.trim() ?? "";
-  const tok = (await readConnectorSecret(vault, "databricks", "token"))?.trim() ?? "";
-  if (hostUrl === "" || tok === "") {
-    return;
-  }
-  const host = hostnameFromUrl(hostUrl);
-  const manifest = manifestWithExtraNetworkHosts("databricks", host === null ? [] : [host]);
-  servers["databricks"] = wrapServerSpec(
-    {
-      ...connectorSpawn("databricks"),
-      env: extensionProcessEnv({ DATABRICKS_HOST: hostUrl, DATABRICKS_TOKEN: tok }),
-    },
-    manifest,
-    sandboxCwd,
-  );
+  await addUrlAndSecretMcp(vault, servers, sandboxCwd, {
+    service: "databricks",
+    urlSecretKey: "host",
+    credentialSecretKey: "token",
+    urlEnvVar: "DATABRICKS_HOST",
+    credentialEnvVar: "DATABRICKS_TOKEN",
+  });
 }
 
 export async function phase3AddMlflowMcp(
@@ -1004,21 +1041,13 @@ export async function phase3AddMlflowMcp(
   servers: Record<string, ServerSpec>,
   sandboxCwd: string,
 ): Promise<void> {
-  const hostUrl = (await readConnectorSecret(vault, "mlflow", "host"))?.trim() ?? "";
-  const tok = (await readConnectorSecret(vault, "mlflow", "token"))?.trim() ?? "";
-  if (hostUrl === "" || tok === "") {
-    return;
-  }
-  const host = hostnameFromUrl(hostUrl);
-  const manifest = manifestWithExtraNetworkHosts("mlflow", host === null ? [] : [host]);
-  servers["mlflow"] = wrapServerSpec(
-    {
-      ...connectorSpawn("mlflow"),
-      env: extensionProcessEnv({ MLFLOW_HOST: hostUrl, MLFLOW_TOKEN: tok }),
-    },
-    manifest,
-    sandboxCwd,
-  );
+  await addUrlAndSecretMcp(vault, servers, sandboxCwd, {
+    service: "mlflow",
+    urlSecretKey: "host",
+    credentialSecretKey: "token",
+    urlEnvVar: "MLFLOW_HOST",
+    credentialEnvVar: "MLFLOW_TOKEN",
+  });
 }
 
 export async function phase3AddVercelMcp(
@@ -1262,21 +1291,13 @@ export async function phase3AddDependencytrackMcp(
   servers: Record<string, ServerSpec>,
   sandboxCwd: string,
 ): Promise<void> {
-  const url = (await readConnectorSecret(vault, "dependencytrack", "base_url"))?.trim() ?? "";
-  const apiKey = (await readConnectorSecret(vault, "dependencytrack", "api_key"))?.trim() ?? "";
-  if (url === "" || apiKey === "") {
-    return;
-  }
-  const host = hostnameFromUrl(url);
-  const manifest = manifestWithExtraNetworkHosts("dependencytrack", host === null ? [] : [host]);
-  servers["dependencytrack"] = wrapServerSpec(
-    {
-      ...connectorSpawn("dependencytrack"),
-      env: extensionProcessEnv({ DEPENDENCYTRACK_URL: url, DEPENDENCYTRACK_API_KEY: apiKey }),
-    },
-    manifest,
-    sandboxCwd,
-  );
+  await addUrlAndSecretMcp(vault, servers, sandboxCwd, {
+    service: "dependencytrack",
+    urlSecretKey: "base_url",
+    credentialSecretKey: "api_key",
+    urlEnvVar: "DEPENDENCYTRACK_URL",
+    credentialEnvVar: "DEPENDENCYTRACK_API_KEY",
+  });
 }
 
 export async function phase3AddElasticsearchMcp(
@@ -1284,21 +1305,13 @@ export async function phase3AddElasticsearchMcp(
   servers: Record<string, ServerSpec>,
   sandboxCwd: string,
 ): Promise<void> {
-  const url = (await readConnectorSecret(vault, "elasticsearch", "url"))?.trim() ?? "";
-  const apiKey = (await readConnectorSecret(vault, "elasticsearch", "api_key"))?.trim() ?? "";
-  if (url === "" || apiKey === "") {
-    return;
-  }
-  const host = hostnameFromUrl(url);
-  const manifest = manifestWithExtraNetworkHosts("elasticsearch", host === null ? [] : [host]);
-  servers["elasticsearch"] = wrapServerSpec(
-    {
-      ...connectorSpawn("elasticsearch"),
-      env: extensionProcessEnv({ ELASTICSEARCH_URL: url, ELASTICSEARCH_API_KEY: apiKey }),
-    },
-    manifest,
-    sandboxCwd,
-  );
+  await addUrlAndSecretMcp(vault, servers, sandboxCwd, {
+    service: "elasticsearch",
+    urlSecretKey: "url",
+    credentialSecretKey: "api_key",
+    urlEnvVar: "ELASTICSEARCH_URL",
+    credentialEnvVar: "ELASTICSEARCH_API_KEY",
+  });
 }
 
 export async function phase3AddAirflowMcp(

--- a/packages/gateway/src/ipc/http-write-routes.ts
+++ b/packages/gateway/src/ipc/http-write-routes.ts
@@ -1122,16 +1122,33 @@ async function runClipPairConfirmRoute(
  * body-supplied client id would turn the ledger row from something the gateway observed into
  * something the caller asserted about itself.
  */
-async function requireAgentAuth(
+type BearerVerdict = { label: string; scopes: readonly ApiScope[] };
+
+/**
+ * The bearer-auth prelude shared by every scoped HTTP write route.
+ *
+ * This body existed verbatim three times — `requireAgentAuth`, `requireFetchAuth`,
+ * `requireBriefAuth` — differing ONLY in which surface supplied `verifyToken`
+ * (`ctx.agents` / `ctx.fetch` / `ctx.briefs`). All four surfaces declare the same
+ * `(presented: string) => Promise<BearerVerdict | null>` shape, so the difference
+ * is a callback, not a control flow.
+ *
+ * Worth collapsing rather than tolerating: this is I13 rejection-recording, and
+ * three copies is three places to forget that the recorded `reason` must track
+ * `refusal.status` — 403 is a real scope gap, 500 is a misconfigured
+ * `HTTP_ROUTE_AUTH` entry, and logging one as the other misreports a
+ * configuration bug as an access-control event.
+ */
+async function requireBearerAuth(
   ctx: WriteRouteContext,
   route: ResolvedRoute,
   fingerprint: string,
   req: Request,
   limit: RateLimitCheck,
-): Promise<Response | { label: string; scopes: readonly ApiScope[] }> {
-  const agents = ctx.agents as AgentsWriteSurface;
+  verifyToken: (presented: string) => Promise<BearerVerdict | null>,
+): Promise<Response | BearerVerdict> {
   const presented = bearerToken(req);
-  const verdict = presented === undefined ? null : await agents.verifyToken(presented);
+  const verdict = presented === undefined ? null : await verifyToken(presented);
   if (verdict === null) {
     recordRejection(ctx, {
       actionType: route.rejectAction,
@@ -1154,6 +1171,17 @@ async function requireAgentAuth(
     return refusal;
   }
   return verdict;
+}
+
+async function requireAgentAuth(
+  ctx: WriteRouteContext,
+  route: ResolvedRoute,
+  fingerprint: string,
+  req: Request,
+  limit: RateLimitCheck,
+): Promise<Response | BearerVerdict> {
+  const agents = ctx.agents as AgentsWriteSurface;
+  return requireBearerAuth(ctx, route, fingerprint, req, limit, (t) => agents.verifyToken(t));
 }
 
 async function runAgentInvokeRoute(
@@ -1266,32 +1294,9 @@ async function requireFetchAuth(
   fingerprint: string,
   req: Request,
   limit: RateLimitCheck,
-): Promise<Response | { label: string; scopes: readonly ApiScope[] }> {
+): Promise<Response | BearerVerdict> {
   const fetchSurface = ctx.fetch as FetchWriteSurface;
-  const presented = bearerToken(req);
-  const verdict = presented === undefined ? null : await fetchSurface.verifyToken(presented);
-  if (verdict === null) {
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: 401,
-      reason: "unauthorized",
-    });
-    return jsonResponse({ error: "unauthorized" }, 401, rateLimitHeaders(limit));
-  }
-  const refusal = scopeRefusal(route.key, verdict.scopes, limit);
-  if (refusal !== null) {
-    // See the twin comment in runClipIngestRoute: refusal.status is 403 (a real scope gap) or 500
-    // (a misconfigured HTTP_ROUTE_AUTH entry), and the recorded reason must match which happened.
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: refusal.status,
-      reason: refusal.status === 403 ? "insufficient_scope" : "internal_error",
-    });
-    return refusal;
-  }
-  return verdict;
+  return requireBearerAuth(ctx, route, fingerprint, req, limit, (t) => fetchSurface.verifyToken(t));
 }
 
 async function runItemsFetchRoute(
@@ -1337,6 +1342,11 @@ async function runItemsFetchRoute(
   }
 }
 
+/**
+ * `Response | null` rather than the verdict: the four brief routes only need to
+ * know whether they were refused, and keeping that shape leaves their call
+ * sites (`if (denied !== null) return denied;`) unchanged.
+ */
 async function requireBriefAuth(
   ctx: WriteRouteContext,
   route: ResolvedRoute,
@@ -1345,30 +1355,10 @@ async function requireBriefAuth(
   limit: RateLimitCheck,
 ): Promise<Response | null> {
   const briefs = ctx.briefs as BriefsWriteSurface;
-  const presented = bearerToken(req);
-  const verdict = presented === undefined ? null : await briefs.verifyToken(presented);
-  if (verdict === null) {
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: 401,
-      reason: "unauthorized",
-    });
-    return jsonResponse({ error: "unauthorized" }, 401, rateLimitHeaders(limit));
-  }
-  const refusal = scopeRefusal(route.key, verdict.scopes, limit);
-  if (refusal !== null) {
-    // See the twin comment in runClipIngestRoute: refusal.status is 403 or 500, and the recorded
-    // reason must match which one actually happened.
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: refusal.status,
-      reason: refusal.status === 403 ? "insufficient_scope" : "internal_error",
-    });
-    return refusal;
-  }
-  return null;
+  const outcome = await requireBearerAuth(ctx, route, fingerprint, req, limit, (t) =>
+    briefs.verifyToken(t),
+  );
+  return outcome instanceof Response ? outcome : null;
 }
 
 function briefValidationResponse(
@@ -1477,6 +1467,45 @@ function lookupRun(
   return jsonResponse({ error: "not_found" }, 404, rateLimitHeaders(limit));
 }
 
+type BriefRunRecord = Exclude<ReturnType<typeof lookupRun>, Response>;
+
+/**
+ * Auth, resolve the run, and require it to be in `expected` state.
+ *
+ * The three brief routes that mutate a run repeated this prelude verbatim,
+ * differing only in the state they demand — `collecting` for add-source,
+ * `done` for save. Collapsing it keeps the 409 `invalid_state` rejection
+ * recorded in exactly one place; three copies is three chances for the
+ * recorded `resultCode` and the returned status to drift apart.
+ *
+ * `runBriefRunRoute` deliberately does NOT use this: a re-run is idempotent and
+ * answers 200 with the run's current state rather than 409, so it shares the
+ * auth+lookup half only.
+ */
+async function requireBriefRunInState(
+  ctx: WriteRouteContext,
+  route: ResolvedRoute,
+  fingerprint: string,
+  req: Request,
+  limit: RateLimitCheck,
+  expected: BriefRunRecord["status"],
+): Promise<Response | BriefRunRecord> {
+  const denied = await requireBriefAuth(ctx, route, fingerprint, req, limit);
+  if (denied !== null) return denied;
+  const found = lookupRun(ctx, route, fingerprint, route.id as string, limit);
+  if (found instanceof Response) return found;
+  if (found.status !== expected) {
+    recordRejection(ctx, {
+      actionType: route.rejectAction,
+      tokenFingerprint: fingerprint,
+      resultCode: 409,
+      reason: "invalid_state",
+    });
+    return jsonResponse({ error: "invalid_state" }, 409, rateLimitHeaders(limit));
+  }
+  return found;
+}
+
 async function runBriefSourceRoute(
   ctx: WriteRouteContext,
   route: ResolvedRoute,
@@ -1486,19 +1515,8 @@ async function runBriefSourceRoute(
   parsed: unknown,
 ): Promise<Response> {
   const briefs = ctx.briefs as BriefsWriteSurface;
-  const denied = await requireBriefAuth(ctx, route, fingerprint, req, limit);
-  if (denied !== null) return denied;
-  const found = lookupRun(ctx, route, fingerprint, route.id as string, limit);
+  const found = await requireBriefRunInState(ctx, route, fingerprint, req, limit, "collecting");
   if (found instanceof Response) return found;
-  if (found.status !== "collecting") {
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: 409,
-      reason: "invalid_state",
-    });
-    return jsonResponse({ error: "invalid_state" }, 409, rateLimitHeaders(limit));
-  }
   try {
     const input = validateSourceInput(parsed);
     const out = briefs.controller.addSource(found, input);
@@ -1579,19 +1597,8 @@ async function runBriefSaveRoute(
   req: Request,
 ): Promise<Response> {
   const briefs = ctx.briefs as BriefsWriteSurface;
-  const denied = await requireBriefAuth(ctx, route, fingerprint, req, limit);
-  if (denied !== null) return denied;
-  const found = lookupRun(ctx, route, fingerprint, route.id as string, limit);
+  const found = await requireBriefRunInState(ctx, route, fingerprint, req, limit, "done");
   if (found instanceof Response) return found;
-  if (found.status !== "done") {
-    recordRejection(ctx, {
-      actionType: route.rejectAction,
-      tokenFingerprint: fingerprint,
-      resultCode: 409,
-      reason: "invalid_state",
-    });
-    return jsonResponse({ error: "invalid_state" }, 409, rateLimitHeaders(limit));
-  }
   try {
     return jsonResponse(briefs.save(found.id), 200, rateLimitHeaders(limit));
   } catch (e) {

--- a/packages/gateway/src/ipc/test-token-vault.ts
+++ b/packages/gateway/src/ipc/test-token-vault.ts
@@ -1,0 +1,39 @@
+import type { NimbusVault } from "../vault/nimbus-vault.ts";
+
+/** The one Vault key every bearer-authed HTTP surface reads. Historical name. */
+export const CLIP_TOKENS_KEY = "http_api.web_clipper_tokens";
+
+/**
+ * An in-memory `NimbusVault` seeded with one `http_api.web_clipper_tokens` blob.
+ *
+ * The four accessors were byte-identical in `agent-runs/agent-test-server.ts`
+ * and `briefs/brief-test-server.ts`; only the seeded JSON differed, and that
+ * difference is deliberate rather than incidental — so it stays the caller's
+ * decision and is NOT given a default here:
+ *
+ *  - the agents harness seeds the SCOPED form including `agents`, because every
+ *    agents route is agents-scoped and a legacy seed would 403 the positive
+ *    tests for the wrong reason;
+ *  - the briefs harness seeds the LEGACY bare-string form, so every existing
+ *    test using it proves, for free, that a pre-scopes token still works.
+ *
+ * Giving this helper a default would quietly erase one of those two intents the
+ * first time someone omitted the argument.
+ */
+export function createSeededTokenVault(tokensJson: string): NimbusVault {
+  const store = new Map<string, string>();
+  store.set(CLIP_TOKENS_KEY, tokensJson);
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+    listKeys: async (prefix?: string) => {
+      const keys = [...store.keys()];
+      return prefix === undefined ? keys : keys.filter((k) => k.startsWith(prefix));
+    },
+  } as NimbusVault;
+}

--- a/scripts/coverage-floor/exclusions.ts
+++ b/scripts/coverage-floor/exclusions.ts
@@ -65,6 +65,12 @@ export const EXCLUSIONS: readonly ExclusionPattern[] = Object.freeze([
   { kind: "exact", path: "packages/gateway/src/agent-runs/agent-test-server.ts" },
   // `http-api-test-server.ts` is the third harness of this shape — same reason.
   { kind: "exact", path: "packages/gateway/src/ipc/http-api-test-server.ts" },
+  // `test-token-vault.ts` is the in-memory seeded Vault those harnesses share. It was extracted
+  // from `brief-test-server.ts` + `agent-test-server.ts` (both already excluded here) when their
+  // byte-identical copies were deduplicated, so it inherits their exemption rather than earning a
+  // new one — the `delete`/`listKeys` accessors exist to satisfy the `NimbusVault` interface and no
+  // harness calls them, which is exactly why the two parents were exempted in the first place.
+  { kind: "exact", path: "packages/gateway/src/ipc/test-token-vault.ts" },
 
   // ── Generated SQL ── (retired 2026-08-01)
   // The `index/*-v<N>-sql.ts` migration constants are single exported template literals that the


### PR DESCRIPTION
Targets the SonarCloud duplication metric: **0.3% → ~0.18%**, by removing roughly **232 of the 492 duplicated lines**. Sonar's analysis on this PR is the authoritative confirmation; locally jscpd moves 3.60% → 3.52% (it counts differently and includes tests, so the two numbers are not comparable — see the note at the bottom).

## What was collapsed

| cluster | dup lines | change |
|---|---|---|
| `ipc/http-write-routes.ts` — 3 bearer-auth preludes | 117 → ~33 | `requireBearerAuth` takes `verifyToken` as a callback |
| `ipc/http-write-routes.ts` — 2 brief-route preludes | ″ | `requireBriefRunInState(…, expected)` |
| `connectors/lazy-mesh/phase3-config.ts` — 5 connector registrars | 70 → 0 | `addUrlAndSecretMcp`, generic over the service id |
| `agents/{decisions,glossary,ownership}.ts` — `subAgent` + `decode` | 48 → 0 | new `agents/_lib/sub-agent.ts` |
| `agent-runs/agent-test-server.ts` + `briefs/brief-test-server.ts` | 30 → 0 | new `ipc/test-token-vault.ts` |

## Two of these needed care, not just extraction

**`phase3-config.ts` touches invariant I15 / static D10** (`every lazy-mesh ServerSpec via wrapServerSpec()`). I checked the rule before moving anything: it is **file-scoped** — a lazy-mesh file mentioning `Record<string, ServerSpec>` must also contain `wrapServerSpec(` — so the file still satisfies it, and `bun run audit:invariants` passes. More importantly the consolidation **strengthens** the invariant's intent: a sixth url+secret connector added through `addUrlAndSecretMcp` *cannot* forget the wrap, where a sixth hand-written copy could.

The helper is generic over the service id (`<S extends ConnectorServiceId>`) rather than taking `service: string`. My first attempt used `string` and `tsc` correctly rejected it — the secret-key parameters are checked against *that service's* own key union, and widening would have typechecked a vault key that does not exist for the connector being wired.

**The bearer-auth collapse is I13 rejection-recording**, which is why it was worth doing rather than tolerating: three copies is three places to forget that the recorded `reason` must track `refusal.status` — 403 is a real scope gap, 500 is a misconfigured `HTTP_ROUTE_AUTH` entry, and logging one as the other misreports a configuration bug as an access-control event.

## What I deliberately did NOT collapse

Sonar flags `decisions/decision-refresh.ts` ↔ `ownership/ownership-refresh.ts` (37 + 30 lines). Their `fire()` bodies are near-identical — but there are **four** refreshers and **four different `trigger()` implementations**:

| refresher | `trigger()` |
|---|---|
| decisions | `stopped` check, clear + arm |
| ownership | …plus `if (running) { dirty = true; return; }` |
| glossary | `!deps.enabled \|\| stopped` |
| premortem | …plus `timer.unref?.()` |

Those differences are real: they change coalescing behaviour mid-pass and whether a pending timer holds the process open at shutdown. A shared debouncer would need three option flags to preserve them, which is worse than the duplication it removes — and flattening them instead would be a behaviour change to four subsystems dressed up as a cleanup. Left alone on purpose.

Same reasoning applied to the seeded token JSON in the two test harnesses: `createSeededTokenVault` takes it as a **required** argument with no default, because the agents harness deliberately seeds the scoped form (every agents route is agents-scoped) while the briefs harness deliberately seeds the legacy bare-string form (so existing tests prove a pre-scopes token still works). A default would have quietly erased one of those intents.

## Verification

- `bun run preflight:fast` — PASSED (all 29 gates, including `audit:invariants` and the jscpd gate)
- `bun test packages/gateway/src packages/cli/src` — **13,091 pass, 30 skip, 0 fail** — identical to the pre-change count, so no test was lost or silently skipped
- `bun run typecheck` — 0 errors

## Note on the two duplication numbers

Sonar reports **0.3%** and the repo's own jscpd gate reports **3.6%** against a threshold of 4. They measure different things — jscpd includes test files and uses `minTokens: 50`. This PR targets the Sonar metric, which is what "reduce duplication to 0.2" was asked against. Driving *jscpd* to 0.2% would be a far larger structural effort and is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
