### PR TITLE
ci: restore wall-clock margin on the Windows gateway test leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,10 +242,14 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.filter.outputs.cross-platform-matrix) }}
     runs-on: ${{ matrix.os }}
-    # Backstop only — each test attempt has its own 10-min wall-clock cap (see the
+    # Backstop only — each test attempt has its own 15-min wall-clock cap (see the
     # unit-tests step), so a hang fails fast via retry rather than burning this
-    # ceiling. Sized for setup + retried typecheck + 2 capped test attempts.
-    timeout-minutes: 25
+    # ceiling. Sized for setup + retried typecheck + 2 capped test attempts:
+    # 2 × 15 min of tests alone is 30 min, so this MUST stay above that or a
+    # double-timeout is cancelled at the job ceiling ("The operation was canceled")
+    # instead of surfacing the wrapper's exit 124 — the very failure mode the
+    # per-attempt cap exists to prevent. Raise both together or neither.
+    timeout-minutes: 40
     permissions:
       contents: read
 
@@ -327,20 +331,32 @@ jobs:
         # true hang; assertion failures fail in <1 s regardless of `--timeout`,
         # so this does not mask logic bugs.
         #
-        # Each attempt is additionally wrapped in a 10-minute wall-clock timeout
+        # Each attempt is additionally wrapped in a 15-minute wall-clock timeout
         # (`scripts/run-with-timeout.ts` — portable because GNU `timeout` is not on
         # the macOS runner). `--timeout 60000` is PER-TEST and does not fire on a
         # hung-at-exit `bun test` (a lingering timer keeps the process alive after
         # all tests finish); without a whole-run cap such a hang spins until the
         # job's `timeout-minutes` ceiling and surfaces as "The operation was
-        # canceled.". The wrapper kills the hang at 10 min (exit 124) so retry-once
-        # actually runs — recovering a transient hang in minutes instead of burning
-        # the full ceiling. 10 min is far above a healthy Windows run (~2-3 min), so
-        # it never false-kills a merely-slow run.
+        # canceled.". The wrapper kills the hang (exit 124) so retry-once actually
+        # runs — recovering a transient hang in minutes instead of burning the full
+        # ceiling.
+        #
+        # The cap is 900 s, NOT the 600 s it was through 2026-08-14. The old value
+        # was justified by "far above a healthy Windows run (~2-3 min)", and that
+        # premise silently expired: the gateway leg on windows-2025 drifted to
+        # 340 s → 404 s → 516 s → 557 s over a single day, and the run that broke it
+        # was killed mid-suite at 600 s (exit 124 on BOTH attempts, zero test
+        # failures). The runner is also highly variable — 11,166 tests / 796 files
+        # took 404 s and then 516 s on consecutive runs, a 28 % swing on identical
+        # work — so a cap sized to the observed mean will keep false-killing green
+        # suites. 900 s sits far enough above the worst observed healthy run (557 s)
+        # to absorb that variance while still bounding a true hang well under the
+        # job ceiling. Re-check this number if a healthy run ever exceeds ~700 s;
+        # the durable fix is making the suite faster, not raising the cap again.
         run: |
           set +e
           for attempt in 1 2; do
-            bun scripts/run-with-timeout.ts 600 bun test "packages/${{ matrix.pkg }}/src" --timeout 60000
+            bun scripts/run-with-timeout.ts 900 bun test "packages/${{ matrix.pkg }}/src" --timeout 60000
             code=$?
             if [ "$code" -eq 0 ]; then
               exit 0

--- a/packages/gateway/src/ipc/http-server.test.ts
+++ b/packages/gateway/src/ipc/http-server.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
@@ -19,10 +19,82 @@ const STATUS_READERS: StatusReaders = {
   syncFreshnessMs: () => 0,
 };
 
