### PR TITLE
test(install): derive the fixture asset name from the release-assets SSoT

### DIFF
--- a/scripts/install/install-remote.test.ts
+++ b/scripts/install/install-remote.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assetNameFor, type InstallTarget } from "./lib/release-assets.ts";
+import { assetNameFor, findSupportedTarget } from "./lib/release-assets.ts";
 
 const isWindows = process.platform === "win32";
 
@@ -14,18 +14,14 @@ const isWindows = process.platform === "win32";
  */
 const FIXTURE_VERSION = "2.2.0";
 
-/** This host as an `InstallTarget`, or null when no build is published for it. */
-function hostTarget(): InstallTarget | null {
-  const os = process.platform;
-  const arch = process.arch;
-  if (os !== "linux" && os !== "darwin" && os !== "win32") return null;
-  if (arch !== "x64" && arch !== "arm64") return null;
-  // assetNameFor() throws for Linux arm64 — no such build is published.
-  if (os === "linux" && arch === "arm64") return null;
-  return { os, arch };
-}
-
-const HOST_TARGET = hostTarget();
+/**
+ * This host as an `InstallTarget`, or null when no build is published for it.
+ * Resolved from `SUPPORTED_TARGETS` rather than by hand-listing the unsupported
+ * pairs: `TARBALL_NAME` below is computed at module scope, so a target this
+ * returns that `assetNameFor` then rejects throws while LOADING the file —
+ * before `skip` is evaluated — turning a should-be-skip into a hard failure.
+ */
+const HOST_TARGET = findSupportedTarget(process.platform, process.arch);
 
 /**
  * The asset name install.sh will ACTUALLY request on this host, derived from

--- a/scripts/install/install-remote.test.ts
+++ b/scripts/install/install-remote.test.ts
@@ -4,11 +4,50 @@ import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { assetNameFor, type InstallTarget } from "./lib/release-assets.ts";
 
 const isWindows = process.platform === "win32";
+
+/**
+ * The version every test here passes to `install.sh --from-release`. The
+ * fixture asset name is derived from it, so the two can never drift apart.
+ */
+const FIXTURE_VERSION = "2.2.0";
+
+/** This host as an `InstallTarget`, or null when no build is published for it. */
+function hostTarget(): InstallTarget | null {
+  const os = process.platform;
+  const arch = process.arch;
+  if (os !== "linux" && os !== "darwin" && os !== "win32") return null;
+  if (arch !== "x64" && arch !== "arm64") return null;
+  // assetNameFor() throws for Linux arm64 — no such build is published.
+  if (os === "linux" && arch === "arm64") return null;
+  return { os, arch };
+}
+
+const HOST_TARGET = hostTarget();
+
+/**
+ * The asset name install.sh will ACTUALLY request on this host, derived from
+ * the same `release-assets.ts` SSoT that `release-assets-drift.test.ts` pins
+ * install.sh's own `detect_asset()` against.
+ *
+ * This was previously hardcoded to the Linux name. Because the Linux tarball
+ * is the ONE asset carrying its version in the filename
+ * (`nimbus-headless-linux-amd64-v2.2.0.tar.gz`) while the macOS tarballs are
+ * unversioned (`nimbus-headless-macos-arm64.tar.gz`), the fixture server
+ * answered 404 for the name install.sh asked for on every macOS runner — so
+ * five tests in this file failed on macos-15 while passing on ubuntu, and
+ * main stayed red. Deriving the name means each OS exercises its own real
+ * asset name instead of Linux's.
+ */
+const TARBALL_NAME = HOST_TARGET ? assetNameFor(HOST_TARGET, FIXTURE_VERSION) : "";
+
 // A missing curl must read as SKIPPED, never as a checksum failure — the
-// verify:docker image (oven/bun:1.3) ships neither curl nor wget.
-const skip = isWindows || !Bun.which("curl");
+// verify:docker image (oven/bun:1.3) ships neither curl nor wget. A host with
+// no published build likewise skips rather than failing on a name it could
+// never have served.
+const skip = isWindows || !Bun.which("curl") || HOST_TARGET === null;
 // The bad-signature test needs a REAL gpg to reject a bad signature with
 // (rather than degrade via the best-effort skip path), so it needs its own,
 // stricter guard on top of `skip`.
