### PR TITLE
feat(connectors): index GitHub PR reviews and size statistics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -100,10 +100,11 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   request indexes that pull request, including ones you did not author, since that is what lets a
   review link to a titled PR rather than a bare id; this indexes pull requests you reviewed, never
   who reviewed your pull requests, because the GitHub events feed reports only the authenticated
-  user's own activity; and coverage begins at first sync — the events feed exposes only a recent
-  window (GitHub caps it at 300 events / 30 days, and Nimbus reads one page of 100 per tick), so
-  reviews from before the connector was first synced are not recoverable by syncing, and a review
-  deleted upstream leaves its graph link in place. Separately, PR size stats (`additions`,
+  user's own activity; and coverage is bounded by the events feed's retained window (GitHub caps
+  it at 300 events / 30 days, and Nimbus reads one page of 100 per tick) — a first successful sync
+  does index recent events created before installation, since that trailing window is what it
+  reads, but reviews older than the retained window, or beyond the per-tick page cap, are not
+  recoverable by syncing, and a review deleted upstream leaves its graph link in place. Separately, PR size stats (`additions`,
   `deletions`, `changed_files`, `commits`) are now captured, and the enrichment pass also re-fetches
   PRs that have a real title but no stats. A secondary-rate-limit bug is fixed alongside: a 403
   carrying `retry-after` is now honored even when quota remains.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,23 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   this change stops future egress, it does not undo past egress. No migration, no schema change,
   no new invariant.
 
+- **2026-08-11 — GitHub connector: pull-request review depth (no schema change).** A review you
+  leave on a GitHub pull request is now indexed as its own `review` item, and the graph gains a
+  `person --reviewed--> pr` edge for it. `nimbus expert` surfaces reviewers as `pr_reviewed`
+  evidence and `nimbus why` names them in its pull-request finding; both now emit an explicit gap
+  note — instead of going silently empty — when a reviewed edge exists but does not resolve to an
+  indexed reviewer. Three limits, documented in
+  [`docs/connectors/github.md`](./connectors/github.md#pull-request-reviews): reviewing a pull
+  request indexes that pull request, including ones you did not author, since that is what lets a
+  review link to a titled PR rather than a bare id; this indexes pull requests you reviewed, never
+  who reviewed your pull requests, because the GitHub events feed reports only the authenticated
+  user's own activity; and coverage begins at first sync — the events feed exposes only a recent
+  window (GitHub caps it at 300 events / 30 days, and Nimbus reads one page of 100 per tick), so
+  reviews from before the connector was first synced are not recoverable by syncing, and a review
+  deleted upstream leaves its graph link in place. Separately, PR size stats (`additions`,
+  `deletions`, `changed_files`, `commits`) are now captured, and the enrichment pass also re-fetches
+  PRs that have a real title but no stats. A secondary-rate-limit bug is fixed alongside: a 403
+  carrying `retry-after` is now honored even when quota remains.
 - **2026-08-11 — `nimbus pre-mortem`: the thirteenth built-in agent (PR B of the S1 pre-mortem
   work).** Reads the schema + background pass PR A shipped 2026-08-09 (V53) and adds the missing
   reader: `agents.premortem`, `nimbus pre-mortem <epic-ref> [--service <name>]… [--json]

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -10,3 +10,19 @@ Migrated from inline comments in `packages/gateway/src/connectors/github-*.ts` a
 **Original comment (excerpt):** `NOTE: The github sync is currently events-driven (/users/{login}/events), not a list-pass over /repos/{owner}/{repo}/pulls. PullRequestEvent payloads populate mergeable_state whenever a PR is touched, but stale open PRs that haven't had activity in the events feed do not refresh. Driving this policy from a periodic refresh pass is deferred; the preflight calculator handles missing state via its unknown_mergeable_state gap branch.`
 
 The GitHub sync handler fetches `PullRequestEvent` entries from the `/users/{login}/events` feed rather than paginating over all open PRs in each repo. This means `mergeable_state` is refreshed only when a PR receives activity in the events feed; long-lived PRs with no recent activity remain stale. `shouldRefreshMergeableState` applies a 24-hour thrash guard and a 7-day activity window to decide whether to issue a detail-endpoint call for a given PR. The preflight calculator gracefully handles missing `mergeable_state` values via an `unknown_mergeable_state` gap in the verdict — it does not assume a stale null means the PR is conflict-free.
+
+### Pull-request reviews
+
+Reviews you leave on pull requests are indexed as their own items and linked to the
+pull request in the relationship graph, so `nimbus expert` and `nimbus why` can
+attribute review work.
+
+Three limits are worth knowing:
+
+- **Reviewing a pull request indexes that pull request**, including ones you did not
+  author. This is what lets a review link to a titled PR rather than a bare id.
+- This indexes **pull requests you reviewed**, not **who reviewed your pull
+  requests** — the GitHub events feed reports your own activity.
+- Coverage begins when the connector first syncs. The events feed exposes only a
+  recent window, so reviews from before then are not recoverable by syncing. A review
+  deleted upstream also leaves its graph link in place.

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -23,11 +23,14 @@ Three limits are worth knowing:
   author. This is what lets a review link to a titled PR rather than a bare id.
 - This indexes **pull requests you reviewed**, not **who reviewed your pull
   requests** — the GitHub events feed reports your own activity.
-- The sync fetches one un-paginated page of 100 events per tick from the events
-  feed. This is not only a first-sync/backfill limitation: a burst of more than
-  100 events between **any** two ordinary ticks — not just before the first
-  sync — silently drops the overflow, exactly as it would before the connector
-  had ever synced. The connector logs a saturation warning whenever a full page
-  comes back, on every tick that fills the page, not only the first. There is
-  no history-recovery command today — syncing more often is the only mitigation.
-  A review deleted upstream also leaves its graph link in place.
+- The events feed exposes only a recent window of activity, so reviews left
+  before the connector was first synced are not recoverable by syncing at
+  all. This is a separate limit from the per-tick page cap below — a
+  different cause, and syncing more often does not help it.
+- The sync also fetches one un-paginated page of 100 events per tick from the
+  events feed. A burst of more than 100 events between **any** two ticks —
+  not only before the first sync — silently drops the overflow; the
+  connector logs a saturation warning whenever a full page comes back. There
+  is no history-recovery command today — syncing more often reduces exposure
+  to this cap but does not eliminate it. A review deleted upstream also
+  leaves its graph link in place.

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -23,10 +23,13 @@ Three limits are worth knowing:
   author. This is what lets a review link to a titled PR rather than a bare id.
 - This indexes **pull requests you reviewed**, not **who reviewed your pull
   requests** — the GitHub events feed reports your own activity.
-- The events feed exposes only a recent window of activity, so reviews left
-  before the connector was first synced are not recoverable by syncing at
-  all. This is a separate limit from the per-tick page cap below — a
-  different cause, and syncing more often does not help it.
+- The events feed exposes only a recent, trailing window of activity (GitHub
+  caps it at 300 events / 30 days), and a first successful sync does index
+  whatever recent events fall inside that window — including ones created
+  before the connector was installed. What is genuinely unrecoverable by
+  syncing is anything **older than the retained events window**, or beyond
+  the per-tick page cap below. This is a separate limit from that page cap —
+  a different cause, and syncing more often does not help either one.
 - The sync also fetches one un-paginated page of 100 events per tick from the
   events feed. A burst of more than 100 events between **any** two ticks —
   not only before the first sync — silently drops the overflow; the

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -23,6 +23,11 @@ Three limits are worth knowing:
   author. This is what lets a review link to a titled PR rather than a bare id.
 - This indexes **pull requests you reviewed**, not **who reviewed your pull
   requests** — the GitHub events feed reports your own activity.
-- Coverage begins when the connector first syncs. The events feed exposes only a
-  recent window, so reviews from before then are not recoverable by syncing. A review
-  deleted upstream also leaves its graph link in place.
+- The sync fetches one un-paginated page of 100 events per tick from the events
+  feed. This is not only a first-sync/backfill limitation: a burst of more than
+  100 events between **any** two ordinary ticks — not just before the first
+  sync — silently drops the overflow, exactly as it would before the connector
+  had ever synced. The connector logs a saturation warning whenever a full page
+  comes back, on every tick that fills the page, not only the first. There is
+  no history-recovery command today — syncing more often is the only mitigation.
+  A review deleted upstream also leaves its graph link in place.

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review-response.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review-response.md
@@ -1,0 +1,134 @@
+# GitHub Contribution Depth PR 1 — Plan Review Response
+
+**Date:** 2026-08-11
+**Responds to:** `2026-08-11-github-contribution-depth-pr1-review.md`
+**Outcome:** 4 accepted (2 of them real defects in the plan), 1 confirmed already covered, 1 rejected.
+
+---
+
+## 1. Verify current file state before editing — **ACCEPTED: this found a real defect**
+
+The suggestion is generic process advice, but checking it against the plan exposed a concrete bug.
+
+**Tasks 4, 5, 6 and 7 all modify `github-sync.ts` in sequence**, and Task 4 inserts roughly 70 lines
+(`githubReviewExternalId`, `upsertReview`, `processPullRequestReviewPayload`) *before* the regions
+Tasks 6 and 7 cite. Every `github-sync.ts` line number in Tasks 6 and 7 — `:366-387`, `:389-459`,
+`:533-544` — is therefore **stale by the time an executor reaches them**. An agent jumping to `:397`
+during Task 6 lands in the wrong function.
+
+Task 5 (`:70-110`) is unaffected, since it edits above the insertion point.
+
+**Fix:** a new global constraint stating that line numbers are as of 2026-08-11, that Tasks 4–7 shift
+them, and that the executor must **locate by symbol name, then confirm the quoted code matches before
+editing** — stopping to re-read if it does not. That is stronger than "print the file first", because
+it says what to do when the printout disagrees with the plan.
+
+---
+
+## 2. Verify the graph really re-populates in the edge-survival test — **ACCEPTED: this found a real hole**
+
+The test asserted the edge exists before the re-seed and after it, which reads as sufficient but is
+not. **It could pass vacuously.** If `upsertIndexedItem` ever skipped graph population for a row it
+considered unchanged, the edge would "survive" because nothing touched it — and the test would stay
+green even with `"reviewed"` absent from `CROSS_ITEM_RELATION_TYPES`, which is the single defect this
+test exists to catch. The red-prove step in Task 1 Step 8 would then fail to go red, and the executor
+would be instructed to treat that as a broken test — but only after wasted effort.
+
+**Fix:** the test now asserts the PR entity's label actually changed to `"Add rate limiter v2"` before
+asserting the edge survived. Since the re-seed passes a new title, a changed label is proof that
+`syncPrGraph` — and therefore `clearRelationsTouchingEntity` — genuinely ran.
+
+---
+
+## 3. Do existing tests assert the exact gap message? — **ACCEPTED, and answered concretely**
+
+The plan previously said "if an existing test asserted the old remediation string, update it", which
+pushed a verifiable question onto the executor. Both call sites are now resolved in the plan:
+
+**`expert.test.ts:220`** ("missing reviewed relation surfaces a missing_relation_emit gap note")
+asserts only `cats).toContain("missing_relation_emit")` — no message matching. Its fixture seeds a
+single PR through a raw `INSERT INTO item`, which bypasses the populator, so no graph rows and no
+`reviewed` edges exist and the gap still fires. **It must keep passing unchanged**, and the plan now
+says so, adding that if it goes red the new lane is returning a stream where there is no evidence.
+
+**`why.test.ts:159`** asserts
+`g.category === "missing_relation_emit" && g.detail.includes("reviewed")`. That matches on `detail`,
+which `detectMissingRelationEmit` generates at `gap-notes.ts:64`. This task changes only the
+`remediation` argument, never `detail`, so the assertion is unaffected.
+
+**No test anywhere asserts the remediation string.** `gap-notes.test.ts:99` asserts
+`remediation).toBeUndefined()` for a call that passes none — a different code path.
+
+One residual wart, recorded and deliberately not fixed: `detectMissingRelationEmit`'s generated
+`detail` reads "edges are defined in the schema but not yet emitted by the graph populator." For
+`reviewed` that wording becomes misleading after Task 1 — the truthful meaning is now "no reviews
+indexed yet." The `detail` string is shared by every relation type using the helper, so rewording it
+here would change gap notes for unrelated lanes. The corrected `remediation` carries the actionable
+text instead.
+
+---
+
+## 4. Coverage-floor risk — **CONFIRMED ALREADY COVERED; no plan change**
+
+The concern is right, and the three specific branches named are each already exercised:
+
+| Suggested coverage | Where the plan covers it |
+| --- | --- |
+| Malformed review event payload | Task 4, two tests: missing `pull_request`, and missing review `id` — both assert `not.toThrow()` and zero items written |
+| Events missing stats vs containing stats | Task 5, two tests: stats captured from a pull-detail payload; keys **absent** (not `null`) when omitted |
+| `retry-after` present | Task 7, two tests: 403 + `retry-after` + non-zero `remaining` throws; 403 with neither does not |
+
+Plus branches the review did not name but the plan already covers: review with no author, review with
+metadata lacking `repo`/`pr_number` (Task 1), and the enrich selector's three predicate arms plus its
+limit cap (Task 6).
+
+The plan's final-verification section already forbids the escape hatch — if the floor fails, add
+tests, do not update the baseline.
+
+---
+
+## 5. Optional chaining on `payload.review` / `payload.pull_request` — **REJECTED**
+
+This would be unsafe and is contrary to the file's idiom.
+
+`payload` is already `asRecord(ev["payload"])` and is checked against `undefined` at
+`github-sync.ts:329-331` before any access. Indexing a `Record<string, unknown>` with `payload["review"]`
+**cannot throw** — it yields `undefined` for a missing key. `asRecord()` then returns `undefined` for
+anything that is not a plain object, and the plan's code checks exactly that:
+
+```typescript
+const review = asRecord(payload["review"]);
+const pr = asRecord(payload["pull_request"]);
+if (review === undefined || pr === undefined) {
+  return false;
+}
+```
+
+That guard is total. There is no `Cannot read properties of undefined` path to defend against.
+
+Adding `?.` would also work against this codebase specifically: Biome 2.5.4 flags unsafe optional
+chaining, and a `?.` applied to an already-narrowed type produced a **fail-open** bug in the recent
+Jira/Linear ticket-depth work — a guard that silently returned "fine" instead of rejecting. Explicit
+`=== undefined` checks after `asRecord` are the established, safer pattern here.
+
+---
+
+## 6. Document that PR 2's search path reuses the rate-limit helpers — **ACCEPTED**
+
+Cheap and worth pinning before PR 2 starts. Task 7 now records that
+`throwGithubRateLimitErrorIfApplicable` and `retryAfterDateFromHeader` are the shared helpers the
+search backfill must reuse, that its only required change is the bucket key becoming a parameter, and
+that forking a second parser is forbidden — GitHub's 403/429 + `retry-after` semantics are identical
+on both surfaces, so two parsers would drift.
+
+---
+
+## Plan changes made
+
+| Location | Change |
+| --- | --- |
+| Global Constraints | Line numbers declared as-of-date; Tasks 4–7 shift `github-sync.ts`; locate by symbol, verify quoted code before editing |
+| Task 1, Step 1 | Survival test now proves re-population ran, via the PR entity's changed label |
+| Task 2, Step 4 | Conditional instruction replaced with the verified state of `expert.test.ts:220` |
+| Task 3, Step 5 | Conditional instruction replaced with the verified state of `why.test.ts:159` |
+| Task 7, Step 3 | Note pinning PR 2 to the same rate-limit helpers |

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review.md
@@ -1,0 +1,30 @@
+# GitHub Contribution Depth PR1 Implementation Plan Review
+
+## Open Questions & Risks
+
+1. **Step-by-Step Execution Verification**
+   - The plan is very structured with `- [ ]` checkboxes and detailed code snippets.
+   - **Question**: When executing these tasks, what if the existing types in `relationship-graph.ts` or other files slightly differ in structure?
+   - **Suggestion**: Before editing each file, print or view the current state of that specific section (e.g. `relationship-graph.ts` line ranges) to ensure drop-in replacement matches.
+
+2. **Idempotence & Edge Survival Test Case**
+   - In Task 1 Step 1, the test `"a reviewed edge survives the PR being re-populated"` is highly critical.
+   - **Suggestion**: Ensure that we verify that the relationship graph actually populates the database correctly before and after the `seedPr` (re-sync) execution. 
+
+3. **`detectMissingRelationEmit` Message Matching**
+   - In Task 2 and Task 3, `detectMissingRelationEmit` is invoked with a custom description: `"Reviews are indexed from the GitHub events feed — sync the connector, or run nimbus index backfill --service github for history."`.
+   - **Question**: Are there existing tests in the test suite (like `expert.test.ts` or `why.test.ts`) that assert on the exact error/gap message structure?
+   - **Suggestion**: If so, we should update those tests to match this new text exactly, otherwise the test suite might break due to message mismatches.
+
+4. **Coverage Floor Gaps**
+   - The plan states: "Neither `github-sync.ts` nor `graph-populator.ts` appears in `docs/structure-audit/coverage-baseline.json`".
+   - **Question**: Will the changes in `github-sync.ts` (especially the parsing and fallback logic) reduce the branch coverage below the 80% floor?
+   - **Suggestion**: Make sure the tests added in Task 4 explicitly exercise:
+     - A malformed review event payload (to cover error handling branches).
+     - Events missing stats vs events containing stats.
+     - Rate-limit handling when `retry-after` header is present.
+
+## Code Improvement Suggestions
+
+- **Task 4 (processEvent payload check)**: In Task 4, when handling the `PullRequestReviewEvent` event, ensure we safely access properties (e.g., `payload?.review` or `payload?.pull_request`) using optional chaining or robust guards to prevent runtime `Cannot read properties of undefined` crashes on unexpected payloads.
+- **Dry-run Search Backfill (PR 2 Prep)**: For Task 7's `retry-after` logic, document that `github_search` will use the same parser helper functions to ensure consistency between PR1 and PR2.

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1-review.md
@@ -9,7 +9,7 @@
 
 2. **Idempotence & Edge Survival Test Case**
    - In Task 1 Step 1, the test `"a reviewed edge survives the PR being re-populated"` is highly critical.
-   - **Suggestion**: Ensure that we verify that the relationship graph actually populates the database correctly before and after the `seedPr` (re-sync) execution. 
+   - **Suggestion**: Ensure that we verify that the relationship graph actually populates the database correctly before and after the `seedPr` (re-sync) execution.
 
 3. **`detectMissingRelationEmit` Message Matching**
    - In Task 2 and Task 3, `detectMissingRelationEmit` is invoked with a custom description: `"Reviews are indexed from the GitHub events feed — sync the connector, or run nimbus index backfill --service github for history."`.

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
@@ -1222,15 +1222,26 @@ it existed to make the SQL`LIKE` precise, but a row now qualifies on either reas
 would silently drop every stats-missing PR with a real title — the exact case this task adds.
 
 `NOT json_valid(metadata)` is deliberate: a row with unparseable metadata cannot be proven to have
-stats, so it must be re-fetched rather than skipped. **Correction (post-review):** the `OR` form
-above does not protect `json_extract` from malformed JSON — SQLite's `OR` does not reliably
-short-circuit left to right here, and `json_extract` on unparseable text raises
-`SQLiteError: malformed JSON`, which kills the whole query for every row, not just the bad one.
-The shipped code wraps the `json_extract` arm in a `CASE WHEN json_valid(metadata) THEN
-json_extract(metadata, '$.additions') IS NULL ELSE 1 END` guard instead of relying on `OR`
-short-circuit — a row whose metadata cannot be parsed falls into the `ELSE 1` branch and remains a
-candidate. See `packages/gateway/src/connectors/github-sync.ts`'s `selectPrEnrichCandidates` for
-the actual guarded query.
+stats, so it must be re-fetched rather than skipped. A guard is genuinely required: an UNGUARDED
+`json_extract(metadata, '$.additions') IS NULL` in the WHERE clause throws
+`SQLiteError: malformed JSON` on a single bad row and kills the query for every row.
+
+**Measured correction (post-review).** The bare `OR` form above is NOT broken, contrary to a review
+finding and to this plan's earlier correction of it. Measured on bun 1.3.14 / SQLite 3.53.0, on both
+Windows and Linux, over real table rows:
+
+| Expression | Result |
+| --- | --- |
+| `WHERE … OR NOT json_valid(metadata) OR json_extract(…) IS NULL` | no throw — short-circuits per row |
+| `WHERE … OR CASE WHEN json_valid(metadata) THEN json_extract(…) IS NULL ELSE 1 END` | no throw |
+| `WHERE json_extract(…) IS NULL` (unguarded) | **throws** |
+
+The review's repro (`SELECT (NOT json_valid('{bad') OR json_extract('{bad', …))`) throws because a
+SELECT-list VALUE context evaluates differently from a WHERE-clause boolean context. The shipped
+code uses the `CASE WHEN json_valid(metadata) THEN … ELSE 1 END` form anyway — not because `OR` was
+wrong, but so correctness does not rest on a context-dependent evaluation detail that is easy to
+mis-test and was in fact mis-tested twice. A row whose metadata cannot be parsed falls into
+`ELSE 1` and remains a candidate. See `selectPrEnrichCandidates` for the shipped query.
 
 - [ ] **Step 4: Rename the caller and update the doc comment**
 

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
@@ -20,8 +20,11 @@ the existing enrichment pass already fetches and currently discards.
 ## Global Constraints
 
 - **No `any`.** Use `unknown` for external data. TypeScript strict mode is non-negotiable.
-- **Bound-param SQL only** (invariant I9). All writes go through `dbRun`/`dbExec` from `db/write.ts`
-  (invariant I14) — never `db.run` directly.
+- **Bound-param SQL only** (invariant I9). **Production** writes go through `dbRun`/`dbExec` from
+  `db/write.ts` (invariant I14, enforced statically by D12) — never `db.run` directly. **This binds
+  `src/` code, not tests:** the static audit scopes I14 to production sites, and the existing suite
+  seeds fixtures with `db.run(...)` (see `expert.test.ts:292`). Test code in this plan uses `db.run`
+  deliberately and must not be "corrected" to `dbRun`.
 - **Never commit on `main`.** All work lands on `dev/asafgolombek/github-contribution-depth`, which
   already exists and is checked out.
 - **No migration in this PR.** `item.type` is free-form `TEXT NOT NULL`; the `reviewed` relation type
@@ -69,11 +72,13 @@ prevent that and are not optional.
 ## Task 1: Emit `person --reviewed--> pr` from a `review` item
 
 **Files:**
+
 - Modify: `packages/gateway/src/graph/relationship-graph.ts:6-23`
 - Modify: `packages/gateway/src/graph/graph-populator.ts:77-81`, `:780`
 - Test: `packages/gateway/src/graph/graph-populator-reviews.test.ts` (create)
 
 **Interfaces:**
+
 - Consumes: `upsertGraphEntity`, `ensureGraphEntity`, `upsertGraphRelation` from
   `./relationship-graph.ts`; `IndexedItemGraphInput` from `graph-populator.ts:14`.
 - Produces: a `review` item whose `metadata` carries `{ repo: string, pr_number: number }` yields
@@ -419,10 +424,12 @@ git commit -m "feat(graph): emit person --reviewed--> pr from review items"
 ## Task 2: `expert`'s reviewer lane returns real evidence
 
 **Files:**
+
 - Modify: `packages/gateway/src/agents/expert.ts:280-288`
 - Test: `packages/gateway/src/agents/expert.test.ts`
 
 **Interfaces:**
+
 - Consumes: the `reviewed` edges Task 1 emits.
 - Produces: `subPrReviewed` returns `{ stream: ExpertEvidenceStream }` with
   `Evidence.type === "pr_reviewed"` and `weight: 0.6`.
@@ -608,10 +615,12 @@ git commit -m "feat(agents): expert surfaces PR reviewers as pr_reviewed evidenc
 ## Task 3: `why`'s pull-request lane names reviewers
 
 **Files:**
+
 - Modify: `packages/gateway/src/agents/why.ts:295-322`
 - Test: `packages/gateway/src/agents/why.test.ts`
 
 **Interfaces:**
+
 - Consumes: the `reviewed` edges Task 1 emits.
 - Produces: the `pull_request` lane's `WhyFinding.detail` names reviewers when any exist; the
   permanent `reviewed` gap note is dropped once edges exist.
@@ -748,11 +757,13 @@ git commit -m "feat(agents): why names PR reviewers in the pull_request lane"
 ## Task 4: Index `PullRequestReviewEvent` as `review` items
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/github-sync.ts:318-339` (`processEvent`), plus a new
   `upsertReview` beside `upsertPr` (`:197`)
 - Test: `packages/gateway/src/connectors/github-sync.test.ts`
 
 **Interfaces:**
+
 - Consumes: `upsertPr` (`github-sync.ts:197`), `resolveGithubActorPersonId` (`:142`),
   `upsertIndexedItemForSync` (`index/item-store.ts:208`).
 - Produces: `review` items with `metadata: { repo, pr_number, review_id, state }` — exactly the shape
@@ -992,10 +1003,12 @@ git commit -m "feat(connectors): index GitHub PR reviews as first-class items"
 ## Task 5: Capture PR size statistics
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/github-sync.ts:70-110` (`extractPrMetadataForIndex`)
 - Test: `packages/gateway/src/connectors/github-sync.test.ts`
 
 **Interfaces:**
+
 - Produces: PR `metadata` gains `additions`, `deletions`, `changed_files`, `commits` when the source
   payload carries them. Task 6's enrich predicate keys on their absence.
 
@@ -1082,10 +1095,12 @@ git commit -m "feat(connectors): capture PR additions/deletions/changed_files/co
 ## Task 6: Widen the enrichment predicate to stats-missing PRs
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/github-sync.ts:389-459`
 - Test: `packages/gateway/src/connectors/github-sync-enrich.test.ts`
 
 **Interfaces:**
+
 - Consumes: the metadata keys Task 5 writes.
 - Produces: `selectPrEnrichCandidates` (renamed from `selectFallbackPrCandidates`) selects PRs with a
   fallback title **or** missing stats, still capped at `MAX_ENRICH_PER_TICK = 10`.
@@ -1203,7 +1218,7 @@ function selectPrEnrichCandidates(db: Database, limit: number): FallbackPrCandid
 ```
 
 The old exact-title JS filter (`if (r.title !== \`PR #${String(num)}\`) continue;`) is **removed**:
-it existed to make the SQL `LIKE` precise, but a row now qualifies on either reason, and keeping it
+it existed to make the SQL`LIKE` precise, but a row now qualifies on either reason, and keeping it
 would silently drop every stats-missing PR with a real title — the exact case this task adds.
 
 `NOT json_valid(metadata)` is deliberate: a row with unparseable metadata cannot be proven to have
@@ -1288,10 +1303,12 @@ git commit -m "feat(connectors): enrich PRs missing size statistics, not just ti
 ## Task 7: Honour `retry-after` independently, and log a saturated tick
 
 **Files:**
+
 - Modify: `packages/gateway/src/connectors/github-sync.ts:366-387`, `:533-544`
 - Test: `packages/gateway/src/connectors/github-sync.test.ts`
 
 **Interfaces:**
+
 - Produces: `throwGithubRateLimitErrorIfApplicable` raises `RateLimitError` for any 403 carrying
   `retry-after`, regardless of `x-ratelimit-remaining`.
 
@@ -1417,6 +1434,7 @@ git commit -m "fix(connectors): treat a 403 with retry-after as rate limiting; l
 ## Task 8: Documentation
 
 **Files:**
+
 - Modify: `docs/CHANGELOG.md`
 - Modify: the GitHub connector page under `docs/connectors/`
 
@@ -1499,7 +1517,7 @@ and suite, so a green run must reach the end.
 The PR **title** carries the conventional-commit type, because release-please parses the squash
 subject; local commit messages are discarded on merge. Suggested title:
 
-```
+```text
 feat(connectors): index GitHub PR reviews and size statistics
 ```
 

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
@@ -33,6 +33,13 @@ the existing enrichment pass already fetches and currently discards.
 - **`bun run typecheck:tests` before pushing.** It is advisory on Windows and gating on CI-Linux, and
   this PR adds test files. Read the "N new" line.
 - **Cross-platform paths.** Use `path.join()`; never hardcode separators.
+- **Line numbers are as of 2026-08-11 and drift as tasks land.** They locate code; they are not
+  addresses to edit blindly. **Tasks 4–7 all modify `github-sync.ts` in sequence**, and Task 4 inserts
+  roughly 70 lines (`githubReviewExternalId`, `upsertReview`, `processPullRequestReviewPayload`)
+  before the regions Tasks 6 and 7 cite — so every `github-sync.ts` line number in Tasks 6 and 7 is
+  stale by the time you reach them. **Locate by symbol name, then confirm the surrounding code matches
+  what the task quotes before editing.** If it does not match, stop and re-read the file: the plan was
+  written against a specific tree and something has moved.
 
 ## Scope note
 
@@ -184,6 +191,16 @@ test("a reviewed edge survives the PR being re-populated", () => {
 
   // The PR is re-synced (title edit, state change, any later PullRequestEvent).
   seedPr(db, "acme/app#1", "Add rate limiter v2", "person-author", now + 1000);
+
+  // PROVE THE RE-POPULATION ACTUALLY RAN. Without this the test is vacuous: if
+  // `upsertIndexedItem` ever skipped graph population for an unchanged row, the
+  // edge would "survive" because nothing touched it, and the assertion below
+  // would stay green even with `reviewed` absent from CROSS_ITEM_RELATION_TYPES
+  // — the precise defect this test exists to catch.
+  const prLabel = db
+    .query("SELECT label FROM graph_entity WHERE type = 'pr' AND external_id = ?")
+    .get("github:acme/app#1") as { label: string };
+  expect(prLabel.label).toBe("Add rate limiter v2");
 
   expect(reviewedPairs(db)).toEqual([
     { person: "person-reviewer", pr: "github:acme/app#1" },
@@ -569,8 +586,14 @@ not a roadmap one.
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `bun test packages/gateway/src/agents/expert.test.ts`
-Expected: PASS, including pre-existing tests. If an existing test asserted the old remediation string,
-update it to the new text.
+Expected: PASS, including pre-existing tests.
+
+**No existing test asserts the remediation string — verified.** The one test covering this lane,
+`expert.test.ts:220` ("missing reviewed relation surfaces a missing_relation_emit gap note"), asserts
+only `cats).toContain("missing_relation_emit")`, and it seeds its fixture with a raw
+`INSERT INTO item` that bypasses the populator entirely — so it creates no graph rows, no `reviewed`
+edges exist, and the gap still fires. **That test must keep passing unchanged.** If it goes red, your
+lane is returning a stream where there is no evidence, which means the query is wrong.
 
 - [ ] **Step 5: Preflight and commit**
 
@@ -704,7 +727,13 @@ is a one-line string, not a list.
 - [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `bun test packages/gateway/src/agents/why.test.ts`
-Expected: PASS. Update any existing test asserting the old remediation string.
+Expected: PASS.
+
+**`why.test.ts:159` is safe — verified.** It asserts
+`g.category === "missing_relation_emit" && g.detail.includes("reviewed")`. That matches on `detail`,
+which `detectMissingRelationEmit` generates (`gap-notes.ts:64`) and which this task does **not**
+change — only the `remediation` argument changes. Its fixture seeds no review items, so the gap still
+fires and the assertion still holds.
 
 - [ ] **Step 6: Preflight and commit**
 
@@ -1332,6 +1361,11 @@ Replace the 403 branch (`:371-380`) with:
 
 The `penalise("github", ...)` bucket stays hardcoded in this PR — parameterising it belongs with PR
 2's `github_search` path, where a second bucket first exists.
+
+**Note for PR 2:** `throwGithubRateLimitErrorIfApplicable` and `retryAfterDateFromHeader` are the
+shared helpers the search backfill must reuse — the only change it needs is the bucket key becoming a
+parameter. Do not fork a second rate-limit parser for search; GitHub's 403/429 + `retry-after`
+semantics are identical on both surfaces, and two parsers would drift.
 
 - [ ] **Step 4: Add the saturation log**
 

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
@@ -1222,8 +1222,15 @@ it existed to make the SQL`LIKE` precise, but a row now qualifies on either reas
 would silently drop every stats-missing PR with a real title — the exact case this task adds.
 
 `NOT json_valid(metadata)` is deliberate: a row with unparseable metadata cannot be proven to have
-stats, so it is re-fetched rather than skipped, and `json_extract` is never reached for it (SQLite's
-`OR` short-circuits left to right).
+stats, so it must be re-fetched rather than skipped. **Correction (post-review):** the `OR` form
+above does not protect `json_extract` from malformed JSON — SQLite's `OR` does not reliably
+short-circuit left to right here, and `json_extract` on unparseable text raises
+`SQLiteError: malformed JSON`, which kills the whole query for every row, not just the bad one.
+The shipped code wraps the `json_extract` arm in a `CASE WHEN json_valid(metadata) THEN
+json_extract(metadata, '$.additions') IS NULL ELSE 1 END` guard instead of relying on `OR`
+short-circuit — a row whose metadata cannot be parsed falls into the `ELSE 1` branch and remains a
+candidate. See `packages/gateway/src/connectors/github-sync.ts`'s `selectPrEnrichCandidates` for
+the actual guarded query.
 
 - [ ] **Step 4: Rename the caller and update the doc comment**
 

--- a/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
+++ b/docs/superpowers/plans/2026-08-11-github-contribution-depth-pr1.md
@@ -1,0 +1,1473 @@
+# GitHub Contribution Depth — PR 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Index GitHub pull-request reviews as first-class items, emit `person --reviewed--> pr`
+graph edges, surface them in the `expert` and `why` agents, and capture PR size statistics — so
+`nimbus negotiate` has real contribution evidence to read later.
+
+**Architecture:** Reviews become their own `item` rows rather than PR metadata, because
+`item-store.ts:130` replaces metadata wholesale and a later `PullRequestEvent` would clobber them.
+The graph populator emits one edge per review item, and `"reviewed"` joins `CROSS_ITEM_RELATION_TYPES`
+so `syncPrGraph`'s blanket clear cannot delete it. PR statistics ride the pull-detail response that
+the existing enrichment pass already fetches and currently discards.
+
+**Tech Stack:** Bun 1.2+, TypeScript strict, `bun:sqlite`, Biome, `bun test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-github-contribution-depth-design.md`
+**Review response:** `docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review-response.md`
+
+## Global Constraints
+
+- **No `any`.** Use `unknown` for external data. TypeScript strict mode is non-negotiable.
+- **Bound-param SQL only** (invariant I9). All writes go through `dbRun`/`dbExec` from `db/write.ts`
+  (invariant I14) — never `db.run` directly.
+- **Never commit on `main`.** All work lands on `dev/asafgolombek/github-contribution-depth`, which
+  already exists and is checked out.
+- **No migration in this PR.** `item.type` is free-form `TEXT NOT NULL`; the `reviewed` relation type
+  has existed since V7. If you find yourself writing SQL DDL, stop — something is wrong.
+- **Run `bun run preflight:fast` after every task**, before committing.
+- **Coverage floor: 85% line, 80% branch, per file.** Neither `github-sync.ts` nor
+  `graph-populator.ts` appears in `docs/structure-audit/coverage-baseline.json`, so both already
+  clear the floor and have **no ratchet headroom** — every new branch needs a test or the gate fails.
+- **`bun run typecheck:tests` before pushing.** It is advisory on Windows and gating on CI-Linux, and
+  this PR adds test files. Read the "N new" line.
+- **Cross-platform paths.** Use `path.join()`; never hardcode separators.
+
+## Scope note
+
+The spec originally claimed `expert.ts:283` and `why.ts:319` were live readers of `reviewed` edges.
+**They are not.** Both are absence-probes: `expert`'s `subPrReviewed` returns `{}` once edges exist,
+and `why`'s pull-request lane only appends a gap note. Emitting edges without Tasks 2 and 3 would turn
+`expert`'s lane from *explained-empty* into *silently empty* — a regression. Tasks 2 and 3 exist to
+prevent that and are not optional.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `packages/gateway/src/graph/relationship-graph.ts` | Registers `review` as a graph-linked item type | Modify |
+| `packages/gateway/src/graph/graph-populator.ts` | Emits `person --reviewed--> pr`; protects the edge from PR re-population | Modify |
+| `packages/gateway/src/graph/graph-populator-reviews.test.ts` | Edge emission, survival, single-edge property | Create |
+| `packages/gateway/src/agents/expert.ts` | `subPrReviewed` returns real evidence | Modify |
+| `packages/gateway/src/agents/why.ts` | Pull-request lane names reviewers | Modify |
+| `packages/gateway/src/connectors/github-sync.ts` | Review events → items; PR stats; enrich predicate; rate-limit fix; saturation log | Modify |
+| `packages/gateway/src/connectors/github-sync.test.ts` | Review event indexing, stats capture, rate limiting | Modify |
+| `packages/gateway/src/connectors/github-sync-enrich.test.ts` | Widened enrich predicate | Modify |
+
+---
+
+## Task 1: Emit `person --reviewed--> pr` from a `review` item
+
+**Files:**
+- Modify: `packages/gateway/src/graph/relationship-graph.ts:6-23`
+- Modify: `packages/gateway/src/graph/graph-populator.ts:77-81`, `:780`
+- Test: `packages/gateway/src/graph/graph-populator-reviews.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `upsertGraphEntity`, `ensureGraphEntity`, `upsertGraphRelation` from
+  `./relationship-graph.ts`; `IndexedItemGraphInput` from `graph-populator.ts:14`.
+- Produces: a `review` item whose `metadata` carries `{ repo: string, pr_number: number }` yields
+  `person(external_id = item.author_id) --reviewed--> pr(external_id = "github:<repo>#<pr_number>")`.
+  Task 4 writes items in exactly that shape; Tasks 2 and 3 read exactly these edges.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/graph/graph-populator-reviews.test.ts`:
+
+```typescript
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+import { isItemLinkedGraphType } from "./relationship-graph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function seedPr(db: Database, externalId: string, title: string, authorId: string | null, at: number): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId,
+    title,
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    authorId,
+    metadata: { repo: "acme/app", number: 1 },
+  });
+}
+
+function seedReview(db: Database, externalId: string, reviewerId: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId,
+    title: "Review on acme/app#1",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    authorId: reviewerId,
+    metadata: { repo: "acme/app", pr_number: 1 },
+  });
+}
+
+/** Every (person external_id, pr external_id) pair joined by a `reviewed` edge. */
+function reviewedPairs(db: Database): Array<{ person: string; pr: string }> {
+  return db
+    .query(
+      `SELECT pe.external_id AS person, pre.external_id AS pr
+         FROM graph_relation r
+         JOIN graph_entity pe  ON pe.id = r.from_id AND pe.type = 'person'
+         JOIN graph_entity pre ON pre.id = r.to_id  AND pre.type = 'pr'
+        WHERE r.type = 'reviewed'
+        ORDER BY person, pr`,
+    )
+    .all() as Array<{ person: string; pr: string }>;
+}
+
+test("review is a graph-linked item type", () => {
+  expect(isItemLinkedGraphType("review")).toBe(true);
+});
+
+test("a review item emits person -> pr reviewed", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+
+  expect(reviewedPairs(db)).toEqual([
+    { person: "person-reviewer", pr: "github:acme/app#1" },
+  ]);
+  db.close();
+});
+
+test("the reviewer is a distinct person from the PR author", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+
+  const authored = db
+    .query(
+      `SELECT pe.external_id AS person
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+        WHERE r.type = 'authored'`,
+    )
+    .all() as Array<{ person: string }>;
+
+  expect(authored).toEqual([{ person: "person-author" }]);
+  expect(reviewedPairs(db)).toEqual([
+    { person: "person-reviewer", pr: "github:acme/app#1" },
+  ]);
+  db.close();
+});
+
+// THE REGRESSION TEST. `syncPrGraph` calls `clearRelationsTouchingEntity`, which
+// deletes every edge touching the PR except CROSS_ITEM_RELATION_TYPES. Without
+// "reviewed" in that list, re-syncing the PR silently destroys the edge and
+// nothing recreates it.
+test("a reviewed edge survives the PR being re-populated", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+  expect(reviewedPairs(db)).toHaveLength(1);
+
+  // The PR is re-synced (title edit, state change, any later PullRequestEvent).
+  seedPr(db, "acme/app#1", "Add rate limiter v2", "person-author", now + 1000);
+
+  expect(reviewedPairs(db)).toEqual([
+    { person: "person-reviewer", pr: "github:acme/app#1" },
+  ]);
+  db.close();
+});
+
+// The safety of having no edge-retirement mechanism (spec 5.F) rests on this.
+test("two reviews by one person on one PR yield exactly one edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+  seedReview(db, "acme/app#1#review-501", "person-reviewer", now + 1);
+
+  expect(reviewedPairs(db)).toHaveLength(1);
+  db.close();
+});
+
+test("a review with no author emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#1#review-500",
+    title: "Review on acme/app#1",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: null,
+    metadata: { repo: "acme/app", pr_number: 1 },
+  });
+
+  expect(reviewedPairs(db)).toEqual([]);
+  db.close();
+});
+
+test("a review whose metadata lacks repo or pr_number emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#1#review-500",
+    title: "Review",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: "person-reviewer",
+    metadata: {},
+  });
+
+  expect(reviewedPairs(db)).toEqual([]);
+  db.close();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-reviews.test.ts`
+Expected: FAIL. The first test fails because `isItemLinkedGraphType("review")` is `false`; the rest
+return empty arrays because no populator branch exists.
+
+- [ ] **Step 3: Register `review` as a graph-linked type**
+
+In `packages/gateway/src/graph/relationship-graph.ts`, add `"review"` to the
+`ITEM_LINKED_ENTITY_TYPES` array (currently 16 entries, ending `"data_quality_test"`):
+
+```typescript
+const ITEM_LINKED_ENTITY_TYPES = [
+  "pr",
+  "issue",
+  "ci_run",
+  "deployment",
+  "alert",
+  "message",
+  "incident",
+  "error_issue",
+  "git_commit",
+  "dependency",
+  "api_endpoint",
+  "code_symbol",
+  "obsidian_note",
+  "data_model",
+  "dashboard",
+  "data_quality_test",
+  "review",
+] as const;
+```
+
+There is no exact-count assertion on this list (only per-type `isItemLinkedGraphType` checks in
+`graph-populator-api-endpoint.test.ts`, `relationship-graph-obsidian.test.ts` and
+`relationship-graph.test.ts`), so adding an entry breaks nothing.
+
+- [ ] **Step 4: Protect the edge from PR re-population**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add `"reviewed"` to `CROSS_ITEM_RELATION_TYPES`
+(line 77):
+
+```typescript
+const CROSS_ITEM_RELATION_TYPES: readonly string[] = Object.freeze([
+  "resolves",
+  "mentions",
+  "correlates_with",
+  "reviewed",
+]);
+```
+
+This is load-bearing, not cosmetic: `clearRelationsTouchingEntity` (`:83`) deletes every edge touching
+an entity *except* these types, and `syncPrGraph` (`:240`) calls it on every PR write.
+
+- [ ] **Step 5: Add `syncReviewGraph`**
+
+In `packages/gateway/src/graph/graph-populator.ts`, add this function immediately after
+`syncPrGraph` (which ends at line 283). It uses `ensureGraphEntity` (`ON CONFLICT DO NOTHING`) for the
+PR rather than `upsertGraphEntity` (`DO UPDATE SET label = excluded.label`), so it can never overwrite
+a real PR title with a placeholder when a review is processed before its PR:
+
+```typescript
+/**
+ * A `review` item is one reviewer acting on one PR, so it maps to exactly one
+ * `person --reviewed--> pr` edge. Nothing is cleared here: the edge is
+ * idempotent under `upsertGraphRelation`'s `ON CONFLICT (from_id, to_id, type)`,
+ * and it is listed in CROSS_ITEM_RELATION_TYPES precisely so that no entity's
+ * re-population retires it. The consequence — a review deleted upstream leaves
+ * a stale edge — is disclosed rather than mechanised (spec 5.F).
+ *
+ * `ensureGraphEntity` (not `upsertGraphEntity`) for the PR side: a review can be
+ * populated before its PR during a `regraph` replay, and clobbering the PR's
+ * label with a synthesised one would corrupt every reader that displays it.
+ */
+function syncReviewGraph(db: Database, row: IndexedItemGraphInput, now: number): void {
+  if (row.authorId === null || row.authorId === "") {
+    return;
+  }
+  const repoFull = stringField(row.metadata, "repo");
+  const prNumber = row.metadata["pr_number"];
+  if (repoFull === undefined || repoFull === "" || typeof prNumber !== "number") {
+    return;
+  }
+
+  const prItemId = `${row.service}:${repoFull}#${String(prNumber)}`;
+  const prEntityId = ensureGraphEntity(db, {
+    type: "pr",
+    externalId: prItemId,
+    label: `${repoFull}#${String(prNumber)}`,
+    service: row.service,
+  });
+
+  const label = personDisplayName(db, row.authorId) ?? row.authorId;
+  const personEntityId = upsertGraphEntity(db, {
+    type: "person",
+    externalId: row.authorId,
+    label,
+    service: row.service,
+  });
+  upsertGraphRelation(db, personEntityId, prEntityId, "reviewed", now);
+}
+```
+
+`stringField`, `personDisplayName`, `ensureGraphEntity`, `upsertGraphEntity` and
+`upsertGraphRelation` are all already imported or defined in this file — `ensureGraphEntity` is
+imported at `:8` and currently used elsewhere, so no import changes are needed.
+
+- [ ] **Step 6: Add the dispatch branch**
+
+In `syncGraphFromIndexedItem` (`graph-populator.ts:766`), add a branch after the `pr` branch at
+`:780-783`:
+
+```typescript
+  if (row.type === "pr") {
+    syncPrGraph(db, row, now);
+    return;
+  }
+  if (row.type === "review") {
+    syncReviewGraph(db, row, now);
+    return;
+  }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/graph/graph-populator-reviews.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 8: Red-prove the `CROSS_ITEM_RELATION_TYPES` change**
+
+Temporarily remove `"reviewed"` from `CROSS_ITEM_RELATION_TYPES`, then run:
+
+`bun test packages/gateway/src/graph/graph-populator-reviews.test.ts`
+
+Expected: the test *"a reviewed edge survives the PR being re-populated"* **FAILS** (receives `[]`).
+Every other test still passes. **Restore the line.** If that test passes without the entry, the test
+is not exercising re-population and must be fixed before continuing — this is the single defect this
+task exists to prevent.
+
+- [ ] **Step 9: Run the surrounding suites for regressions**
+
+Run: `bun test packages/gateway/src/graph`
+Expected: PASS. Pay attention to `graph-populator-branches.test.ts:94` ("returns early for a type not
+in ITEM_LINKED_ENTITY_TYPES") — if it happened to use `"review"` as its not-in-the-list example, it
+now needs a different type. Check it explicitly.
+
+- [ ] **Step 10: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/graph/relationship-graph.ts packages/gateway/src/graph/graph-populator.ts packages/gateway/src/graph/graph-populator-reviews.test.ts
+git commit -m "feat(graph): emit person --reviewed--> pr from review items"
+```
+
+---
+
+## Task 2: `expert`'s reviewer lane returns real evidence
+
+**Files:**
+- Modify: `packages/gateway/src/agents/expert.ts:280-288`
+- Test: `packages/gateway/src/agents/expert.test.ts`
+
+**Interfaces:**
+- Consumes: the `reviewed` edges Task 1 emits.
+- Produces: `subPrReviewed` returns `{ stream: ExpertEvidenceStream }` with
+  `Evidence.type === "pr_reviewed"` and `weight: 0.6`.
+
+**Context:** `subPrReviewed` is currently a stub that returns `{}` whenever `reviewed` edges exist.
+Task 1 makes them exist, so without this task the lane goes silently empty. `Evidence.type` in
+`@nimbus-dev/sdk` already includes `"pr_reviewed"` — the slot has been unused since it was defined.
+Existing weights in this file: `commit_authored` 1, `pr_authored` 0.8, `chat_post` 0.4; `pr_reviewed`
+sits at **0.6** — reviewing is real expertise evidence, but weaker than authoring.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/gateway/src/agents/expert.test.ts`. That file creates its database inline
+(`new Database(":memory:"); LocalIndex.ensureSchema(db);` — see `:207`) and seeds people with
+`db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:alice", "Alice"])` (`:292`),
+using `person:`-prefixed ids. Follow both conventions.
+
+**The `person` row is not optional.** The lane's query joins `person p ON p.id = pe.external_id`, so
+an `author_id` with no matching `person` row produces zero results and the test would fail for the
+wrong reason.
+
+```typescript
+test("subPrReviewed surfaces a reviewer as pr_reviewed evidence", async () => {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  const now = Date.now();
+  db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:author", "Author"]);
+  db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Add rate limiter",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: "person:author",
+    metadata: { repo: "acme/app", number: 1 },
+  });
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#1#review-500",
+    title: "Review on acme/app#1",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: "person:reviewer",
+    metadata: { repo: "acme/app", pr_number: 1 },
+  });
+
+  const result = await subPrReviewed(db, "rate limiter");
+
+  expect(result.gap).toBeUndefined();
+  expect(result.stream?.personId).toBe("person:reviewer");
+  expect(result.stream?.displayName).toBe("Reviewer");
+  expect(result.stream?.evidence).toHaveLength(1);
+  expect(result.stream?.evidence[0]?.type).toBe("pr_reviewed");
+  expect(result.stream?.evidence[0]?.itemId).toBe("github:acme/app#1");
+  db.close();
+});
+
+test("subPrReviewed still reports the gap when no reviewed edges exist", async () => {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  const result = await subPrReviewed(db, "anything");
+  expect(result.gap?.category).toBe("missing_relation_emit");
+  expect(result.stream).toBeUndefined();
+  db.close();
+});
+```
+
+`subPrReviewed` is currently module-private. Export it (`export async function subPrReviewed`) so the
+test can call it directly — this matches how other lanes in this file are structured for testing;
+verify against the file and follow whatever it already does.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/agents/expert.test.ts -t "pr_reviewed"`
+Expected: FAIL — `result.stream` is `undefined` because the lane returns `{}`.
+
+- [ ] **Step 3: Implement the lane**
+
+Replace `subPrReviewed` (`expert.ts:280-288`) with:
+
+```typescript
+export async function subPrReviewed(db: Database, input: string): Promise<SubAgentResult> {
+  const rows = db
+    .query(
+      `SELECT
+         p.id                           AS person_id,
+         COALESCE(p.display_name, p.id) AS display_name,
+         i.id                           AS item_id,
+         i.title                        AS title,
+         i.modified_at                  AS modified_at,
+         i.service                      AS service_id
+       FROM graph_relation gr
+       JOIN graph_entity  pe ON pe.id = gr.from_id AND pe.type = 'person'
+       JOIN person        p  ON p.id = pe.external_id
+       JOIN graph_entity  pre ON pre.id = gr.to_id AND pre.type = 'pr'
+       JOIN item          i  ON i.id = pre.external_id
+       WHERE gr.type = 'reviewed'
+         AND (i.title LIKE '%' || ? || '%' OR i.body_preview LIKE '%' || ? || '%')
+       ORDER BY i.modified_at DESC
+       LIMIT 50`,
+    )
+    .all(input, input) as Array<{
+    person_id: string;
+    display_name: string;
+    item_id: string;
+    title: string;
+    modified_at: number;
+    service_id: string;
+  }>;
+
+  if (rows.length === 0) {
+    const gap = detectMissingRelationEmit(
+      db,
+      "reviewed",
+      "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
+    );
+    return gap === null ? {} : { gap };
+  }
+
+  const merged = new Map<string, ExpertEvidenceStream>();
+  for (const r of rows) {
+    const ev: Evidence = {
+      itemId: r.item_id,
+      type: "pr_reviewed",
+      serviceId: r.service_id,
+      title: r.title.slice(0, 512),
+      modifiedAt: r.modified_at,
+      weight: 0.6,
+    };
+    const existing = merged.get(r.person_id);
+    if (existing === undefined) {
+      merged.set(r.person_id, {
+        personId: r.person_id,
+        displayName: r.display_name,
+        evidence: [ev],
+      });
+    } else {
+      existing.evidence.push(ev);
+    }
+  }
+  const winner = [...merged.values()].sort((a, b) => b.evidence.length - a.evidence.length)[0];
+  return winner === undefined ? {} : { stream: winner };
+}
+```
+
+This mirrors `subChatMentions` (`:310`) exactly — same join-to-`person` shape, same merge-and-pick-
+winner tail, same `LIMIT 50`. The `JOIN item i ON i.id = pre.external_id` is required, not optional:
+a PR entity with no backing item row is invisible to it, which is the behaviour Task 4 relies on
+(spec § 4).
+
+**Note the remediation text change.** The old note said "Tracked as a graph-populator follow-up" — no
+longer true once Task 1 lands. The gap now means "no reviews indexed yet", which is a sync problem,
+not a roadmap one.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/agents/expert.test.ts`
+Expected: PASS, including pre-existing tests. If an existing test asserted the old remediation string,
+update it to the new text.
+
+- [ ] **Step 5: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/agents/expert.ts packages/gateway/src/agents/expert.test.ts
+git commit -m "feat(agents): expert surfaces PR reviewers as pr_reviewed evidence"
+```
+
+---
+
+## Task 3: `why`'s pull-request lane names reviewers
+
+**Files:**
+- Modify: `packages/gateway/src/agents/why.ts:295-322`
+- Test: `packages/gateway/src/agents/why.test.ts`
+
+**Interfaces:**
+- Consumes: the `reviewed` edges Task 1 emits.
+- Produces: the `pull_request` lane's `WhyFinding.detail` names reviewers when any exist; the
+  permanent `reviewed` gap note is dropped once edges exist.
+
+**Context:** the lane builds exactly one `WhyFinding` with `detail: "Opened by <author>"`, then
+unconditionally appends a `reviewed` gap note whose comment reads "never promised — no populator emits
+`reviewed`". Task 1 falsifies that comment.
+
+- [ ] **Step 1: Write the failing test**
+
+`why.test.ts` already has `freshDb()` (`:27`) and `seedWhyFixture(db, parts)` (`:55`), which seeds a
+commit → linear issue `NIM-88` → **github PR `acme/app#412`** → blame chain. Reuse it; the review must
+therefore reference `repo: "acme/app"` and `pr_number: 412` to attach to that PR.
+
+```typescript
+test("the pull_request lane names reviewers when reviewed edges exist", async () => {
+  const db = freshDb();
+  seedWhyFixture(db, { commit: true, issue: true, pr: true, blame: { lineNo: 12 } });
+  const now = Date.now();
+  db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#412#review-500",
+    title: "Review on acme/app#412",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: "person:reviewer",
+    metadata: { repo: "acme/app", pr_number: 412 },
+  });
+
+  const brief = await runWhy({ ref: refAt(12) }, ctxFor(db));
+  const prFinding = brief.findings.find((f) => f.lane === "pull_request");
+
+  expect(prFinding?.detail).toContain("Reviewed by");
+  expect(brief.gaps.some((g) => g.detail.includes("`reviewed`"))).toBe(false);
+  db.close();
+});
+```
+
+This drives the whole agent through `runWhy` rather than calling the private lane, matching how the
+file's other lane tests are written — check the existing `pull_request` tests and mirror whichever
+entry point they use. `refAt(line)` (`:37`) builds the `<file>:<line>` ref the blame row is seeded at.
+
+**Note the reviewer label.** `syncReviewGraph` labels the person entity with
+`personDisplayName(db, authorId) ?? authorId`, so without the `person` row the detail would read
+`Reviewed by person:reviewer` and the assertion above would still pass — seed the row so the test
+exercises the display path the user actually sees.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "names reviewers"`
+Expected: FAIL — `detail` is `"Opened by ..."` with no reviewer text, and `gap` is defined.
+
+- [ ] **Step 3: Query reviewers and fold them into the detail**
+
+In `why.ts`, after the `authorRow` query (`:295-303`) and before the `finding` literal (`:305`), add:
+
+```typescript
+  const reviewerRows = db
+    .query(
+      `SELECT DISTINCT pe.label AS label
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+        WHERE r.to_id = ? AND r.type = 'reviewed'
+        ORDER BY label
+        LIMIT 5`,
+    )
+    .all(pr.entityId) as Array<{ label: string }>;
+```
+
+Then build the detail from both parts:
+
+```typescript
+  const openedBy =
+    authorRow !== null ? `Opened by ${authorRow.label}` : "PR author not resolved in the graph.";
+  const detail =
+    reviewerRows.length === 0
+      ? openedBy
+      : `${openedBy} · Reviewed by ${reviewerRows.map((r) => r.label).join(", ")}`;
+
+  const finding: WhyFinding = {
+    lane: "pull_request",
+    title: `#${pr.number ?? "?"} ${pr.title}`,
+    detail,
+    url: pr.url,
+    occurredAt: pr.modifiedAt,
+    entityId: pr.entityId,
+  };
+```
+
+- [ ] **Step 4: Update the gap-note comment and remediation**
+
+Replace the comment and call at `:315-322` with:
+
+```typescript
+  // Reviewers come from `review` items indexed off the GitHub events feed. The
+  // gap note now means "no reviews indexed yet", not "this is unimplemented".
+  const reviewedGap = detectMissingRelationEmit(
+    db,
+    "reviewed",
+    "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
+  );
+  return reviewedGap !== null ? { findings: [finding], gap: reviewedGap } : { findings: [finding] };
+```
+
+The `detectMissingRelationEmit` call is deliberately kept: it correctly reports "no reviews anywhere
+in the index", which stays useful. It is `LIMIT 5` on the reviewer list because a `WhyFinding.detail`
+is a one-line string, not a list.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts`
+Expected: PASS. Update any existing test asserting the old remediation string.
+
+- [ ] **Step 6: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/agents/why.ts packages/gateway/src/agents/why.test.ts
+git commit -m "feat(agents): why names PR reviewers in the pull_request lane"
+```
+
+---
+
+## Task 4: Index `PullRequestReviewEvent` as `review` items
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:318-339` (`processEvent`), plus a new
+  `upsertReview` beside `upsertPr` (`:197`)
+- Test: `packages/gateway/src/connectors/github-sync.test.ts`
+
+**Interfaces:**
+- Consumes: `upsertPr` (`github-sync.ts:197`), `resolveGithubActorPersonId` (`:142`),
+  `upsertIndexedItemForSync` (`index/item-store.ts:208`).
+- Produces: `review` items with `metadata: { repo, pr_number, review_id, state }` — exactly the shape
+  Task 1's `syncReviewGraph` reads.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/gateway/src/connectors/github-sync.test.ts`. Define the event once as a factory so
+each test gets a fresh object — a shared literal mutated by one test would leak into the next:
+
+```typescript
+function reviewEvent(): Record<string, unknown> {
+  return {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: {
+      action: "created",
+      review: {
+        id: 500,
+        state: "approved",
+        body: "LGTM",
+        html_url: "https://github.com/acme/app/pull/1#pullrequestreview-500",
+        submitted_at: "2026-08-11T10:00:00Z",
+        user: { login: "reviewer" },
+      },
+      pull_request: {
+        number: 1,
+        title: "Add rate limiter",
+        body: "",
+        html_url: "https://github.com/acme/app/pull/1",
+        user: { login: "author" },
+        state: "open",
+      },
+    },
+  };
+}
+
+test("a PullRequestReviewEvent indexes both the review and its PR", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const now = Date.now();
+
+  expect(processEvent(ctx, reviewEvent(), now)).toBe(true);
+
+  const review = db
+    .query("SELECT id, author_id, metadata FROM item WHERE service = 'github' AND type = 'review'")
+    .get() as { id: string; author_id: string | null; metadata: string };
+  expect(review.id).toBe("github:acme/app#1#review-500");
+  expect(review.author_id).not.toBeNull();
+  expect(JSON.parse(review.metadata)).toMatchObject({ repo: "acme/app", pr_number: 1, review_id: 500 });
+
+  const pr = db
+    .query("SELECT title FROM item WHERE id = 'github:acme/app#1'")
+    .get() as { title: string };
+  expect(pr.title).toBe("Add rate limiter");
+  db.close();
+});
+
+test("the reviewer resolves to a different person than the PR author", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const now = Date.now();
+  processEvent(ctx, reviewEvent(), now);
+
+  const prAuthor = db.query("SELECT author_id FROM item WHERE id = 'github:acme/app#1'").get() as {
+    author_id: string;
+  };
+  const reviewer = db
+    .query("SELECT author_id FROM item WHERE id = 'github:acme/app#1#review-500'")
+    .get() as { author_id: string };
+
+  expect(reviewer.author_id).not.toBe(prAuthor.author_id);
+  db.close();
+});
+
+test("a review event missing its pull_request is skipped without throwing", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: { action: "created", review: { id: 500, user: { login: "reviewer" } } },
+  };
+
+  expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expectServiceItemCount(db, "github", 0);
+  db.close();
+});
+
+test("a review event missing its review id is skipped without throwing", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: { action: "created", pull_request: { number: 1, title: "x", user: { login: "a" } } },
+  };
+
+  expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expectServiceItemCount(db, "github", 0);
+  db.close();
+});
+```
+
+`processEvent` (`github-sync.ts:318`) is module-private. Export it (`export function processEvent`)
+and import it in the test. If the file already exposes a test seam for events, use that instead of
+adding a second entry point.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts -t "Review"`
+Expected: FAIL — `processEvent` returns `false` for `PullRequestReviewEvent` and writes nothing.
+
+- [ ] **Step 3: Add `upsertReview`**
+
+In `github-sync.ts`, immediately after `upsertPr` (which ends at line 244), add:
+
+```typescript
+function githubReviewExternalId(repoFull: string, prNum: number, reviewId: number): string {
+  return `${repoFull}#${String(prNum)}#review-${String(reviewId)}`;
+}
+
+/**
+ * A review is indexed as its own item rather than as PR metadata: the item
+ * upsert replaces `metadata` wholesale (`index/item-store.ts`), so a later
+ * `PullRequestEvent` for the same PR would silently erase reviewer data stored
+ * there. Separate rows cannot clobber one another.
+ *
+ * The events feed is the authenticated user's own activity, so `author_id` here
+ * is always the local user — this indexes "PRs I reviewed", never "who reviewed
+ * my PRs".
+ */
+function upsertReview(
+  ctx: SyncContext,
+  repoFull: string,
+  review: Record<string, unknown>,
+  prNum: number,
+  now: number,
+): boolean {
+  const reviewId = numberField(review, "id");
+  if (reviewId === undefined) {
+    return false;
+  }
+  const user = asRecord(review["user"]);
+  const authorId = resolveGithubActorPersonId(ctx.db, user);
+  const state = stringField(review, "state");
+  const body = stringField(review, "body");
+  const submitted = stringField(review, "submitted_at");
+  const modified = submitted === undefined ? now : Date.parse(submitted);
+  const htmlUrl = stringField(review, "html_url");
+
+  upsertIndexedItemForSync(ctx, {
+    service: SERVICE_ID,
+    type: "review",
+    externalId: githubReviewExternalId(repoFull, prNum, reviewId),
+    title: `Review on ${repoFull}#${String(prNum)}`,
+    body: body ?? "",
+    url: htmlUrl ?? null,
+    canonicalUrl: htmlUrl ?? null,
+    modifiedAt: Number.isFinite(modified) ? modified : now,
+    authorId,
+    metadata: {
+      repo: repoFull,
+      pr_number: prNum,
+      review_id: reviewId,
+      state: state ?? null,
+    },
+    pinned: false,
+    syncedAt: now,
+  });
+  return true;
+}
+```
+
+- [ ] **Step 4: Add the event branch**
+
+Add this function beside `processPullRequestPayload` (`:290`):
+
+```typescript
+function processPullRequestReviewPayload(
+  ctx: SyncContext,
+  fullName: string,
+  payload: Record<string, unknown>,
+  now: number,
+): boolean {
+  const review = asRecord(payload["review"]);
+  const pr = asRecord(payload["pull_request"]);
+  if (review === undefined || pr === undefined) {
+    return false;
+  }
+  const num = numberField(pr, "number");
+  if (num === undefined) {
+    return false;
+  }
+  // Index the PR too, so the `reviewed` edge targets a titled item rather than a
+  // stub: 14 call sites inner-join `item` on `graph_entity.external_id`, and an
+  // item-less entity is invisible to all of them.
+  upsertPr(ctx, fullName, pr, now);
+  return upsertReview(ctx, fullName, review, num, now);
+}
+```
+
+Then add the dispatch in `processEvent` (`:332`):
+
+```typescript
+  if (type === "PullRequestEvent") {
+    return processPullRequestPayload(ctx, fullName, payload, now);
+  }
+  if (type === "PullRequestReviewEvent") {
+    return processPullRequestReviewPayload(ctx, fullName, payload, now);
+  }
+  if (type === "IssuesEvent") {
+    return processIssuesPayload(ctx, fullName, payload, now);
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts`
+Expected: PASS, including pre-existing tests.
+
+- [ ] **Step 6: Verify the end-to-end path**
+
+Run: `bun test packages/gateway/src/graph packages/gateway/src/agents/expert.test.ts`
+Expected: PASS. Task 1's populator and Task 2's reader now have a real producer.
+
+- [ ] **Step 7: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/connectors/github-sync.ts packages/gateway/src/connectors/github-sync.test.ts
+git commit -m "feat(connectors): index GitHub PR reviews as first-class items"
+```
+
+---
+
+## Task 5: Capture PR size statistics
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:70-110` (`extractPrMetadataForIndex`)
+- Test: `packages/gateway/src/connectors/github-sync.test.ts`
+
+**Interfaces:**
+- Produces: PR `metadata` gains `additions`, `deletions`, `changed_files`, `commits` when the source
+  payload carries them. Task 6's enrich predicate keys on their absence.
+
+**Context:** these four fields exist on the single-PR response (`GET /repos/{owner}/{repo}/pulls/{n}`)
+and **not** on the list response or event payloads — confirmed against GitHub's documentation. The
+enrichment pass already fetches pull detail and discards them, so capture is free there and a no-op
+on the events path.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("PR stats are captured from a pull-detail payload", () => {
+  const meta = extractPrMetadataForIndex("acme/app", {
+    number: 1,
+    title: "Add rate limiter",
+    state: "open",
+    user: { login: "author" },
+    additions: 120,
+    deletions: 30,
+    changed_files: 7,
+    commits: 3,
+  });
+
+  expect(meta["additions"]).toBe(120);
+  expect(meta["deletions"]).toBe(30);
+  expect(meta["changed_files"]).toBe(7);
+  expect(meta["commits"]).toBe(3);
+});
+
+test("PR stats are absent, not null, when the payload omits them", () => {
+  const meta = extractPrMetadataForIndex("acme/app", {
+    number: 1,
+    title: "Add rate limiter",
+    state: "open",
+    user: { login: "author" },
+  });
+
+  expect("additions" in meta).toBe(false);
+  expect("deletions" in meta).toBe(false);
+  expect("changed_files" in meta).toBe(false);
+  expect("commits" in meta).toBe(false);
+});
+```
+
+Absence rather than `null` matters: Task 6's predicate uses SQL `json_extract(...) IS NULL` to find
+PRs needing enrichment, and an explicit `null` is indistinguishable from a missing key there.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts -t "stats"`
+Expected: FAIL — `meta["additions"]` is `undefined` in the first test.
+
+- [ ] **Step 3: Capture the fields**
+
+In `extractPrMetadataForIndex` (`:70`), after the `mergeable_state` block (`:91-95`) and before the
+`if (merged)` block (`:96`), add:
+
+```typescript
+  for (const key of ["additions", "deletions", "changed_files", "commits"] as const) {
+    const v = numberField(pr, key);
+    if (v !== undefined) {
+      out[key] = v;
+    }
+  }
+```
+
+`numberField` is already imported and used in this function (`:79`).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/connectors/github-sync.ts packages/gateway/src/connectors/github-sync.test.ts
+git commit -m "feat(connectors): capture PR additions/deletions/changed_files/commits"
+```
+
+---
+
+## Task 6: Widen the enrichment predicate to stats-missing PRs
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:389-459`
+- Test: `packages/gateway/src/connectors/github-sync-enrich.test.ts`
+
+**Interfaces:**
+- Consumes: the metadata keys Task 5 writes.
+- Produces: `selectPrEnrichCandidates` (renamed from `selectFallbackPrCandidates`) selects PRs with a
+  fallback title **or** missing stats, still capped at `MAX_ENRICH_PER_TICK = 10`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/gateway/src/connectors/github-sync-enrich.test.ts`:
+
+```typescript
+test("a PR with a real title but no stats is selected for enrichment", () => {
+  const db = createMemoryIndexDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Add rate limiter", // NOT the `PR #1` fallback
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app", number: 1 }, // no additions/deletions
+  });
+
+  const candidates = selectPrEnrichCandidates(db, 10);
+  expect(candidates.map((c) => c.externalId)).toEqual(["acme/app#1"]);
+  db.close();
+});
+
+test("a PR with stats already captured is not selected", () => {
+  const db = createMemoryIndexDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#1",
+    title: "Add rate limiter",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app", number: 1, additions: 120, deletions: 30 },
+  });
+
+  expect(selectPrEnrichCandidates(db, 10)).toEqual([]);
+  db.close();
+});
+
+test("a fallback-titled PR is still selected even with stats", () => {
+  const db = createMemoryIndexDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId: "acme/app#2",
+    title: "PR #2",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    metadata: { repo: "acme/app", number: 2, additions: 1, deletions: 1 },
+  });
+
+  expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).toEqual(["acme/app#2"]);
+  db.close();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/connectors/github-sync-enrich.test.ts`
+Expected: FAIL — `selectPrEnrichCandidates` does not exist yet. Once renamed, the first test would
+still fail against the old predicate, which is the point.
+
+- [ ] **Step 3: Widen the predicate**
+
+Replace `selectFallbackPrCandidates` (`:397`) with:
+
+```typescript
+/**
+ * Candidates for a pull-detail re-fetch. Two independent reasons:
+ *   1. the title is still the id-only `PR #<n>` fallback (the events feed omits
+ *      `title` on `PullRequestEvent` payloads), or
+ *   2. size statistics are missing — `additions`/`deletions`/`changed_files`/
+ *      `commits` exist only on the single-PR response, never on events or the
+ *      list endpoint.
+ *
+ * `json_extract` is used rather than a LIKE over the raw metadata blob so a PR
+ * body mentioning "additions" cannot mask a genuinely missing field. Guarded by
+ * `json_valid` because `json_extract` RAISES on malformed JSON, and one bad row
+ * would otherwise kill selection for every PR.
+ */
+function selectPrEnrichCandidates(db: Database, limit: number): FallbackPrCandidate[] {
+  const rows = db
+    .query(
+      `SELECT external_id, title, metadata FROM item
+         WHERE service = 'github' AND type = 'pr'
+           AND (
+             title LIKE 'PR #%'
+             OR NOT json_valid(metadata)
+             OR json_extract(metadata, '$.additions') IS NULL
+           )
+         ORDER BY modified_at DESC LIMIT ?`,
+    )
+    .all(limit * 3) as { external_id: string; title: string; metadata: string }[];
+  const out: FallbackPrCandidate[] = [];
+  for (const r of rows) {
+    const hash = r.external_id.lastIndexOf("#");
+    if (hash <= 0) continue;
+    const repoFull = r.external_id.slice(0, hash);
+    const num = Number.parseInt(r.external_id.slice(hash + 1), 10);
+    if (!Number.isFinite(num)) continue;
+    out.push({ externalId: r.external_id, repoFull, num });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+```
+
+The old exact-title JS filter (`if (r.title !== \`PR #${String(num)}\`) continue;`) is **removed**:
+it existed to make the SQL `LIKE` precise, but a row now qualifies on either reason, and keeping it
+would silently drop every stats-missing PR with a real title — the exact case this task adds.
+
+`NOT json_valid(metadata)` is deliberate: a row with unparseable metadata cannot be proven to have
+stats, so it is re-fetched rather than skipped, and `json_extract` is never reached for it (SQLite's
+`OR` short-circuits left to right).
+
+- [ ] **Step 4: Rename the caller and update the doc comment**
+
+Rename the call inside `enrichFallbackPrTitles` (`:431`) to `selectPrEnrichCandidates`, rename the
+function itself to `enrichPrDetail`, and update its docstring (`:419-424`) to describe both reasons.
+Update the call site in `syncGithubUserEvents` (`:548`) and the surrounding log message at `:553`
+("PR title enrichment pass failed" → "PR detail enrichment pass failed"). Export
+`selectPrEnrichCandidates` for the test.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/connectors/github-sync-enrich.test.ts`
+Expected: PASS, including pre-existing enrichment tests.
+
+- [ ] **Step 6: Log the remaining stats backlog**
+
+Enrichment converges at 10 PRs per tick, so a large index takes many ticks to fill in statistics.
+Operators need to see that catching-up is progressing rather than stalled (review response, item 6).
+This is a **log line, not a metric** — nothing consumes a metric today, and adding a registration for
+a transient catch-up window would be speculative.
+
+At the end of `enrichPrDetail`, after the loop:
+
+```typescript
+  const remaining = selectPrEnrichCandidates(ctx.db, MAX_ENRICH_PER_TICK + 1).length;
+  if (remaining > MAX_ENRICH_PER_TICK) {
+    ctx.logger.info(
+      { service: SERVICE_ID, enriched, remainingAtLeast: MAX_ENRICH_PER_TICK },
+      "PR detail enrichment has more candidates queued for the next tick",
+    );
+  }
+```
+
+The `+ 1` and `remainingAtLeast` naming are deliberate: the selector is capped, so it can prove
+"more than 10 remain" but never report an exact backlog. Claiming a precise figure it cannot compute
+would be the kind of false number this project's honesty rules exist to prevent.
+
+Add a test asserting the selector still returns at most `limit` rows when more candidates exist:
+
+```typescript
+test("selectPrEnrichCandidates never returns more than the limit", () => {
+  const db = createMemoryIndexDb();
+  const now = Date.now();
+  for (let i = 1; i <= 15; i += 1) {
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: `acme/app#${String(i)}`,
+      title: `PR title ${String(i)}`,
+      bodyPreview: "",
+      modifiedAt: now + i,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: i },
+    });
+  }
+
+  expect(selectPrEnrichCandidates(db, 10)).toHaveLength(10);
+  db.close();
+});
+```
+
+- [ ] **Step 7: Red-prove the widening**
+
+Temporarily revert the SQL `WHERE` clause to `AND title LIKE 'PR #%'` only. Run the suite.
+Expected: *"a PR with a real title but no stats is selected for enrichment"* **FAILS**. Restore.
+
+- [ ] **Step 8: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/connectors/github-sync.ts packages/gateway/src/connectors/github-sync-enrich.test.ts
+git commit -m "feat(connectors): enrich PRs missing size statistics, not just titles"
+```
+
+---
+
+## Task 7: Honour `retry-after` independently, and log a saturated tick
+
+**Files:**
+- Modify: `packages/gateway/src/connectors/github-sync.ts:366-387`, `:533-544`
+- Test: `packages/gateway/src/connectors/github-sync.test.ts`
+
+**Interfaces:**
+- Produces: `throwGithubRateLimitErrorIfApplicable` raises `RateLimitError` for any 403 carrying
+  `retry-after`, regardless of `x-ratelimit-remaining`.
+
+**Context:** GitHub's documentation states a secondary rate limit returns *"either a `403` or `429`"*
+and treats `retry-after` as independent of `x-ratelimit-remaining`. The current handler only honours
+`retry-after` when `remaining === "0" || remaining === null` (`:373`); a 403 with `retry-after` and a
+non-zero `remaining` falls through to `return` at `:379` and is not treated as rate limiting at all —
+the caller sees a plain `!res.ok` and retries next tick. Task 6 widens how often the enrich path runs,
+increasing exposure.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+test("a 403 with retry-after is rate limiting even when remaining is non-zero", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const res = new Response("secondary rate limit", {
+    status: 403,
+    headers: { "retry-after": "60", "x-ratelimit-remaining": "4999" },
+  });
+
+  expect(() => throwGithubRateLimitErrorIfApplicable(ctx, res, "events")).toThrow(RateLimitError);
+  db.close();
+});
+
+test("a 403 with no retry-after and remaining left is not rate limiting", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const res = new Response("forbidden", {
+    status: 403,
+    headers: { "x-ratelimit-remaining": "4999" },
+  });
+
+  expect(() => throwGithubRateLimitErrorIfApplicable(ctx, res, "events")).not.toThrow();
+  db.close();
+});
+```
+
+Export `throwGithubRateLimitErrorIfApplicable` for the test.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts -t "retry-after"`
+Expected: the first test FAILS (nothing thrown); the second passes already.
+
+- [ ] **Step 3: Fix the handler**
+
+Replace the 403 branch (`:371-380`) with:
+
+```typescript
+  if (res.status === 403) {
+    const remaining = res.headers.get("x-ratelimit-remaining");
+    const retryAfter = res.headers.get("retry-after");
+    // GitHub returns 403 OR 429 for secondary (abuse) limits, and documents
+    // `retry-after` as an independent signal: a secondary limit can arrive with
+    // primary quota still available. Keying only on `remaining === 0` misses
+    // every one of those and retries straight into the limit.
+    if (remaining === "0" || remaining === null || retryAfter !== null) {
+      const retryAt = retryAfterDateFromHeader(retryAfter, 60);
+      const ms = Math.max(1000, retryAt.getTime() - Date.now());
+      ctx.rateLimiter.penalise("github", ms);
+      throw new RateLimitError(retryAt, `GitHub ${label}: rate limited (403)`);
+    }
+    return;
+  }
+```
+
+The `penalise("github", ...)` bucket stays hardcoded in this PR — parameterising it belongs with PR
+2's `github_search` path, where a second bucket first exists.
+
+- [ ] **Step 4: Add the saturation log**
+
+The events sync issues exactly one request per tick with `per_page=100` and no pagination, so a full
+page is evidence the window may have overflowed and events may have been missed entirely. In
+`syncGithubUserEvents`, after the event loop (`:544`), add:
+
+```typescript
+  // One request per tick at per_page=100 (no pagination): a full page means the
+  // window may have overflowed between syncs, and anything older is unreachable
+  // from the events feed. Loss is silent by construction, so record it.
+  if (parsed.length >= GITHUB_EVENTS_PAGE_SIZE) {
+    ctx.logger.warn(
+      { service: SERVICE_ID, events: parsed.length },
+      "github events page was full; older events in this window may have been missed",
+    );
+  }
+```
+
+Add the constant beside `MAX_ENRICH_PER_TICK` (`:395`) and use it in `eventsUrlFor` (`:112-114`) so
+the page size has one definition:
+
+```typescript
+const GITHUB_EVENTS_PAGE_SIZE = 100;
+```
+
+```typescript
+function eventsUrlFor(login: string): string {
+  return `https://api.github.com/users/${encodeURIComponent(login)}/events?per_page=${String(GITHUB_EVENTS_PAGE_SIZE)}`;
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/connectors/github-sync.test.ts`
+Expected: PASS. Existing tests asserting the events URL string must still match — the interpolation
+produces the identical `per_page=100`.
+
+- [ ] **Step 6: Preflight and commit**
+
+```bash
+bun run preflight:fast
+git add packages/gateway/src/connectors/github-sync.ts packages/gateway/src/connectors/github-sync.test.ts
+git commit -m "fix(connectors): treat a 403 with retry-after as rate limiting; log saturated event pages"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+- Modify: `docs/CHANGELOG.md`
+- Modify: the GitHub connector page under `docs/connectors/`
+
+**Context:** connector deliveries go in `docs/CHANGELOG.md`, not the CLAUDE.md status line.
+
+- [ ] **Step 1: Document the three user-visible facts**
+
+The page is `docs/connectors/github.md` (verified — do not create a new file). Add, in its own
+subsection:
+
+```markdown
+### Pull-request reviews
+
+Reviews you leave on pull requests are indexed as their own items and linked to the
+pull request in the relationship graph, so `nimbus expert` and `nimbus why` can
+attribute review work.
+
+Three limits are worth knowing:
+
+- **Reviewing a pull request indexes that pull request**, including ones you did not
+  author. This is what lets a review link to a titled PR rather than a bare id.
+- This indexes **pull requests you reviewed**, not **who reviewed your pull
+  requests** — the GitHub events feed reports your own activity.
+- Coverage begins when the connector first syncs. The events feed exposes only a
+  recent window, so reviews from before then are not recoverable by syncing. A review
+  deleted upstream also leaves its graph link in place.
+```
+
+- [ ] **Step 2: Add the changelog entry**
+
+Add an entry to `docs/CHANGELOG.md` under the current unreleased heading, matching the surrounding
+entries' format exactly (check the two entries above it before writing).
+
+- [ ] **Step 3: Verify links**
+
+Run: `bun run preflight:fast`
+Then check for Windows-absolute paths, which resolve locally and 404 on CI-Linux:
+
+```bash
+grep -rn "file:///" docs/ || echo "clean"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: GitHub review indexing, and its three stated limits"
+```
+
+---
+
+## Final verification before pushing
+
+- [ ] **Full test suite**
+
+Run: `bun test packages/gateway/src/connectors packages/gateway/src/graph packages/gateway/src/agents`
+Expected: PASS.
+
+- [ ] **Test typecheck (CI-Linux-gating, Windows-advisory)**
+
+Run: `bun run typecheck:tests`
+Expected: read the "**N new**" line. It must be **0**. This PR adds test files, and a non-zero count
+fails CI on Linux while staying silent on Windows.
+
+- [ ] **Coverage floor**
+
+Run the Linux-authoritative check per the `nimbus-coverage-floor` skill. Neither `github-sync.ts` nor
+`graph-populator.ts` is in `docs/structure-audit/coverage-baseline.json`, so both currently clear 85%
+line / 80% branch with **no ratchet headroom** — any new uncovered branch is a new violation. If it
+fails, add tests; do not update the baseline.
+
+- [ ] **Full preflight**
+
+Run: `bun run preflight`
+Expected: PASS. Note that preflight fail-fasts — an early lint failure hides the later audits, build
+and suite, so a green run must reach the end.
+
+- [ ] **Push and open the PR**
+
+The PR **title** carries the conventional-commit type, because release-please parses the squash
+subject; local commit messages are discarded on merge. Suggested title:
+
+```
+feat(connectors): index GitHub PR reviews and size statistics
+```
+
+Put the reasoning in the PR description — that becomes the permanent commit body. Do **not** include a
+bare `Release-As:` trailer.

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review-response.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review-response.md
@@ -1,0 +1,149 @@
+# GitHub Contribution Depth — Design Review Response
+
+**Date:** 2026-08-11
+**Responds to:** `2026-08-11-github-contribution-depth-design-review.md`
+**Outcome:** 4 accepted (2 with corrections that make them stronger), 1 rejected on verified grounds,
+1 accepted in reduced form.
+
+Every item below was checked against the tree or vendor documentation before deciding. Two checks
+surfaced problems larger than the review described; one check showed the review's premise was false.
+
+---
+
+## 1. Gap detection when Nimbus is off for >30 days — **ACCEPTED, with a correction that widens it**
+
+The concern is valid and the underlying problem is **worse than the review states**.
+
+`syncGithubUserEvents` (`github-sync.ts:492`) issues **exactly one request per tick** — `per_page=100`,
+no pagination loop, no `page` parameter. So the binding limit is not the vendor's 300-event/30-day
+ceiling; it is **the newest ~100 events between two successful syncs**. A user need not be offline for
+30 days to lose evidence — a busy enough account, or any outage during which more than 100 events
+accumulate, loses everything older than the newest 100, silently, well inside the vendor window.
+
+A 30-day threshold as proposed would therefore give false assurance: it would stay quiet through
+exactly the cases that lose data.
+
+**What ships instead**, split by where the remediation exists (§ 5.H of the spec):
+
+- **PR 1 — saturation logging.** A tick that parses a full page is direct evidence the window may have
+  overflowed. Logged structurally via `ctx.logger`, matching how the sync already reports partial
+  failures. Detection belongs where the loss happens, not on a timer.
+- **PR 2 — staleness note.** `connectors/health.ts` already tracks `last_sync_at` /
+  `lastSuccessfulSync`, so the suggested surface exists. It ships in PR 2 rather than PR 1 because its
+  only useful remediation is `nimbus index backfill`, which does not exist until then. Telling a user
+  about a gap they have no means to close is noise, not honesty.
+
+The single-page behaviour is pre-existing and not introduced by this design, so widening the fetch to
+paginate is deliberately **out of scope** here — it changes the sync's request profile and deserves
+its own change. It is now recorded in § 2 as the real loss boundary rather than left implicit.
+
+---
+
+## 2. Distinguishing authorship from review in retrieval — **ACCEPTED as documentation; the suggested work is unnecessary**
+
+The suggestion is to ensure agent queries filter by `author_id` versus the `reviewed` relation rather
+than pulling `github:pr` items indiscriminately. Checked: **that distinction is already structural and
+needs no new mechanism.** A colleague's PR row carries *their* `author_id`, so every query already
+keyed on `author_id = me` excludes reviewed-only PRs for free — `catchup.ts:284` (`subOwnedServices`)
+and `:305` (`subActiveRepos`) both do exactly this. The `reviewed` edge is a separate traversal
+entirely.
+
+One real downstream effect the review did not identify: `catchup.ts:364` `subWindowItems` selects
+`FROM item WHERE modified_at >= ?` with **no author filter**, so colleague PRs the user reviewed will
+begin appearing in `nimbus catchup`'s window.
+
+That is recorded in § 4 as a known consequence and deliberately **not** mitigated. A PR you reviewed
+is genuinely relevant to your day, and `scoreAndGroup` already ranks unrelated items down to
+`SCORE_DEFAULT`. Suppressing reviewed PRs from `catchup` would be a product regression dressed up as
+a scoping fix.
+
+---
+
+## 3. Duplicate/stale `reviewed` edges — **REJECTED: premise is false, and the proposed fix is unsafe**
+
+**The premise does not hold.** `upsertGraphRelation` (`relationship-graph.ts:114`) is
+`ON CONFLICT (from_id, to_id, type) DO UPDATE`. A dismissed review followed by a new review from the
+same person on the same PR produces **one** edge, not two. Duplicate review relationships cannot be
+displayed because they cannot exist. The review items themselves are distinct rows (distinct review
+ids), but the edges collapse by construction.
+
+**The proposed fix would introduce a bug.** "Delete all `reviewed` edges for a specific PR and
+re-insert current ones" is unsafe inside PR 2's *quarter-bucketed* backfill: a delete-all keyed on the
+PR, executed while processing one bucket, discards edges established by other buckets and re-inserts
+only what the current bucket happens to contain. It is harmless today only because every `reviewed`
+edge belongs to the local user (§ 3, "one direction only") — the moment a "who reviewed my PRs"
+direction is ever added, with multiple reviewers per PR, it becomes real data loss. Adding a
+reconciliation step that is safe only by accident, to solve a problem that cannot occur, is the wrong
+trade.
+
+**The genuine residual risk is narrower than the review frames it** and is already disclosed: a review
+deleted *entirely* upstream leaves its edge behind, because `reviewed` joins
+`CROSS_ITEM_RELATION_TYPES` and nothing retires it (§ 5.F). That is stated on the connector page
+rather than engineered away. A test now pins the single-edge property, since skipping the retirement
+mechanism rests on it.
+
+---
+
+## 4. Secondary rate limits — **ACCEPTED, confirmed by vendor docs, plus a second bug the review did not name**
+
+Confirmed against GitHub's rate-limit documentation: a secondary limit returns *"either a `403` or
+`429`"*, and `retry-after` is an independent signal — *"If the `retry-after` response header is
+present, you should not retry your request until after that many seconds has elapsed."*
+
+`throwGithubRateLimitErrorIfApplicable` (`github-sync.ts:366`) only honours `retry-after` when
+`remaining === "0" || remaining === null` (`:373`). **A 403 carrying `retry-after` with a non-zero
+`remaining` falls through to `return` at `:379`** and is not treated as rate limiting at all; the
+caller sees a plain `!res.ok` and retries next tick. That is a live bug on the existing enrich path,
+which PR 1 widens — so the fix lands in **PR 1**, with a red-proved test that fails against the
+current handler.
+
+**Second bug, found while verifying this one:** `penalise("github", ms)` (`:376`, `:384`) hardcodes the
+bucket name. Calling this helper from a `github_search` context would penalise the *core* bucket and
+leave the offending one unthrottled — the exact opposite of the separation § 5.D exists to provide.
+The key becomes a parameter in **PR 2**, alongside the search path.
+
+The review's alternative suggestion — an adaptive sleep inside the backfill loop instead of relying on
+the rate limiter — is **not adopted**. `ctx.rateLimiter` already supports `penalise(bucket, ms)`,
+which is the codebase's existing mechanism for exactly this; a bespoke sleep in one loop would be a
+second, divergent throttling path. Fixing the two defects above makes the existing mechanism correct
+rather than routing around it.
+
+---
+
+## 5. Test a third-party reviewer resolves to a distinct person — **ACCEPTED**
+
+Added to § 6 as a required test: a review whose `user` differs from the PR's `user` must yield two
+`person` entities, with `authored` and `reviewed` pointing at the same PR from different people.
+
+This also **closes § 8's third open item**, which had flagged that `resolveGithubActorPersonId` has
+only ever been exercised on the author path. Better as an assertion than an assumption.
+
+---
+
+## 6. Metric for missing stats — **ACCEPTED in reduced form: a log line, not a metric**
+
+The signal is worth having. The form is not: a counter surfaced through `index.metrics` would need a
+new metric registration for something relevant only during a transient catch-up window, and nothing
+consumes it today.
+
+PR 1 emits a structured `ctx.logger` line reporting the stats-missing backlog, matching how the sync
+already reports partial state. If it is ever actually monitored, promoting it to a metric is a small
+follow-up; building the metric first is speculative.
+
+Independently, § 5.B already requires that **every aggregate in the brief carries its own coverage
+count** (`over M of K PRs with stats available`), so the user-facing honesty property does not depend
+on this signal at all — the log serves operators, not the brief.
+
+---
+
+## Spec changes made
+
+| Section | Change |
+| --- | --- |
+| § 2 | Single-page fetch recorded as the real loss boundary; ~100-events-per-tick supersedes the 300/30-day framing |
+| § 4 | New subsection: `catchup` window side-effect documented, explicitly not mitigated |
+| § 5.D | Two rate-limit fixes specified — `retry-after` honoured independently (PR 1), bucket key parameterised (PR 2) |
+| § 5.H | New: saturation logging (PR 1) + stale-connector note (PR 2) |
+| § 6 | Three tests added — third-party reviewer, red-proved 403 handling, single-edge property |
+| § 7 | File lists updated for both PRs |
+| § 8 | Open item 3 struck, now covered by a test |

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
@@ -3,7 +3,7 @@
 ## Open Questions & Risks
 
 1. **GitHub Timeline API Limitations vs. Incremental Accumulation**