+/**
+ * Per-test DBs used to be built by replaying the whole migration chain inside every
+ * `beforeEach` — up to CURRENT_SCHEMA_VERSION migrations per test across ~50 tests. That cost
+ * ~114 s on the Windows CI runner (20 % of the entire gateway suite) and was a large part of
+ * why the job reached its wall-clock cap. Each distinct DB shape is now migrated ONCE into a
+ * module-scoped template file and copied per test: every test still gets its own pristine
+ * file, so isolation is unchanged, but the per-test cost is a file copy rather than a
+ * migration replay.
+ *
+ * Copying the bare `.db` is sufficient: `runIndexedSchemaMigrations` never switches the
+ * database to WAL, so a closed template leaves no `-wal`/`-shm` sidecar holding pages that
+ * the copy would miss.
+ */
+const templateDir = mkdtempSync(join(tmpdir(), "nimbus-http-server-templates-"));
+const dbTemplates = new Map<string, string>();
+
+afterAll(() => {
+  try {
+    rmSync(templateDir, { recursive: true, force: true });
+  } catch {
+    /* non-fatal */
+  }
+});
+
+/** Materialize `dbPath` from a lazily-built, cached template for `shape`. */
+function materializeDb(dbPath: string, shape: string, build: (templatePath: string) => void): void {
+  let template = dbTemplates.get(shape);
+  if (template === undefined) {
+    template = join(templateDir, `${shape}.db`);
+    build(template);
+    dbTemplates.set(shape, template);
+  }
+  copyFileSync(template, dbPath);
+}
+
 function makeEmptyDb(dbPath: string, targetVersion = 28): void {
-  const db = new Database(dbPath);
-  runIndexedSchemaMigrations(db, targetVersion);
-  db.close();
+  materializeDb(dbPath, `empty-v${targetVersion}`, (templatePath) => {
+    const db = new Database(templatePath);
+    runIndexedSchemaMigrations(db, targetVersion);
+    db.close();
+  });
+}
+
+/** An index at CURRENT_SCHEMA_VERSION carrying the one item/person/audit/sync_state row
+ *  that the read-only route assertions expect. */
+function makeSeededDb(dbPath: string): void {
+  materializeDb(dbPath, "routes-seeded", (templatePath) => {
+    const db = new Database(templatePath);
+    runIndexedSchemaMigrations(db, CURRENT_SCHEMA_VERSION);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url,
+                         canonical_url, modified_at, author_id, metadata,
+                         synced_at, pinned)
+       VALUES ('github:pr_1', 'github', 'pr', 'pr_1', 'Hello',
+               'preview', NULL, NULL, 1000, NULL, NULL, 2000, 0)`,
+    );
+    db.run(
+      `INSERT INTO person (id, display_name, canonical_email,
+                           github_login, gitlab_login, slack_handle,
+                           linear_member_id, jira_account_id, notion_user_id,
+                           metadata, linked)
+       VALUES ('person:1', 'Alice', 'alice@example.com',
+               NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1)`,
+    );
+    db.run(
+      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp)
+       VALUES ('test.action', 'not_required', '{"k":"v"}', 1000)`,
+    );
+    db.run(
+      `INSERT INTO sync_state (connector_id, last_sync_at, next_sync_token,
+                               health_state, retry_after, backoff_until,
+                               backoff_attempt, last_error)
+       VALUES ('github', 1000, NULL, 'healthy', NULL, NULL, 0, NULL)`,
+    );
+    db.close();
+  });
 }
 
 /** Path to the real built admin-console dist (packages/admin-console/dist). */
@@ -311,34 +383,7 @@ describe("startReadOnlyHttpServer — simple read-only routes", () => {
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "nimbus-http-server-routes-"));
     dbPath = join(tmpDir, "nimbus.db");