@@ -180,7 +219,7 @@ async function makeTarball(work: string, tarballName: string): Promise<string> {
  */
 async function runInstallSh(env: Record<string, string | undefined>) {
   const proc = Bun.spawn(
-    ["sh", "scripts/install/unix/install.sh", "--from-release", "2.2.0", "--yes"],
+    ["sh", "scripts/install/unix/install.sh", "--from-release", FIXTURE_VERSION, "--yes"],
     {
       env,
       stdout: "pipe",
@@ -210,7 +249,7 @@ test.skipIf(skip)(
       await writeFile(p, "#!/bin/sh\necho 2.2.0\n");
       await chmod(p, 0o755);
     }
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     await Bun.$`tar -czf ${join(work, tarballName)} -C ${payload} .`.quiet();
 
     const server = await serveFakeRelease(work, tarballName);
@@ -245,7 +284,7 @@ test.skipIf(skip)(
     const work = await mkdtemp(join(tmpdir(), "nimbus-tamper-"));
     const home = join(work, "home");
     await mkdir(home, { recursive: true });
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     await writeFile(join(work, tarballName), "not a real tarball");
 
     // SHA256SUMS advertises a digest that does not match the served bytes.
@@ -299,7 +338,7 @@ test.skipIf(skip)(
     const work = await mkdtemp(join(tmpdir(), "nimbus-dup-"));
     const home = join(work, "home");
     await mkdir(home, { recursive: true });
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     const tarballPath = await makeTarball(work, tarballName);
     const tarball = await Bun.file(tarballPath).arrayBuffer();
     const digest = new Bun.CryptoHasher("sha256").update(tarball).digest("hex");
@@ -343,7 +382,7 @@ test.skipIf(skip)(
     const work = await mkdtemp(join(tmpdir(), "nimbus-nogpg-remote-"));
     const home = join(work, "home");
     await mkdir(home, { recursive: true });
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     await makeTarball(work, tarballName);
 
     const server = await serveFakeRelease(work, tarballName);
@@ -379,7 +418,7 @@ test.skipIf(skipSigCheck)(
     const work = await mkdtemp(join(tmpdir(), "nimbus-badsig-"));
     const home = join(work, "home");
     await mkdir(home, { recursive: true });
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     const tarballPath = await makeTarball(work, tarballName);
     const tarball = await Bun.file(tarballPath).arrayBuffer();
     const digest = new Bun.CryptoHasher("sha256").update(tarball).digest("hex");
@@ -424,7 +463,7 @@ test.skipIf(skipSigCheck)(
     const work = await mkdtemp(join(tmpdir(), "nimbus-untrusted-"));
     const home = join(work, "home");
     await mkdir(home, { recursive: true });
-    const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
+    const tarballName = TARBALL_NAME;
     const tarballPath = await makeTarball(work, tarballName);
     const tarball = await Bun.file(tarballPath).arrayBuffer();
     const digest = new Bun.CryptoHasher("sha256").update(tarball).digest("hex");

--- a/scripts/install/lib/release-assets-drift.test.ts
+++ b/scripts/install/lib/release-assets-drift.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assetNameFor, SUPPORTED_TARGETS } from "./release-assets.ts";
+import { assetNameFor, type InstallTarget, SUPPORTED_TARGETS } from "./release-assets.ts";
 
 const WORKFLOW = join(".github", "workflows", "release.yml");
 const LINUX_PACKAGER = join("scripts", "package-linux-installers.ts");
@@ -74,6 +76,78 @@ test("install.ps1's remote-mode asset name matches the release-assets SSoT", asy
     expect(installPs1).toContain(stem);
   }
 });
+
+/**
+ * The `toContain` guards above prove each stem is PRESENT in install.sh. They
+ * cannot prove install.sh actually RESOLVES to that name on a given platform —
+ * a stem can sit in a dead branch, or be paired with the wrong `uname` arm.
+ *
+ * This runs install.sh for real, in `--dry-run` mode (which "prints planned
+ * actions and exits", touching neither disk nor network), with `uname` stubbed
+ * to each supported platform, and compares the name it would request against
+ * the SSoT by EXACT equality.
+ *
+ * The point is that it does this for macOS from a Linux runner. install.sh's
+ * macOS naming previously had no executable cover at PR time at all: the
+ * PR-time cross-platform job runs gateway/CLI unit tests only, so a macOS-only
+ * naming break could only ever be caught by the post-merge matrix — which is
+ * exactly how five install tests stayed red on main for six consecutive runs.
+ */
+const UNAME_FOR: Record<string, { readonly s: string; readonly m: string }> = {
+  "linux/x64": { s: "Linux", m: "x86_64" },
+  "darwin/arm64": { s: "Darwin", m: "arm64" },
+  "darwin/x64": { s: "Darwin", m: "x86_64" },
+};
+
+/** A directory holding a `uname` that reports the given platform. */
+function unameShimDir(os: string, machine: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-uname-"));
+  const shim = join(dir, "uname");
+  writeFileSync(
+    shim,
+    `#!/bin/sh\ncase "$1" in\n  -m) echo ${machine} ;;\n  *) echo ${os} ;;\nesac\n`,
+  );
+  chmodSync(shim, 0o755);
+  return dir;
+}
+
+async function dryRunAssetName(target: InstallTarget, version: string): Promise<string> {
+  const uname = UNAME_FOR[`${target.os}/${target.arch}`];
+  if (uname === undefined) throw new Error(`no uname mapping for ${target.os}/${target.arch}`);
+  const shim = unameShimDir(uname.s, uname.m);
+  const proc = Bun.spawn(["sh", INSTALL_SH, "--dry-run", "--from-release", version, "--yes"], {
+    // POSIX-only by construction (skipped on Windows), so ":" is correct here.
+    env: { ...process.env, PATH: `${shim}:${process.env["PATH"]}` }, // cross-platform-ok
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+  const line = stdout.split("\n").find((l) => l.includes("Would download:"));
+  if (line === undefined) {
+    throw new Error(
+      `install.sh --dry-run printed no download plan.\nstdout:${stdout}\nstderr:${stderr}`,
+    );
+  }
+  return line.slice(line.lastIndexOf("/") + 1).trim();
+}
+
+const skipDryRun = process.platform === "win32" || !Bun.which("sh");
+
+test.skipIf(skipDryRun)(
+  "install.sh --dry-run resolves EXACTLY the SSoT asset name on every supported target",
+  async () => {
+    const version = "2.2.0";
+    for (const target of SUPPORTED_TARGETS) {
+      if (target.os === "win32") continue; // install.ps1's job.
+      expect(await dryRunAssetName(target, version)).toBe(assetNameFor(target, version));
+    }
+  },
+  30_000,
+);
 
 // `/releases/latest/download/` resolves an exact filename and silently
 // ignores a pinned version — forbidden by both installers' own remote-mode

--- a/scripts/install/lib/release-assets.test.ts
+++ b/scripts/install/lib/release-assets.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test";
-import { assetNameFor, assetUrl, SUPPORTED_TARGETS } from "./release-assets.ts";
+import {
+  assetNameFor,
+  assetUrl,
+  findSupportedTarget,
+  SUPPORTED_TARGETS,
+} from "./release-assets.ts";
 
 test("linux x64 asset name carries the version", () => {
   expect(assetNameFor({ os: "linux", arch: "x64" }, "2.2.0")).toBe(
@@ -23,6 +28,49 @@ test("linux arm64 is not published and must fail loudly", () => {
   expect(() => assetNameFor({ os: "linux", arch: "arm64" }, "2.2.0")).toThrow(
     /no Linux arm64 build is published/,
   );
+});
+
+test("findSupportedTarget resolves every published (os, arch) pair", () => {
+  for (const target of SUPPORTED_TARGETS) {
+    expect(findSupportedTarget(target.os, target.arch)).toEqual(target);
+  }
+});
+
+/**
+ * The two must agree exactly, or a caller that gates on `findSupportedTarget`
+ * still reaches an `assetNameFor` that throws. Asserting BOTH halves per pair
+ * is what makes this a lock rather than two independent checks: adding a target
+ * to `SUPPORTED_TARGETS` without teaching `assetNameFor` about it fails here,
+ * and so does the reverse.
+ */
+test("findSupportedTarget returns null for exactly the pairs assetNameFor rejects", () => {
+  const oses = ["linux", "darwin", "win32", "freebsd"];
+  const arches = ["x64", "arm64", "ia32"];
+  let unsupported = 0;
+  for (const os of oses) {
+    for (const arch of arches) {
+      const found = findSupportedTarget(os, arch);
+      if (found !== null) {
+        expect(() => assetNameFor(found, "2.2.0")).not.toThrow();
+        continue;
+      }
+      unsupported++;
+      // Cast: the point is that this pair is NOT a valid InstallTarget, and
+      // assetNameFor must refuse it rather than return a name.
+      expect(() => assetNameFor({ os, arch } as never, "2.2.0")).toThrow();
+    }
+  }
+  // 12 combinations, 4 of them published — guards against the loop silently
+  // testing nothing if the lists are edited.
+  expect(unsupported).toBe(8);
+});
+
+// Windows arm64 is the pair that actually bit: it is a plausible dev machine,
+// it is NOT published, and a guard that only special-cased Linux arm64 let it
+// through into assetNameFor's throw.
+test("windows arm64 and linux arm64 are both unsupported", () => {
+  expect(findSupportedTarget("win32", "arm64")).toBeNull();
+  expect(findSupportedTarget("linux", "arm64")).toBeNull();
 });
 
 // The whole point of the review's finding #2: a pinned version must be honoured

--- a/scripts/install/lib/release-assets.ts
+++ b/scripts/install/lib/release-assets.ts
@@ -29,9 +29,34 @@ export function assetNameFor(target: InstallTarget, version: string): string {
   if (os === "linux") {
     throw new Error("no Linux arm64 build is published — build from source, or use x64 emulation");
   }
-  if (os === "darwin") return `nimbus-headless-macos-${arch}.tar.gz`;
+  // Spelled per arch rather than interpolating `arch`, mirroring install.sh's
+  // own `detect_asset` case arms. Interpolating meant ANY arch produced a
+  // confident-looking `nimbus-headless-macos-<arch>.tar.gz` for an asset that
+  // is not published. No caller can reach that today — `InstallTarget` types
+  // arch as x64|arm64 and this module is imported only by tests — so this is
+  // defence in depth, not a fixed user-facing bug. It matters because this
+  // module is the SSoT the drift tests pin install.sh against: the shell
+  // REFUSES an unknown macOS arch, and an SSoT that is laxer than the script
+  // it certifies cannot certify it.
+  if (os === "darwin" && arch === "arm64") return "nimbus-headless-macos-arm64.tar.gz";
+  if (os === "darwin" && arch === "x64") return "nimbus-headless-macos-x64.tar.gz";
   if (os === "win32" && arch === "x64") return "nimbus-headless-windows-x64.zip";
   throw new Error(`unsupported target: ${os}/${arch}`);
+}
+
+/**
+ * The `InstallTarget` for an (os, arch) pair, or null when no build is published
+ * for it — resolved by lookup in `SUPPORTED_TARGETS`, which is exactly the set
+ * `assetNameFor` accepts.
+ *
+ * Callers pass `process.platform` / `process.arch` straight in. Deriving the
+ * answer from the same table `assetNameFor` is written against is the point: a
+ * hand-maintained list of unsupported pairs drifts from it silently. It already
+ * did — a guard that special-cased only Linux arm64 still returned a target for
+ * Windows arm64, which `assetNameFor` throws on.
+ */
+export function findSupportedTarget(os: string, arch: string): InstallTarget | null {
+  return SUPPORTED_TARGETS.find((t) => t.os === os && t.arch === arch) ?? null;
 }
 
 /**


### PR DESCRIPTION
`main`'s macOS CI leg has been red since #1172 landed — six consecutive runs of
**Unit + Coverage — macos-15**, both retry attempts each time. Five tests in
`scripts/install/install-remote.test.ts` fail there while the ubuntu and windows
legs stay green.

## Root cause

The test hardcoded the **Linux** tarball name in all six of its fixtures:

```ts
const tarballName = "nimbus-headless-linux-amd64-v2.2.0.tar.gz";
```

`install.sh` does not use a fixed name — `detect_asset()` derives it from
`uname`. And the Linux tarball is the one asset that carries its version in the
filename; the macOS tarballs are unversioned by design (`release-assets.ts`
documents this and says not to harmonise them). Both shapes are real, and both
ship on every release:

```
nimbus-headless-linux-amd64-v2.4.1.tar.gz
nimbus-headless-macos-arm64.tar.gz
```

So on a macos-15 runner install.sh requested `nimbus-headless-macos-arm64.tar.gz`,
the fixture server only served the Linux name, and it answered **404**:

```
Downloading nimbus-headless-macos-arm64.tar.gz (v2.2.0)…
curl: (22) The requested URL returned error: 404
Error: download failed
```

The one test that passed on macOS — "aborts on a tampered archive" — passes only
because its server returns bytes for *any* path with no 404 fallback.

**`install.sh` itself was correct and is unchanged** — this was only ever a test
defect.

## Fix

**1. Derive the fixture name from the SSoT.** `assetNameFor()` in
`release-assets.ts` is the same source `release-assets-drift.test.ts` already
pins install.sh's `detect_asset()` against. Each OS now exercises its own real
asset name rather than Linux's. A host with no published build (Linux arm64)
skips instead of failing on a name that could never have been served, and
`--from-release` takes the same `FIXTURE_VERSION` constant the name is built
from, so the two cannot drift.

**2. Close the gap that let this reach `main` at all.** install.sh's macOS
naming had *no executable cover at PR time*: the PR-time cross-platform job
runs gateway/CLI unit tests only ("just `bun test` on source"), so `scripts/`
tests never run there, and a macOS-only naming break could be caught only by
the post-merge matrix. The new drift test runs install.sh for real in
`--dry-run` mode (which touches neither disk nor network) with `uname` stubbed
to each supported platform, and compares the name it would request against the
SSoT by **exact equality** — so macOS naming is now covered from a Linux runner,
before merge. That is strictly stronger than the existing `toContain` stem
checks, which prove a stem is *present* but not that it is *reached*.

## Verification

- All 6 tests pass on Linux x64 (`oven/bun:1.3` + curl/gpg), so the previously
  green leg is unregressed: `29 pass, 14 skip, 0 fail` across all of
  `scripts/install/`.
- The derivation is exact for the failing platform:
  `assetNameFor({darwin, arm64}, "2.2.0")` → `nimbus-headless-macos-arm64.tar.gz`,
  character-for-character the name the failing CI log shows install.sh requesting.
- The new drift test is **red-proved**: renaming install.sh's darwin/arm64 asset
  to `macos-aarch64` fails it with the exact mismatch, on Linux.
- `bun run preflight:fast` — all 29 gates pass.

### Scope of that verification, stated plainly

This PR's own checks do **not** execute `install-remote.test.ts` on macOS —
no PR-time job runs `scripts/` tests off Linux. The macOS evidence before merge
is the exact-equality dry-run test above plus the string match against the
failing log; `install-remote.test.ts` itself is re-exercised on macOS by the
post-merge matrix, which is the leg that has been failing.

---

## Review follow-up (16f21749)

CodeRabbit flagged that `hostTarget()` returned `{win32, arm64}` — a target
`assetNameFor` rejects — and that because `TARBALL_NAME` is module-scope, that
throws while *loading* the file, before `skip` is evaluated. Valid, and
confirmed empirically.

Fixed differently than proposed: the suggested diff adds `win32/arm64` beside
`linux/arm64`, which keeps a hand-maintained list that must track
`assetNameFor`'s throw conditions by hand — the very thing that caused the bug.
The host target is now resolved by lookup in `SUPPORTED_TARGETS`, which *is* the
set `assetNameFor` accepts, so the two cannot diverge.

Writing the paired test surfaced a **latent** defect the review didn't reach:
`assetNameFor` interpolated `arch` for darwin, so `{darwin, ia32}` produced a
confident `nimbus-headless-macos-ia32.tar.gz` for an unpublished asset. To be
precise about impact: **nothing user-facing was broken** — `InstallTarget` types
arch as `x64|arm64`, and this module is imported only by three test files, so no
caller could reach it. It still matters, because `install.sh`'s `detect_asset`
*refuses* an unknown macOS arch and this module is the SSoT the drift tests pin
`install.sh` against; an SSoT laxer than the script it certifies cannot certify
it. The darwin arms now mirror the shell.

Red-proved both directions: adding `{win32, arm64}` to `SUPPORTED_TARGETS`
without teaching `assetNameFor` about it fails 3 tests.

Because `release-assets.ts` ships in nothing, this PR stays `test(...)` — it
should cut no release.