-   - The spec notes: "incremental accumulation works, retroactive backfill does not" due to the 30-day/300-event ceiling. 
+   - The spec notes: "incremental accumulation works, retroactive backfill does not" due to the 30-day/300-event ceiling.
    - **Question**: When a user goes OOO or shuts down Nimbus for >30 days, is there any warning or detection mechanism? If they miss the 30-day window, will Nimbus silently omit reviews that occurred during that period, leading to silent data gaps?
    - **Suggestion**: In the connector status or next-sync output, if `last_synced_at` (or equivalent sync high-water mark) is older than 30 days, log a warning or suggest triggering the search-based backfill (`nimbus index backfill --service github`).
 

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
@@ -1,0 +1,28 @@
+# GitHub Contribution Depth Design Review
+
+## Open Questions & Risks
+
+1. **GitHub Timeline API Limitations vs. Incremental Accumulation**
+   - The spec notes: "incremental accumulation works, retroactive backfill does not" due to the 30-day/300-event ceiling. 
+   - **Question**: When a user goes OOO or shuts down Nimbus for >30 days, is there any warning or detection mechanism? If they miss the 30-day window, will Nimbus silently omit reviews that occurred during that period, leading to silent data gaps?
+   - **Suggestion**: In the connector status or next-sync output, if `last_synced_at` (or equivalent sync high-water mark) is older than 30 days, log a warning or suggest triggering the search-based backfill (`nimbus index backfill --service github`).
+
+2. **Differentiating PR Authorship from PR Review in Context Retrieval**
+   - Under § 4 ("Chosen — reuse `upsertPr` verbatim"), colleague PR descriptions are fully indexed.
+   - **Question**: When an agent runs a prompt or queries semantic search for "my code changes" or "PRs I worked on", does the system have a robust way to filter out PRs where the user was *only* a reviewer, to avoid mixing colleague code context with own code context?
+   - **Suggestion**: Ensure that the queries in the agent layer explicitly filter by relations (`author_id` vs `--reviewed-->`) rather than just pulling all indexed `github:pr` items indiscriminately.
+
+3. **`CROSS_ITEM_RELATION_TYPES` Leakage / Staleness**
+   - Under § 5.F, a dismissed or deleted review leaves a stale edge because no retirement mechanism is implemented.
+   - **Question**: If a review is dismissed and then a new review is submitted, will we display duplicate/stale review relationships in the self-advocacy brief?
+   - **Suggestion**: In the backfill (PR 2) or when processing a full list, we should consider a basic pruning/reconciliation step (e.g., delete all `reviewed` edges for a specific PR and re-insert current ones) to avoid stale duplicate edges.
+
+4. **Rate Limit Separation & Throttling**
+   - The backfill will run on `github_search` rate-limit bucket.
+   - **Question**: How does the rate limiter handle sub-division of buckets or secondary limits (such as GitHub's abuse detection limits for search)?
+   - **Suggestion**: Implement an adaptive backoff delay specifically for the search backfill loop (e.g., sleep between search queries) rather than relying solely on the static rate limiter.
+
+## Suggestions for PR 1 Implementation Plan
+
+- **Explicit Validation of `resolveGithubActorPersonId`**: Add a test case in `graph-populator-reviews.test.ts` where a third-party reviewer is resolved, verifying that they map to a distinct Person entity from the PR author.
+- **Stats-missing Metric**: Log a metric or trace when stats are missing, so we can monitor how quickly the enrich queue catching up with historical PRs.

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design-review.md
@@ -5,7 +5,7 @@
 1. **GitHub Timeline API Limitations vs. Incremental Accumulation**
    - The spec notes: "incremental accumulation works, retroactive backfill does not" due to the 30-day/300-event ceiling.
    - **Question**: When a user goes OOO or shuts down Nimbus for >30 days, is there any warning or detection mechanism? If they miss the 30-day window, will Nimbus silently omit reviews that occurred during that period, leading to silent data gaps?
-   - **Suggestion**: In the connector status or next-sync output, if `last_synced_at` (or equivalent sync high-water mark) is older than 30 days, log a warning or suggest triggering the search-based backfill (`nimbus index backfill --service github`).
+   - **Suggestion**: In the connector status or next-sync output, if `last_synced_at` (or equivalent sync high-water mark) is older than 30 days, log a warning or suggest triggering the search-based backfill (`nimbus index backfill --service github`). **[HISTORICAL — not adopted: `nimbus index backfill` was never shipped and does not exist in the CLI; this PR's own tests assert no gap note may reference it. Preserved verbatim as the question was originally asked.]**
 
 2. **Differentiating PR Authorship from PR Review in Context Retrieval**
    - Under § 4 ("Chosen — reuse `upsertPr` verbatim"), colleague PR descriptions are fully indexed.

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design.md
@@ -1,0 +1,311 @@
+# GitHub Contribution Depth — Design
+
+**Date:** 2026-08-11
+**Spine slot:** S1 (Local Brain)
+**Position:** sub-project A/B of the `nimbus negotiate` workstream — the first of five substrate
+pieces, ahead of the agent itself.
+**Ships as:** two PRs, neither requiring a migration, a new invariant, or a Tauri allowlist change.
+**Plan boundary:** the implementation plan that follows this spec covers **PR 1 only**. PR 2 reuses
+PR 1's writers unchanged and gets its own plan once PR 1 has merged — planning both at once would
+bank assumptions about writers that do not exist yet.
+
+---
+
+## 1. Why this exists
+
+`docs/roadmap.md:1121` specifies `nimbus negotiate` as a compensation-conversation prep brief
+assembled from nine named evidence sources. Every one was checked against the tree before any design
+work. **Four do not exist, two are partial, and three are real.**
+
+| Claimed input | Verdict | Evidence |
+| --- | --- | --- |
+| PRs merged (count) | ✅ real | `item type='pr'`, `author_id` resolved across github/gitlab/bitbucket |
+| PRs **reviewed** | ❌ dead | `reviewed` declared at `graph-v7-sql.ts:33`; **no populator writes it**. `graph-populator.ts` emits 16 relation types; `reviewed` is not among them. `ownership.ts:192` already states "no reviewer data" as a standing gap note. |
+| PR **complexity** | ❌ not indexed | `extractPrMetadataForIndex` (`github-sync.ts:70`) captures number/repo/state/draft/merged/user/labels/mergeable/merged_at/merge_commit_sha. No additions, deletions, or changed_files. |
+| Incidents resolved, attributed | ❌ dead | `pagerduty-sync.ts:96` writes `authorId: null`; metadata carries status/incidentId/opened_at/service/severity/urgency only. `gap-notes.ts:76` calls `person -> incident "resolves"` **"a future"** edge. `catchup.ts:328`'s incident lane returns empty today. |
+| Deploys triggered, no rollback | ❌ dead | `deployment/types.ts` `DeploymentAnnotateInput` has **no actor field** and no rollback concept. |
+| ADRs authored | ⚠️ derivable | `decision_record` has no author column; `source_item_id` → `item.author_id` joins. |
+| On-call shifts | ❌ dead | `pagerduty-sync.ts` calls `/incidents` only. The PagerDuty MCP connector exposes no schedule tool either. |
+| 1:1 themes | ⚠️ undefined | No "1:1" concept exists; the "asks before reading" consent mechanism does not exist. |
+| `--peer-benchmark` comp ranges | ❌ blocked by design | No federated comp primitive exists, and `workday-field-allowlist.ts` **deliberately excludes compensation**. Building it means reversing a privacy decision already made. |
+
+The decision (2026-08-11) was to **widen the substrate before writing the agent**, and to land all
+five substrate pieces. This spec covers the first.
+
+### Workstream decomposition
+
+Agreed order: **A/B → C → F → D → E**. Every PR has a live reader the day it merges, which is
+specifically a response to how pre-mortem PR A shipped a substrate that turned out unreachable.
+
+| # | Sub-project | Migration | Reader on merge day |
+| --- | --- | --- | --- |
+| **A/B** | **GitHub contribution depth (this spec)** | No | Yes — `expert.ts:283`, `why.ts:319` query `reviewed` and get nothing today |
+| C | Incident attribution (PagerDuty assignee/resolver + `person --resolves--> incident`) | No | Yes — `catchup.ts:328`, dead today |
+| F | The `negotiate` agent | No | — |
+| D | On-call shifts (new endpoint, new item type) | Likely | The agent |
+| E | Deployment actor + rollback (cross-repo; rollback is a new concept) | Possibly | The agent |
+
+---
+
+## 2. Verified constraints
+
+Everything below was checked against the tree or against vendor documentation. Nothing here is
+asserted from memory.
+
+**The GitHub events feed is capped.** Per GitHub's REST documentation: *"The timeline will include
+up to 300 events. Only events created within the past 30 days will be included."* Private events are
+included because the sync authenticates as the user (`fetchAuthenticatedLogin`, `github-sync.ts:461`).
+Consequence: **incremental accumulation works, retroactive backfill does not.** A gateway running for
+a year holds a year of evidence; a fresh install holds nothing. A comp cycle is quarterly or annual,
+so PR 1 alone cannot serve the use case — hence PR 2.
+
+**Review events are silently discarded today.** `processEvent` (`github-sync.ts:318`) handles exactly
+`PullRequestEvent` and `IssuesEvent`. `PullRequestReviewEvent` falls through to `return false`.
+
+**PR stats exist on pull detail and nowhere else.** Per GitHub's documentation, the single-PR response
+carries `additions`, `deletions`, `changed_files`, `commits`; the list response does not.
+`enrichFallbackPrTitles` (`github-sync.ts:425`) **already fetches pull detail and discards them**.
+
+**Search can reach arbitrary history.** `reviewed-by:`, `author:` and `merged:>=` are supported with
+no documented history limit. Limits: **30 requests/minute** for search (a distinct budget from core)
+and **1,000 results per query**.
+
+**`rebody` cannot help here.** `REBODY_REQUIRED_META_VERSION` (`index-rebody-rpc.ts:134`) is the
+existing mechanism for recovering new metadata on already-indexed rows, and its own docstring says
+"a later depth PR adds a row here; it does not add a mechanism." But it works by clearing the sync
+watermark, and a cleared GitHub etag still only replays 30 days. **GitHub is a third cost category
+the `rebody` docstring does not model: bounded by the source feed, and unable to complete.**
+
+**Three clobber traps, each verified:**
+
+1. **Metadata is replaced wholesale.** `item-store.ts:130` — `metadata = excluded.metadata`. Storing
+   reviewers in PR metadata would be destroyed by the next `PullRequestEvent` for that PR, and vice
+   versa. Ordering-dependent, intermittent, and invisible to correctness tests.
+2. **Graph edges touching a PR are cleared on re-population.** `clearRelationsTouchingEntity`
+   (`graph-populator.ts:83`) deletes every edge touching the entity except
+   `CROSS_ITEM_RELATION_TYPES` = `["resolves", "mentions", "correlates_with"]` (`:77`). `reviewed` is
+   not in that list, so `syncPrGraph:240` would delete the edge on every PR re-population, and
+   `syncPrGraph` cannot re-create it because reviews live in a different item.
+3. **`synced_at` is overwritten on every upsert.** `item-store.ts:131` — so `MIN(synced_at)` drifts
+   forward and cannot mark when Nimbus started watching. Neither `scheduler_state` nor `sync_state`
+   records a first-sync time.
+
+**A graph entity with no backing item is invisible.** 14 non-test sites inner-join `item` on
+`entity.external_id` — `why.ts:222`, `why-peek.ts:71`, `catchup.ts:327`, `premortem.ts:153`,
+`decision-corroborate.ts:146` among them. An edge pointing at an item-less entity is written,
+queryable in principle, and dead in practice.
+
+**Free-form types, per-service depth.** `item.type` is `TEXT NOT NULL` with no constraint
+(`unified-item-v3-sql.ts:19`), and `applyDepth` reads `ctx.depth`, which is per-service. A new
+`review` type under `github` therefore needs no migration and no depth registration.
+
+**`github:pr` is not prose-heavy.** `PROSE_HEAVY_TYPES` has 23 entries; `github:issue` is present,
+`github:pr` is not. PR bodies cap at 512 characters and stay on the local MiniLM route.
+
+**`index.*` long-running jobs are CLI-only.** Only `index.metrics` appears in the Tauri allowlist;
+`index.rebody`/`reembed`/`regraph` do not. `NO_TIMEOUT_METHODS` has exactly 5 entries, none of them
+`index.*`.
+
+---
+
+## 3. Architecture
+
+### PR 1 — "Accumulate forward" (events + enrich)
+
+Two independent channels into the existing index. No migration, no new IPC, no allowlist change.
+
+**Channel 1 — reviews as first-class items.** `processEvent` gains a `PullRequestReviewEvent` branch.
+Reviewers are deliberately **not** stored in PR metadata (trap 1). Each review becomes its own row:
+
+- `service='github'`, `type='review'`
+- `external_id = <repo>#<pr-number>#review-<review-id>`, where `<review-id>` is GitHub's own review
+  id from the event payload — not the PR number, and not a hash. Two reviews by the same person on
+  the same PR are distinct rows.
+- `author_id` via the existing `resolveGithubActorPersonId`, which already upserts through
+  `resolvePersonForSync` — no new person plumbing
+- body = the review's own text, at GitHub's configured depth
+
+The same branch also calls the existing `upsertPr` on the event's `pull_request` payload, so the edge
+targets a real, titled PR (see § 4).
+
+The populator gains `syncReviewGraph` plus one branch in the `row.type` chain (`graph-populator.ts:780`),
+emitting `person --reviewed--> pr` via `upsertGraphRelation` only. One review is one edge, so it is
+idempotent with nothing to retire. **`"reviewed"` is added to `CROSS_ITEM_RELATION_TYPES`** — without
+it, trap 2 deletes the edge on every PR re-population.
+
+**Channel 2 — PR stats.** `extractPrMetadataForIndex` captures `additions`, `deletions`,
+`changed_files`, `commits` when present: a no-op on the events path, free on the enrich path. The
+enrich predicate (`selectFallbackPrCandidates:397`) widens from "title is the exact `PR #<n>`
+fallback" to "fallback title **or** stats missing", still bounded by `MAX_ENRICH_PER_TICK = 10`.
+
+### PR 2 — opt-in search backfill
+
+A separate, user-triggered path in a new `connectors/github-backfill.ts`: quarter-bucketed
+`author:@me` and `reviewed-by:@me` searches calling PR 1's `upsertPr` and `upsertReview` **unchanged**.
+A different source, not a different shape.
+
+A new `ipc/index-backfill-rpc.ts` mirrors `index-rebody-rpc.ts`: `index.backfill` plus
+`backfillProgress` / `backfillDone` / `backfillError` / `backfillCancel` over `LongRunningJobRegistry`.
+Params are strictly validated the way `rebody`'s `--limit` is, because they bound real API requests
+rather than local CPU.
+
+CLI: `nimbus index backfill --service github [--since <duration>] [--limit N] [--dry-run] [--yes] [--json]`,
+alongside `add` / `reembed` / `rebody` / `regraph`.
+
+### Scope property — one direction only
+
+`/users/{login}/events` returns events performed **by** the authenticated user, and `reviewed-by:`
+finds PRs reviewed by a named person. Both PRs therefore deliver **"PRs I reviewed"**, never
+**"who reviewed my PRs."** The latter needs per-PR review listing — a different endpoint and a
+different design. For a self-advocacy brief the first direction is the useful one, but it must be
+stated so nobody expects the second. A consequence worth noting: **every `review` row is authored by
+the local user.**
+
+---
+
+## 4. Decision: reviewing a PR indexes that PR
+
+A review event carries the full `pull_request` payload, and a PR you reviewed is usually not yours.
+Three options were weighed.
+
+**Rejected — emit the edge against an item-less PR entity.** Disqualified on the merits: 14 sites
+inner-join `item` on `entity.external_id`, so the edge would be invisible to every existing reader
+including `why`, one of the two this work exists to light up. That is the shipped-but-unreachable
+shape again, and the brief could only ever print `repo#number`.
+
+**Rejected — index the PR at metadata-only depth** (`body: ""` + `bodyTruncated: true`, mirroring
+`applyDepth`'s metadata_only arm at `item-store.ts:200`, which works through the depth chokepoint
+rather than bypassing it). It buys a partial privacy improvement — bodies excluded, titles still
+indexed and searchable — and pays with a **false promise**: those rows land at `body_complete = 0`,
+and because `github` is in `REBODY_IMPROVABLE_SERVICES` (`index-rebody-rpc.ts:263`), `nimbus index
+rebody` would report them as recoverable and then never recover them. Suppressing that needs a
+carve-out in `computePendingByService`, i.e. new complexity in a carefully-reasoned subsystem.
+
+**Chosen — reuse `upsertPr` verbatim.** Simplest change, consistent with every other PR row, no new
+special case, no `rebody` wart, zero additional egress (the payload is already in a response we
+fetched). The cost is that colleagues' PR descriptions enter the index and `nimbus decisions` will
+mine them — bounded by `github:pr` not being prose-heavy, so bodies cap at 512 characters and stay
+off the OpenAI embedding route.
+
+Volume supports this: PR 1 only ever sees PRs the user personally reviewed inside a rolling 30-day
+window. The place colleague-PR volume genuinely matters is PR 2's backfill over arbitrary history,
+and that stays behind an explicit opt-in.
+
+**Paired with a disclosure rather than a mechanism:** the GitHub connector page and, later, the
+`negotiate` brief state plainly that reviewing a PR indexes that PR — matching how `ownership`
+carries its unconditional "authorship is not accountability" note.
+
+---
+
+## 5. Error handling & honesty
+
+**A. Coverage is stated from content dates, never sync dates.** `synced_at` is overwritten on every
+upsert (trap 3), so the brief reports the observed range — `MIN(modified_at)` / `MAX(modified_at)`
+over contributing GitHub items, plus the item count — and never asserts completeness for any
+sub-window.
+
+**B. Stats coverage is reported, not assumed.** Enrich converges at ≤10 PRs/tick, so at any moment
+some PRs have stats and some do not. Every aggregate carries `over M of K PRs with stats available`;
+a total computed over a 60%-covered set and printed bare is a lie by omission. Silent when coverage
+is complete — a conditional note, following `decisions`' truncated-source count rather than a
+standing disclaimer readers learn to skip.
+
+**C. The 1,000-result cap never truncates silently.** If a quarter bucket's total exceeds 1,000,
+subdivide to months; if a month still exceeds it, **report that bucket as truncated with its count**
+rather than returning the first 1,000 and implying completeness.
+
+**D. Search gets its own rate-limit bucket.** 30 req/min for search is a distinct budget from core's
+hourly limit. Sharing `ctx.rateLimiter.acquire("github")` would let a backfill starve the 60-second
+freshness sync and vice versa, so backfill acquires on `github_search`. The existing
+`throwGithubRateLimitErrorIfApplicable` already handles 403 + `x-ratelimit-remaining` + `retry-after`
+and is reused unchanged.
+
+**E. Backfill resumes by idempotence, not by cursor.** Every write is an upsert on a deterministic
+`external_id`, so a cancelled or failed run converges on re-run. No new cursor state; the cost of
+repeated API calls on resume is stated in the command output rather than engineered away.
+`--dry-run` reports the bucket plan and estimated request count before spending quota, matching
+`rebody`.
+
+**F. The stale-edge limit is stated, not hidden.** Because `reviewed` joins
+`CROSS_ITEM_RELATION_TYPES`, no re-population retires it and nothing else does. A review dismissed or
+deleted upstream leaves its edge behind. Documented on the connector page; not worth a retirement
+mechanism at this volume, but not silent either.
+
+**G. A bad event skips, never throws.** A malformed review payload, a missing `pull_request` object,
+or an unresolvable actor returns early. Throwing out of `processEvent` would abort the tick and stall
+the etag cursor; the existing branches return `false` rather than throwing, and the new one matches.
+
+---
+
+## 6. Testing
+
+**The headline test is reachability, not existence.** `reviewed` has been declared since V7 and never
+emitted, and an item-less entity is invisible to 14 readers. So the test that matters asserts through
+the real query path in `expert.ts:283` / `why.ts:319`, not a hand-rolled `SELECT`. A test that only
+checks for a `graph_relation` row would pass in every world where this feature is still dead.
+
+**Red-prove the `CROSS_ITEM_RELATION_TYPES` change.** Review event → `PullRequestEvent` for the same
+PR → assert the edge survives. Then remove `"reviewed"` from the list and confirm the test goes red.
+Without that step there is no evidence the line is load-bearing rather than decorative.
+
+**Red-prove the widened enrich predicate.** A PR with a good title but no stats must be selected;
+under the old predicate it would not be, so the test should fail against the unmodified selector.
+
+**Seed through real writers.** Follow `graph-populator-resolves.test.ts`: `LocalIndex.ensureSchema`
+on `:memory:`, then `upsertIndexedItem`. No hand-rolled `INSERT INTO graph_entity` — fixtures that
+invent their own row shape hid three separate defects in the pre-mortem work, including a query that
+returned nothing in production while six tests passed.
+
+**Connector tests reuse the existing harness** — `createMemoryIndexDb`, `syncTestContext`,
+`describeWithFetchRestore`, `urlFromFetchInput` from `connector-sync-test-helpers.ts`; stubbed fetch,
+no network. Cases: a well-formed review event; a malformed payload skips without throwing (guarding
+G's etag-stall mode); an events payload lacking stats produces no stats keys and no crash; a
+pull-detail payload captures all four stats.
+
+**PR 2 adds:** bucket subdivision when a period exceeds 1,000; a truncated bucket is reported rather
+than silently capped; `github_search` acquired as a distinct key; `--dry-run` issues zero requests.
+
+**Gates, per branch and not per session.** `bun run preflight:fast` after every change. The
+Linux-authoritative coverage floor before pushing: neither `github-sync.ts` nor `graph-populator.ts`
+appears in `docs/structure-audit/coverage-baseline.json`, so both already clear the 85% line / 80%
+branch floor and have **no ratchet headroom** — new untested branches create a new violation rather
+than eroding existing debt. And `bun run typecheck:tests`, reading the "N new" line, because it is
+advisory on Windows and gating on CI-Linux and these PRs add test files.
+
+**Deliberately not here:** no agent e2e test and no HITL-free structural assertion — there is no
+agent until sub-project F.
+
+---
+
+## 7. Files touched
+
+### PR 1
+
+- `packages/gateway/src/connectors/github-sync.ts` — `PullRequestReviewEvent` branch; new
+  `upsertReview`; stats capture in `extractPrMetadataForIndex`; widened enrich predicate + rename.
+- `packages/gateway/src/graph/graph-populator.ts` — `"reviewed"` into `CROSS_ITEM_RELATION_TYPES`;
+  new `syncReviewGraph`; one dispatch branch.
+- Tests: `github-sync.test.ts`, `github-sync-enrich.test.ts`, new `graph-populator-reviews.test.ts`.
+- Docs: GitHub connector page + `docs/CHANGELOG.md` (connector deliveries go in the changelog, not
+  the CLAUDE.md status line).
+
+### PR 2
+
+- New `packages/gateway/src/connectors/github-backfill.ts`.
+- New `packages/gateway/src/ipc/index-backfill-rpc.ts` + IPC registration.
+- `packages/cli/src/commands/index-cmd.ts` — `nimbus index backfill`.
+- Docs: `docs/cli-reference.md` + `docs/CHANGELOG.md`.
+
+---
+
+## 8. To confirm at plan time
+
+Deliberately left open rather than guessed, since each is a vendor-response detail that the repo's
+hand-authored fixtures cannot settle:
+
+1. The exact `PullRequestReviewEvent` payload shape in the user-events feed — specifically that it
+   carries both `review` (with a stable id) and a full `pull_request` object.
+2. The search response fields carrying the result total and any incomplete-results flag, which
+   § 5.C's truncation reporting depends on.
+3. Whether `resolveGithubActorPersonId` behaves correctly when a review's `user` differs from the
+   PR's `user` — expected, but it has only ever been exercised on the author path.

--- a/docs/superpowers/specs/2026-08-11-github-contribution-depth-design.md
+++ b/docs/superpowers/specs/2026-08-11-github-contribution-depth-design.md
@@ -52,9 +52,19 @@ specifically a response to how pre-mortem PR A shipped a substrate that turned o
 Everything below was checked against the tree or against vendor documentation. Nothing here is
 asserted from memory.
 
-**The GitHub events feed is capped.** Per GitHub's REST documentation: *"The timeline will include
-up to 300 events. Only events created within the past 30 days will be included."* Private events are
-included because the sync authenticates as the user (`fetchAuthenticatedLogin`, `github-sync.ts:461`).
+**The GitHub events feed is capped, and Nimbus reads less of it than the cap allows.** Per GitHub's
+REST documentation: *"The timeline will include up to 300 events. Only events created within the past
+30 days will be included."* Private events are included because the sync authenticates as the user
+(`fetchAuthenticatedLogin`, `github-sync.ts:461`).
+
+But the vendor ceiling is not the binding one. `syncGithubUserEvents` (`github-sync.ts:492`) issues
+**exactly one request per tick** — `per_page=100`, no pagination loop, no `page` parameter. So the
+practical window is **the newest ~100 events between two successful syncs**, not 300. In steady state
+at a 60-second interval that is ample; after an outage, or for a very active account, everything
+older than the newest 100 events is lost permanently and silently, well inside the 30-day vendor
+window. This is pre-existing behaviour, not introduced here, but it sets the real loss boundary and
+§ 5.H exists because of it.
+
 Consequence: **incremental accumulation works, retroactive backfill does not.** A gateway running for
 a year holds a year of evidence; a fresh install holds nothing. A comp cycle is quarterly or annual,
 so PR 1 alone cannot serve the use case — hence PR 2.
@@ -195,6 +205,21 @@ and that stays behind an explicit opt-in.
 `negotiate` brief state plainly that reviewing a PR indexes that PR — matching how `ownership`
 carries its unconditional "authorship is not accountability" note.
 
+### Downstream effect on `catchup`, documented not mitigated
+
+Distinguishing "PRs I wrote" from "PRs I reviewed" needs **no new mechanism**: a colleague's PR row
+carries *their* `author_id`, so every query already keyed on `author_id = me` — `catchup.ts:284`
+(`subOwnedServices`), `:305` (`subActiveRepos`) — excludes reviewed-only PRs for free, and the
+`reviewed` edge is a separate traversal.
+
+One query is not author-scoped and will change behaviour: `catchup.ts:364` `subWindowItems` selects
+`FROM item WHERE modified_at >= ?` with no author filter, so colleague PRs the user reviewed will
+begin appearing in `nimbus catchup`'s window. That is arguably an improvement — a PR you reviewed is
+genuinely relevant to your day — and `scoreAndGroup` already ranks unrelated items down to
+`SCORE_DEFAULT`. It is recorded here so it lands as a known consequence rather than a surprise, and
+deliberately not "fixed": suppressing reviewed PRs from `catchup` would be a product regression
+dressed as a scoping fix.
+
 ---
 
 ## 5. Error handling & honesty
@@ -214,11 +239,40 @@ standing disclaimer readers learn to skip.
 subdivide to months; if a month still exceeds it, **report that bucket as truncated with its count**
 rather than returning the first 1,000 and implying completeness.
 
-**D. Search gets its own rate-limit bucket.** 30 req/min for search is a distinct budget from core's
-hourly limit. Sharing `ctx.rateLimiter.acquire("github")` would let a backfill starve the 60-second
-freshness sync and vice versa, so backfill acquires on `github_search`. The existing
-`throwGithubRateLimitErrorIfApplicable` already handles 403 + `x-ratelimit-remaining` + `retry-after`
-and is reused unchanged.
+**D. Search gets its own rate-limit bucket, and the 403 handler needs two fixes.** 30 req/min for
+search is a distinct budget from core's hourly limit. Sharing `ctx.rateLimiter.acquire("github")`
+would let a backfill starve the 60-second freshness sync and vice versa, so backfill acquires on
+`github_search`.
+
+`throwGithubRateLimitErrorIfApplicable` (`github-sync.ts:366`) cannot be reused unchanged, for two
+separate reasons found while reviewing:
+
+1. **It misses secondary rate limits.** GitHub's documentation states a secondary limit returns
+   *"either a `403` or `429`"*, and treats `retry-after` as a signal independent of
+   `x-ratelimit-remaining`: *"If the `retry-after` response header is present, you should not retry
+   your request until after that many seconds has elapsed."* The current handler only honours
+   `retry-after` when `remaining === "0" || remaining === null` (`:373`); a 403 carrying `retry-after`
+   with a non-zero `remaining` falls through to `return` at `:379` and is not treated as rate
+   limiting at all. The caller then sees a plain `!res.ok` and retries on the next tick. Fix: honour
+   a present `retry-after` regardless of `remaining`. **This is a live bug on the existing enrich
+   path, so it lands in PR 1**, whose widened predicate increases exposure to it.
+2. **The penalised bucket is hardcoded.** `penalise("github", ms)` (`:376`, `:384`) names the bucket
+   literally, so calling this helper from a search context would penalise the core bucket and leave
+   the offending one unthrottled. Fix: take the bucket key as a parameter. Lands in PR 2 with the
+   search path.
+
+**H. A saturated tick is logged; a stale connector is surfaced.** Because the events sync reads a
+single page (§ 2), evidence loss is silent by construction. Two signals, split by where the
+remediation exists:
+
+- **PR 1 — saturation.** A tick that parses a full page of events is evidence the window may have
+  overflowed. Log it structurally via `ctx.logger`, matching how the sync already reports partial
+  failures. Detection belongs where the loss happens.
+- **PR 2 — staleness.** `connectors/health.ts` already tracks `last_sync_at` /
+  `lastSuccessfulSync` per connector, so a "GitHub last synced N days ago; review evidence in that
+  window is unrecoverable from the events feed" note has a natural home. It ships in PR 2 rather
+  than PR 1 because its only useful remediation is `nimbus index backfill`, which does not exist
+  until then — warning a user about a gap they have no way to close is noise, not honesty.
 
 **E. Backfill resumes by idempotence, not by cursor.** Every write is an upsert on a deterministic
 `external_id`, so a cancelled or failed run converges on re-run. No new cursor state; the cost of
@@ -262,6 +316,20 @@ no network. Cases: a well-formed review event; a malformed payload skips without
 G's etag-stall mode); an events payload lacking stats produces no stats keys and no crash; a
 pull-detail payload captures all four stats.
 
+**A third-party reviewer resolves to a distinct person.** A review whose `user` differs from the PR's
+`user` must produce two separate `person` entities, with `authored` and `reviewed` pointing at the
+same PR from different people. This closes § 8's third open item — `resolveGithubActorPersonId` has
+only ever been exercised on the author path — and is the single test that proves the edge means what
+the brief will claim it means.
+
+**A 403 carrying `retry-after` with non-zero `x-ratelimit-remaining` raises `RateLimitError`.** Red-
+prove it: the test must fail against the unmodified `throwGithubRateLimitErrorIfApplicable`, which
+returns early in exactly that case (§ 5.D).
+
+**Two reviews by one person on one PR yield one edge, not two.** `upsertGraphRelation` is
+`ON CONFLICT (from_id, to_id, type)` (`relationship-graph.ts:114`), so this is already true — the
+test pins it, because the safety of skipping any edge-retirement mechanism (§ 5.F) rests on it.
+
 **PR 2 adds:** bucket subdivision when a period exceeds 1,000; a truncated bucket is reported rather
 than silently capped; `github_search` acquired as a distinct key; `--dry-run` issues zero requests.
 
@@ -282,7 +350,9 @@ agent until sub-project F.
 ### PR 1
 
 - `packages/gateway/src/connectors/github-sync.ts` — `PullRequestReviewEvent` branch; new
-  `upsertReview`; stats capture in `extractPrMetadataForIndex`; widened enrich predicate + rename.
+  `upsertReview`; stats capture in `extractPrMetadataForIndex`; widened enrich predicate + rename;
+  `throwGithubRateLimitErrorIfApplicable` honours a present `retry-after` regardless of
+  `x-ratelimit-remaining` (§ 5.D fix 1); saturation log when a tick parses a full page (§ 5.H).
 - `packages/gateway/src/graph/graph-populator.ts` — `"reviewed"` into `CROSS_ITEM_RELATION_TYPES`;
   new `syncReviewGraph`; one dispatch branch.
 - Tests: `github-sync.test.ts`, `github-sync-enrich.test.ts`, new `graph-populator-reviews.test.ts`.
@@ -294,6 +364,9 @@ agent until sub-project F.
 - New `packages/gateway/src/connectors/github-backfill.ts`.
 - New `packages/gateway/src/ipc/index-backfill-rpc.ts` + IPC registration.
 - `packages/cli/src/commands/index-cmd.ts` — `nimbus index backfill`.
+- `packages/gateway/src/connectors/github-sync.ts` — parameterise the penalised bucket key
+  (§ 5.D fix 2).
+- `packages/gateway/src/connectors/health.ts` — stale-connector note (§ 5.H).
 - Docs: `docs/cli-reference.md` + `docs/CHANGELOG.md`.
 
 ---
@@ -307,5 +380,6 @@ hand-authored fixtures cannot settle:
    carries both `review` (with a stable id) and a full `pull_request` object.
 2. The search response fields carrying the result total and any incomplete-results flag, which
    § 5.C's truncation reporting depends on.
-3. Whether `resolveGithubActorPersonId` behaves correctly when a review's `user` differs from the
-   PR's `user` — expected, but it has only ever been exercised on the author path.
+3. ~~Whether `resolveGithubActorPersonId` behaves correctly when a review's `user` differs from the
+   PR's `user`.~~ **Closed by review (2026-08-11)** — now covered by a required test in § 6 rather
+   than left as an assumption.

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { upsertIndexedItem } from "../index/item-store.ts";
 import { LocalIndex } from "../index/local-index.ts";
-import { emitExpertBrief, rankExpertFindings, runExpert } from "./expert.ts";
+import { emitExpertBrief, rankExpertFindings, runExpert, subPrReviewed } from "./expert.ts";
 
 describe("rankExpertFindings", () => {
   test("merges evidence from multiple streams by personId, summing weights", () => {
@@ -229,6 +229,58 @@ describe("runExpert gap-note coverage", () => {
     const brief = await runExpert({ topicOrFile: "noop" }, ctx);
     const cats = brief.gaps.map((g) => g.category);
     expect(cats).toContain("missing_relation_emit");
+  });
+});
+
+describe("subPrReviewed", () => {
+  test("subPrReviewed surfaces a reviewer as pr_reviewed evidence", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const now = Date.now();
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:author", "Author"]);
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Add rate limiter",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      authorId: "person:author",
+      metadata: { repo: "acme/app", number: 1 },
+    });
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "review",
+      externalId: "acme/app#1#review-500",
+      title: "Review on acme/app#1",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      authorId: "person:reviewer",
+      metadata: { repo: "acme/app", pr_number: 1 },
+    });
+
+    const result = await subPrReviewed(db, "rate limiter");
+
+    expect(result.gap).toBeUndefined();
+    expect(result.stream?.personId).toBe("person:reviewer");
+    expect(result.stream?.displayName).toBe("Reviewer");
+    expect(result.stream?.evidence).toHaveLength(1);
+    expect(result.stream?.evidence[0]?.type).toBe("pr_reviewed");
+    expect(result.stream?.evidence[0]?.itemId).toBe("github:acme/app#1");
+    db.close();
+  });
+
+  test("subPrReviewed still reports the gap when no reviewed edges exist", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const result = await subPrReviewed(db, "anything");
+    expect(result.gap?.category).toBe("missing_relation_emit");
+    expect(result.stream).toBeUndefined();
+    db.close();
   });
 });
 

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -229,6 +229,20 @@ describe("runExpert gap-note coverage", () => {
     const brief = await runExpert({ topicOrFile: "noop" }, ctx);
     const cats = brief.gaps.map((g) => g.category);
     expect(cats).toContain("missing_relation_emit");
+
+    // C-1: the zero-edge `reviewed` gap note must not claim the populator
+    // fails to emit `reviewed` (it does, since `syncReviewGraph` shipped),
+    // and must not tell the user to run a `nimbus index backfill` command
+    // that does not exist anywhere in the shipped CLI.
+    const reviewedGap = brief.gaps.find(
+      (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
+    );
+    expect(reviewedGap).toBeDefined();
+    expect(reviewedGap?.detail).not.toMatch(/not yet emitted by the graph populator/);
+    for (const g of brief.gaps) {
+      expect(g.detail).not.toMatch(/index backfill/);
+      expect(g.remediation ?? "").not.toMatch(/index backfill/);
+    }
   });
 });
 