-    const db = new Database(dbPath);
-    runIndexedSchemaMigrations(db, CURRENT_SCHEMA_VERSION);
-    db.run(
-      `INSERT INTO item (id, service, type, external_id, title, body_preview, url,
-                         canonical_url, modified_at, author_id, metadata,
-                         synced_at, pinned)
-       VALUES ('github:pr_1', 'github', 'pr', 'pr_1', 'Hello',
-               'preview', NULL, NULL, 1000, NULL, NULL, 2000, 0)`,
-    );
-    db.run(
-      `INSERT INTO person (id, display_name, canonical_email,
-                           github_login, gitlab_login, slack_handle,
-                           linear_member_id, jira_account_id, notion_user_id,
-                           metadata, linked)
-       VALUES ('person:1', 'Alice', 'alice@example.com',
-               NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1)`,
-    );
-    db.run(
-      `INSERT INTO audit_log (action_type, hitl_status, action_json, timestamp)
-       VALUES ('test.action', 'not_required', '{"k":"v"}', 1000)`,
-    );
-    db.run(
-      `INSERT INTO sync_state (connector_id, last_sync_at, next_sync_token,
-                               health_state, retry_after, backoff_until,
-                               backoff_attempt, last_error)
-       VALUES ('github', 1000, NULL, 'healthy', NULL, NULL, 0, NULL)`,
-    );
-    db.close();
+    makeSeededDb(dbPath);
     handle = startReadOnlyHttpServer(dbPath, 0);
   });
 


### PR DESCRIPTION
## Why

`PR quality — Cross-platform (gateway, windows-2025)` failed on #1184 with `exit code 124` — the `scripts/run-with-timeout.ts` wall-clock cap firing, on **both** attempts. Zero tests failed; no summary line was ever printed, because the run was killed mid-suite at 600 s.

This was not a regression from any product change. The leg has simply had no margin left:

| Run (2026-08-14) | Tests | Files | Duration |
| --- | --- | --- | --- |
| 03:19 | 11,082 | 794 | 340.7 s |
| 07:47 | 11,166 | 796 | 404.1 s |
| 09:24 | 11,166 | 796 | 516.0 s |
| 09:45 | 11,183 | 796 | **557.0 s** |
| 15:53 | — | — | **killed at 600 s** |

The last passing run cleared the cap with **43 seconds to spare (93 % of budget)**. Test count grew 0.9 % across the day while duration grew 63 %, so this is runner variance, not suite growth — note 07:47 vs 09:24: identical work (11,166 tests / 796 files), 404 s then 516 s, a 28 % swing. The proximate trigger was one test stalling for 59.2 s (`GET /v1/preflight/deploy returns 400 when max_findings is not an integer`, normally ~2-3 s), which alone exceeded the remaining slack.

## What

**1. Stop rebuilding the schema per test.** Every `beforeEach` in `http-server.test.ts` replayed the full migration chain (up to `CURRENT_SCHEMA_VERSION` = 53) against a fresh on-disk DB. That one file cost **113.9 s — 20.4 % of the entire gateway suite**, for tests that are trivial read-only route assertions.

Each distinct DB shape is now migrated once into a module-scoped template and copied per test. Isolation is unchanged: every test still gets its own pristine file. Copying the bare `.db` is sound because `runIndexedSchemaMigrations` never switches the database to WAL, so a closed template leaves no `-wal`/`-shm` sidecar holding pages the copy would miss.

Measured locally (Windows), same 52 tests passing both ways:

```
before: Ran 52 tests across 1 file. [6.60s]
after:  Ran 52 tests across 1 file. [724.00ms]
```

**2. Raise the cap 600 s → 900 s.** The old value was justified in-comment as *"far above a healthy Windows run (~2-3 min)"*. That premise had silently expired — a healthy run is now ~9.3 min — and the comment asserted this failure mode "never" happens while it was actively happening. The comment is rewritten to record the real numbers and to say when to revisit.

**3. Raise the job ceiling 25 → 40 min.** This is required, not incidental: 2 × 900 s of tests is 30 min, so leaving the ceiling at 25 would have cancelled a double-timeout at the job level ("The operation was canceled") instead of surfacing the wrapper's exit 124 — reintroducing exactly the failure mode the per-attempt cap exists to prevent. The comment now states the two must move together.

## Verification

- `bun run preflight:fast` — PASSED (29 gates, incl. `audit:workflow-lint`)
- `bun test packages/gateway/src/ipc` — 1718 pass, 17 skip, **0 fail**

## Note

Raising the cap is the stopgap; the suite getting faster is the fix. The remaining known hotspot is `db.verify > returns clean:true on an empty fresh DB` at **41.6 s** in one test — that one is real work (`PRAGMA integrity_check` over a real DB), so it is deliberately left alone here rather than papered over from a test.
