### PR TITLE
docs(install): correct the broken one-liner install and prove the Linux first run

### DIFF
--- a/.github/workflows/released-install-smoke.yml
+++ b/.github/workflows/released-install-smoke.yml
@@ -1,0 +1,116 @@
+name: released-install-smoke
+
+# SCOPE: this proves the DOCUMENTED INSTALL PATH works against PUBLISHED assets.
+# It deliberately stops at `nimbus --version` — first-run behaviour (init → why)
+# is already covered by `install-smoke.yml` against freshly built binaries.
+# The gap this closes is narrower, and was real: see #1167.
+
+# Why this exists, separately from `install-smoke.yml`:
+#
+# `install-smoke.yml` copies the built binaries next to the install script and
+# then runs it. That proves the TARBALL path. It cannot prove the path the docs
+# actually tell a user to take, because on a PR there is no published release to
+# install from. That blind spot is how #1167 shipped: `install.sh` was published
+# as a standalone asset the README told people to curl, but it has no download
+# capability, so the documented one-liner failed on every platform while
+# install-smoke stayed green.
+#
+# So this workflow runs the commands from README.md / install.mdx VERBATIM
+# against a real published release. Keep the commands below in sync with those
+# two files — if they drift, this proves the wrong thing.
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  schedule:
+    # Weekly: catches a release asset that is renamed, dropped, or unpublished
+    # after the fact, which no release-time check can see.
+    - cron: "37 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  documented-install:
+    name: ${{ matrix.os }} documented install
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Linux — install exactly as the docs say
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          BASE: https://github.com/nimbus-agent/Nimbus/releases/latest/download
+        run: |
+          set -euo pipefail
+          # Documented prerequisite.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libsecret-tools
+
+          curl -fsSL "$BASE/nimbus_amd64.deb" -o /tmp/nimbus.deb
+          # apt, NOT `dpkg -i` — the package depends on bubblewrap and
+          # libcap2-bin, and dpkg does not resolve those. Documented as apt
+          # because `dpkg -i` was verified to fail on a clean ubuntu:24.04.
+          sudo apt-get install -y /tmp/nimbus.deb
+
+      - name: macOS — install exactly as the docs say
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          BASE: https://github.com/nimbus-agent/Nimbus/releases/latest/download
+        run: |
+          set -euo pipefail
+          # macos-14 is Apple silicon; the docs tell Intel users to swap to -x64.
+          curl -fsSL "$BASE/nimbus-headless-macos-arm64.tar.gz" -o /tmp/nimbus.tar.gz
+          mkdir -p /tmp/nimbus && tar -xzf /tmp/nimbus.tar.gz -C /tmp/nimbus
+          # `--yes` is the ONLY divergence from the documented command: the docs
+          # show the interactive form, which cannot answer a prompt in CI.
+          /tmp/nimbus/install.sh --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Windows — install exactly as the docs say
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $url = "https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-headless-windows-x64.zip"
+          Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\nimbus.zip"
+          Expand-Archive -Path "$env:TEMP\nimbus.zip" -DestinationPath "$env:TEMP\nimbus" -Force
+          # `-Yes` is the ONLY divergence from the documented command.
+          & "$env:TEMP\nimbus\install.ps1" -Yes
+          # install.ps1 sets the USER PATH, which this already-running job will
+          # not pick up; mirror its target so later steps resolve `nimbus`.
+          "$env:LOCALAPPDATA\Programs\Nimbus\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      - name: Assert the installed binary runs (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v nimbus || { echo "::error::nimbus is not on PATH after the documented install"; exit 1; }
+          nimbus --version
+
+      - name: Assert the installed binary runs (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if (-not (Get-Command nimbus -ErrorAction SilentlyContinue)) {
+            Write-Error "nimbus is not on PATH after the documented install"; exit 1
+          }
+          nimbus --version

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ nimbus ask "what PRs did I open in the last 7 days?"
 ## How it works
 
 ```text
-90+ cloud services ─▶ first-party MCP connectors ─▶ local SQLite index (+ embeddings)
+~90 cloud services ─▶ first-party MCP connectors ─▶ local SQLite index (+ embeddings)
                                                           │
                               your question ─▶ engine ─▶ HITL consent gate ─▶ action
                                                           │

--- a/README.md
+++ b/README.md
@@ -36,26 +36,56 @@ Three things, in one query:
 
 ## Quickstart
 
-**1. Install** (per-user, no admin/sudo required):
+**1. Install.** No admin on macOS and Windows; the Linux `.deb` uses `sudo`.
 
 <details open>
-<summary><b>macOS / Linux</b></summary>
+<summary><b>macOS</b></summary>
 
 ```bash
-# Linux only — credentials live in the OS keystore, and the Gateway will not
-# start without it:  sudo apt install libsecret-tools   (Debian/Ubuntu)
-#                    sudo dnf install libsecret         (Fedora/RHEL)
-# macOS only — the keychain must be UNLOCKED. Nimbus never shows an
-# authorization dialog (a background service could not answer one), so on a
-# locked keychain it fails immediately and tells you what to run. Over SSH or
-# in CI, give it its own keychain:  security create-keychain -p "" nimbus.keychain
-#                                   security default-keychain -s nimbus.keychain
-#                                   security unlock-keychain  -p "" nimbus.keychain
-curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.sh -o /tmp/nimbus-install.sh
-# inspect it first if you like:  less /tmp/nimbus-install.sh
-bash /tmp/nimbus-install.sh
+# The keychain must be UNLOCKED. Nimbus never shows an authorization dialog (a
+# background service could not answer one), so on a locked keychain it fails
+# immediately and tells you what to run. Over SSH or in CI, give it its own
+# keychain:  security create-keychain -p "" nimbus.keychain
+#            security default-keychain -s nimbus.keychain
+#            security unlock-keychain  -p "" nimbus.keychain
+
+# Apple silicon — for Intel, swap arm64 → x64.
+curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-headless-macos-arm64.tar.gz -o /tmp/nimbus.tar.gz
+mkdir -p /tmp/nimbus && tar -xzf /tmp/nimbus.tar.gz -C /tmp/nimbus
+# inspect it first if you like:  less /tmp/nimbus/install.sh
+/tmp/nimbus/install.sh
 nimbus --version
 ```
+
+</details>
+
+<details>
+<summary><b>Linux</b></summary>
+
+```bash
+# Credentials live in the OS keystore, and the Gateway will not start without it:
+sudo apt install libsecret-tools   # Debian/Ubuntu
+# sudo dnf install libsecret       # Fedora/RHEL
+# Headless box — server, container, SSH session or WSL? libsecret also needs a
+# D-Bus session and an unlocked keyring, which those machines usually lack;
+# `nimbus doctor` tells you which of the two is missing. If the machine has
+# never had a login keyring, create one first (creating it otherwise needs a
+# GUI prompt no headless box can answer):
+#   mkdir -p ~/.local/share/keyrings
+#   printf '[keyring]\ndisplay-name=login\nctime=0\nmtime=0\nlock-on-idle=false\nlock-after=false\n' \
+#     > ~/.local/share/keyrings/login.keyring
+#   printf 'login' > ~/.local/share/keyrings/default
+# then start Nimbus inside a session:
+#   dbus-run-session -- bash -c 'printf "\n" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'
+
+curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb -o /tmp/nimbus.deb
+# apt, not `dpkg -i` — the package depends on bubblewrap and libcap2-bin,
+# and dpkg will not install those for you.
+sudo apt install /tmp/nimbus.deb
+nimbus --version
+```
+
+Prefer no `sudo`? The [AppImage](https://nimbus-agent.dev/user-guide/install/#appimage-linux-alternative) is a portable single file.
 
 </details>
 
@@ -63,7 +93,11 @@ nimbus --version
 <summary><b>Windows (PowerShell, no admin)</b></summary>
 
 ```powershell
-irm https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.ps1 | Invoke-Expression
+$url = "https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-headless-windows-x64.zip"
+Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\nimbus.zip"
+Expand-Archive -Path "$env:TEMP\nimbus.zip" -DestinationPath "$env:TEMP\nimbus" -Force
+# inspect it first if you like:  notepad "$env:TEMP\nimbus\install.ps1"
+& "$env:TEMP\nimbus\install.ps1"
 # open a new PowerShell window:
 nimbus --version
 ```

--- a/README.md
+++ b/README.md
@@ -66,17 +66,6 @@ nimbus --version
 # Credentials live in the OS keystore, and the Gateway will not start without it:
 sudo apt install libsecret-tools   # Debian/Ubuntu
 # sudo dnf install libsecret       # Fedora/RHEL
-# Headless box — server, container, SSH session or WSL? libsecret also needs a
-# D-Bus session and an unlocked keyring, which those machines usually lack;
-# `nimbus doctor` tells you which of the two is missing. If the machine has
-# never had a login keyring, create one first (creating it otherwise needs a
-# GUI prompt no headless box can answer):
-#   mkdir -p ~/.local/share/keyrings
-#   printf '[keyring]\ndisplay-name=login\nctime=0\nmtime=0\nlock-on-idle=false\nlock-after=false\n' \
-#     > ~/.local/share/keyrings/login.keyring
-#   printf 'login' > ~/.local/share/keyrings/default
-# then start Nimbus inside a session:
-#   dbus-run-session -- bash -c 'printf "\n" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'
 
 curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb -o /tmp/nimbus.deb
 # apt, not `dpkg -i` — the package depends on bubblewrap and libcap2-bin,
@@ -86,6 +75,11 @@ nimbus --version
 ```
 
 Prefer no `sudo`? The [AppImage](https://nimbus-agent.dev/user-guide/install/#appimage-linux-alternative) is a portable single file.
+
+**Headless box** — server, container, SSH session or WSL? `libsecret` also needs
+a D-Bus session and an unlocked keyring, which those machines usually lack. Run
+`nimbus doctor`; it names which piece is missing. Full recipe:
+[Headless Linux](https://nimbus-agent.dev/user-guide/install/#headless-linux-no-desktop-session).
 
 </details>
 

--- a/docs/superpowers/plans/2026-07-28-launch-execution.md
+++ b/docs/superpowers/plans/2026-07-28-launch-execution.md
@@ -791,7 +791,71 @@ first command the README gives a new user.
   sequence verbatim — which means it belongs in a post-release or scheduled
   workflow, not PR CI, since a PR has no published release to test against.
 
-- [ ] Linux: clean `ubuntu:24.04` container, no Bun preinstalled. Run the README quickstart verbatim against a **cloned third-party repo**, not Nimbus. (#925 is fixed, but a headless container is precisely where it bit — verify the documented prerequisite is sufficient in practice.)
+**Action taken (2026-08-13).** The product freeze was kept: no installer code
+was changed under this plan.
+
+- **Docs rewritten to the paths that actually work**, on both surfaces, and each
+  one verified rather than assumed. `README.md` and
+  `packages/docs/src/content/docs/user-guide/install.mdx` now document: macOS →
+  tarball → `./install.sh`; Linux → `.deb`; Windows → zip → `.\install.ps1`.
+- **`sudo dpkg -i` does NOT work** and was caught only by running it: the package
+  depends on `bubblewrap` and `libcap2-bin`, which `dpkg` will not resolve, so it
+  exits 1 leaving the package unconfigured. The documented command is
+  `sudo apt install /tmp/nimbus.deb`, verified green on a clean container. The
+  first draft of this very fix had the wrong command in it — which is the whole
+  argument for the runbook.
+- **Two further false claims removed from `install.mdx`** while correcting it: it
+  described an installer that "detects your architecture, downloads the matching
+  `.deb`, verifies the GPG signature and SHA-256" — none of which exists — and
+  three **Autostart** rows (a systemd user unit, a LaunchAgent plist, and an
+  `HKCU\...\Run` entry). Nothing anywhere in the repo creates any of them.
+- **[#1167](https://github.com/nimbus-agent/Nimbus/issues/1167)** tracks giving
+  the installers a real download mode (with GPG + SHA-256 verification, since an
+  installer that downloads without verifying would be a downgrade).
+- **`.github/workflows/released-install-smoke.yml`** closes the CI blind spot: it
+  runs the documented commands verbatim against PUBLISHED assets on
+  `release: published`, weekly, and on dispatch. It stops at `nimbus --version`
+  by design — first-run behaviour stays with `install-smoke.yml`.
+
+**Remaining install gaps, recorded not fixed.** The Linux tarball is the only
+archive with a *versioned* asset name, so it cannot be linked from docs that
+outlive a release; and the `.rpm` is versioned-only, which leaves **Fedora/RHEL
+with no documented install command**. Both pre-date this work.
+
+- [x] Linux: clean `ubuntu:24.04` container, no Bun preinstalled. Run the README quickstart verbatim against a **cloned third-party repo**, not Nimbus. (#925 is fixed, but a headless container is precisely where it bit — verify the documented prerequisite is sufficient in practice.)
+
+  **PERFORMED 2026-08-13. Green end to end on the corrected docs**, against
+  `chalk/ansi-styles` (119 commits) in a clean `ubuntu:24.04` container with no
+  Bun: install → `nimbus --version` → `2.1.0`, `nimbus doctor` →
+  `[ok] Vault: Secret Service reachable with an unlocked default keyring`,
+  `nimbus init` → gateway up and index populated, and `nimbus why index.js:1` →
+  a real `## Authorship` section (`Richie Bendall · 9150f611ced8`, 2020-12-01).
+
+  **The documented prerequisite is NOT sufficient in practice — answering the
+  question this checkbox was written to ask.** `libsecret-tools` alone leaves a
+  headless machine unable to start: the Gateway exits 2 with
+  `org.freedesktop.secrets has no default collection`. The diagnosis is
+  excellent and the failure is fast, so this is a docs gap, not a hang.
+
+  **`nimbus doctor`'s printed remedy is INCOMPLETE, and this is worth its own
+  fix.** `VAULT_UNLOCK_HINT` (`doctor-core.ts`) tells a headless user to run
+  `dbus-run-session -- bash -c 'echo "" | gnome-keyring-daemon --unlock
+  --components=secrets; nimbus start'`. Run verbatim on a bare container that
+  has **never had a login keyring**, that command fails: gnome-keyring must
+  *create* the collection, creation escalates to the GUI prompter, and
+  `gcr-prompter` dies with `cannot open display`. The ONLY difference between
+  the failing run and the green one was pre-creating
+  `~/.local/share/keyrings/login.keyring` plus a `default` pointer. The hint is
+  aimed squarely at headless machines, which are exactly the machines with no
+  login keyring. The README now carries the complete recipe, and the hint itself
+  is tracked as
+  **[#1168](https://github.com/nimbus-agent/Nimbus/issues/1168)**.
+
+  **Caveat on what this proves.** The container's embedding worker failed to
+  initialize (`semantic search disabled`), so this proves the deterministic
+  path — index, authorship, briefs — and *not* semantic search. The gateway
+  still bound and served, which is #928's bind-first fix behaving correctly.
+  This is the same boundary the macOS row below already records.
 - [ ] Windows: fresh local user account or a VM (Win 11 Home has neither Hyper-V nor Windows Sandbox). Same quickstart, same foreign repo. **Least-covered platform:** no first-run defect was ever found here, which is weaker evidence than it looks — the macOS and Linux failures were only found because CI ran them.
 - [ ] macOS: partly covered by Task 1's `macos-14` job, which no longer sets `NIMBUS_SKIP_EMBEDDING_RUNTIME` and now asserts embeddings are not `disabled`. **Remaining gap:** it accepts `warming` and `unavailable`, so it proves the shipped configuration boots — **not** that the MiniLM download completes. A human still has to do one genuinely cold macOS first-run and confirm semantic search actually works afterwards.
 - [ ] Every break gets a fix **and** a regression test at the real-gateway layer. A unit test with an injected fake does not count.

--- a/docs/superpowers/plans/2026-07-28-launch-execution.md
+++ b/docs/superpowers/plans/2026-07-28-launch-execution.md
@@ -754,6 +754,43 @@ All three were product-behaviour changes, deliberately **not** made under this
 plan's original freeze; the freeze was lifted for them once they proved to be
 Gate 1 blockers rather than polish.
 
+**A FOURTH Gate 1 blocker, found 2026-08-13 by performing the Linux checkbox
+below — OPEN. The documented one-liner install is broken on all three
+platforms.** The Linux run never reached `nimbus init`; it failed on the very
+first command the README gives a new user.
+
+- **Evidence (Linux, live).** In a clean `ubuntu:24.04` container with no Bun
+  preinstalled, the README quickstart run verbatim —
+  `curl -fsSL .../releases/latest/download/install.sh -o /tmp/nimbus-install.sh`
+  then `bash /tmp/nimbus-install.sh` — exits 1 with
+  `Error: cannot locate 'nimbus' or 'nimbus-gateway' beside /tmp/nimbus-install.sh`.
+  Every later step then fails 127 (`nimbus: No such file or directory`).
+- **Root cause.** `scripts/install/unix/install.sh` is a *local-staging*
+  installer: it resolves binaries from `$SCRIPT_DIR` (falling back to
+  `$SCRIPT_DIR/bin/`) and has **no download capability at all**. Downloading the
+  script on its own therefore cannot ever work.
+- **Windows is broken by the same shape, and slightly worse.**
+  `scripts/install/windows/install.ps1` resolves `$ScriptDir` from
+  `Split-Path -Parent $MyInvocation.MyCommand.Path`. Under the documented
+  `irm ... | Invoke-Expression`, `$MyInvocation.MyCommand.Path` is **null**
+  (verified live), so `Split-Path` throws under the script's own
+  `$ErrorActionPreference = "Stop"`. The install guide's download-then-run
+  alternative fails the same way Unix does — no binaries beside the script.
+- **Both surfaces carry the broken instructions:** `README.md` and
+  `packages/docs/src/content/docs/user-guide/install.mdx`.
+- **Not affected:** the AppImage path (its URL resolves 200) and the tarball
+  path. The release tarball ships `install.sh` alongside `bin/nimbus` +
+  `bin/nimbus-gateway`, which is exactly the layout `install.sh` expects, so
+  *extract-then-run* works. Only the standalone-download one-liner is broken.
+- **Why CI never caught it — the blind spot is structural, and it is Task 1's.**
+  `install-smoke.yml` **stages the binaries beside the script** (lines 147–156
+  Unix, 450–454 Windows) and then runs `"$STAGE/install.sh"`. That proves the
+  *tarball* path and has never once exercised the *documented* path. This is the
+  #895 pattern exactly: a green install job on an install route no user takes.
+  A regression test here must fetch the published assets and run the README
+  sequence verbatim — which means it belongs in a post-release or scheduled
+  workflow, not PR CI, since a PR has no published release to test against.
+
 - [ ] Linux: clean `ubuntu:24.04` container, no Bun preinstalled. Run the README quickstart verbatim against a **cloned third-party repo**, not Nimbus. (#925 is fixed, but a headless container is precisely where it bit — verify the documented prerequisite is sufficient in practice.)
 - [ ] Windows: fresh local user account or a VM (Win 11 Home has neither Hyper-V nor Windows Sandbox). Same quickstart, same foreign repo. **Least-covered platform:** no first-run defect was ever found here, which is weaker evidence than it looks — the macOS and Linux failures were only found because CI ran them.
 - [ ] macOS: partly covered by Task 1's `macos-14` job, which no longer sets `NIMBUS_SKIP_EMBEDDING_RUNTIME` and now asserts embeddings are not `disabled`. **Remaining gap:** it accepts `warming` and `unavailable`, so it proves the shipped configuration boots — **not** that the MiniLM download completes. A human still has to do one genuinely cold macOS first-run and confirm semantic search actually works afterwards.
@@ -790,12 +827,25 @@ Gate 1 blockers rather than polish.
 
 ### Gate 3 runbook — public launch
 
-- [ ] Confirm launch copy cites the Task 2 audit numbers, not "80+", unless the audit supports it.
+- [x] Confirm launch copy cites the Task 2 audit numbers, not "80+", unless the audit supports it.
 
-  **Audit result (run 2026-07-29):** `tier1=4 implemented=85 unknown=5 total=94`.
-  So **89 of 94 connectors register MCP tools and make outbound calls** — the
-  "80+ services" claim is supported on the static evidence, provided it is
-  never phrased as live-API verification (only 4 have any test at all).
+  **Audit re-run 2026-08-13:** `tier1=5 implemented=84 unknown=5 total=94`
+  (was `4 / 85 / 5 / 94` on 2026-07-29 — one connector gained a test; the
+  totals are unchanged). So **89 of 94 connectors register MCP tools and make
+  outbound calls**, and the conclusion below is unchanged: the claim is
+  supported on static evidence, provided it is never phrased as live-API
+  verification (only 5 have any test at all).
+
+  **Copy verified 2026-08-13.** `docs/launch-messaging.md` carries no
+  connector-count claim, so there was nothing there to correct. The public
+  counts live in `README.md` and the docs-site index, and one of them was
+  wrong: the "How it works" diagram said `90+ cloud services`, but only 89
+  connectors reach a network — the other 5 (`dataprofile`,
+  `great-expectations`, `localdb`, `obsidian`, `storybook`) are pure
+  local-filesystem readers. Corrected to `~90 cloud services` (same character
+  width, so the diagram stays aligned). The other counts were checked and are
+  accurate as written: "90+ first-party MCP connectors" and "90+ connectors"
+  describe all 94, and "~90 cloud services" / "~90 others" ≈ 89.
 
   **Known tier-definition gap — decide before writing copy.** All 5 `unknown`
   connectors (`dataprofile`, `great-expectations`, `localdb`, `obsidian`,
@@ -803,7 +853,11 @@ Gate 1 blockers rather than polish.
   `makesOutboundCalls` is legitimately `false` for them. They are implemented;
   the tier scheme just has no "local-only" bucket. Treat 89 as a floor, not a
   ceiling — the honest full count of implemented connectors is 94 of 94.
-- [ ] Confirm the telemetry position from Task 3 is in the copy.
+- [x] Confirm the telemetry position from Task 3 is in the copy.
+
+  **Verified 2026-08-13:** `docs/launch-messaging.md` § "Pre-empt: the telemetry
+  question" is present with the quotable paragraph intact, and the README's
+  opt-in note survives. Nothing to change.
 - [ ] Re-read `docs/launch-messaging.md` honesty guardrails immediately before posting.
 - [ ] Fire channels in order, spaced out — MCP directories and `awesome-*` lists, then Lobsters and r/selfhosted, then r/devops and r/sre, then Show HN last.
 - [ ] **Exit:** Show HN posted with the funnel already known-good.

--- a/packages/docs/src/content/docs/user-guide/install.mdx
+++ b/packages/docs/src/content/docs/user-guide/install.mdx
@@ -217,6 +217,49 @@ See the full walkthrough: [Verify your download](/user-guide/verify-your-downloa
 
 ---
 
+## Headless Linux (no desktop session)
+
+Credentials live in the OS keystore, and on Linux that is `libsecret` talking to
+a Secret Service provider over D-Bus. Installing `libsecret-tools` is necessary
+but **not sufficient**: the provider also needs a session bus and an unlocked
+default collection. A server, container, SSH session or WSL install usually has
+neither, and the Gateway will exit with
+`org.freedesktop.secrets has no default collection`.
+
+Run `nimbus doctor` first — it distinguishes "no session bus", "no Secret
+Service provider" and "no default collection", so you only fix what is missing.
+
+If the machine has **never had a login keyring**, create one before unlocking.
+Creating it otherwise escalates to a GUI prompt that a headless box cannot
+answer:
+
+```bash
+sudo apt install -y gnome-keyring dbus-x11
+
+mkdir -p ~/.local/share/keyrings
+printf '[keyring]\ndisplay-name=login\nctime=0\nmtime=0\nlock-on-idle=false\nlock-after=false\n' \
+  > ~/.local/share/keyrings/login.keyring
+printf 'login' > ~/.local/share/keyrings/default
+chmod 600 ~/.local/share/keyrings/login.keyring
+```
+
+Then start Nimbus inside a session:
+
+```bash
+dbus-run-session -- bash -c \
+  'printf "\n" | gnome-keyring-daemon --unlock --components=secrets; nimbus start'
+```
+
+`nimbus doctor` should then report
+`[ok] Vault: Secret Service reachable with an unlocked default keyring`.
+
+:::note
+This keyring is unencrypted at rest. That is the standard trade-off for an
+unattended machine — the secret has to be readable without a human to type a
+passphrase. On a machine with a real desktop session, log in normally instead
+and skip all of the above.
+:::
+
 ## AppImage (Linux alternative)
 
 If you prefer a portable single-file executable that does not require `dpkg`,

--- a/packages/docs/src/content/docs/user-guide/install.mdx
+++ b/packages/docs/src/content/docs/user-guide/install.mdx
@@ -16,23 +16,28 @@ data directory, and configures the Gateway to autostart with your session.
 <Tabs>
   <TabItem label="Linux (.deb)">
 
-Import the Nimbus signing key, then download and run the install script:
+Download the `.deb`, verify its signature, then install it:
 
 ```bash
 # Import the signing key (fingerprint cross-checked in scripts/release/nimbus-verify.sh)
 gpg --keyserver keys.openpgp.org --recv-keys 5A20457CCD8B53FFAA945240886ADA6B487CAB6E
 
-# Download and run the installer
-curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.sh \
-  -o /tmp/nimbus-install.sh
-# Inspect the script before running it (recommended):
-# less /tmp/nimbus-install.sh
-bash /tmp/nimbus-install.sh
+# Download the package and its detached signature
+curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb \
+  -o /tmp/nimbus.deb
+curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus_amd64.deb.asc \
+  -o /tmp/nimbus.deb.asc
+
+# Verify BEFORE installing — this step is yours, nothing does it for you
+gpg --verify /tmp/nimbus.deb.asc /tmp/nimbus.deb
+
+# Install with apt, NOT `dpkg -i` — the package depends on bubblewrap and
+# libcap2-bin, and dpkg will not resolve those for you.
+sudo apt install /tmp/nimbus.deb
 ```
 
-The install script detects your architecture (`amd64` / `arm64`), downloads the
-matching `.deb` package, verifies the GPG signature and SHA-256 hash, then
-installs it with `dpkg`.
+`libsecret-tools` is required — credentials live in the OS keystore and the
+Gateway will not start without it (`sudo apt install libsecret-tools`).
 
 After installation:
 
@@ -43,18 +48,24 @@ nimbus --version
   </TabItem>
   <TabItem label="macOS">
 
-Download and run the install script:
+Download the archive for your architecture, extract it, and run the installer
+it contains:
 
 ```bash
-curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.sh \
-  -o /tmp/nimbus-install.sh
+# Apple silicon — for Intel, swap arm64 → x64.
+curl -fsSL https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-headless-macos-arm64.tar.gz \
+  -o /tmp/nimbus.tar.gz
+mkdir -p /tmp/nimbus && tar -xzf /tmp/nimbus.tar.gz -C /tmp/nimbus
+
 # Inspect the script before running it (recommended):
-# less /tmp/nimbus-install.sh
-bash /tmp/nimbus-install.sh
+# less /tmp/nimbus/install.sh
+/tmp/nimbus/install.sh
 ```
 
-The script downloads a signed `SHA256SUMS.asc` manifest and verifies the
-tarball hash before extracting. **Gatekeeper note:** macOS will display an
+`install.sh` installs the binaries that were extracted alongside it into
+`~/.local/bin` and updates your shell `PATH`. To check the download's integrity,
+verify it against the signed `SHA256SUMS.asc` manifest — see
+[Verify your download](/user-guide/verify-your-download/). **Gatekeeper note:** macOS will display an
 "unverified developer" warning the first time the `nimbus` binary runs. See
 [First-run setup](/user-guide/first-run-setup/) for the one-time bypass step.
 
@@ -67,27 +78,27 @@ nimbus --version
   </TabItem>
   <TabItem label="Windows">
 
-Open **PowerShell** (no administrator required) and run:
-
-```powershell
-irm https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.ps1 |
-  Invoke-Expression
-```
-
-Or download first and inspect before running (recommended):
+Open **PowerShell** (no administrator required). Download the archive, expand
+it, and run the installer it contains:
 
 ```powershell
 # Download
-Invoke-WebRequest `
-  -Uri "https://github.com/nimbus-agent/Nimbus/releases/latest/download/install.ps1" `
-  -OutFile "$env:TEMP\nimbus-install.ps1"
+$url = "https://github.com/nimbus-agent/Nimbus/releases/latest/download/nimbus-headless-windows-x64.zip"
+Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\nimbus.zip"
 
-# Inspect
-notepad "$env:TEMP\nimbus-install.ps1"
+# Expand
+Expand-Archive -Path "$env:TEMP\nimbus.zip" -DestinationPath "$env:TEMP\nimbus" -Force
+
+# Inspect the script before running it (recommended)
+notepad "$env:TEMP\nimbus\install.ps1"
 
 # Run
-& "$env:TEMP\nimbus-install.ps1"
+& "$env:TEMP\nimbus\install.ps1"
 ```
+
+`install.ps1` installs the binaries expanded alongside it and updates your user
+`PATH`. Prefer a packaged install? `nimbus-headless-windows-x64.msi` is on the
+same release page (that one does require administrator).
 
 **SmartScreen note:** Windows may show an "unrecognised app" warning. Click
 **More info → Run anyway**. The `SHA256SUMS.asc` GPG manifest is your
@@ -111,15 +122,18 @@ The installer is non-privileged and idempotent on all three platforms.
 
 ### Linux
 
+Installed from the `.deb`:
+
 | Item | Location |
 |---|---|
-| `nimbus` binary | `~/.local/bin/nimbus` |
+| `nimbus`, `nimbus-gateway` | `/usr/local/bin/` (thin wrappers; real binaries under `/usr/lib/nimbus/bin/`) |
 | Gateway data dir | `~/.local/share/nimbus/` |
-| Shell PATH update | Sentinel marker block added to `~/.bashrc`, `~/.zshrc`, `~/.profile` |
-| Autostart | `~/.config/systemd/user/nimbus-gateway.service` (if systemd available) |
+| Shell PATH update | None needed — `/usr/local/bin` is already on `PATH` |
 
-The installer checks for the sentinel block before writing — it will not
-duplicate PATH entries.
+If you install from the tarball or AppImage instead, `install.sh` copies the
+binaries to `~/.local/bin` and adds a sentinel marker block to `~/.bashrc`,
+`~/.zshrc` or `~/.profile`. It checks for that block before writing, so it will
+not duplicate PATH entries.
 
 ### macOS
 
@@ -128,7 +142,6 @@ duplicate PATH entries.
 | `nimbus` binary | `~/.local/bin/nimbus` |
 | Gateway data dir | `~/Library/Application Support/nimbus/` |
 | Shell PATH update | Sentinel marker block added to `~/.zshrc` (and `~/.bash_profile` if present) |
-| Autostart | `~/Library/LaunchAgents/dev.nimbus-agent.gateway.plist` |
 
 ### Windows
 
@@ -137,10 +150,12 @@ duplicate PATH entries.
 | `nimbus.exe`, `nimbus-gateway.exe` | `%LOCALAPPDATA%\Programs\Nimbus\bin\` |
 | Gateway data dir | `%LOCALAPPDATA%\nimbus\` |
 | PATH update | User `PATH` registry key under `HKCU\Environment` |
-| Autostart | `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Run` |
 
 The installer performs a case-insensitive PATH segment check before writing —
 it will not add a duplicate entry if `Nimbus\bin` is already present.
+
+None of the installers configure autostart on any platform — start the Gateway
+yourself with `nimbus init` or `nimbus start`.
 
 ---
 


### PR DESCRIPTION
Performing the Gate 1 (foreign-machine) Linux runbook from `docs/superpowers/plans/2026-07-28-launch-execution.md` found that the documented one-liner install was broken on **all three platforms**. This corrects the docs to the paths that actually work, proves the Linux first run end to end, and adds the CI job that would have caught it.

No installer or product code is changed here — the plan's freeze is kept. The installer fix itself is tracked separately in #1167.

## The defect

In a clean `ubuntu:24.04` container with no Bun, the README quickstart run verbatim fails on the first command a new user ever runs:

```
$ bash /tmp/nimbus-install.sh
Error: cannot locate 'nimbus' or 'nimbus-gateway' beside /tmp/nimbus-install.sh
```

`scripts/install/unix/install.sh` is a *local-staging* installer: it resolves binaries from `$SCRIPT_DIR` (falling back to `$SCRIPT_DIR/bin/`) and has no download capability at all, so fetching it standalone can never work. `install.ps1` fails earlier under the documented `irm ... | iex` — `$MyInvocation.MyCommand.Path` is null, so `Split-Path` throws under its own `ErrorActionPreference = "Stop"` (reproduced live). macOS uses the same script and the same documented command.

Both surfaces carried the broken instructions: `README.md` and `packages/docs/.../user-guide/install.mdx`.

## Why CI never caught it

`install-smoke.yml` copies the built binaries next to the script (lines 147–156 Unix, 450–454 Windows) and then runs `"$STAGE/install.sh"`. That proves the **tarball** path and has never exercised the **documented** path. Same shape as #895: a green install job on a route no user takes.

`scripts/release/documented-asset-urls.ts` was working as designed — it checks that every documented `releases/latest/download/<name>` URL *names a staged asset*, and by construction cannot tell whether the downloaded script can function alone. The standalone assets were added deliberately to fix six 404s, which converted a clean 404 into a script that downloads fine and then fails.

## What changed

- **`README.md` + `install.mdx`** rewritten to the working paths: macOS → tarball → `./install.sh`; Linux → `.deb`; Windows → zip → `.\install.ps1`. Verified against the published v2.1.0 assets — every archive ships the installer beside the binaries.
- **`sudo dpkg -i` does not work** and is documented as `sudo apt install`: the package depends on `bubblewrap` and `libcap2-bin`, which dpkg will not resolve, so it exits 1 leaving the package unconfigured. The first draft of this PR had `dpkg -i` in it; running it in the container is what caught that.
- **Two further false claims removed from `install.mdx`**: it described an installer that "detects your architecture, downloads the matching `.deb`, verifies the GPG signature and SHA-256" — none of which exists — and three **Autostart** rows (systemd user unit, LaunchAgent plist, `HKCU\...\Run`). Nothing anywhere in the repo creates any of them.
- **New "Headless Linux" section** in the install guide, plus a short README pointer.
- **`.github/workflows/released-install-smoke.yml`** runs the documented commands verbatim against **published** assets on `release: published`, weekly, and on dispatch. It cannot live in PR CI — a PR has no published release to install from. Scoped to `nimbus --version`; first-run behaviour stays with `install-smoke.yml`.
- **Gate 3 copy checks closed.** Connector audit re-run: `tier1=5 implemented=84 unknown=5 total=94` (was `4/85/5/94`). Corrected the README's `90+ cloud services` to `~90` — only 89 of the 94 connectors reach a network; the other 5 are local-filesystem readers. The other count claims were checked and are accurate.

## Verification

Gate 1 Linux is green end to end in a clean `ubuntu:24.04` container against a cloned third-party repo (`chalk/ansi-styles`, 119 commits):

- install → `nimbus --version` → `2.1.0`
- `nimbus doctor` → `[ok] Vault: Secret Service reachable with an unlocked default keyring`
- `nimbus init` → gateway up, index populated
- `nimbus why index.js:1` → a real `## Authorship` section (`Richie Bendall · 9150f611ced8`, 2020-12-01)

`preflight:fast` passes (28 gates); docs site builds with 0 errors and valid internal links.

**Caveat, stated rather than hidden:** the container's embedding worker failed to initialize, so this proves the deterministic path — index, authorship, briefs — and **not** semantic search. The gateway still bound and served, which is #928's bind-first fix behaving correctly. This is the same boundary the plan already records for the macOS job.

## Follow-ups filed

- **#1167** — give the installers a real download mode (with GPG + SHA-256 verification, since an installer that downloads without verifying would be a downgrade).
- **#1168** — `nimbus doctor`'s headless-Linux remedy fails on the machines it targets: `--unlock` unlocks an *existing* login keyring, and a headless box has none, so creation escalates to `gcr-prompter` and dies with `cannot open display`. Pre-creating the keyring was the only difference between the failing and passing runs. Detection is good; only the remedy string is short.

## Known gaps, recorded not fixed

The Linux tarball is the only archive with a *versioned* asset name, so it cannot be linked from docs that outlive a release; and the `.rpm` is versioned-only, leaving **Fedora/RHEL with no documented install command**. Both pre-date this work.