@@ -312,6 +326,47 @@ describe("subPrReviewed", () => {
     // Distinct from the "no edges at all" gap's detail — proves this is the
     // resolution-aware branch, not the pre-existing zero-edges check.
     expect(result.gap?.detail).toContain("none resolve");
+    db.close();
+  });
+
+  test("subPrReviewed emits no gap note when a reviewed edge resolves but the topic just has no match (M-10)", async () => {
+    // A fully resolvable `reviewed` edge exists (real person + real indexed PR),
+    // but the free-text query below matches nothing in it. This must return
+    // `null` from `detectUnresolvedReviewedRelation` — a topic with no match is
+    // not a data gap — never a false "missing_relation_emit" gap note.
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const now = Date.now();
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:author", "Author"]);
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Add rate limiter",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      authorId: "person:author",
+      metadata: { repo: "acme/app", number: 1 },
+    });
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "review",
+      externalId: "acme/app#1#review-500",
+      title: "Review on acme/app#1",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      authorId: "person:reviewer",
+      metadata: { repo: "acme/app", pr_number: 1 },
+    });
+
+    const result = await subPrReviewed(db, "no-such-topic-anywhere");
+
+    expect(result.stream).toBeUndefined();
+    expect(result.gap).toBeUndefined();
     db.close();
   });
 });

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -458,10 +458,20 @@ describe("runExpert — subPrReviewed / subIncidentResolved suppressed gaps", ()
   test("existing reviewed + resolves relations and an incident entity produce no gap for those", async () => {
     const db = makePopulatedDb();
     const now = Date.now();
-    // Populate graph with 'reviewed' relation so subPrReviewed returns {}
+    // Populate graph with a 'reviewed' relation whose endpoints genuinely
+    // resolve through the join chain `subPrReviewed` reads — a real `item`
+    // row backing the `pr` graph_entity (id matches its external_id) and a
+    // real `person` row backing the `person` graph_entity (id matches its
+    // external_id) — so `subPrReviewed`'s resolution-aware probe finds a
+    // resolvable edge and stays quiet.
+    db.run(
+      "INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ["github:pr:1", "github", "pr", "pr:1", "auth overhaul", now, now],
+    );
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:1", "Person"]);
     db.run(
       "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
-      ["ge:pr:1", "pr", "pr:1", "PR", "github"],
+      ["ge:pr:1", "pr", "github:pr:1", "PR", "github"],
     );
     db.run(
       "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -282,6 +282,38 @@ describe("subPrReviewed", () => {
     expect(result.stream).toBeUndefined();
     db.close();
   });
+
+  test("subPrReviewed reports a distinct gap when a reviewed edge exists but its PR does not resolve to an indexed item", async () => {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    const now = Date.now();
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+    db.run(
+      "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
+      ["ge:person:reviewer", "person", "person:reviewer", "Reviewer", "github"],
+    );
+    // PR graph_entity with NO backing `item` row — this is the partial-join
+    // failure the old `detectMissingRelationEmit`-only probe couldn't see.
+    db.run(
+      "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
+      ["ge:pr:orphan", "pr", "github:pr:orphan", "Orphan PR", "github"],
+    );
+    db.run("INSERT INTO graph_relation (from_id, to_id, type, created_at) VALUES (?, ?, ?, ?)", [
+      "ge:person:reviewer",
+      "ge:pr:orphan",
+      "reviewed",
+      now,
+    ]);
+
+    const result = await subPrReviewed(db, "anything");
+
+    expect(result.stream).toBeUndefined();
+    expect(result.gap?.category).toBe("missing_relation_emit");
+    // Distinct from the "no edges at all" gap's detail — proves this is the
+    // resolution-aware branch, not the pre-existing zero-edges check.
+    expect(result.gap?.detail).toContain("none resolve");
+    db.close();
+  });
 });
 
 /** Helper: set up a minimal non-empty DB with both sync connectors registered. */

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -299,12 +299,18 @@ async function subPrAuthored(db: Database, input: string): Promise<SubAgentResul
  *     result is then just "no match for this search topic", not a data gap.
  */
 function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
