### PR TITLE
fix(egress): count the whole prove window, not the first page of it

### DIFF
--- a/packages/cli/src/commands/prove.ts
+++ b/packages/cli/src/commands/prove.ts
@@ -15,6 +15,9 @@ export interface ProveCompleteness {
 
 type ProveResult = {
   rows: EgressRow[];
+  /** Total rows in the window. `rows` is a page of at most 1000 of them. */
+  rowsTotal?: number;
+  rowsTruncated?: boolean;
   completeness: ProveCompleteness;
   verify: VerifyResult;
   receipt?: { sigB64: string; pubkeyB64: string; digest: string };
@@ -219,6 +222,13 @@ export async function runEgressReport(
   for (const r of out.rows) {
     const ts = new Date(r.timestamp).toISOString().replace("T", " ").slice(0, 19);
     console.log(`  ${ts}  ${r.method.padEnd(28)} ${r.resultStatus}`);
+  }
+  if (out.rowsTruncated === true) {
+    // The COUNT above is exact for the whole window; only this listing is a page. Saying so keeps
+    // the listing from reading as the complete set of what left.
+    console.log(
+      `  … showing the oldest ${String(out.rows.length)} of ${String(out.rowsTotal ?? out.rows.length)} rows in this window (the count above covers all of them)`,
+    );
   }
   if (out.receipt !== undefined) {
     console.log(`receipt: digest=${out.receipt.digest} sig=${out.receipt.sigB64.slice(0, 16)}…`);

--- a/packages/gateway/src/egress/egress-sign.test.ts
+++ b/packages/gateway/src/egress/egress-sign.test.ts
@@ -20,19 +20,41 @@ function fakeVault(): NimbusVault {
   };
 }
 
+const SUMMARY = { outboundEgressEvents: 2, rowsTotal: 2 };
+
 describe("digestEgressWindow", () => {
   test("is a stable 64-char hex over the row hashes", () => {
-    const d1 = digestEgressWindow([{ rowHash: "a".repeat(64) }, { rowHash: "b".repeat(64) }]);
-    const d2 = digestEgressWindow([{ rowHash: "a".repeat(64) }, { rowHash: "b".repeat(64) }]);
+    const rows = [{ rowHash: "a".repeat(64) }, { rowHash: "b".repeat(64) }];
+    const d1 = digestEgressWindow(rows, SUMMARY);
+    const d2 = digestEgressWindow(rows, SUMMARY);
     expect(d1).toBe(d2);
     expect(d1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  /**
+   * The whole reason the totals are bound in. `rows` is a page; two windows can present the SAME
+   * page while differing in how much actually left. A receipt that cannot tell them apart is
+   * attesting the page, not the window.
+   */
+  test("differs when the counted totals differ, even for an identical page", () => {
+    const rows = [{ rowHash: "a".repeat(64) }];
+    const truncated = digestEgressWindow(rows, { outboundEgressEvents: 1, rowsTotal: 1 });
+    const whole = digestEgressWindow(rows, { outboundEgressEvents: 3000, rowsTotal: 3001 });
+    expect(truncated).not.toBe(whole);
+  });
+
+  test("distinguishes outbound count from total row count", () => {
+    const rows = [{ rowHash: "e".repeat(64) }];
+    expect(digestEgressWindow(rows, { outboundEgressEvents: 5, rowsTotal: 9 })).not.toBe(
+      digestEgressWindow(rows, { outboundEgressEvents: 9, rowsTotal: 5 }),
+    );
   });
 });
 
 describe("signWindowDigest", () => {
   test("produces a signature that verifies against the returned pubkey", async () => {
     const vault = fakeVault();
-    const digest = digestEgressWindow([{ rowHash: "c".repeat(64) }]);
+    const digest = digestEgressWindow([{ rowHash: "c".repeat(64) }], SUMMARY);
     const { sigB64, pubkeyB64 } = await signWindowDigest(vault, digest);
     const ok = nacl.sign.detached.verify(
       new TextEncoder().encode(digest),
@@ -44,7 +66,10 @@ describe("signWindowDigest", () => {
 
   test("never returns the private key material", async () => {
     const vault = fakeVault();
-    const out = await signWindowDigest(vault, digestEgressWindow([{ rowHash: "d".repeat(64) }]));
+    const out = await signWindowDigest(
+      vault,
+      digestEgressWindow([{ rowHash: "d".repeat(64) }], SUMMARY),
+    );
     expect(Object.keys(out).sort()).toEqual(["pubkeyB64", "sigB64"]);
     expect(JSON.stringify(out)).not.toContain("privkey");
   });

--- a/packages/gateway/src/egress/egress-sign.ts
+++ b/packages/gateway/src/egress/egress-sign.ts
@@ -5,10 +5,33 @@ import nacl from "tweetnacl";
 import { ensureShareKeypair } from "../share/share-keypair.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
 
-/** A stable BLAKE3 digest over a window's ordered row hashes — the thing the receipt signs. */
-export function digestEgressWindow(rows: readonly { rowHash: string }[]): string {
-  const encoder = new TextEncoder();
-  return bytesToHex(blake3(encoder.encode(rows.map((r) => r.rowHash).join("|"))));
+/**
+ * A stable BLAKE3 digest over a window's ordered row hashes AND its counted totals — the thing the
+ * receipt signs.
+ *
+ * The totals are bound in, not just the rows, because `rows` is a page: `listEgress` caps it at
+ * 1000 by default. Signing the page alone produced a receipt that attested a truncated prefix of
+ * the window while the printed count claimed the whole of it — the signature was over different
+ * evidence than the claim it accompanied. Binding `outboundEgressEvents` and `rowsTotal` means a
+ * receipt cannot be reused to vouch for a window whose totals differ, even when the visible page
+ * is identical.
+ *
+ * The `v2` tag is part of the hashed payload so a digest produced under the old (rows-only) rule
+ * can never collide with one produced under this rule. Receipts are local and short-lived (the
+ * portable EAF artifact is deferred), and nothing verifies a stored digest, so there is no
+ * compatibility surface to preserve here.
+ */
+export function digestEgressWindow(
+  rows: readonly { rowHash: string }[],
+  summary: { outboundEgressEvents: number; rowsTotal: number },
+): string {
+  const payload = [
+    "nimbus-egress-window-v2",
+    `outbound=${summary.outboundEgressEvents}`,
+    `rowsTotal=${summary.rowsTotal}`,
+    rows.map((r) => r.rowHash).join("|"),
+  ].join("\n");
+  return bytesToHex(blake3(new TextEncoder().encode(payload)));
 }
 
 /**

--- a/packages/gateway/src/egress/egress-verify.test.ts
+++ b/packages/gateway/src/egress/egress-verify.test.ts
@@ -6,7 +6,18 @@ import { appendBootMarker } from "./egress-boot-marker.ts";
 import { THIS_BINARY_COVERAGE } from "./egress-coverage.ts";
 import { appendEgressEntry } from "./egress-ledger.ts";
 import type { EgressEntry } from "./egress-record.ts";
-import { egressHead, listEgress, proveWindow, verifyEgressChain } from "./egress-verify.ts";
+import {
+  EGRESS_SOURCE_TYPES,
+  isMarkerSourceType,
+  MARKER_SOURCE_TYPES,
+} from "./egress-source-type.ts";
+import {
+  countOutboundEgress,
+  egressHead,
+  listEgress,
+  proveWindow,
+  verifyEgressChain,
+} from "./egress-verify.ts";
 
 function e(over: Partial<EgressEntry> = {}): EgressEntry {
   return {
@@ -183,5 +194,89 @@ describe("proveWindow", () => {
     const out = proveWindow(db, {});
     expect(out.completeness.indeterminate).toBe(true);
     expect(out.completeness.coverage.task).toBe("none");
+  });
+});
+
+/**
+ * `nimbus prove` is the product's honesty primitive: the number it prints is a claim about how
+ * much left this machine. Before this, `outboundEgressEvents` was derived by filtering the rows
+ * `listEgress` returned — a page capped at 1000 and ordered `id ASC` — so any window with more
+ * than a page of rows under-reported, dropped the NEWEST rows while doing it, and still said
+ * `indeterminate: false` with `verify.ok: true`. A confident wrong number is worse than an
+ * admitted unknown, which is the rule the rest of this module is built around.
+ */
+describe("proveWindow — the count is not a page", () => {
+  const PAGE = 1000; // listEgress' default page size
+
+  test("counts every outbound row in the window, well past the page limit", () => {
+    appendBootMarker(db, THIS_BINARY_COVERAGE, 1);
+    const total = PAGE * 3;
+    for (let i = 0; i < total; i++) {
+      appendEgressEntry(db, e({ timestamp: 100 + i, method: `m.${String(i)}` }));
+    }
+
+    const out = proveWindow(db, {});
+
+    expect(out.completeness.outboundEgressEvents).toBe(total);
+    // The page itself stays bounded — that is deliberate, it crosses IPC.
+    expect(out.rows.length).toBe(PAGE);
+    // ...but it must announce that it is a page, not the window.
+    expect(out.rowsTruncated).toBe(true);
+    expect(out.rowsTotal).toBe(total + 1); // + the boot marker row
+    expect(out.completeness.indeterminate).toBe(false);
+  });
+
+  test("counts past the page limit inside an explicit since/until window too", () => {
+    appendBootMarker(db, THIS_BINARY_COVERAGE, 1);
+    for (let i = 0; i < PAGE + 500; i++) {
+      appendEgressEntry(db, e({ timestamp: 100 + i, method: `m.${String(i)}` }));
+    }
+    const out = proveWindow(db, { since: 100, until: 100 + PAGE + 500 });
+    expect(out.completeness.outboundEgressEvents).toBe(PAGE + 500);
+  });
+
+  test("a window that fits in one page reports rowsTruncated false", () => {
+    appendBootMarker(db, THIS_BINARY_COVERAGE, 1);
+    appendEgressEntry(db, e({ timestamp: 100 }));
+    const out = proveWindow(db, {});
+    expect(out.rowsTruncated).toBe(false);
+    expect(out.completeness.outboundEgressEvents).toBe(1);
+  });
+
+  test("blocked rows are never counted as outbound, at any size", () => {
+    appendBootMarker(db, THIS_BINARY_COVERAGE, 1);
+    for (let i = 0; i < PAGE + 10; i++) {
+      appendEgressEntry(db, e({ timestamp: 100 + i, resultStatus: "blocked" }));
+    }
+    appendEgressEntry(db, e({ timestamp: 9000 }));
+    expect(proveWindow(db, {}).completeness.outboundEgressEvents).toBe(1);
+  });
+});
+
+/**
+ * The SQL predicate in `countOutboundEgress` and the TypeScript predicate `isMarkerSourceType` are
+ * two encodings of one rule. Asserting them against each other for EVERY member of the frozen
+ * source-type union is what stops them drifting: adding a member to `MARKER_SOURCE_TYPES` without
+ * teaching the SQL about it (or the reverse) fails here rather than silently mis-counting egress.
+ */
+describe("countOutboundEgress — marker parity with isMarkerSourceType", () => {
+  test("every source type is counted iff it is not a marker", () => {
+    let expected = 0;
+    for (const [i, sourceType] of EGRESS_SOURCE_TYPES.entries()) {
+      appendEgressEntry(db, e({ timestamp: 100 + i, sourceType, method: `m.${sourceType}` }));
+      if (!isMarkerSourceType(sourceType)) expected++;
+    }
+    expect(countOutboundEgress(db, {})).toBe(expected);
+    // Guard against the loop asserting nothing if the union is emptied.
+    expect(expected).toBeGreaterThan(0);
+    expect(EGRESS_SOURCE_TYPES.length - expected).toBe(MARKER_SOURCE_TYPES.size);
+  });
+
+  test("an UNRECOGNISED source type counts, rather than vanishing from the total", () => {
+    // isMarkerSourceType documents this: "Unknown values are NOT markers — an unknown row counts."
+    // A `NOT IN (...)` predicate would agree, but a naive `IN (known outbound types)` would not,
+    // and would under-report — the direction that matters for a proof.
+    appendEgressEntry(db, e({ timestamp: 100, sourceType: "not-a-known-type" as never }));
+    expect(countOutboundEgress(db, {})).toBe(1);
   });
 });

--- a/packages/gateway/src/egress/egress-verify.ts
+++ b/packages/gateway/src/egress/egress-verify.ts
@@ -10,7 +10,7 @@ import {
   weakestCoverage,
 } from "./egress-coverage.ts";
 import { computeEgressRowHash } from "./egress-ledger.ts";
-import { isMarkerSourceType } from "./egress-source-type.ts";
+import { MARKER_SOURCE_TYPES } from "./egress-source-type.ts";
 
 /** Hard ceiling on `listEgress` rows — bounds the cost of an IPC-supplied `limit`. */
 const MAX_EGRESS_LIST_LIMIT = 5000;
@@ -185,6 +185,55 @@ export function listEgress(
     )
     .all(since, until, limit) as RawRow[];
   return rows.map(toRow);
+}
+
+/**
+ * The exact number of OUTBOUND rows in a window — counted in SQL, never by filtering a page.
+ *
+ * `listEgress` returns at most 1000 rows by default (5000 hard ceiling) ordered `id ASC`, so
+ * deriving this count from its result silently under-reports on any window wider than a page, and
+ * drops the MOST RECENT rows while doing it. That is the worst possible direction for a primitive
+ * whose entire job is to state how much left the machine: it under-claims egress with
+ * `indeterminate: false`, which reads as a confident, verified number.
+ *
+ * This is the same pagination hazard `lastMarkerAtOrBefore` already had to escape (see its note on
+ * "fix 1"); the marker lookup was moved into SQL and this count was not.
+ *
+ * Predicate parity with `isMarkerSourceType` is deliberate and load-bearing: markers legitimately
+ * carry `result_status='authorized'`, and an UNKNOWN `source_type` must COUNT rather than be
+ * dropped. `NOT IN` alone would silently exclude a NULL `source_type`, so NULL is counted
+ * explicitly — an unrecognised row inflating the number is safe; one vanishing from it is not.
+ */
+export function countOutboundEgress(
+  db: Database,
+  opts: { since?: number | undefined; until?: number | undefined },
+): number {
+  const since = opts.since ?? 0;
+  const until = opts.until ?? Number.MAX_SAFE_INTEGER;
+  const markers = [...MARKER_SOURCE_TYPES];
+  const placeholders = markers.map(() => "?").join(", ");
+  const row = db
+    .query(
+      `SELECT COUNT(*) AS n FROM egress_ledger
+       WHERE timestamp >= ? AND timestamp <= ?
+         AND result_status = 'authorized'
+         AND (source_type IS NULL OR source_type NOT IN (${placeholders}))`,
+    )
+    .get(since, until, ...markers) as { n: number } | null;
+  return row?.n ?? 0;
+}
+
+/** Total rows in the window, so a truncated page can say what it is a page OF. */
+export function countEgressRows(
+  db: Database,
+  opts: { since?: number | undefined; until?: number | undefined },
+): number {
+  const since = opts.since ?? 0;
+  const until = opts.until ?? Number.MAX_SAFE_INTEGER;
+  const row = db
+    .query(`SELECT COUNT(*) AS n FROM egress_ledger WHERE timestamp >= ? AND timestamp <= ?`)
+    .get(since, until) as { n: number } | null;
+  return row?.n ?? 0;
 }
 
 type MarkerRow = { id: number; timestamp: number; source_id: string | null };
@@ -383,18 +432,29 @@ export type EgressCompleteness = {
 export function proveWindow(
   db: Database,
   opts: { since?: number | undefined; until?: number | undefined },
-): { rows: EgressRow[]; completeness: EgressCompleteness; verify: EgressVerifyResult } {
+): {
+  rows: EgressRow[];
+  rowsTotal: number;
+  rowsTruncated: boolean;
+  completeness: EgressCompleteness;
+  verify: EgressVerifyResult;
+} {
   const rows = listEgress(db, {
     ...(opts.since !== undefined && { since: opts.since }),
     ...(opts.until !== undefined && { until: opts.until }),
   });
-  const outbound = rows.filter(
-    (r) => r.resultStatus === "authorized" && !isMarkerSourceType(r.sourceType),
-  ).length;
+  // Counted in SQL over the WHOLE window. Deriving it from `rows` capped the answer at the
+  // 1000-row page and dropped the newest rows — see `countOutboundEgress`.
+  const outbound = countOutboundEgress(db, opts);
+  // `rows` stays paginated on purpose: it crosses IPC to the CLI, and an unbounded window would
+  // ship the entire ledger. What changes is that the page no longer PRETENDS to be the window.
+  const rowsTotal = countEgressRows(db, opts);
   const coverage = coverageForWindow(db, opts);
   const indeterminate = COVERAGE_CLASSES.every((c) => coverage[c] === "none");
   return {
     rows,
+    rowsTotal,
+    rowsTruncated: rows.length < rowsTotal,
     completeness: { coverage, outboundEgressEvents: outbound, indeterminate },
     verify: verifyEgressChain(db),
   };

--- a/packages/gateway/src/ipc/egress-rpc.ts
+++ b/packages/gateway/src/ipc/egress-rpc.ts
@@ -81,7 +81,10 @@ async function handleProveWindow(
   const rec = asRecord(params);
   const sign = rec?.["sign"] === true;
   if (!sign) return window;
-  const digest = digestEgressWindow(window.rows);
+  const digest = digestEgressWindow(window.rows, {
+    outboundEgressEvents: window.completeness.outboundEgressEvents,
+    rowsTotal: window.rowsTotal,
+  });
   const { sigB64, pubkeyB64 } = await signWindowDigest(ctx.vault, digest);
   return { ...window, receipt: { sigB64, pubkeyB64, digest } };
 }


### PR DESCRIPTION
`nimbus prove` is the product's honesty primitive — the number it prints is a
claim about how much left this machine. On any window holding more than 1000
rows that number was **wrong, and wrong in the worst direction**.

## The defect

`proveWindow` derived `outboundEgressEvents` by filtering the rows `listEgress`
returned. `listEgress` caps at **1000 rows by default** and orders `id ASC`, so:

- a window with 3,000 authorized rows reported **999**;
- the rows it dropped were the **most recent** ones;
- and it reported `indeterminate: false` with `verify.ok: true`, so the CLI
  printed the wrong number **with full confidence and exit 0**.

An under-claim delivered confidently is the exact failure this subsystem is
built to prevent — its own rule is "indeterminate, never a false zero".

This is also a **second instance of a hazard the file had already escaped
once**: `lastMarkerAtOrBefore` carries a note explaining that `listEgress`'s
1000-row page would make a boot marker past row 1000 invisible, and was moved
into SQL for that reason ("fix 1"). The count immediately below it was left on
the same page.

The signed receipt inherited the same flaw: `digestEgressWindow(window.rows)`
signed only the truncated page while the printed count claimed the whole
window — the signature covered different evidence than the claim beside it.

## The fix

- `countOutboundEgress()` counts in **SQL over the whole window**. The marker
  set comes from `MARKER_SOURCE_TYPES` rather than being re-spelled, and NULL
  `source_type` is counted explicitly — `NOT IN` alone would drop it, and for a
  proof an unrecognised row inflating the number is safe while one vanishing
  from it is not. This matches `isMarkerSourceType`'s documented "unknown
  values are NOT markers — an unknown row counts".
- `proveWindow` now returns `rowsTotal` + `rowsTruncated`. `rows` stays
  paginated on purpose (it crosses IPC; an unbounded window would ship the
  whole ledger) — what changed is that the page no longer *pretends* to be the
  window. The CLI now prints `… showing the oldest N of M rows in this window
  (the count above covers all of them)`.
- The receipt digest binds `outboundEgressEvents` and `rowsTotal`, tagged
  `nimbus-egress-window-v2` so it cannot collide with a digest made under the
  old rule. Receipts are local and nothing verifies a stored digest (the
  portable EAF artifact is deferred), so there is no compatibility surface.

## Verification

**Red-proved.** Reverting `proveWindow` to the old page-filter fails 3 of the
new tests. The sharpest is `blocked rows are never counted as outbound, at any
size`: with 1,010 blocked rows followed by one authorized row, the old code
reports **0** — the page fills with blocked rows and the single real egress
event falls outside it. A window that genuinely emitted something reported
nothing.

New tests cover: counting past the page limit unbounded and within an explicit
`since`/`until`; `rowsTruncated` false when the window fits; blocked rows never
counted at any size; and a parity suite asserting the SQL predicate and
`isMarkerSourceType` agree for **every** member of the frozen source-type
union, so the two encodings cannot drift — plus that an unrecognised
`source_type` counts rather than vanishing.

- `bun test packages/gateway/src/egress/` — 97 pass, 0 fail
- egress-rpc + CLI prove + egress — 133 pass, 0 fail
- `packages/gateway/src/security-invariants.test.ts` — 115 pass, 0 fail
- `bun run preflight:fast` — all 29 gates pass

## Note on what this does not change

`verifyEgressChain` still walks the entire ledger, so `proveWindow` was already
O(whole ledger) before this change — the page limit was never buying the cost
saving it looked like it was. Its 124 MB / 1.67 s cost at 200k rows is a real,
separate problem and is deliberately left for its own PR.