-  const missingEmit = detectMissingRelationEmit(
-    db,
-    "reviewed",
-    "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
-  );
-  if (missingEmit !== null) return missingEmit;
+  const missingEmit = detectMissingRelationEmit(db, "reviewed");
+  if (missingEmit !== null) {
+    // `detectMissingRelationEmit`'s hard-coded detail ("not yet emitted by
+    // the graph populator") is false for `reviewed` — `syncReviewGraph` does
+    // emit it. Override with an honest, scoped detail/remediation instead of
+    // changing the shared helper's detail for every other relation type.
+    return {
+      category: missingEmit.category,
+      detail: "No `reviewed` edges yet — the GitHub connector has not indexed PR reviews.",
+      remediation: "Sync the GitHub connector so PR reviews are indexed.",
+    };
+  }
 
   const resolvedRow = db
     .query(
@@ -324,8 +330,7 @@ function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
     category: "missing_relation_emit",
     detail:
       "`reviewed` edges exist in the graph but none resolve to an indexed PR and reviewer — the referenced PRs or reviewers are not (yet) indexed.",
-    remediation:
-      "Sync the GitHub connector so the reviewed PRs and their authors are indexed, then run `nimbus index backfill --service github` for history.",
+    remediation: "Sync the GitHub connector so the reviewed PRs and their authors are indexed.",
   };
 }
 

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -277,6 +277,58 @@ async function subPrAuthored(db: Database, input: string): Promise<SubAgentResul
   return winner === undefined ? {} : { stream: winner };
 }
 
+/**
+ * Resolution-aware probe for the `reviewed` lane.
+ *
+ * `detectMissingRelationEmit` only checks that *some* `graph_relation` row of
+ * type `reviewed` exists — it does not require that row to resolve through
+ * the person/pr/item join chain `subPrReviewed`'s real query needs. Without
+ * this check, a `reviewed` edge whose `pr` graph_entity has no backing `item`
+ * row (or whose `person` graph_entity has no backing `person` row) makes the
+ * real query return 0 rows AND makes `detectMissingRelationEmit` report "all
+ * clear" — the exact "silently empty instead of explaining itself"
+ * regression `subIncidentResolved`'s neighbouring comment (see below) already
+ * warns about, here triggered by partial-join failure rather than by zero
+ * edges.
+ *
+ * Returns:
+ *   - the "no `reviewed` edges at all" gap if none exist,
+ *   - a distinct "edges exist but none resolve" gap if edges exist but the
+ *     join chain never completes for any of them (a real indexing gap),
+ *   - `null` if at least one edge resolves — the real query's zero-row
+ *     result is then just "no match for this search topic", not a data gap.
+ */
+function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
+  const missingEmit = detectMissingRelationEmit(
+    db,
+    "reviewed",
+    "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
+  );
+  if (missingEmit !== null) return missingEmit;
+
+  const resolvedRow = db
+    .query(
+      `SELECT 1 AS n
+         FROM graph_relation gr
+         JOIN graph_entity  pe  ON pe.id = gr.from_id AND pe.type = 'person'
+         JOIN person        p   ON p.id = pe.external_id
+         JOIN graph_entity  pre ON pre.id = gr.to_id AND pre.type = 'pr'
+         JOIN item          i   ON i.id = pre.external_id
+        WHERE gr.type = 'reviewed'
+        LIMIT 1`,
+    )
+    .get() as { n?: number } | null;
+  if (resolvedRow !== null) return null;
+
+  return {
+    category: "missing_relation_emit",
+    detail:
+      "`reviewed` edges exist in the graph but none resolve to an indexed PR and reviewer — the referenced PRs or reviewers are not (yet) indexed.",
+    remediation:
+      "Sync the GitHub connector so the reviewed PRs and their authors are indexed, then run `nimbus index backfill --service github` for history.",
+  };
+}
+
 export async function subPrReviewed(db: Database, input: string): Promise<SubAgentResult> {
   const rows = db
     .query(
@@ -307,11 +359,7 @@ export async function subPrReviewed(db: Database, input: string): Promise<SubAge
   }>;
 
   if (rows.length === 0) {
-    const gap = detectMissingRelationEmit(
-      db,
-      "reviewed",
-      "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
-    );
+    const gap = detectUnresolvedReviewedRelation(db);
     return gap === null ? {} : { gap };
   }
 

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -277,14 +277,67 @@ async function subPrAuthored(db: Database, input: string): Promise<SubAgentResul
   return winner === undefined ? {} : { stream: winner };
 }
 
-async function subPrReviewed(db: Database, _input: string): Promise<SubAgentResult> {
-  const gap = detectMissingRelationEmit(
-    db,
-    "reviewed",
-    "Tracked as a graph-populator follow-up; not gated on a specific Phase 5 wave.",
-  );
-  if (gap !== null) return { gap };
-  return {};
+export async function subPrReviewed(db: Database, input: string): Promise<SubAgentResult> {
+  const rows = db
+    .query(
+      `SELECT
+         p.id                           AS person_id,
+         COALESCE(p.display_name, p.id) AS display_name,
+         i.id                           AS item_id,
+         i.title                        AS title,
+         i.modified_at                  AS modified_at,
+         i.service                      AS service_id
+       FROM graph_relation gr
+       JOIN graph_entity  pe ON pe.id = gr.from_id AND pe.type = 'person'
+       JOIN person        p  ON p.id = pe.external_id
+       JOIN graph_entity  pre ON pre.id = gr.to_id AND pre.type = 'pr'
+       JOIN item          i  ON i.id = pre.external_id
+       WHERE gr.type = 'reviewed'
+         AND (i.title LIKE '%' || ? || '%' OR i.body_preview LIKE '%' || ? || '%')
+       ORDER BY i.modified_at DESC
+       LIMIT 50`,
+    )
+    .all(input, input) as Array<{
+    person_id: string;
+    display_name: string;
+    item_id: string;
+    title: string;
+    modified_at: number;
+    service_id: string;
+  }>;
+
+  if (rows.length === 0) {
+    const gap = detectMissingRelationEmit(
+      db,
+      "reviewed",
+      "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
+    );
+    return gap === null ? {} : { gap };
+  }
+
+  const merged = new Map<string, ExpertEvidenceStream>();
+  for (const r of rows) {
+    const ev: Evidence = {
+      itemId: r.item_id,
+      type: "pr_reviewed",
+      serviceId: r.service_id,
+      title: r.title.slice(0, 512),
+      modifiedAt: r.modified_at,
+      weight: 0.6,
+    };
+    const existing = merged.get(r.person_id);
+    if (existing === undefined) {
+      merged.set(r.person_id, {
+        personId: r.person_id,
+        displayName: r.display_name,
+        evidence: [ev],
+      });
+    } else {
+      existing.evidence.push(ev);
+    }
+  }
+  const winner = [...merged.values()].sort((a, b) => b.evidence.length - a.evidence.length)[0];
+  return winner === undefined ? {} : { stream: winner };
 }
 
 async function subIncidentResolved(db: Database, _input: string): Promise<SubAgentResult> {

--- a/packages/gateway/src/agents/ownership.ts
+++ b/packages/gateway/src/agents/ownership.ts
@@ -174,9 +174,8 @@ function buildGaps(args: {
     category: "missing_relation_emit",
     detail:
       "Blame measures who wrote lines, not who is accountable. There is no CODEOWNERS and no " +
-      "on-call rotation in the index — reviewer data now exists (`reviewed` edges from GitHub " +
-      "PR reviews) but is not yet factored into this ranking — so this is authorship-derived " +
-      "ownership.",
+      "on-call rotation in the index, and reviewer data (`reviewed` edges from GitHub PR " +
+      "reviews) is not factored into this ranking — so this is authorship-derived ownership.",
     remediation: "Treat the ranking as a starting point for who to ask, not as an approval list.",
   });
 

--- a/packages/gateway/src/agents/ownership.ts
+++ b/packages/gateway/src/agents/ownership.ts
@@ -173,8 +173,9 @@ function buildGaps(args: {
   gaps.push({
     category: "missing_relation_emit",
     detail:
-      "Blame measures who wrote lines, not who is accountable. There is no CODEOWNERS, no " +
-      "reviewer data and no on-call rotation in the index, so this is authorship-derived " +
+      "Blame measures who wrote lines, not who is accountable. There is no CODEOWNERS and no " +
+      "on-call rotation in the index — reviewer data now exists (`reviewed` edges from GitHub " +
+      "PR reviews) but is not yet factored into this ranking — so this is authorship-derived " +
       "ownership.",
     remediation: "Treat the ranking as a starting point for who to ask, not as an approval list.",
   });

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -159,6 +159,19 @@ describe("runWhy", () => {
         (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
       ),
     ).toBe(true);
+
+    // C-1: the zero-edge `reviewed` gap note must not claim the populator
+    // fails to emit `reviewed` (it does, since `syncReviewGraph` shipped),
+    // and must not tell the user to run a `nimbus index backfill` command
+    // that does not exist anywhere in the shipped CLI.
+    const reviewedGap = brief.gaps.find(
+      (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
+    );
+    expect(reviewedGap?.detail).not.toMatch(/not yet emitted by the graph populator/);
+    for (const g of brief.gaps) {
+      expect(g.detail).not.toMatch(/index backfill/);
+      expect(g.remediation ?? "").not.toMatch(/index backfill/);
+    }
   });
 
   test("the pull_request lane names reviewers when reviewed edges exist", async () => {
@@ -184,6 +197,37 @@ describe("runWhy", () => {
 
     expect(prFinding?.detail).toContain("Reviewed by");
     expect(brief.gaps.some((g) => g.detail.includes("`reviewed`"))).toBe(false);
+  });
+
+  test("I-5: a reviewer list beyond the display limit names the cut instead of silently truncating", async () => {
+    const db = freshDb();
+    seedWhyFixture(db, { commit: true, issue: true, pr: true, blame: { lineNo: 12 } });
+    const now = Date.now();
+
+    // 6 reviewers — one past the 5-reviewer display limit.
+    for (let i = 1; i <= 6; i++) {
+      const personId = `person:reviewer-${String(i)}`;
+      db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", [personId, `R${String(i)}`]);
+      upsertIndexedItem(db, {
+        service: "github",
+        type: "review",
+        externalId: `acme/app#412#review-${String(500 + i)}`,
+        title: "Review on acme/app#412",
+        bodyPreview: "",
+        modifiedAt: now,
+        syncedAt: now,
+        authorId: personId,
+        metadata: { repo: "acme/app", pr_number: 412 },
+      });
+    }
+
+    const brief = await runWhy({ ref: refAt(12) }, ctxFor(db));
+    const prFinding = brief.findings.find((f) => f.lane === "pull_request");
+
+    expect(prFinding?.detail).toContain("Reviewed by");
+    // The cut is named, not silent: exactly 5 reviewers are listed by name,
+    // and the overflow count (1) is stated explicitly.
+    expect(prFinding?.detail).toContain("R1, R2, R3, R4, R5, and 1 more");
   });
 
   test("pull_request lane: a reviewed edge that exists but doesn't resolve still yields a gap note, not silence", async () => {

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -161,6 +161,77 @@ describe("runWhy", () => {
     ).toBe(true);
   });
 
+  test("the pull_request lane names reviewers when reviewed edges exist", async () => {
+    const db = freshDb();
+    seedWhyFixture(db, { commit: true, issue: true, pr: true, blame: { lineNo: 12 } });
+    const now = Date.now();
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", ["person:reviewer", "Reviewer"]);
+
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "review",
+      externalId: "acme/app#412#review-500",
+      title: "Review on acme/app#412",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      authorId: "person:reviewer",
+      metadata: { repo: "acme/app", pr_number: 412 },
+    });
+
+    const brief = await runWhy({ ref: refAt(12) }, ctxFor(db));
+    const prFinding = brief.findings.find((f) => f.lane === "pull_request");
+
+    expect(prFinding?.detail).toContain("Reviewed by");
+    expect(brief.gaps.some((g) => g.detail.includes("`reviewed`"))).toBe(false);
+  });
+
+  test("pull_request lane: a reviewed edge that exists but doesn't resolve still yields a gap note, not silence", async () => {
+    const db = freshDb();
+    seedWhyFixture(db, { pr: true, blame: { lineNo: 42 } });
+
+    // A `reviewed` edge exists in the graph, but it targets a `pr`
+    // graph_entity with NO backing `item` row — the partial-join failure the
+    // old `detectMissingRelationEmit`-only probe couldn't see. It does not
+    // reference this PR at all, so the reviewer query for THIS PR also finds
+    // nothing: exactly the "silently empty AND no gap note" regression.
+    db.run(
+      "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
+      [
+        "ge:person:orphan-reviewer",
+        "person",
+        "person:orphan-reviewer",
+        "Orphan Reviewer",
+        "github",
+      ],
+    );
+    db.run(
+      "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
+      ["ge:pr:orphan", "pr", "github:pr:orphan", "Orphan PR", "github"],
+    );
+    db.run("INSERT INTO graph_relation (from_id, to_id, type, created_at) VALUES (?, ?, ?, ?)", [
+      "ge:person:orphan-reviewer",
+      "ge:pr:orphan",
+      "reviewed",
+      Date.now(),
+    ]);
+
+    const brief = await runWhy({ ref: refAt(42) }, ctxFor(db));
+
+    const prFinding = brief.findings.find((f) => f.lane === "pull_request");
+    expect(prFinding?.detail).not.toContain("Reviewed by");
+
+    const reviewedGap = brief.gaps.find(
+      (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
+    );
+    expect(reviewedGap).toBeDefined();
+    // Distinct from the "no `reviewed` edges at all" gap's detail — proves
+    // this is the resolution-aware branch, not the pre-existing zero-edges
+    // check (which a bare "edges exist / don't exist" probe would also pass
+    // for the zero-edges case, proving nothing about state (b)).
+    expect(reviewedGap?.detail).toContain("none resolve");
+  });
+
   test("ticket lane: pr → resolves → issue, endpoint-scoped", async () => {
     const db = freshDb();
     seedWhyFixture(db, { issue: true, pr: true, blame: { lineNo: 42 } });

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -232,6 +232,95 @@ describe("runWhy", () => {
     expect(reviewedGap?.detail).toContain("none resolve");
   });
 
+  test("pull_request lane: a per-PR reviewed edge that doesn't resolve still yields a gap note even when a DIFFERENT PR's reviewed edge resolves cleanly", async () => {
+    const db = freshDb();
+    const t = Date.now();
+
+    // PR A — from the shared fixture, healthy: a `reviewed` edge that
+    // resolves cleanly (real person row + real reviewer graph_entity).
+    seedWhyFixture(db, { pr: true, blame: { lineNo: 42 } });
+    db.run("INSERT INTO person (id, display_name) VALUES (?, ?)", [
+      "person:reviewer-a",
+      "Reviewer A",
+    ]);
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "review",
+      externalId: "acme/app#412#review-1",
+      title: "Review on acme/app#412",
+      bodyPreview: "",
+      modifiedAt: t,
+      syncedAt: t,
+      authorId: "person:reviewer-a",
+      metadata: { repo: "acme/app", pr_number: 412 },
+    });
+
+    // PR B — a second, REAL pr item constructed the same way the fixture
+    // builds PR A (not a hand-rolled graph_entity row), merged via a
+    // distinct commit SHA and blamed at a distinct line so this `why`
+    // invocation resolves to PR B, not PR A.
+    const SHA_B = "b2c3d4e5f60718293a4b5c6d7e8f9012345678a1";
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#413",
+      title: "Second PR",
+      bodyPreview: "",
+      url: "https://github.com/acme/app/pull/413",
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: {
+        number: 413,
+        repo: "acme/app",
+        state: "merged",
+        draft: false,
+        merged: true,
+        merge_commit_sha: SHA_B,
+      },
+    });
+    upsertBlameLines(db, ROOT, "src/retry.ts", [
+      {
+        lineNo: 99,
+        commitSha: SHA_B,
+        authorName: "bob",
+        authorEmail: "bob@example.com",
+        authorTimeMs: 1_700_000_000_000,
+      },
+    ]);
+
+    // PR B's `reviewed` edge is broken: its `from_id` resolves to a real
+    // graph_entity row (satisfying the FK), but NOT one of type `person` —
+    // "no matching person graph_entity" — so it can never resolve through
+    // the join the reviewer query (and the probe) both use.
+    const prBRow = db
+      .query("SELECT id FROM graph_entity WHERE type = 'pr' AND external_id = ?")
+      .get("github:acme/app#413") as { id: string };
+    db.run(
+      "INSERT INTO graph_entity (id, type, external_id, label, service) VALUES (?, ?, ?, ?, ?)",
+      ["ge:not-a-person", "ghost", "ghost:not-a-person", "Not A Person", "github"],
+    );
+    db.run("INSERT INTO graph_relation (from_id, to_id, type, created_at) VALUES (?, ?, ?, ?)", [
+      "ge:not-a-person",
+      prBRow.id,
+      "reviewed",
+      t,
+    ]);
+
+    const brief = await runWhy({ ref: refAt(99) }, ctxFor(db));
+
+    const prFinding = brief.findings.find((f) => f.lane === "pull_request");
+    expect(prFinding?.title).toContain("413");
+    expect(prFinding?.detail).not.toContain("Reviewed by");
+
+    // The bug this test guards against: an UNSCOPED probe finds PR A's
+    // healthy `reviewed` edge and reports "all clear" globally, silencing
+    // the gap note for PR B even though PR B's own reviewers never resolve.
+    const reviewedGap = brief.gaps.find(
+      (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
+    );
+    expect(reviewedGap).toBeDefined();
+  });
+
   test("ticket lane: pr → resolves → issue, endpoint-scoped", async () => {
     const db = freshDb();
     seedWhyFixture(db, { issue: true, pr: true, blame: { lineNo: 42 } });

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -167,6 +167,7 @@ describe("runWhy", () => {
     const reviewedGap = brief.gaps.find(
       (g) => g.category === "missing_relation_emit" && g.detail.includes("reviewed"),
     );
+    expect(reviewedGap).toBeDefined();
     expect(reviewedGap?.detail).not.toMatch(/not yet emitted by the graph populator/);
     for (const g of brief.gaps) {
       expect(g.detail).not.toMatch(/index backfill/);

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -311,12 +311,18 @@ async function subAuthorship(db: Database, lane: LaneInput): Promise<SubAgentRes
  *     already surfaced the reviewer in that case.
  */
 function detectUnresolvedReviewedRelation(db: Database, prEntityId: string): GapNote | null {
-  const missingEmit = detectMissingRelationEmit(
-    db,
-    "reviewed",
-    "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
-  );
-  if (missingEmit !== null) return missingEmit;
+  const missingEmit = detectMissingRelationEmit(db, "reviewed");
+  if (missingEmit !== null) {
+    // `detectMissingRelationEmit`'s hard-coded detail ("not yet emitted by
+    // the graph populator") is false for `reviewed` — `syncReviewGraph` does
+    // emit it. Override with an honest, scoped detail/remediation instead of
+    // changing the shared helper's detail for every other relation type.
+    return {
+      category: missingEmit.category,
+      detail: "No `reviewed` edges yet — the GitHub connector has not indexed PR reviews.",
+      remediation: "Sync the GitHub connector so PR reviews are indexed.",
+    };
+  }
 
   const resolvedRow = db
     .query(
@@ -334,7 +340,7 @@ function detectUnresolvedReviewedRelation(db: Database, prEntityId: string): Gap
     detail:
       "`reviewed` edges exist in the graph but none resolve to a reviewer for this PR — its reviewers are not (yet) indexed.",
     remediation:
-      "Sync the GitHub connector so this PR's reviewed events and their authors are indexed, then run `nimbus index backfill --service github` for history.",
+      "Sync the GitHub connector so this PR's reviewed events and their authors are indexed.",
   };
 }
 
@@ -360,6 +366,7 @@ async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentRe
     )
     .get(pr.entityId) as { label: string } | null;
 
+  const REVIEWER_DISPLAY_LIMIT = 5;
   const reviewerRows = db
     .query(
       `SELECT DISTINCT pe.label AS label
@@ -367,16 +374,29 @@ async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentRe
          JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
         WHERE r.to_id = ? AND r.type = 'reviewed'
         ORDER BY label
-        LIMIT 5`,
+        LIMIT ?`,
     )
-    .all(pr.entityId) as Array<{ label: string }>;
+    .all(pr.entityId, REVIEWER_DISPLAY_LIMIT) as Array<{ label: string }>;
+  const reviewerCountRow = db
+    .query(
+      `SELECT COUNT(DISTINCT pe.label) AS n
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+        WHERE r.to_id = ? AND r.type = 'reviewed'`,
+    )
+    .get(pr.entityId) as { n: number } | null;
+  const reviewerTotal = reviewerCountRow?.n ?? reviewerRows.length;
+  const reviewerOverflow = reviewerTotal - reviewerRows.length;
 
   const openedBy =
     authorRow !== null ? `Opened by ${authorRow.label}` : "PR author not resolved in the graph.";
-  const detail =
-    reviewerRows.length === 0
-      ? openedBy
-      : `${openedBy} · Reviewed by ${reviewerRows.map((r) => r.label).join(", ")}`;
+  // A total truncated silently is a lie by omission — name the cut, don't
+  // hide it (mirrors the `+N more` pattern the `decisions`/`glossary` agents
+  // already use for truncated lists).
+  const reviewerList =
+    reviewerRows.map((r) => r.label).join(", ") +
+    (reviewerOverflow > 0 ? `, and ${String(reviewerOverflow)} more` : "");
+  const detail = reviewerRows.length === 0 ? openedBy : `${openedBy} · Reviewed by ${reviewerList}`;
 
   const finding: WhyFinding = {
     lane: "pull_request",

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -391,8 +391,10 @@ async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentRe
   const openedBy =
     authorRow !== null ? `Opened by ${authorRow.label}` : "PR author not resolved in the graph.";
   // A total truncated silently is a lie by omission — name the cut, don't
-  // hide it (mirrors the `+N more` pattern the `decisions`/`glossary` agents
-  // already use for truncated lists).
+  // hide it. Discloses the overflow inline as ", and N more", the same
+  // truncation-disclosure format `packages/cli/src/commands/glossary.ts` uses
+  // when rendering a truncated list (the `decisions` agent instead discloses
+  // truncation via a separate gap note).
   const reviewerList =
     reviewerRows.map((r) => r.label).join(", ") +
     (reviewerOverflow > 0 ? `, and ${String(reviewerOverflow)} more` : "");

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -281,25 +281,36 @@ async function subAuthorship(db: Database, lane: LaneInput): Promise<SubAgentRes
 // ---------------------------------------------------------------------------
 
 /**
- * Resolution-aware probe for the `reviewed` lane — mirrors
- * `expert.ts`'s `detectUnresolvedReviewedRelation`.
+ * Resolution-aware probe for the `reviewed` lane — mirrors the shape of
+ * `expert.ts`'s `detectUnresolvedReviewedRelation`, but scoped to a single
+ * PR: unlike `expert.ts`'s `subPrReviewed` (a free-text topic search across
+ * *all* PRs, where "does anything resolve anywhere" is the right question),
+ * `why.ts`'s `subPullRequest` lane is already scoped to one resolved
+ * `pr.entityId` — its `reviewerRows` query filters `WHERE r.to_id = ?` bound
+ * to that PR. A probe that asks "does ANY `reviewed` edge ANYWHERE resolve"
+ * would report "all clear" as soon as a *different* PR's edge resolves,
+ * silencing a real per-PR failure (a `reviewed` edge on *this* PR with a
+ * dangling `from_id` or no matching `person` graph_entity) the moment the
+ * graph holds more than one PR's review data. So this probe binds
+ * `prEntityId` into the resolution check too, matching `reviewerRows`.
  *
  * `detectMissingRelationEmit` only checks that *some* `graph_relation` row of
  * type `reviewed` exists — it does not require that row to resolve through
- * the person/pr/item join chain this lane's reviewer query needs. Without
- * this check, a `reviewed` edge whose `pr` graph_entity has no backing `item`
- * row (or whose `person` graph_entity doesn't exist) makes the reviewer query
- * return 0 rows AND makes `detectMissingRelationEmit` report "all clear" —
- * silently empty instead of explaining itself.
+ * the person/pr join chain this lane's reviewer query needs. Without this
+ * check, a `reviewed` edge on this PR whose `person` graph_entity doesn't
+ * exist makes the reviewer query return 0 rows AND makes
+ * `detectMissingRelationEmit` report "all clear" — silently empty instead of
+ * explaining itself.
  *
  * Returns:
- *   - the "no `reviewed` edges at all" gap if none exist,
- *   - a distinct "edges exist but none resolve" gap if edges exist but the
- *     join chain never completes for any of them (a real indexing gap),
- *   - `null` if at least one edge resolves — an empty reviewer list for THIS
- *     PR is then just "not reviewed yet", not a data gap.
+ *   - the "no `reviewed` edges at all" gap if none exist anywhere,
+ *   - a distinct "edges exist but none resolve on this PR" gap if edges
+ *     exist elsewhere but the join chain never completes for this PR's
+ *     `pr.entityId` specifically (a real indexing gap for this PR),
+ *   - `null` if at least one edge resolves on this PR — the real query
+ *     already surfaced the reviewer in that case.
  */
-function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
+function detectUnresolvedReviewedRelation(db: Database, prEntityId: string): GapNote | null {
   const missingEmit = detectMissingRelationEmit(
     db,
     "reviewed",
@@ -312,20 +323,18 @@ function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
       `SELECT 1 AS n
          FROM graph_relation gr
          JOIN graph_entity  pe  ON pe.id = gr.from_id AND pe.type = 'person'
-         JOIN graph_entity  pre ON pre.id = gr.to_id  AND pre.type = 'pr'
-         JOIN item          i   ON i.id = pre.external_id
-        WHERE gr.type = 'reviewed'
+        WHERE gr.type = 'reviewed' AND gr.to_id = ?
         LIMIT 1`,
     )
-    .get() as { n?: number } | null;
+    .get(prEntityId) as { n?: number } | null;
   if (resolvedRow !== null) return null;
 
   return {
     category: "missing_relation_emit",
     detail:
-      "`reviewed` edges exist in the graph but none resolve to an indexed PR and reviewer — the referenced PRs or reviewers are not (yet) indexed.",
+      "`reviewed` edges exist in the graph but none resolve to a reviewer for this PR — its reviewers are not (yet) indexed.",
     remediation:
-      "Sync the GitHub connector so the reviewed PRs and their authors are indexed, then run `nimbus index backfill --service github` for history.",
+      "Sync the GitHub connector so this PR's reviewed events and their authors are indexed, then run `nimbus index backfill --service github` for history.",
   };
 }
 
@@ -379,9 +388,10 @@ async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentRe
   };
 
   // Reviewers come from `review` items indexed off the GitHub events feed.
-  // The gap note now means "no reviews indexed yet" (or "reviewed edges exist
-  // but don't resolve to an indexed PR/reviewer") — never "unimplemented".
-  const reviewedGap = detectUnresolvedReviewedRelation(db);
+  // The gap note now means "no reviews indexed yet anywhere" or "this PR's
+  // reviewed edges don't resolve to an indexed reviewer" — never
+  // "unimplemented".
+  const reviewedGap = detectUnresolvedReviewedRelation(db, pr.entityId);
   return reviewedGap !== null ? { findings: [finding], gap: reviewedGap } : { findings: [finding] };
 }
 

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -280,6 +280,55 @@ async function subAuthorship(db: Database, lane: LaneInput): Promise<SubAgentRes
 // Lane 2: pull_request
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolution-aware probe for the `reviewed` lane — mirrors
+ * `expert.ts`'s `detectUnresolvedReviewedRelation`.
+ *
+ * `detectMissingRelationEmit` only checks that *some* `graph_relation` row of
+ * type `reviewed` exists — it does not require that row to resolve through
+ * the person/pr/item join chain this lane's reviewer query needs. Without
+ * this check, a `reviewed` edge whose `pr` graph_entity has no backing `item`
+ * row (or whose `person` graph_entity doesn't exist) makes the reviewer query
+ * return 0 rows AND makes `detectMissingRelationEmit` report "all clear" —
+ * silently empty instead of explaining itself.
+ *
+ * Returns:
+ *   - the "no `reviewed` edges at all" gap if none exist,
+ *   - a distinct "edges exist but none resolve" gap if edges exist but the
+ *     join chain never completes for any of them (a real indexing gap),
+ *   - `null` if at least one edge resolves — an empty reviewer list for THIS
+ *     PR is then just "not reviewed yet", not a data gap.
+ */
+function detectUnresolvedReviewedRelation(db: Database): GapNote | null {
+  const missingEmit = detectMissingRelationEmit(
+    db,
+    "reviewed",
+    "Reviews are indexed from the GitHub events feed — sync the connector, or run `nimbus index backfill --service github` for history.",
+  );
+  if (missingEmit !== null) return missingEmit;
+
+  const resolvedRow = db
+    .query(
+      `SELECT 1 AS n
+         FROM graph_relation gr
+         JOIN graph_entity  pe  ON pe.id = gr.from_id AND pe.type = 'person'
+         JOIN graph_entity  pre ON pre.id = gr.to_id  AND pre.type = 'pr'
+         JOIN item          i   ON i.id = pre.external_id
+        WHERE gr.type = 'reviewed'
+        LIMIT 1`,
+    )
+    .get() as { n?: number } | null;
+  if (resolvedRow !== null) return null;
+
+  return {
+    category: "missing_relation_emit",
+    detail:
+      "`reviewed` edges exist in the graph but none resolve to an indexed PR and reviewer — the referenced PRs or reviewers are not (yet) indexed.",
+    remediation:
+      "Sync the GitHub connector so the reviewed PRs and their authors are indexed, then run `nimbus index backfill --service github` for history.",
+  };
+}
+
 async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentResult> {
   const sha = lane.blame?.commitSha;
   const pr = sha === undefined ? null : findPrForSha(db, sha);
@@ -302,23 +351,37 @@ async function subPullRequest(db: Database, lane: LaneInput): Promise<SubAgentRe
     )
     .get(pr.entityId) as { label: string } | null;
 
+  const reviewerRows = db
+    .query(
+      `SELECT DISTINCT pe.label AS label
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+        WHERE r.to_id = ? AND r.type = 'reviewed'
+        ORDER BY label
+        LIMIT 5`,
+    )
+    .all(pr.entityId) as Array<{ label: string }>;
+
+  const openedBy =
+    authorRow !== null ? `Opened by ${authorRow.label}` : "PR author not resolved in the graph.";
+  const detail =
+    reviewerRows.length === 0
+      ? openedBy
+      : `${openedBy} · Reviewed by ${reviewerRows.map((r) => r.label).join(", ")}`;
+
   const finding: WhyFinding = {
     lane: "pull_request",
     title: `#${pr.number ?? "?"} ${pr.title}`,
-    detail:
-      authorRow !== null ? `Opened by ${authorRow.label}` : "PR author not resolved in the graph.",
+    detail,
     url: pr.url,
     occurredAt: pr.modifiedAt,
     entityId: pr.entityId,
   };
 
-  // Reviewers: never promised — no populator emits `reviewed` (a Phase 5+
-  // follow-up, not gated on a specific wave), so this note is permanent.
-  const reviewedGap = detectMissingRelationEmit(
-    db,
-    "reviewed",
-    "Tracked as a graph-populator follow-up; not gated on a specific Phase 5 wave.",
-  );
+  // Reviewers come from `review` items indexed off the GitHub events feed.
+  // The gap note now means "no reviews indexed yet" (or "reviewed edges exist
+  // but don't resolve to an indexed PR/reviewer") — never "unimplemented".
+  const reviewedGap = detectUnresolvedReviewedRelation(db);
   return reviewedGap !== null ? { findings: [finding], gap: reviewedGap } : { findings: [finding] };
 }
 

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -140,11 +140,13 @@ describe("enrichPrDetail", () => {
     expect(titleOf(db, "acme/app#7")).toBe("PR #7");
   });
 
-  // Note: a title LIKE 'PR #%' (e.g. literally starting with that text) is now always
-  // treated as fallback-shaped, even with stats present — the exact-match JS filter that
-  // used to guard against this was intentionally removed (see selectPrEnrichCandidates'
-  // docstring). This fixture uses a title that does not collide with that prefix, so it
-  // still verifies that a real title with stats already captured is left untouched.
+  // Note: `selectPrEnrichCandidates` over-selects via `title LIKE 'PR #%'` and then narrows
+  // in JS with an exact-match check (`isExactFallback`, restored after an earlier fix round —
+  // see that function's docstring): a title merely starting with "PR #" (e.g. "Revert of PR
+  // #1") that already has stats is filtered back out, while a title that IS the exact
+  // fallback ("PR #<num>") stays a candidate regardless of stats, so its real title still
+  // gets fetched. This fixture's title does not collide with the LIKE prefix, so it verifies
+  // the plain case: a real title with stats already captured is left untouched.
   test("a real title with stats already captured is not clobbered", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -266,6 +266,41 @@ describe("selectPrEnrichCandidates", () => {
     db.close();
   });
 
+  test("a row with malformed metadata does not throw and the good row is still returned", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Add rate limiter", // NOT the `PR #1` fallback, no stats -> genuine candidate
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 1 },
+    });
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#2",
+      title: "Fine already",
+      bodyPreview: "",
+      modifiedAt: now + 1,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 2 },
+    });
+    // Plant deliberately malformed JSON directly — the normal write path always
+    // JSON-stringifies, so this can only be reproduced via a raw UPDATE.
+    db.run("UPDATE item SET metadata = ? WHERE external_id = ?", ["{bad", "acme/app#2"]);
+
+    let candidates: ReturnType<typeof selectPrEnrichCandidates> | undefined;
+    expect(() => {
+      candidates = selectPrEnrichCandidates(db, 10);
+    }).not.toThrow();
+    expect(candidates?.map((c) => c.externalId)).toContain("acme/app#1");
+    db.close();
+  });
+
   test("selectPrEnrichCandidates never returns more than the limit", () => {
     const db = createMemoryIndexDb();
     const now = Date.now();

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -7,7 +7,7 @@ import {
   createStubVault,
   syncTestContext,
 } from "./connector-sync-test-helpers.ts";
-import { enrichFallbackPrTitles } from "./github-sync.ts";
+import { enrichPrDetail, selectPrEnrichCandidates } from "./github-sync.ts";
 
 function seedPrRow(
   db: ReturnType<typeof createMemoryIndexDb>,
@@ -15,6 +15,7 @@ function seedPrRow(
   num: number,
   title: string,
   modifiedAt: number,
+  extraMetadata: Record<string, unknown> = {},
 ): void {
   upsertIndexedItem(db, {
     service: "github",
@@ -25,7 +26,7 @@ function seedPrRow(
     url: null,
     canonicalUrl: null,
     modifiedAt,
-    metadata: { number: num, repo: repoFull },
+    metadata: { number: num, repo: repoFull, ...extraMetadata },
     syncedAt: modifiedAt,
   });
 }
@@ -41,12 +42,12 @@ function titleOf(db: ReturnType<typeof createMemoryIndexDb>, externalId: string)
   return row.title;
 }
 
-describe("enrichFallbackPrTitles", () => {
+describe("enrichPrDetail", () => {
   test("enriches only fallback-titled PRs, newest-first, capped at 10", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);
     seedPrRow(db, "acme/app", 1, "PR #1", 1000); // fallback -> enrich
-    seedPrRow(db, "acme/app", 2, "Real title", 2000); // not fallback -> skip
+    seedPrRow(db, "acme/app", 2, "Real title", 2000, { additions: 5, deletions: 2 }); // real title + stats -> skip
     const fetchImpl = ((): Promise<Response> =>
       Promise.resolve(
         new Response(
@@ -55,7 +56,7 @@ describe("enrichFallbackPrTitles", () => {
         ),
       )) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 3000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 3000, fetchImpl);
 
     expect(n).toBe(1);
     expect(titleOf(db, "acme/app#1")).toBe("Fix the retry loop");
@@ -69,20 +70,20 @@ describe("enrichFallbackPrTitles", () => {
     const fetchImpl = (() =>
       Promise.resolve(new Response("nope", { status: 404 }))) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 2000, fetchImpl);
 
     expect(n).toBe(0);
     expect(titleOf(db, "acme/app#9")).toBe("PR #9");
   });
 
-  test("returns 0 when there are no fallback-titled rows", async () => {
+  test("returns 0 when there are no PRs needing enrichment", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);
-    seedPrRow(db, "acme/app", 3, "Add retry backoff", 1000);
+    seedPrRow(db, "acme/app", 3, "Add retry backoff", 1000, { additions: 5, deletions: 2 });
     const fetchImpl = (() =>
       Promise.resolve(new Response("{}", { status: 200 }))) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 2000, fetchImpl);
 
     expect(n).toBe(0);
   });
@@ -105,7 +106,7 @@ describe("enrichFallbackPrTitles", () => {
       );
     }) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 20000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 20000, fetchImpl);
 
     expect(n).toBe(10);
     expect(fetched).toHaveLength(10);
@@ -122,9 +123,7 @@ describe("enrichFallbackPrTitles", () => {
     const fetchImpl = (() =>
       Promise.resolve(new Response("nope", { status: 401 }))) as unknown as typeof fetch;
 
-    await expect(enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl)).rejects.toThrow(
-      /unauthorized/,
-    );
+    await expect(enrichPrDetail(ctx, "pat", 2000, fetchImpl)).rejects.toThrow(/unauthorized/);
   });
 
   test("a rate-limited (403, no remaining) response propagates and aborts the tick", async () => {
@@ -137,16 +136,19 @@ describe("enrichFallbackPrTitles", () => {
         new Response("nope", { status: 403, headers: { "x-ratelimit-remaining": "0" } }),
       )) as unknown as typeof fetch;
 
-    await expect(enrichFallbackPrTitles(ctx, "pat", 3000, fetchImpl)).rejects.toThrow(
-      /rate limited/,
-    );
+    await expect(enrichPrDetail(ctx, "pat", 3000, fetchImpl)).rejects.toThrow(/rate limited/);
     expect(titleOf(db, "acme/app#7")).toBe("PR #7");
   });
 
-  test("a real title that merely starts with the fallback shape is not clobbered", async () => {
+  // Note: a title LIKE 'PR #%' (e.g. literally starting with that text) is now always
+  // treated as fallback-shaped, even with stats present — the exact-match JS filter that
+  // used to guard against this was intentionally removed (see selectPrEnrichCandidates'
+  // docstring). This fixture uses a title that does not collide with that prefix, so it
+  // still verifies that a real title with stats already captured is left untouched.
+  test("a real title with stats already captured is not clobbered", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);
-    seedPrRow(db, "acme/app", 1, "PR #1 revert", 1000);
+    seedPrRow(db, "acme/app", 1, "Revert of PR #1", 1000, { additions: 5, deletions: 2 });
     const fetchImpl = (() =>
       Promise.resolve(
         new Response(JSON.stringify({ number: 1, title: "Fix the retry loop" }), {
@@ -154,10 +156,10 @@ describe("enrichFallbackPrTitles", () => {
         }),
       )) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 2000, fetchImpl);
 
     expect(n).toBe(0);
-    expect(titleOf(db, "acme/app#1")).toBe("PR #1 revert");
+    expect(titleOf(db, "acme/app#1")).toBe("Revert of PR #1");
   });
 
   test("a malformed JSON response is skipped, not enriched", async () => {
@@ -167,7 +169,7 @@ describe("enrichFallbackPrTitles", () => {
     const fetchImpl = (() =>
       Promise.resolve(new Response("not json", { status: 200 }))) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 2000, fetchImpl);
 
     expect(n).toBe(0);
     expect(titleOf(db, "acme/app#8")).toBe("PR #8");
@@ -180,9 +182,86 @@ describe("enrichFallbackPrTitles", () => {
     const fetchImpl = (() =>
       Promise.resolve(new Response("[1,2,3]", { status: 200 }))) as unknown as typeof fetch;
 
-    const n = await enrichFallbackPrTitles(ctx, "pat", 2000, fetchImpl);
+    const n = await enrichPrDetail(ctx, "pat", 2000, fetchImpl);
 
     expect(n).toBe(0);
     expect(titleOf(db, "acme/app#10")).toBe("PR #10");
+  });
+});
+
+describe("selectPrEnrichCandidates", () => {
+  test("a PR with a real title but no stats is selected for enrichment", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Add rate limiter", // NOT the `PR #1` fallback
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 1 }, // no additions/deletions
+    });
+
+    const candidates = selectPrEnrichCandidates(db, 10);
+    expect(candidates.map((c) => c.externalId)).toEqual(["acme/app#1"]);
+    db.close();
+  });
+
+  test("a PR with stats already captured is not selected", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "Add rate limiter",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 1, additions: 120, deletions: 30 },
+    });
+
+    expect(selectPrEnrichCandidates(db, 10)).toEqual([]);
+    db.close();
+  });
+
+  test("a fallback-titled PR is still selected even with stats", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#2",
+      title: "PR #2",
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 2, additions: 1, deletions: 1 },
+    });
+
+    expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).toEqual(["acme/app#2"]);
+    db.close();
+  });
+
+  test("selectPrEnrichCandidates never returns more than the limit", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    for (let i = 1; i <= 15; i += 1) {
+      upsertIndexedItem(db, {
+        service: "github",
+        type: "pr",
+        externalId: `acme/app#${String(i)}`,
+        title: `PR title ${String(i)}`,
+        bodyPreview: "",
+        modifiedAt: now + i,
+        syncedAt: now,
+        metadata: { repo: "acme/app", number: i },
+      });
+    }
+
+    expect(selectPrEnrichCandidates(db, 10)).toHaveLength(10);
+    db.close();
   });
 });

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -227,6 +227,24 @@ describe("selectPrEnrichCandidates", () => {
     db.close();
   });
 
+  test("a real title that merely starts with the fallback prefix is NOT re-selected once it has stats (prevents permanent re-enrichment)", () => {
+    const db = createMemoryIndexDb();
+    const now = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/app#1",
+      title: "PR #1 revert", // starts with the fallback prefix but is a real title
+      bodyPreview: "",
+      modifiedAt: now,
+      syncedAt: now,
+      metadata: { repo: "acme/app", number: 1, additions: 5, deletions: 2 },
+    });
+
+    expect(selectPrEnrichCandidates(db, 10)).toEqual([]);
+    db.close();
+  });
+
   test("a fallback-titled PR is still selected even with stats", () => {
     const db = createMemoryIndexDb();
     const now = Date.now();

--- a/packages/gateway/src/connectors/github-sync-enrich.test.ts
+++ b/packages/gateway/src/connectors/github-sync-enrich.test.ts
@@ -141,12 +141,13 @@ describe("enrichPrDetail", () => {
   });
 
   // Note: `selectPrEnrichCandidates` over-selects via `title LIKE 'PR #%'` and then narrows
-  // in JS with an exact-match check (`isExactFallback`, restored after an earlier fix round —
-  // see that function's docstring): a title merely starting with "PR #" (e.g. "Revert of PR
-  // #1") that already has stats is filtered back out, while a title that IS the exact
-  // fallback ("PR #<num>") stays a candidate regardless of stats, so its real title still
-  // gets fetched. This fixture's title does not collide with the LIKE prefix, so it verifies
-  // the plain case: a real title with stats already captured is left untouched.
+  // in JS with an exact-match check (`isExactFallback` — see that function's docstring): a
+  // title merely starting with "PR #" (e.g. "PR #142 fix bug") that already has stats is
+  // filtered back out, while a title that IS the exact fallback ("PR #<num>") stays a
+  // candidate regardless of stats, so its real title still gets fetched. This fixture's
+  // title ("Revert of PR #1") does not start with "PR #" at all, so it never collides with
+  // the LIKE prefix in the first place — it verifies the plain case: a real title with stats
+  // already captured is left untouched.
   test("a real title with stats already captured is not clobbered", async () => {
     const db = createMemoryIndexDb();
     const ctx = ctxFor(db);

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -5,10 +5,13 @@ import {
   createMemoryIndexDb,
   createStubVault,
   describeWithFetchRestore,
+  EMPTY_NIMBUS_VAULT,
+  expectServiceItemCount,
   type SyncTestFetchParams,
   silentSyncContextExtras,
+  syncTestContext,
 } from "./connector-sync-test-helpers.ts";
-import { createGithubSyncable } from "./github-sync.ts";
+import { createGithubSyncable, processEvent } from "./github-sync.ts";
 
 function ctxWithPat(db: ReturnType<typeof createMemoryIndexDb>, pat: string | null) {
   return {
@@ -269,4 +272,100 @@ describeWithFetchRestore("github-sync fetchOne", () => {
 
     expect(out).toEqual({ status: "not_found", reason: "upstream_error" });
   });
+});
+
+function reviewEvent(): Record<string, unknown> {
+  return {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: {
+      action: "created",
+      review: {
+        id: 500,
+        state: "approved",
+        body: "LGTM",
+        html_url: "https://github.com/acme/app/pull/1#pullrequestreview-500",
+        submitted_at: "2026-08-11T10:00:00Z",
+        user: { login: "reviewer" },
+      },
+      pull_request: {
+        number: 1,
+        title: "Add rate limiter",
+        body: "",
+        html_url: "https://github.com/acme/app/pull/1",
+        user: { login: "author" },
+        state: "open",
+      },
+    },
+  };
+}
+
+test("a PullRequestReviewEvent indexes both the review and its PR", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const now = Date.now();
+
+  expect(processEvent(ctx, reviewEvent(), now)).toBe(true);
+
+  const review = db
+    .query("SELECT id, author_id, metadata FROM item WHERE service = 'github' AND type = 'review'")
+    .get() as { id: string; author_id: string | null; metadata: string };
+  expect(review.id).toBe("github:acme/app#1#review-500");
+  expect(review.author_id).not.toBeNull();
+  expect(JSON.parse(review.metadata)).toMatchObject({
+    repo: "acme/app",
+    pr_number: 1,
+    review_id: 500,
+  });
+
+  const pr = db.query("SELECT title FROM item WHERE id = 'github:acme/app#1'").get() as {
+    title: string;
+  };
+  expect(pr.title).toBe("Add rate limiter");
+  db.close();
+});
+
+test("the reviewer resolves to a different person than the PR author", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const now = Date.now();
+  processEvent(ctx, reviewEvent(), now);
+
+  const prAuthor = db.query("SELECT author_id FROM item WHERE id = 'github:acme/app#1'").get() as {
+    author_id: string;
+  };
+  const reviewer = db
+    .query("SELECT author_id FROM item WHERE id = 'github:acme/app#1#review-500'")
+    .get() as { author_id: string };
+
+  expect(reviewer.author_id).not.toBe(prAuthor.author_id);
+  db.close();
+});
+
+test("a review event missing its pull_request is skipped without throwing", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: { action: "created", review: { id: 500, user: { login: "reviewer" } } },
+  };
+
+  expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expectServiceItemCount(db, "github", 0);
+  db.close();
+});
+
+test("a review event missing its review id is skipped without throwing", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: { action: "created", pull_request: { number: 1, title: "x", user: { login: "a" } } },
+  };
+
+  expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expectServiceItemCount(db, "github", 0);
+  db.close();
 });

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -11,12 +11,15 @@ import {
   type SyncTestFetchParams,
   silentSyncContextExtras,
   syncTestContext,
+  urlFromFetchInput,
 } from "./connector-sync-test-helpers.ts";
 import {
   createGithubSyncable,
   extractPrMetadataForIndex,
   processEvent,
+  selectPrEnrichCandidates,
   throwGithubRateLimitErrorIfApplicable,
+  upsertPr,
 } from "./github-sync.ts";
 
 function ctxWithPat(db: ReturnType<typeof createMemoryIndexDb>, pat: string | null) {
@@ -280,6 +283,73 @@ describeWithFetchRestore("github-sync fetchOne", () => {
   });
 });
 
+describeWithFetchRestore("github-sync events sync (I-3)", () => {
+  test("PR detail enrichment still runs on a 304 (unchanged) events tick", async () => {
+    const db = createMemoryIndexDb();
+    const ctx = ctxWithPat(db, "pat-value");
+    const now = Date.now();
+
+    // A previously-indexed PR missing stats — a live enrichment candidate.
+    upsertPr(
+      ctx,
+      "acme/app",
+      {
+        number: 1,
+        title: "Add rate limiter",
+        body: "",
+        html_url: "https://github.com/acme/app/pull/1",
+        user: { login: "author" },
+        state: "open",
+      },
+      now,
+    );
+    expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).toContain("acme/app#1");
+
+    let pullDetailCalled = false;
+    globalThis.fetch = ((input: SyncTestFetchParams[0]) => {
+      const url = urlFromFetchInput(input);
+      if (url === "https://api.github.com/user") {
+        return Promise.resolve(new Response(JSON.stringify({ login: "octocat" }), { status: 200 }));
+      }
+      if (url.startsWith("https://api.github.com/users/octocat/events")) {
+        // The events feed itself is UNCHANGED — this is the 304 path under test.
+        return Promise.resolve(new Response(null, { status: 304 }));
+      }
+      if (url === "https://api.github.com/repos/acme/app/pulls/1") {
+        pullDetailCalled = true;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              number: 1,
+              title: "Add rate limiter",
+              additions: 10,
+              deletions: 2,
+              changed_files: 1,
+              commits: 1,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      throw new Error(`unexpected fetch in I-3 test: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const syncable = createGithubSyncable({ ensureGithubMcpRunning: async () => {} });
+    const result = await syncable.sync(ctx, null);
+
+    // The 304 path's own cursor/return semantics are preserved exactly.
+    expect(result.itemsUpserted).toBe(0);
+    expect(result.itemsDeleted).toBe(0);
+    expect(result.hasMore).toBe(false);
+    expect(result.cursor).not.toBeNull();
+
+    // But enrichment newly ran on this quiet tick.
+    expect(pullDetailCalled).toBe(true);
+    expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).not.toContain("acme/app#1");
+    db.close();
+  });
+});
+
 function reviewEvent(): Record<string, unknown> {
   return {
     type: "PullRequestReviewEvent",
@@ -460,6 +530,69 @@ test("PR stats are absent, not null, when the payload omits them", () => {
   expect("deletions" in meta).toBe(false);
   expect("changed_files" in meta).toBe(false);
   expect("commits" in meta).toBe(false);
+});
+
+test("I-2: an events-path upsert after enrichment preserves stats and does not re-queue the PR", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const now = Date.now();
+
+  // Simulate `enrichPrDetail`'s single-PR response: real title + full stats.
+  upsertPr(
+    ctx,
+    "acme/app",
+    {
+      number: 1,
+      title: "Add rate limiter",
+      body: "",
+      html_url: "https://github.com/acme/app/pull/1",
+      user: { login: "author" },
+      state: "open",
+      additions: 120,
+      deletions: 30,
+      changed_files: 7,
+      commits: 3,
+    },
+    now,
+  );
+
+  expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).not.toContain("acme/app#1");
+
+  // A later PullRequestEvent for the same PR — real event payloads never carry stats.
+  expect(
+    processEvent(
+      ctx,
+      {
+        type: "PullRequestEvent",
+        repo: { full_name: "acme/app" },
+        payload: {
+          action: "labeled",
+          pull_request: {
+            number: 1,
+            title: "Add rate limiter",
+            body: "",
+            html_url: "https://github.com/acme/app/pull/1",
+            user: { login: "author" },
+            state: "open",
+          },
+        },
+      },
+      now + 60_000,
+    ),
+  ).toBe(true);
+
+  const row = db.query("SELECT metadata FROM item WHERE id = 'github:acme/app#1'").get() as {
+    metadata: string;
+  };
+  const meta = JSON.parse(row.metadata) as Record<string, unknown>;
+  expect(meta["additions"]).toBe(120);
+  expect(meta["deletions"]).toBe(30);
+  expect(meta["changed_files"]).toBe(7);
+  expect(meta["commits"]).toBe(3);
+
+  // Stats survived the events-path upsert, so the PR must not re-qualify for enrichment.
+  expect(selectPrEnrichCandidates(db, 10).map((c) => c.externalId)).not.toContain("acme/app#1");
+  db.close();
 });
 
 test("a 403 with retry-after is rate limiting even when remaining is non-zero", () => {

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -11,7 +11,7 @@ import {
   silentSyncContextExtras,
   syncTestContext,
 } from "./connector-sync-test-helpers.ts";
-import { createGithubSyncable, processEvent } from "./github-sync.ts";
+import { createGithubSyncable, extractPrMetadataForIndex, processEvent } from "./github-sync.ts";
 
 function ctxWithPat(db: ReturnType<typeof createMemoryIndexDb>, pat: string | null) {
   return {
@@ -422,4 +422,36 @@ test("a review event whose pull_request has no usable number is skipped without 
   expect(processEvent(ctx, ev, Date.now())).toBe(false);
   expectServiceItemCount(db, "github", 0);
   db.close();
+});
+
+test("PR stats are captured from a pull-detail payload", () => {
+  const meta = extractPrMetadataForIndex("acme/app", {
+    number: 1,
+    title: "Add rate limiter",
+    state: "open",
+    user: { login: "author" },
+    additions: 120,
+    deletions: 30,
+    changed_files: 7,
+    commits: 3,
+  });
+
+  expect(meta["additions"]).toBe(120);
+  expect(meta["deletions"]).toBe(30);
+  expect(meta["changed_files"]).toBe(7);
+  expect(meta["commits"]).toBe(3);
+});
+
+test("PR stats are absent, not null, when the payload omits them", () => {
+  const meta = extractPrMetadataForIndex("acme/app", {
+    number: 1,
+    title: "Add rate limiter",
+    state: "open",
+    user: { login: "author" },
+  });
+
+  expect("additions" in meta).toBe(false);
+  expect("deletions" in meta).toBe(false);
+  expect("changed_files" in meta).toBe(false);
+  expect("commits" in meta).toBe(false);
 });

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -356,16 +356,70 @@ test("a review event missing its pull_request is skipped without throwing", () =
   db.close();
 });
 
-test("a review event missing its review id is skipped without throwing", () => {
+test("a review missing a usable id writes the PR but skips the review, and processEvent reports false", () => {
   const db = createMemoryIndexDb();
   const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
   const ev = {
     type: "PullRequestReviewEvent",
     repo: { full_name: "acme/app" },
-    payload: { action: "created", pull_request: { number: 1, title: "x", user: { login: "a" } } },
+    payload: {
+      action: "created",
+      review: { user: { login: "reviewer" } },
+      pull_request: { number: 1, title: "x", user: { login: "a" } },
+    },
   };
 
   expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expect(processEvent(ctx, ev, Date.now())).toBe(false);
+
+  const pr = db.query("SELECT title FROM item WHERE id = 'github:acme/app#1'").get() as {
+    title: string;
+  } | null;
+  expect(pr).not.toBeNull();
+  const review = db.query("SELECT id FROM item WHERE service = 'github' AND type = 'review'").get();
+  expect(review).toBeNull();
+  db.close();
+});
+
+test("a review id sent as a string (not a number) writes the PR but skips the review", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: {
+      action: "created",
+      review: { id: "500", user: { login: "reviewer" } },
+      pull_request: { number: 1, title: "x", user: { login: "a" } },
+    },
+  };
+
+  expect(processEvent(ctx, ev, Date.now())).toBe(false);
+
+  const pr = db.query("SELECT title FROM item WHERE id = 'github:acme/app#1'").get() as {
+    title: string;
+  } | null;
+  expect(pr).not.toBeNull();
+  const review = db.query("SELECT id FROM item WHERE service = 'github' AND type = 'review'").get();
+  expect(review).toBeNull();
+  db.close();
+});
+
+test("a review event whose pull_request has no usable number is skipped without throwing", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const ev = {
+    type: "PullRequestReviewEvent",
+    repo: { full_name: "acme/app" },
+    payload: {
+      action: "created",
+      review: { id: 500, user: { login: "reviewer" } },
+      pull_request: { title: "x", user: { login: "a" } },
+    },
+  };
+
+  expect(() => processEvent(ctx, ev, Date.now())).not.toThrow();
+  expect(processEvent(ctx, ev, Date.now())).toBe(false);
   expectServiceItemCount(db, "github", 0);
   db.close();
 });

--- a/packages/gateway/src/connectors/github-sync.test.ts
+++ b/packages/gateway/src/connectors/github-sync.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { resolveItemByUrl } from "../index/resolve-by-url.ts";
+import { RateLimitError } from "../sync/types.ts";
 import {
   createMemoryIndexDb,
   createStubVault,
@@ -11,7 +12,12 @@ import {
   silentSyncContextExtras,
   syncTestContext,
 } from "./connector-sync-test-helpers.ts";
-import { createGithubSyncable, extractPrMetadataForIndex, processEvent } from "./github-sync.ts";
+import {
+  createGithubSyncable,
+  extractPrMetadataForIndex,
+  processEvent,
+  throwGithubRateLimitErrorIfApplicable,
+} from "./github-sync.ts";
 
 function ctxWithPat(db: ReturnType<typeof createMemoryIndexDb>, pat: string | null) {
   return {
@@ -454,4 +460,28 @@ test("PR stats are absent, not null, when the payload omits them", () => {
   expect("deletions" in meta).toBe(false);
   expect("changed_files" in meta).toBe(false);
   expect("commits" in meta).toBe(false);
+});
+
+test("a 403 with retry-after is rate limiting even when remaining is non-zero", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const res = new Response("secondary rate limit", {
+    status: 403,
+    headers: { "retry-after": "60", "x-ratelimit-remaining": "4999" },
+  });
+
+  expect(() => throwGithubRateLimitErrorIfApplicable(ctx, res, "events")).toThrow(RateLimitError);
+  db.close();
+});
+
+test("a 403 with no retry-after and remaining left is not rate limiting", () => {
+  const db = createMemoryIndexDb();
+  const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT);
+  const res = new Response("forbidden", {
+    status: 403,
+    headers: { "x-ratelimit-remaining": "4999" },
+  });
+
+  expect(() => throwGithubRateLimitErrorIfApplicable(ctx, res, "events")).not.toThrow();
+  db.close();
 });

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -607,8 +607,13 @@ function metadataHasStats(metadata: string): boolean {
  *
  * `json_extract` is used (via `metadataHasStats`) rather than a LIKE over the
  * raw metadata blob so a PR body mentioning "additions" cannot mask a
- * genuinely missing field. Guarded by `json_valid` in SQL and mirrored by
- * `metadataHasStats`'s parse-failure fallback, because malformed JSON must
+ * genuinely missing field. `OR` does NOT short-circuit SQLite's evaluation
+ * order in a way that protects `json_extract` from malformed JSON — a single
+ * row with unparseable `metadata` throws `SQLiteError: malformed JSON` and
+ * kills the whole query. The `json_extract` arm is therefore wrapped in a
+ * `CASE WHEN json_valid(metadata) THEN … ELSE 1 END` guard, mirrored by
+ * `metadataHasStats`'s parse-failure fallback: a row whose metadata cannot be
+ * parsed must remain a CANDIDATE (the `ELSE 1`), because malformed JSON must
  * never be treated as "has stats" — that would incorrectly skip a row that
  * cannot be proven enriched.
  */
@@ -619,8 +624,10 @@ export function selectPrEnrichCandidates(db: Database, limit: number): FallbackP
          WHERE service = 'github' AND type = 'pr'
            AND (
              title LIKE 'PR #%'
-             OR NOT json_valid(metadata)
-             OR json_extract(metadata, '$.additions') IS NULL
+             OR CASE
+                  WHEN json_valid(metadata) THEN json_extract(metadata, '$.additions') IS NULL
+                  ELSE 1
+                END
            )
          ORDER BY modified_at DESC LIMIT ?`,
     )

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -608,9 +608,11 @@ function metadataHasStats(metadata: string): boolean {
  * `json_extract` is used (via `metadataHasStats`) rather than a LIKE over the
  * raw metadata blob so a PR body mentioning "additions" cannot mask a
  * genuinely missing field. `OR` does NOT short-circuit SQLite's evaluation
- * order in a way that protects `json_extract` from malformed JSON — a single
- * row with unparseable `metadata` throws `SQLiteError: malformed JSON` and
- * kills the whole query. The `json_extract` arm is therefore wrapped in a
+ * order in a way that is guaranteed by contract. Measured behaviour (bun 1.3.14 /
+ * SQLite 3.53.0): the bare `OR` form DOES short-circuit per row in WHERE-clause
+ * context and does not throw; the same expression in a SELECT-list value context
+ * DOES throw. Rather than depend on that context distinction, the `json_extract`
+ * arm is wrapped in a
  * `CASE WHEN json_valid(metadata) THEN … ELSE 1 END` guard, mirrored by
  * `metadataHasStats`'s parse-failure fallback: a row whose metadata cannot be
  * parsed must remain a CANDIDATE (the `ELSE 1`), because malformed JSON must

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -216,6 +216,23 @@ const PR_STAT_KEYS = ["additions", "deletions", "changed_files", "commits"] as c
  * Accepted tradeoff: once merged forward, stats can go stale (an event bumps `modified_at`
  * without new commit/diff counts) until the next detail fetch refreshes them. That is strictly
  * better than losing the stats outright and re-enriching the same PR on every tick.
+ *
+ * Scope, deliberately: this merges forward the four `PR_STAT_KEYS` only. `mergeable`,
+ * `mergeable_state`, and `mergeable_state_fetched_at_ms` are subject to the same wholesale
+ * `metadata = excluded.metadata` replacement and are NOT merged forward here — left as-is
+ * because no re-queue loop results: `shouldRefreshMergeableState` currently has no production
+ * caller, so nothing re-derives or re-fetches `mergeable_state` off the back of a cleared value.
+ * Not an oversight; revisit together if `shouldRefreshMergeableState` ever gets wired up.
+ *
+ * Open question (unverified): `extractPrMetadataForIndex`'s own docstring and
+ * `selectPrEnrichCandidates`'s docstring both assert the GitHub events feed omits `title` on
+ * `PullRequestEvent` payloads. If that holds, an events-path `upsertPr` call for an
+ * already-enriched PR falls back to the id-only `PR #<num>` title (see `upsertPr`), which is a
+ * plain field on the `item` row, not something this function merges forward. `title LIKE
+ * 'PR #%'` would then re-match, and `selectPrEnrichCandidates`'s exact-fallback arm re-queues
+ * the row regardless of stats — so this stats merge-forward would close only one of the
+ * selector's two arms, not both. This could not be confirmed from GitHub's published docs and
+ * needs verification against the live API before anyone treats it as fixed either way.
  */
 function mergeForwardPrStats(
   db: Database,

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -93,6 +93,12 @@ export function extractPrMetadataForIndex(
     out["mergeable_state"] = mergeableState;
     out["mergeable_state_fetched_at_ms"] = nowMs;
   }
+  for (const key of ["additions", "deletions", "changed_files", "commits"] as const) {
+    const v = numberField(pr, key);
+    if (v !== undefined) {
+      out[key] = v;
+    }
+  }
   if (merged) {
     const mergedAtIso = stringField(pr, "merged_at");
     if (mergedAtIso !== undefined) {

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -116,7 +116,7 @@ export function extractPrMetadataForIndex(
 }
 
 function eventsUrlFor(login: string): string {
-  return `https://api.github.com/users/${encodeURIComponent(login)}/events?per_page=100`;
+  return `https://api.github.com/users/${encodeURIComponent(login)}/events?per_page=${String(GITHUB_EVENTS_PAGE_SIZE)}`;
 }
 
 type GithubSyncCursorV1 = { etag: string | null; login: string | null };
@@ -449,15 +449,20 @@ function parseGithubEventsPayload(text: string): unknown[] {
   return parsed;
 }
 
-function throwGithubRateLimitErrorIfApplicable(
+export function throwGithubRateLimitErrorIfApplicable(
   ctx: SyncContext,
   res: Response,
   label: string,
 ): void {
   if (res.status === 403) {
     const remaining = res.headers.get("x-ratelimit-remaining");
-    if (remaining === "0" || remaining === null) {
-      const retryAt = retryAfterDateFromHeader(res.headers.get("retry-after"), 60);
+    const retryAfter = res.headers.get("retry-after");
+    // GitHub returns 403 OR 429 for secondary (abuse) limits, and documents
+    // `retry-after` as an independent signal: a secondary limit can arrive with
+    // primary quota still available. Keying only on `remaining === 0` misses
+    // every one of those and retries straight into the limit.
+    if (remaining === "0" || remaining === null || retryAfter !== null) {
+      const retryAt = retryAfterDateFromHeader(retryAfter, 60);
       const ms = Math.max(1000, retryAt.getTime() - Date.now());
       ctx.rateLimiter.penalise("github", ms);
       throw new RateLimitError(retryAt, `GitHub ${label}: rate limited (403)`);
@@ -479,6 +484,12 @@ interface FallbackPrCandidate {
 }
 
 const MAX_ENRICH_PER_TICK = 10;
+
+/**
+ * Single source of truth for the events feed's `per_page`, shared by `eventsUrlFor` (the request)
+ * and `syncGithubUserEvents` (the full-page saturation check) so the two can never drift.
+ */
+const GITHUB_EVENTS_PAGE_SIZE = 100;
 
 /**
  * True when `metadata` (a JSON blob) already carries a non-null `additions` field.
@@ -689,6 +700,16 @@ async function syncGithubUserEvents(
     if (processEvent(ctx, ev, now)) {
       upserted += 1;
     }
+  }
+
+  // One request per tick at per_page=100 (no pagination): a full page means the
+  // window may have overflowed between syncs, and anything older is unreachable
+  // from the events feed. Loss is silent by construction, so record it.
+  if (parsed.length >= GITHUB_EVENTS_PAGE_SIZE) {
+    ctx.logger.warn(
+      { service: SERVICE_ID, events: parsed.length },
+      "github events page was full; older events in this window may have been missed",
+    );
   }
 
   // Best-effort detail enrichment for fallback-titled or stats-missing PRs (existing rows + this tick's events).

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -200,6 +200,59 @@ function githubPrExternalId(repoFull: string, num: number): string {
   return `${repoFull}#${String(num)}`;
 }
 
+const PR_STAT_KEYS = ["additions", "deletions", "changed_files", "commits"] as const;
+
+/**
+ * I-2: `extractPrMetadataForIndex` only sets the four size-stat keys when the incoming payload
+ * carries them — true only of the single-PR / pull-detail response, never of the events feed's
+ * `PullRequestEvent`/`PullRequestReviewEvent` payloads. `upsertIndexedItem` writes metadata with
+ * `metadata = excluded.metadata`, which REPLACES the row's metadata wholesale, so any later
+ * events-path upsert for a PR that `enrichPrDetail` already filled in would otherwise silently
+ * erase its stats — and `selectPrEnrichCandidates` would then re-queue that PR forever, since
+ * `modified_at` also just advanced, pushing it to the front of the `modified_at DESC` candidate
+ * list. Merge the four keys forward from the currently-indexed row whenever the incoming payload
+ * omits them.
+ *
+ * Accepted tradeoff: once merged forward, stats can go stale (an event bumps `modified_at`
+ * without new commit/diff counts) until the next detail fetch refreshes them. That is strictly
+ * better than losing the stats outright and re-enriching the same PR on every tick.
+ */
+function mergeForwardPrStats(
+  db: Database,
+  meta: Record<string, unknown>,
+  externalId: string,
+): Record<string, unknown> {
+  const missing = PR_STAT_KEYS.filter((k) => meta[k] === undefined);
+  if (missing.length === 0) {
+    return meta;
+  }
+  const id = itemPrimaryKey(SERVICE_ID, externalId);
+  const row = db.query("SELECT metadata FROM item WHERE id = ?").get(id) as {
+    metadata: string | null;
+  } | null;
+  if (row === null || row.metadata === null) {
+    return meta;
+  }
+  let existing: unknown;
+  try {
+    existing = JSON.parse(row.metadata) as unknown;
+  } catch {
+    return meta;
+  }
+  const existingRec = asRecord(existing);
+  if (existingRec === undefined) {
+    return meta;
+  }
+  const merged = { ...meta };
+  for (const k of missing) {
+    const v = existingRec[k];
+    if (v !== undefined) {
+      merged[k] = v;
+    }
+  }
+  return merged;
+}
+
 export function upsertPr(
   ctx: SyncContext,
   repoFull: string,
@@ -232,8 +285,12 @@ export function upsertPr(
   const modified = modifiedMsFromGithubTimestamps(pr, now);
   const user = asRecord(pr["user"]);
   const authorId = resolveGithubActorPersonId(ctx.db, user);
-  const meta = extractPrMetadataForIndex(repoFull, pr, now);
   const externalId = githubPrExternalId(repoFull, num);
+  const meta = mergeForwardPrStats(
+    ctx.db,
+    extractPrMetadataForIndex(repoFull, pr, now),
+    externalId,
+  );
   upsertIndexedItemForSync(ctx, {
     service: SERVICE_ID,
     type: "pr",
@@ -617,6 +674,29 @@ export async function enrichPrDetail(
   return enriched;
 }
 
+/**
+ * I-3: shared by both the changed-events path and the 304 (unchanged) path, so a quiet tick still
+ * drains the enrichment backlog. `selectPrEnrichCandidates` is `modified_at DESC`-ordered and
+ * `MAX_ENRICH_PER_TICK`-capped; before this helper existed, `syncGithubUserEvents` only reached
+ * `enrichPrDetail` when the events feed itself changed, so on a low-activity account most ticks
+ * returned 304 and the backlog drained at roughly zero.
+ */
+async function runPrDetailEnrichmentBestEffort(
+  ctx: SyncContext,
+  pat: string,
+  now: number,
+): Promise<void> {
+  try {
+    await enrichPrDetail(ctx, pat, now);
+  } catch (err) {
+    if (err instanceof RateLimitError) throw err; // honor backoff
+    ctx.logger.warn(
+      { service: SERVICE_ID, err: String(err) },
+      "PR detail enrichment pass failed (non-fatal)",
+    );
+  }
+}
+
 async function fetchAuthenticatedLogin(ctx: SyncContext, pat: string): Promise<string> {
   await ctx.rateLimiter.acquire("github");
   const res = await fetch(USER_URL, {
@@ -672,6 +752,10 @@ async function syncGithubUserEvents(
   bytesTransferred += text.length;
 
   if (res.status === 304) {
+    // I-3: the events feed did not change, but the enrichment backlog is independent of it —
+    // run it here too so a quiet account still drains. The cursor/return shape below is
+    // otherwise byte-identical to before this fix.
+    await runPrDetailEnrichmentBestEffort(ctx, pat, Date.now());
     return {
       ...syncNoopResult(cursor, t0),
       cursor: encodeCursor({ etag, login }),
@@ -713,15 +797,7 @@ async function syncGithubUserEvents(
   }
 
   // Best-effort detail enrichment for fallback-titled or stats-missing PRs (existing rows + this tick's events).
-  try {
-    await enrichPrDetail(ctx, pat, now);
-  } catch (err) {
-    if (err instanceof RateLimitError) throw err; // honor backoff
-    ctx.logger.warn(
-      { service: SERVICE_ID, err: String(err) },
-      "PR detail enrichment pass failed (non-fatal)",
-    );
-  }
+  await runPrDetailEnrichmentBestEffort(ctx, pat, now);
 
   const newEtag = res.headers.get("etag");
   const nextCursor = encodeCursor({ etag: newEtag, login });

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -480,14 +480,32 @@ interface FallbackPrCandidate {
 
 const MAX_ENRICH_PER_TICK = 10;
 
-function selectFallbackPrCandidates(db: Database, limit: number): FallbackPrCandidate[] {
+/**
+ * Candidates for a pull-detail re-fetch. Two independent reasons:
+ *   1. the title is still the id-only `PR #<n>` fallback (the events feed omits
+ *      `title` on `PullRequestEvent` payloads), or
+ *   2. size statistics are missing — `additions`/`deletions`/`changed_files`/
+ *      `commits` exist only on the single-PR response, never on events or the
+ *      list endpoint.
+ *
+ * `json_extract` is used rather than a LIKE over the raw metadata blob so a PR
+ * body mentioning "additions" cannot mask a genuinely missing field. Guarded by
+ * `json_valid` because `json_extract` RAISES on malformed JSON, and one bad row
+ * would otherwise kill selection for every PR.
+ */
+export function selectPrEnrichCandidates(db: Database, limit: number): FallbackPrCandidate[] {
   const rows = db
     .query(
-      `SELECT external_id, title FROM item
-         WHERE service = 'github' AND type = 'pr' AND title LIKE 'PR #%'
+      `SELECT external_id, title, metadata FROM item
+         WHERE service = 'github' AND type = 'pr'
+           AND (
+             title LIKE 'PR #%'
+             OR NOT json_valid(metadata)
+             OR json_extract(metadata, '$.additions') IS NULL
+           )
          ORDER BY modified_at DESC LIMIT ?`,
     )
-    .all(limit * 3) as { external_id: string; title: string }[]; // over-select; JS filter is exact
+    .all(limit * 3) as { external_id: string; title: string; metadata: string }[];
   const out: FallbackPrCandidate[] = [];
   for (const r of rows) {
     const hash = r.external_id.lastIndexOf("#");
@@ -495,7 +513,6 @@ function selectFallbackPrCandidates(db: Database, limit: number): FallbackPrCand
     const repoFull = r.external_id.slice(0, hash);
     const num = Number.parseInt(r.external_id.slice(hash + 1), 10);
     if (!Number.isFinite(num)) continue;
-    if (r.title !== `PR #${String(num)}`) continue; // exact fallback only
     out.push({ externalId: r.external_id, repoFull, num });
     if (out.length >= limit) break;
   }
@@ -503,18 +520,20 @@ function selectFallbackPrCandidates(db: Database, limit: number): FallbackPrCand
 }
 
 /**
- * Re-fetches pull-request detail for any indexed `pr` row still carrying the
- * id-only `PR #<num>` fallback title (the GitHub events feed omits `title`
- * on `PullRequestEvent` payloads). Processes up to `MAX_ENRICH_PER_TICK`
- * rows, newest-first, sequentially through the shared rate limiter.
+ * Re-fetches pull-request detail for any indexed `pr` row that either still
+ * carries the id-only `PR #<num>` fallback title (the GitHub events feed omits
+ * `title` on `PullRequestEvent` payloads) or is missing size statistics
+ * (`additions`/`deletions`/`changed_files`/`commits`, which exist only on the
+ * single-PR response). Processes up to `MAX_ENRICH_PER_TICK` rows, newest-first,
+ * sequentially through the shared rate limiter.
  */
-export async function enrichFallbackPrTitles(
+export async function enrichPrDetail(
   ctx: SyncContext,
   pat: string,
   now: number,
   fetchImpl: typeof fetch = fetch,
 ): Promise<number> {
-  const candidates = selectFallbackPrCandidates(ctx.db, MAX_ENRICH_PER_TICK);
+  const candidates = selectPrEnrichCandidates(ctx.db, MAX_ENRICH_PER_TICK);
   let enriched = 0;
   for (const c of candidates) {
     await ctx.rateLimiter.acquire("github");
@@ -540,6 +559,13 @@ export async function enrichFallbackPrTitles(
     }
     upsertPr(ctx, c.repoFull, pr, now);
     enriched += 1;
+  }
+  const remaining = selectPrEnrichCandidates(ctx.db, MAX_ENRICH_PER_TICK + 1).length;
+  if (remaining > MAX_ENRICH_PER_TICK) {
+    ctx.logger.info(
+      { service: SERVICE_ID, enriched, remainingAtLeast: MAX_ENRICH_PER_TICK },
+      "PR detail enrichment has more candidates queued for the next tick",
+    );
   }
   return enriched;
 }
@@ -629,14 +655,14 @@ async function syncGithubUserEvents(
     }
   }
 
-  // Best-effort title enrichment for fallback-titled PRs (existing rows + this tick's title-less events).
+  // Best-effort detail enrichment for fallback-titled or stats-missing PRs (existing rows + this tick's events).
   try {
-    await enrichFallbackPrTitles(ctx, pat, now);
+    await enrichPrDetail(ctx, pat, now);
   } catch (err) {
     if (err instanceof RateLimitError) throw err; // honor backoff
     ctx.logger.warn(
       { service: SERVICE_ID, err: String(err) },
-      "PR title enrichment pass failed (non-fatal)",
+      "PR detail enrichment pass failed (non-fatal)",
     );
   }
 

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -244,6 +244,61 @@ export function upsertPr(
   });
 }
 
+function githubReviewExternalId(repoFull: string, prNum: number, reviewId: number): string {
+  return `${repoFull}#${String(prNum)}#review-${String(reviewId)}`;
+}
+
+/**
+ * A review is indexed as its own item rather than as PR metadata: the item
+ * upsert replaces `metadata` wholesale (`index/item-store.ts`), so a later
+ * `PullRequestEvent` for the same PR would silently erase reviewer data stored
+ * there. Separate rows cannot clobber one another.
+ *
+ * The events feed is the authenticated user's own activity, so `author_id` here
+ * is always the local user — this indexes "PRs I reviewed", never "who reviewed
+ * my PRs".
+ */
+function upsertReview(
+  ctx: SyncContext,
+  repoFull: string,
+  review: Record<string, unknown>,
+  prNum: number,
+  now: number,
+): boolean {
+  const reviewId = numberField(review, "id");
+  if (reviewId === undefined) {
+    return false;
+  }
+  const user = asRecord(review["user"]);
+  const authorId = resolveGithubActorPersonId(ctx.db, user);
+  const state = stringField(review, "state");
+  const body = stringField(review, "body");
+  const submitted = stringField(review, "submitted_at");
+  const modified = submitted === undefined ? now : Date.parse(submitted);
+  const htmlUrl = stringField(review, "html_url");
+
+  upsertIndexedItemForSync(ctx, {
+    service: SERVICE_ID,
+    type: "review",
+    externalId: githubReviewExternalId(repoFull, prNum, reviewId),
+    title: `Review on ${repoFull}#${String(prNum)}`,
+    body: body ?? "",
+    url: htmlUrl ?? null,
+    canonicalUrl: htmlUrl ?? null,
+    modifiedAt: Number.isFinite(modified) ? modified : now,
+    authorId,
+    metadata: {
+      repo: repoFull,
+      pr_number: prNum,
+      review_id: reviewId,
+      state: state ?? null,
+    },
+    pinned: false,
+    syncedAt: now,
+  });
+  return true;
+}
+
 function upsertFromIssue(
   ctx: SyncContext,
   repoFull: string,
@@ -298,6 +353,28 @@ function processPullRequestPayload(
   return true;
 }
 
+function processPullRequestReviewPayload(
+  ctx: SyncContext,
+  fullName: string,
+  payload: Record<string, unknown>,
+  now: number,
+): boolean {
+  const review = asRecord(payload["review"]);
+  const pr = asRecord(payload["pull_request"]);
+  if (review === undefined || pr === undefined) {
+    return false;
+  }
+  const num = numberField(pr, "number");
+  if (num === undefined) {
+    return false;
+  }
+  // Index the PR too, so the `reviewed` edge targets a titled item rather than a
+  // stub: 14 call sites inner-join `item` on `graph_entity.external_id`, and an
+  // item-less entity is invisible to all of them.
+  upsertPr(ctx, fullName, pr, now);
+  return upsertReview(ctx, fullName, review, num, now);
+}
+
 function processIssuesPayload(
   ctx: SyncContext,
   fullName: string,
@@ -315,7 +392,7 @@ function processIssuesPayload(
   return true;
 }
 
-function processEvent(ctx: SyncContext, ev: Record<string, unknown>, now: number): boolean {
+export function processEvent(ctx: SyncContext, ev: Record<string, unknown>, now: number): boolean {
   const repo = asRecord(ev["repo"]);
   if (repo === undefined) {
     return false;
@@ -331,6 +408,9 @@ function processEvent(ctx: SyncContext, ev: Record<string, unknown>, now: number
   }
   if (type === "PullRequestEvent") {
     return processPullRequestPayload(ctx, fullName, payload, now);
+  }
+  if (type === "PullRequestReviewEvent") {
+    return processPullRequestReviewPayload(ctx, fullName, payload, now);
   }
   if (type === "IssuesEvent") {
     return processIssuesPayload(ctx, fullName, payload, now);

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -481,6 +481,26 @@ interface FallbackPrCandidate {
 const MAX_ENRICH_PER_TICK = 10;
 
 /**
+ * True when `metadata` (a JSON blob) already carries a non-null `additions` field.
+ * Unparseable JSON returns `false` — mirrors the SQL's `NOT json_valid(metadata)` arm:
+ * a row that cannot be proven to have stats must remain a candidate, never be skipped.
+ */
+function metadataHasStats(metadata: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata) as unknown;
+  } catch {
+    return false;
+  }
+  const rec = asRecord(parsed);
+  if (rec === undefined) {
+    return false;
+  }
+  const additions = rec["additions"];
+  return additions !== undefined && additions !== null;
+}
+
+/**
  * Candidates for a pull-detail re-fetch. Two independent reasons:
  *   1. the title is still the id-only `PR #<n>` fallback (the events feed omits
  *      `title` on `PullRequestEvent` payloads), or
@@ -488,10 +508,24 @@ const MAX_ENRICH_PER_TICK = 10;
  *      `commits` exist only on the single-PR response, never on events or the
  *      list endpoint.
  *
- * `json_extract` is used rather than a LIKE over the raw metadata blob so a PR
- * body mentioning "additions" cannot mask a genuinely missing field. Guarded by
- * `json_valid` because `json_extract` RAISES on malformed JSON, and one bad row
- * would otherwise kill selection for every PR.
+ * The SQL `WHERE` deliberately over-selects: its `title LIKE 'PR #%'` arm also
+ * matches a REAL title that merely starts with that text (e.g. `"PR #142 fix
+ * bug"`), and `upsertPr` writes GitHub's real title back unchanged, so such a
+ * row would otherwise re-qualify forever — permanently occupying a slot in the
+ * `MAX_ENRICH_PER_TICK`-capped, `modified_at DESC`-ordered result and starving
+ * rows that genuinely still need enrichment. The JS loop below narrows each
+ * over-selected row to the exact two reasons: keep it only if the title is the
+ * EXACT `PR #<num>` fallback, or its stats are still missing. Since the SQL
+ * already guarantees every row matched one of the two arms, a row that is not
+ * the exact fallback and already has stats can only have matched via the LIKE
+ * over-select, so skipping it is safe and sufficient.
+ *
+ * `json_extract` is used (via `metadataHasStats`) rather than a LIKE over the
+ * raw metadata blob so a PR body mentioning "additions" cannot mask a
+ * genuinely missing field. Guarded by `json_valid` in SQL and mirrored by
+ * `metadataHasStats`'s parse-failure fallback, because malformed JSON must
+ * never be treated as "has stats" — that would incorrectly skip a row that
+ * cannot be proven enriched.
  */
 export function selectPrEnrichCandidates(db: Database, limit: number): FallbackPrCandidate[] {
   const rows = db
@@ -505,7 +539,7 @@ export function selectPrEnrichCandidates(db: Database, limit: number): FallbackP
            )
          ORDER BY modified_at DESC LIMIT ?`,
     )
-    .all(limit * 3) as { external_id: string; title: string; metadata: string }[];
+    .all(limit * 3) as { external_id: string; title: string; metadata: string }[]; // over-select; JS narrows below
   const out: FallbackPrCandidate[] = [];
   for (const r of rows) {
     const hash = r.external_id.lastIndexOf("#");
@@ -513,6 +547,8 @@ export function selectPrEnrichCandidates(db: Database, limit: number): FallbackP
     const repoFull = r.external_id.slice(0, hash);
     const num = Number.parseInt(r.external_id.slice(hash + 1), 10);
     if (!Number.isFinite(num)) continue;
+    const isExactFallback = r.title === `PR #${String(num)}`;
+    if (!isExactFallback && metadataHasStats(r.metadata)) continue; // only matched via the LIKE over-select
     out.push({ externalId: r.external_id, repoFull, num });
     if (out.length >= limit) break;
   }

--- a/packages/gateway/src/graph/graph-populator-reviews.test.ts
+++ b/packages/gateway/src/graph/graph-populator-reviews.test.ts
@@ -1,0 +1,173 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+import { isItemLinkedGraphType } from "./relationship-graph.ts";
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  return db;
+}
+
+function seedPr(
+  db: Database,
+  externalId: string,
+  title: string,
+  authorId: string | null,
+  at: number,
+): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "pr",
+    externalId,
+    title,
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    authorId,
+    metadata: { repo: "acme/app", number: 1 },
+  });
+}
+
+function seedReview(db: Database, externalId: string, reviewerId: string, at: number): void {
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId,
+    title: "Review on acme/app#1",
+    bodyPreview: "",
+    modifiedAt: at,
+    syncedAt: at,
+    authorId: reviewerId,
+    metadata: { repo: "acme/app", pr_number: 1 },
+  });
+}
+
+/** Every (person external_id, pr external_id) pair joined by a `reviewed` edge. */
+function reviewedPairs(db: Database): Array<{ person: string; pr: string }> {
+  return db
+    .query(
+      `SELECT pe.external_id AS person, pre.external_id AS pr
+         FROM graph_relation r
+         JOIN graph_entity pe  ON pe.id = r.from_id AND pe.type = 'person'
+         JOIN graph_entity pre ON pre.id = r.to_id  AND pre.type = 'pr'
+        WHERE r.type = 'reviewed'
+        ORDER BY person, pr`,
+    )
+    .all() as Array<{ person: string; pr: string }>;
+}
+
+test("review is a graph-linked item type", () => {
+  expect(isItemLinkedGraphType("review")).toBe(true);
+});
+
+test("a review item emits person -> pr reviewed", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+
+  expect(reviewedPairs(db)).toEqual([{ person: "person-reviewer", pr: "github:acme/app#1" }]);
+  db.close();
+});
+
+test("the reviewer is a distinct person from the PR author", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+
+  const authored = db
+    .query(
+      `SELECT pe.external_id AS person
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+        WHERE r.type = 'authored'`,
+    )
+    .all() as Array<{ person: string }>;
+
+  expect(authored).toEqual([{ person: "person-author" }]);
+  expect(reviewedPairs(db)).toEqual([{ person: "person-reviewer", pr: "github:acme/app#1" }]);
+  db.close();
+});
+
+// THE REGRESSION TEST. `syncPrGraph` calls `clearRelationsTouchingEntity`, which
+// deletes every edge touching the PR except CROSS_ITEM_RELATION_TYPES. Without
+// "reviewed" in that list, re-syncing the PR silently destroys the edge and
+// nothing recreates it.
+test("a reviewed edge survives the PR being re-populated", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+  expect(reviewedPairs(db)).toHaveLength(1);
+
+  // The PR is re-synced (title edit, state change, any later PullRequestEvent).
+  seedPr(db, "acme/app#1", "Add rate limiter v2", "person-author", now + 1000);
+
+  // PROVE THE RE-POPULATION ACTUALLY RAN. Without this the test is vacuous: if
+  // `upsertIndexedItem` ever skipped graph population for an unchanged row, the
+  // edge would "survive" because nothing touched it, and the assertion below
+  // would stay green even with `reviewed` absent from CROSS_ITEM_RELATION_TYPES
+  // — the precise defect this test exists to catch.
+  const prLabel = db
+    .query("SELECT label FROM graph_entity WHERE type = 'pr' AND external_id = ?")
+    .get("github:acme/app#1") as { label: string };
+  expect(prLabel.label).toBe("Add rate limiter v2");
+
+  expect(reviewedPairs(db)).toEqual([{ person: "person-reviewer", pr: "github:acme/app#1" }]);
+  db.close();
+});
+
+// The safety of having no edge-retirement mechanism (spec 5.F) rests on this.
+test("two reviews by one person on one PR yield exactly one edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  seedReview(db, "acme/app#1#review-500", "person-reviewer", now);
+  seedReview(db, "acme/app#1#review-501", "person-reviewer", now + 1);
+
+  expect(reviewedPairs(db)).toHaveLength(1);
+  db.close();
+});
+
+test("a review with no author emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  seedPr(db, "acme/app#1", "Add rate limiter", "person-author", now);
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#1#review-500",
+    title: "Review on acme/app#1",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: null,
+    metadata: { repo: "acme/app", pr_number: 1 },
+  });
+
+  expect(reviewedPairs(db)).toEqual([]);
+  db.close();
+});
+
+test("a review whose metadata lacks repo or pr_number emits no edge", () => {
+  const db = freshDb();
+  const now = Date.now();
+  upsertIndexedItem(db, {
+    service: "github",
+    type: "review",
+    externalId: "acme/app#1#review-500",
+    title: "Review",
+    bodyPreview: "",
+    modifiedAt: now,
+    syncedAt: now,
+    authorId: "person-reviewer",
+    metadata: {},
+  });
+
+  expect(reviewedPairs(db)).toEqual([]);
+  db.close();
+});

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -78,6 +78,7 @@ const CROSS_ITEM_RELATION_TYPES: readonly string[] = Object.freeze([
   "resolves",
   "mentions",
   "correlates_with",
+  "reviewed",
 ]);
 
 function clearRelationsTouchingEntity(db: Database, entityId: string): void {
@@ -280,6 +281,46 @@ function syncPrGraph(db: Database, row: IndexedItemGraphInput, now: number): voi
   for (const issueId of findIssueEntityIds(db, row.service, repoFull, refs)) {
     upsertGraphRelation(db, prEntityId, issueId, "resolves", now);
   }
+}
+
+/**
+ * A `review` item is one reviewer acting on one PR, so it maps to exactly one
+ * `person --reviewed--> pr` edge. Nothing is cleared here: the edge is
+ * idempotent under `upsertGraphRelation`'s `ON CONFLICT (from_id, to_id, type)`,
+ * and it is listed in CROSS_ITEM_RELATION_TYPES precisely so that no entity's
+ * re-population retires it. The consequence — a review deleted upstream leaves
+ * a stale edge — is disclosed rather than mechanised (spec 5.F).
+ *
+ * `ensureGraphEntity` (not `upsertGraphEntity`) for the PR side: a review can be
+ * populated before its PR during a `regraph` replay, and clobbering the PR's
+ * label with a synthesised one would corrupt every reader that displays it.
+ */
+function syncReviewGraph(db: Database, row: IndexedItemGraphInput, now: number): void {
+  if (row.authorId === null || row.authorId === "") {
+    return;
+  }
+  const repoFull = stringField(row.metadata, "repo");
+  const prNumber = row.metadata["pr_number"];
+  if (repoFull === undefined || repoFull === "" || typeof prNumber !== "number") {
+    return;
+  }
+
+  const prItemId = `${row.service}:${repoFull}#${String(prNumber)}`;
+  const prEntityId = ensureGraphEntity(db, {
+    type: "pr",
+    externalId: prItemId,
+    label: `${repoFull}#${String(prNumber)}`,
+    service: row.service,
+  });
+
+  const label = personDisplayName(db, row.authorId) ?? row.authorId;
+  const personEntityId = upsertGraphEntity(db, {
+    type: "person",
+    externalId: row.authorId,
+    label,
+    service: row.service,
+  });
+  upsertGraphRelation(db, personEntityId, prEntityId, "reviewed", now);
 }
 
 function syncIssueGraph(db: Database, row: IndexedItemGraphInput, now: number): void {
@@ -779,6 +820,10 @@ export function syncGraphFromIndexedItem(
 
   if (row.type === "pr") {
     syncPrGraph(db, row, now);
+    return;
+  }
+  if (row.type === "review") {
+    syncReviewGraph(db, row, now);
     return;
   }
   if (row.type === "issue") {

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -72,7 +72,19 @@ function repoPathFromMetadata(meta: Record<string, unknown>): string | undefined
  * The blanket clear below must not touch them: the entity being cleared is
  * only one endpoint, and the other side is authoritative for the edge.
  * Each emitting sync function clears its own outgoing edges of these types
- * via `clearOutgoingRelationsOfType` immediately before re-emitting them.
+ * via `clearOutgoingRelationsOfType` immediately before re-emitting them —
+ * WITH ONE DELIBERATE EXCEPTION: `reviewed`. Do NOT "fix" `syncReviewGraph`
+ * to call `clearOutgoingRelationsOfType(db, personEntityId, "reviewed")`
+ * before emitting. A `reviewed` edge's outgoing side is the PERSON, and one
+ * reviewer reviews many PRs — clearing that person's outgoing `reviewed`
+ * edges before re-emitting would delete every OTHER PR they reviewed, each
+ * time any one of their reviews is re-populated (e.g. `nimbus index regraph`
+ * would collapse a reviewer's entire history down to whichever review was
+ * populated last). `syncReviewGraph` relies on `upsertGraphRelation`'s
+ * `ON CONFLICT (from_id, to_id, type)` idempotency instead, and disclosed
+ * staleness (a deleted upstream review leaves a stale edge) rather than a
+ * clear that would silently destroy unrelated data. See `syncReviewGraph`'s
+ * own doc comment for the full rationale.
  */
 const CROSS_ITEM_RELATION_TYPES: readonly string[] = Object.freeze([
   "resolves",
@@ -301,7 +313,9 @@ function syncReviewGraph(db: Database, row: IndexedItemGraphInput, now: number):
   }
   const repoFull = stringField(row.metadata, "repo");
   const prNumber = row.metadata["pr_number"];
-  if (repoFull === undefined || repoFull === "" || typeof prNumber !== "number") {
+  // `stringField` already returns `undefined` for an empty/whitespace-only value — an
+  // `=== ""` disjunct here would be dead code (M-3).
+  if (repoFull === undefined || typeof prNumber !== "number") {
     return;
   }
 

--- a/packages/gateway/src/graph/regraph.ts
+++ b/packages/gateway/src/graph/regraph.ts
@@ -202,7 +202,14 @@ function regraphSlice(
  * Processed in `REGRAPH_TYPE_ORDER` so reference targets are graphed before
  * the items that reference them; every edge this plan emits therefore settles
  * in a single pass. Idempotent regardless — each sync function clears and
- * rebuilds the edges it owns — so re-running is always safe.
+ * rebuilds the edges it owns — so re-running is always safe. ONE EXCEPTION:
+ * `reviewed` edges are deliberately never cleared (`syncReviewGraph` in
+ * `graph-populator.ts`) because their outgoing side is a `person`, who
+ * reviews many PRs — clearing on re-population would destroy every other PR
+ * that reviewer touched. A regraph pass is still safe for `reviewed`: each
+ * review row re-emits its own edge idempotently via `upsertGraphRelation`'s
+ * `ON CONFLICT`, it just never subtracts one that a deleted-upstream review
+ * left behind. See `graph-populator.ts`'s `CROSS_ITEM_RELATION_TYPES` comment.
  *
  * A row whose sync throws is skipped (not fatal to the pass) and counted in
  * `skipped`; `graphed` counts only items that actually produced graph writes.

--- a/packages/gateway/src/graph/relationship-graph.ts
+++ b/packages/gateway/src/graph/relationship-graph.ts
@@ -20,6 +20,7 @@ const ITEM_LINKED_ENTITY_TYPES = [
   "data_model",
   "dashboard",
   "data_quality_test",
+  "review",
 ] as const;
 
 export type ItemLinkedEntityType = (typeof ITEM_LINKED_ENTITY_TYPES)[number];


### PR DESCRIPTION
## Summary

Substrate for `nimbus negotiate` (Spine S1). GitHub PR reviews become first-class `review` items, the relationship graph gains `person --reviewed--> pr` edges, and the `expert` and `why` agents surface reviewers instead of reporting the capability as unimplemented. PR size statistics are captured, and the enrichment pass now also re-fetches PRs that have a real title but no stats.

Reviews are indexed as their own rows rather than PR metadata, because `index/item-store.ts` replaces `metadata` wholesale on upsert — a later `PullRequestEvent` would have silently clobbered reviewer data stored there. `"reviewed"` joins `CROSS_ITEM_RELATION_TYPES` so `syncPrGraph`'s blanket clear cannot delete the edge, and `review` is registered in `ITEM_LINKED_ENTITY_TYPES` so the populator runs at all.

Also fixes a **pre-existing** secondary-rate-limit bug: a 403 carrying `retry-after` with non-zero `x-ratelimit-remaining` was not treated as rate limiting, so the sync retried straight back into the limit. GitHub documents secondary limits as returning 403 **or** 429 with `retry-after` independent of remaining quota.

No migration, no new security invariant, no Tauri allowlist change.

## Related Issue

Relates to the `nimbus negotiate` substrate work (S1 — Local Brain). This is sub-project A/B of five; PR 2 (search-backed history backfill) follows.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [x] Test improvement
- [x] Documentation only
- [ ] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`) — 3,393 pass / 0 fail across `agents`, `graph`, `connectors`
- [x] New behaviour is covered by tests
- [x] No `any` types introduced — `audit:any` total equals baseline
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] Does not touch `docs/README.md`

## Coverage (if engine/ or vault/ was changed)

Neither `engine/` nor `vault/` was modified. Per-file floor (85% line / 80% branch) verified against a full 72-shard lcov:

| File | Line | Branch |
| --- | --- | --- |
| `connectors/github-sync.ts` | 96.9% | 89.3% |
| `graph/graph-populator.ts` | 100% | 98.7% |
| `graph/relationship-graph.ts` | 95.5% | 92.3% |
| `agents/expert.ts` | 98.2% | 89.7% |
| `agents/why.ts` | 97.5% | 82.0% |
| `agents/ownership.ts` | 93.7% | 90.8% |

`audit:coverage-floor` reports three violations locally, all in files this branch does not touch (`platform/linux.ts`, `ipc/server/socket-listeners.ts`). Both are Linux-only paths that cannot execute on a Windows host — the documented local false-violation pattern. CI-Linux is authoritative.

## Testing

Scoped suites plus the three touched subsystems in full. Every behaviour this branch depends on structurally was **red-proved** — the guard was removed, the test confirmed to fail, and the guard restored:

- `"reviewed"` in `CROSS_ITEM_RELATION_TYPES` — without it, a PR re-population deletes the edge and nothing recreates it. The test asserts the PR entity's label actually changed first, so it cannot pass vacuously.
- The resolution-aware gap probes in both agents — with the old probe, the state-(b) test fails because the gap is suppressed.
- `why`'s per-PR probe scoping — a two-PR fixture (A resolves, B broken) fails against a global probe.
- The widened enrich predicate, and separately the restored exact-fallback narrowing — each fails when the other is reverted.
- The 403 `retry-after` fix, with the companion "403 without `retry-after` must NOT throw" test passing before and after, so the fix cannot have simply widened into throwing on everything.

End-to-end verified by driving a real `PullRequestReviewEvent` through `processEvent`: both items written with distinct reviewer/author person ids, the edge emitted, and `expert` returning a populated `pr_reviewed` evidence stream.

## Notes for Reviewers

**Reviewing a PR indexes that PR**, including ones you did not author. Deliberate — 14 call sites inner-join `item` on `graph_entity.external_id`, so an edge pointing at an item-less entity is invisible to every existing reader. The alternative (metadata-only indexing) was rejected because `github` is in `REBODY_IMPROVABLE_SERVICES`, so `nimbus index rebody` would have reported those rows recoverable and never recovered them.

**This indexes PRs you reviewed, never who reviewed your PRs.** `/users/{login}/events` reports only the authenticated user's own activity.

**One open question, recorded in the code and deliberately not claimed as fixed.** Two docstrings in `github-sync.ts` assert the events feed omits `title` on `PullRequestEvent` payloads. If that holds, an events-path upsert still resets an enriched PR's title to the `PR #<n>` fallback, and the selector's exact-fallback arm re-queues it regardless of stats — meaning this PR's stats merge-forward closes only one of two re-queue arms. GitHub's documentation does not settle it (the events API returns abbreviated payloads for some event types), and the covering test sidesteps it by including `title` in its fixture. Pre-existing either way. **This PR therefore does not claim the enrichment backlog now drains** — that needs verification against the live API first.

**Known follow-ups, none blocking:** `review` rows compete for `catchup`'s per-service window quota alongside their sibling `pr` rows; `syncReviewGraph`'s five rejection paths are silent (a producer writing `pr_number` as a string would emit no edges and log nothing); `mergeable*` metadata fields are subject to the same wholesale replacement as stats but are not merged forward (no re-queue loop results, since `shouldRefreshMergeableState` has no production caller); and the zero-edge gap-note block is duplicated verbatim in `expert.ts` and `why.ts`.

Reviewed across eight per-task reviews plus a whole-branch pass. The whole-branch pass is what caught the blocking issues — in every case the false claim lived in a file the individual task never touched, including a gap note that instructed a command shipping in a later PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub pull-request reviews are now indexed and linked to the reviewed pull requests.
  - Reviewer evidence appears in contribution insights and pull-request explanations, including unresolved-data notices.
  - Pull-request statistics such as additions, deletions, changed files, and commits are captured and enriched when missing.

- **Bug Fixes**
  - Improved handling of GitHub pagination limits and event-history gaps.
  - Rate-limit responses now respect `retry-after` guidance.
  - Preserved pull-request statistics across updates and handled malformed review data safely.

- **Documentation**
  - Added documentation covering review indexing, data limitations, and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->