### PR TITLE
ci(coverage): enforce the per-area coverage floors that CLAUDE.md advertises

### DIFF
--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -60,7 +60,24 @@ Derive gate commands from `PREFLIGHT_GATES` rather than retyping them — severa
 
 ## Coverage gates (enforced in CI)
 
-Run all via `bun run test:ci`. Individual gates:
+**What actually enforces these floors is `bun run audit:coverage-scopes`** — it reads the merged
+`coverage/lcov.info` and asserts each scope's aggregate line coverage over its *non-exempt* files
+(same exemption registry as `audit:coverage-floor`). It runs on Linux in `_test-suite.yml`
+immediately after the floor gate, and costs no extra test run.
+
+The `test:coverage:*` scripts below run each scope's tests and **do not enforce a threshold**,
+despite their `--coverage-threshold-lines=N` argument. Two independent reasons, both verified on
+Bun 1.3.14:
+
+1. `--coverage-threshold-lines` is not a Bun flag (`bun test --help` lists only `--coverage`,
+   `--coverage-reporter`, `--coverage-dir`) and Bun ignores unknown flags silently.
+2. `bunfig.toml` sets `[test] coverage = false`, which suppresses collection outright — even an
+   explicit `--coverage --coverage-reporter=lcov --coverage-dir=X` writes no lcov under it.
+
+The percentages in the list below are therefore the floors `audit:coverage-scopes` enforces, not
+something the adjacent command checks. The commands remain useful for running a scope's tests, and
+their CI jobs still do real work the main suite does not (the Sandbox job builds the sandbox helper
+and runs `cppcheck --error-exitcode=1` on its C source; the Vault job installs libsecret + D-Bus).
 
 ```bash
 # Engine + agents

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -357,6 +357,23 @@ jobs:
         shell: bash
         run: bun run audit:coverage-floor
 
+      - name: Coverage scopes — the per-area floors CLAUDE.md advertises
+        if: runner.os == 'Linux'
+        # The floors named in CLAUDE.md (Engine >=85%, Vault >=90%, Embedding
+        # >=80%, ...) used to be spelled as `--coverage-threshold-lines=N` in 25
+        # package.json scripts. That flag DOES NOT EXIST in Bun (`bun test
+        # --help` lists only --coverage/--coverage-reporter/--coverage-dir) and
+        # unknown flags are ignored silently; `bunfig.toml`'s `[test] coverage =
+        # false` additionally suppresses collection entirely, so no lcov was
+        # produced for a threshold to read even in principle. Every one of those
+        # gates passed unconditionally.
+        #
+        # This step enforces the same floors for real, against the merged lcov
+        # built a few steps above — so it adds no test run and no CI minutes.
+        # It is Linux-only for the same reason the floor gate above is.
+        shell: bash
+        run: bun run audit:coverage-scopes
+
       - name: Coverage floor — exclusion parity (sonar <-> registry)
         if: runner.os == 'Linux'
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Several surfaces live in their own standalone repos and release independently of
 - **Vault tests** prove no secret value escapes through any interface.
 - **Integration tests** use real SQLite + real Bun subprocesses + fresh temp dirs — no mocks at the DB layer.
 - **E2E CLI tests** use a real Gateway subprocess + mock MCP servers — no real cloud calls.
-- **Coverage gates** in CI: Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people (see `_test-suite.yml` + `nimbus-commands` skill).
+- **Coverage gates** in CI: Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people — enforced by `audit:coverage-scopes` over the merged lcov, NOT by the `test:coverage:*` scripts (their `--coverage-threshold-lines` flag does not exist in Bun and is silently ignored; `bunfig.toml`'s `[test] coverage = false` suppresses collection anyway). Denominator is non-exempt files, matching `audit:coverage-floor`. See `scripts/coverage-floor/check-scopes.ts`.
 - Focus on the current phase; do not add Phase N+1 features in Phase N code.
 
 PRs gate on Ubuntu (`pr-quality`); pushes run the full Windows/macOS/Linux matrix.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -95,7 +95,7 @@ Several surfaces live in their own standalone repos and release independently of
 - **Vault tests** prove no secret value escapes through any interface.
 - **Integration tests** use real SQLite + real Bun subprocesses + fresh temp dirs — no mocks at the DB layer.
 - **E2E CLI tests** use a real Gateway subprocess + mock MCP servers — no real cloud calls.
-- **Coverage gates** in CI: Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people (see `_test-suite.yml` + `nimbus-commands` skill).
+- **Coverage gates** in CI: Engine ≥85%, Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people — enforced by `audit:coverage-scopes` over the merged lcov, NOT by the `test:coverage:*` scripts (their `--coverage-threshold-lines` flag does not exist in Bun and is silently ignored; `bunfig.toml`'s `[test] coverage = false` suppresses collection anyway). Denominator is non-exempt files, matching `audit:coverage-floor`. See `scripts/coverage-floor/check-scopes.ts`.
 - Focus on the current phase; do not add Phase N+1 features in Phase N code.
 
 PRs gate on Ubuntu (`pr-quality`); pushes run the full Windows/macOS/Linux matrix.

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "audit:structure": "bun scripts/structure-audit/audit-structure.ts",
     "audit:boundaries": "bunx dependency-cruiser --config .dependency-cruiser.cjs --no-progress packages",
     "audit:coverage-floor": "bun scripts/coverage-floor/check.ts",
+    "audit:coverage-scopes": "bun scripts/coverage-floor/check-scopes.ts",
     "mutation": "stryker run",
     "mutation:diff": "bun scripts/mutation/run-mutation.ts --diff",
     "audit:coverage-floor:build-lcov": "bun scripts/coverage-floor/build-lcov.ts",

--- a/scripts/coverage-floor/check-scopes.test.ts
+++ b/scripts/coverage-floor/check-scopes.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { checkScopes, SCOPE_GATES } from "./check-scopes.ts";
+import { EXCLUSIONS } from "./exclusions.ts";
+
+/** Minimal lcov for one file: `lines` DA records, `covered` of them hit. */
+function lcovFor(entries: ReadonlyArray<{ path: string; lines: number; covered: number }>): string {
+  return entries
+    .map(({ path, lines, covered }) => {
+      const da = Array.from(
+        { length: lines },
+        (_, i) => `DA:${String(i + 1)},${i < covered ? "1" : "0"}`,
+      );
+      return [
+        `SF:${path}`,
+        ...da,
+        `LF:${String(lines)}`,
+        `LH:${String(covered)}`,
+        "end_of_record",
+      ].join("\n");
+    })
+    .join("\n");
+}
+
+/** A scope's predicate is data; pick a real path it matches so tests bind to the table. */
+function pathForScope(name: string): string {
+  const candidates = [
+    "packages/gateway/src/engine/executor.ts",
+    "packages/gateway/src/vault/key-format.ts",
+    "packages/gateway/src/agents/catchup.ts",
+    "packages/cli/src/tui/app.ts",
+  ];
+  const gate = SCOPE_GATES.find((g) => g.name === name);
+  if (gate === undefined) throw new Error(`no scope named ${name}`);
+  const hit = candidates.find((c) => gate.match(c));
+  if (hit === undefined) throw new Error(`no candidate path matches scope ${name}`);
+  return hit;
+}
+
+describe("checkScopes", () => {
+  test("passes a scope at or above its floor", () => {
+    const path = pathForScope("Engine"); // floor 85
+    const out = checkScopes(lcovFor([{ path, lines: 100, covered: 90 }]));
+    const engine = out.results.find((r) => r.name === "Engine");
+    expect(engine?.ok).toBe(true);
+    expect(engine?.linePct).toBeCloseTo(90, 5);
+  });
+
+  test("FAILS a scope below its floor", () => {
+    const path = pathForScope("Engine"); // floor 85
+    const out = checkScopes(lcovFor([{ path, lines: 100, covered: 84 }]));
+    expect(out.ok).toBe(false);
+    expect(out.errors.join(" ")).toContain("Engine");
+    expect(out.errors.join(" ")).toContain("84.00%");
+  });
+
+  test("a floor is a floor: exactly at it passes", () => {
+    const path = pathForScope("Engine");
+    const out = checkScopes(lcovFor([{ path, lines: 100, covered: 85 }]));
+    expect(out.results.find((r) => r.name === "Engine")?.ok).toBe(true);
+  });
+
+  /**
+   * The gate-that-cannot-fail case. These predicates name directories, and
+   * directories get renamed; a scope silently matching nothing would report ok
+   * forever while measuring no code at all.
+   */
+  test("a scope matching ZERO files fails rather than vacuously passing", () => {
+    // An lcov containing only an unrelated file: every scope matches nothing.
+    const out = checkScopes(
+      lcovFor([{ path: "packages/docs/src/whatever.ts", lines: 10, covered: 10 }]),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.errors.length).toBe(SCOPE_GATES.length);
+    expect(out.errors.join(" ")).toContain("matched 0 non-exempt files");
+  });
+
+  /**
+   * Exempt files must not enter the denominator — that is what keeps this gate
+   * measuring testable code rather than how much untestable per-OS glue a scope
+   * happens to contain.
+   */
+  test("exempt files are excluded from the denominator", () => {
+    const exemptExact = EXCLUSIONS.find(
+      (e) => e.kind === "exact" && e.path.startsWith("packages/gateway/src/vault/"),
+    );
+    expect(exemptExact).toBeDefined();
+    const exemptPath = (exemptExact as { path: string }).path;
+
+    const covered = pathForScope("Vault"); // non-exempt vault file, floor 90
+    // The exempt file is 0% and would drag the scope to 50% if it counted.
+    const out = checkScopes(
+      lcovFor([
+        { path: covered, lines: 100, covered: 100 },
+        { path: exemptPath, lines: 100, covered: 0 },
+      ]),
+    );
+    const vault = out.results.find((r) => r.name === "Vault");
+    expect(vault?.files).toBe(1);
+    expect(vault?.linePct).toBeCloseTo(100, 5);
+    expect(vault?.ok).toBe(true);
+  });
+});
+
+describe("SCOPE_GATES table", () => {
+  test("names are unique", () => {
+    const names = SCOPE_GATES.map((g) => g.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every floor is a sane percentage", () => {
+    for (const g of SCOPE_GATES) {
+      expect(g.floorLines).toBeGreaterThan(0);
+      expect(g.floorLines).toBeLessThanOrEqual(100);
+    }
+  });
+
+  // The floors CLAUDE.md names explicitly. If one of these is ever loosened,
+  // the docs become wrong again — which is the failure this whole gate exists
+  // to end.
+  test("the documented headline floors are the ones enforced", () => {
+    const floorOf = (n: string): number | undefined =>
+      SCOPE_GATES.find((g) => g.name === n)?.floorLines;
+    expect(floorOf("Engine")).toBe(85);
+    expect(floorOf("Vault")).toBe(90);
+    expect(floorOf("Embedding")).toBe(80);
+  });
+});

--- a/scripts/coverage-floor/check-scopes.ts
+++ b/scripts/coverage-floor/check-scopes.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env bun
+
+/**
+ * Per-scope coverage floors — the gates CLAUDE.md advertises ("Engine ≥85%,
+ * Vault ≥90%, Embedding ≥80%, plus scheduler/rate-limiter/people").
+ *
+ * Those floors used to be spelled as `bun test <scope> --coverage
+ * --coverage-threshold-lines=N` in 25 package.json scripts. **They enforced
+ * nothing**, for two independent reasons, both verified against Bun 1.3.14:
+ *
+ *   1. `--coverage-threshold-lines` is not a Bun flag. `bun test --help` lists
+ *      only `--coverage`, `--coverage-reporter` and `--coverage-dir`, and Bun
+ *      ignores unknown flags silently — `bun test x.test.js --totally-bogus-flag=7`
+ *      exits 0. A scope at 28% "passed" a threshold of 99%.
+ *   2. `bunfig.toml` sets `[test] coverage = false`, which suppresses coverage
+ *      collection outright. Even an explicit `--coverage --coverage-reporter=lcov
+ *      --coverage-dir=X` writes no lcov at all under that setting, so there was
+ *      nothing for a threshold to read even in principle.
+ *
+ * This module enforces the same floors for real, against the merged lcov that
+ * `audit:coverage-floor` already consumes — so it costs no extra test run.
+ *
+ * TWO DELIBERATE SEMANTICS, both chosen to match the existing floor gate:
+ *
+ * - **Exempt files are excluded from the denominator.** `audit:coverage-floor`
+ *   exempts per-OS and FFI shells that cannot be exercised on a single runner.
+ *   Counting them here would make a scope's number describe how much untestable
+ *   glue it contains rather than how well its testable code is covered: with
+ *   exempt files in, `vault` reads 89.9% and `sandbox` 65.5%; with them out,
+ *   both are 100%. The exemptions remain a real hole — `vault/win32.ts` carries
+ *   I12 and is measured by nothing — but that hole is not this gate's to close,
+ *   and pretending otherwise by reporting a low number here would just add a
+ *   second misleading signal.
+ * - **A scope matching zero files is a FAILURE, not a pass.** These predicates
+ *   name directories that get moved. A silently-empty scope is exactly the
+ *   shape of gate that cannot fail.
+ *
+ * Not covered here, and stated plainly: this reads the LINUX merged lcov, so
+ * the floors are enforced on Linux only. That is not a regression — the
+ * per-OS jobs never enforced anything — but `vault/win32.ts` and
+ * `vault/darwin.ts` still have no floor on their own platforms.
+ */
+
+import { readFileSync } from "node:fs";
+import { isExempt } from "./exclusions.ts";
+import { parseLcov } from "./lcov-parse.ts";
+
+export interface ScopeGate {
+  /** Display name, matching the CI job label where one exists. */
+  readonly name: string;
+  /** Minimum aggregate LINE coverage percentage over non-exempt files. */
+  readonly floorLines: number;
+  readonly match: (relPath: string) => boolean;
+}
+
+const gw = (sub: string) => (p: string) => p.startsWith(`packages/gateway/src/${sub}`);
+
+/**
+ * The 24 scopes, carrying the floors the old scripts documented. Every one of
+ * them passes today with margin — measured against the merged lcov of main
+ * @ de196f8c — so turning enforcement on is not a ratchet reset.
+ */
+export const SCOPE_GATES: readonly ScopeGate[] = Object.freeze([
+  { name: "Agents", floorLines: 80, match: gw("agents/") },
+  { name: "Engine", floorLines: 85, match: gw("engine/") },
+  { name: "Vault", floorLines: 90, match: gw("vault/") },
+  {
+    name: "Scheduler",
+    floorLines: 80,
+    match: (p) => p === "packages/gateway/src/sync/scheduler.ts",
+  },
+  {
+    name: "Rate limiter",
+    floorLines: 85,
+    match: (p) => p === "packages/gateway/src/sync/rate-limiter.ts",
+  },
+  { name: "People", floorLines: 80, match: gw("people/") },
+  { name: "Embedding", floorLines: 80, match: gw("embedding/") },
+  {
+    name: "Workflow",
+    floorLines: 80,
+    match: (p) => p.startsWith("packages/gateway/src/automation/workflow-"),
+  },
+  {
+    name: "Watcher",
+    floorLines: 80,
+    match: (p) =>
+      p.startsWith("packages/gateway/src/automation/watcher-") ||
+      p.startsWith("packages/gateway/src/automation/graph-predicate") ||
+      p.startsWith("packages/gateway/src/watcher/"),
+  },
+  { name: "Extensions", floorLines: 85, match: gw("extensions/") },
+  { name: "Sandbox", floorLines: 80, match: gw("platform/sandbox/") },
+  { name: "Security", floorLines: 80, match: gw("security/") },
+  { name: "Config", floorLines: 80, match: gw("config/") },
+  { name: "Telemetry", floorLines: 85, match: gw("telemetry/") },
+  { name: "DB layer", floorLines: 85, match: gw("db/") },
+  { name: "Deployment", floorLines: 80, match: gw("deployment/") },
+  { name: "Metrics", floorLines: 80, match: gw("metrics/") },
+  { name: "Preflight", floorLines: 80, match: gw("preflight/") },
+  {
+    name: "Doctor",
+    floorLines: 80,
+    match: (p) => p.startsWith("packages/cli/src/commands/doctor"),
+  },
+  {
+    name: "MCP connectors",
+    floorLines: 70,
+    match: (p) => p.startsWith("packages/mcp-connectors/"),
+  },
+  { name: "TUI", floorLines: 80, match: (p) => p.startsWith("packages/cli/src/tui/") },
+  { name: "Updater", floorLines: 80, match: gw("updater/") },
+  { name: "LAN", floorLines: 80, match: (p) => p.startsWith("packages/gateway/src/ipc/lan-") },
+  { name: "Perf", floorLines: 80, match: gw("perf/") },
+]);
+
+export interface ScopeResult {
+  readonly name: string;
+  readonly floorLines: number;
+  readonly files: number;
+  readonly linePct: number;
+  readonly ok: boolean;
+}
+
+export interface ScopeCheckResult {
+  readonly ok: boolean;
+  readonly results: readonly ScopeResult[];
+  readonly errors: readonly string[];
+}
+
+export function checkScopes(lcovText: string): ScopeCheckResult {
+  const coverage = parseLcov(lcovText);
+  const results: ScopeResult[] = [];
+  const errors: string[] = [];
+
+  for (const gate of SCOPE_GATES) {
+    let covered = 0;
+    let lines = 0;
+    let files = 0;
+    for (const [path, c] of coverage) {
+      if (!gate.match(path) || isExempt(path)) continue;
+      files += 1;
+      covered += c.covered;
+      lines += c.lines;
+    }
+
+    if (files === 0) {
+      errors.push(
+        `${gate.name}: matched 0 non-exempt files in the lcov — the scope moved or was renamed. ` +
+          `A scope that matches nothing would pass every floor forever, so this fails instead.`,
+      );
+      results.push({
+        name: gate.name,
+        floorLines: gate.floorLines,
+        files: 0,
+        linePct: 0,
+        ok: false,
+      });
+      continue;
+    }
+
+    const linePct = lines === 0 ? 100 : (covered / lines) * 100;
+    const ok = linePct + 1e-9 >= gate.floorLines;
+    if (!ok) {
+      errors.push(
+        `${gate.name}: ${linePct.toFixed(2)}% line coverage over ${String(files)} non-exempt file(s) ` +
+          `— below the ${String(gate.floorLines)}% floor.`,
+      );
+    }
+    results.push({ name: gate.name, floorLines: gate.floorLines, files, linePct, ok });
+  }
+
+  return { ok: errors.length === 0, results, errors };
+}
+
+if (import.meta.main) {
+  const lcovPath = process.argv[2] ?? "coverage/lcov.info";
+  let text: string;
+  try {
+    text = readFileSync(lcovPath, "utf8");
+  } catch {
+    console.error(
+      `audit:coverage-scopes: cannot read ${lcovPath}. Run \`bun run audit:coverage-floor:build-lcov\` first (CI-Linux authoritative).`,
+    );
+    process.exit(1);
+  }
+
+  const result = checkScopes(text);
+  for (const r of result.results) {
+    const mark = r.ok ? "ok  " : "FAIL";
+    console.log(
+      `  ${mark} ${r.name.padEnd(16)} ${r.linePct.toFixed(1).padStart(6)}% >= ${String(r.floorLines).padStart(2)}%  (${String(r.files)} files)`,
+    );
+  }
+  if (!result.ok) {
+    for (const e of result.errors) console.error(`audit:coverage-scopes: ${e}`);
+    process.exit(1);
+  }
+  console.log(`audit:coverage-scopes: ok (${String(SCOPE_GATES.length)} scopes)`);
+}

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -120,6 +120,9 @@ const FULL: readonly Gate[] = [
     tier: "full",
   },
   { name: "audit:coverage-floor", cmd: ["bun", "run", "audit:coverage-floor"], tier: "full" },
+  // Same input as the floor gate above (coverage/lcov.info), so it belongs in
+  // the same tier — it needs build-lcov to have run.
+  { name: "audit:coverage-scopes", cmd: ["bun", "run", "audit:coverage-scopes"], tier: "full" },
 ];
 
 export const PREFLIGHT_GATES: readonly Gate[] = [...FAST, ...FULL];


### PR DESCRIPTION
CLAUDE.md advertises "Coverage gates in CI: Engine ≥85%, Vault ≥90%, Embedding
≥80%, plus scheduler/rate-limiter/people". **All 24 of those gates passed
unconditionally.** ~30 CI jobs ran full test suites and asserted nothing.

## Two independent causes, both verified on Bun 1.3.14

**1. The flag does not exist.** `bun test --help` lists only `--coverage`,
`--coverage-reporter` and `--coverage-dir`. There is no
`--coverage-threshold-lines`, and Bun ignores unknown flags silently:

```
$ bun test lib.test.js --totally-bogus-flag=7      → exit 0
$ bun test lib.test.js --coverage --coverage-threshold-lines=99   → exit 0
```

…at **28%** line coverage. Worse than silent: `--coverage` *does* work, so the
coverage table prints and the run looks like it is being measured.

**2. Collection is off anyway.** `bunfig.toml` sets `[test] coverage = false`.
Under it, even an explicit `--coverage --coverage-reporter=lcov
--coverage-dir=X` writes **no lcov at all** — so there was nothing for a
threshold to read even in principle. Verified: the directory is never created.

Proved positively too — moving the same threshold to where Bun actually reads
it (`[test.coverageThreshold]` with `coverage = true`) exits **1** on the same
fixture. The mechanism works; the spelling never reached it.

## The fix

`audit:coverage-scopes` asserts the same 24 floors against the merged
`coverage/lcov.info` that `audit:coverage-floor` already consumes, wired into
the Linux job immediately after it. **No extra test run and no extra CI
minutes.**

Measured against CI's real merged lcov (main @ `de196f8c`) — every scope passes
today, so this is not a ratchet reset:

```
ok  Engine      97.1% >= 85%      ok  Vault      100.0% >= 90%
ok  Embedding   97.1% >= 80%      ok  Sandbox    100.0% >= 80%
ok  MCP conn.   95.8% >= 70%      ok  Deployment  87.1% >= 80%   … 24/24
```

Two deliberate semantics, both chosen to match the existing floor gate:

- **Exempt files are out of the denominator.** With them in, `vault` reads
  89.9% and `sandbox` 65.5% — numbers that describe how much untestable per-OS
  glue a scope contains, not how well its testable code is covered. Both are
  100% over non-exempt files.
- **A scope matching zero files FAILS.** These predicates name directories, and
  directories get renamed; a silently-empty scope is exactly the shape of gate
  that cannot fail.

## What I deliberately did *not* do

The audit that surfaced this recommended deleting the ~30 now-pointless jobs.
**That would have been a real regression.** Those jobs do work the main suite
does not:

- the **Sandbox** job builds the sandbox helper and runs
  `cppcheck --enable=all --error-exitcode=1` over its C source — a genuine
  static gate — then `setcap`s the binary;
- the **Vault** job installs libsecret + D-Bus and runs under
  `run-with-optional-dbus.sh`.

Delete them and that static analysis disappears while those tests quietly start
skipping. They stay. Their `--coverage-threshold-lines` arguments are left in
place too — inert either way, and stripping 25 script bodies would churn the
`coverage-gates-pal` matrix, `audit:coverage-gate-pal` and the docs in a change
whose point is enforcement. Called out below instead.

## Honesty about scope

This reads the **Linux** merged lcov, so the floors are enforced on Linux only.
That is not a regression — the per-OS jobs never enforced anything — but
`vault/win32.ts` (which carries I12) and `vault/darwin.ts` still have no floor
on their own platforms. That hole is real and is not closed here.

## Verification

- `bun run audit:coverage-scopes` against CI's downloaded lcov artifact: 24/24 ok.
- 8 new tests, including the two red-proves that matter: a scope one point below
  its floor **fails**, and an lcov where every scope matches nothing **fails**
  with `matched 0 non-exempt files` rather than reporting 24 passes.
- Exempt-file exclusion is pinned by a test that reads a real entry out of
  `EXCLUSIONS` rather than hardcoding a path.
- `bun test scripts/coverage-floor/` — 102 pass, 0 fail.
- `bun run preflight:fast` — all 29 gates pass, including `audit:coverage-gate-pal`
  (untouched by design) and `audit:doc-refs`.
- Docs corrected in CLAUDE.md, GEMINI.md and the `nimbus-commands` skill: they
  now name the mechanism that enforces the floors and state plainly that the
  `test:coverage:*` flag does not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated coverage enforcement across 24 defined project areas.
  * Coverage checks now report each area’s results and fail when required floors are not met.
  * Added coverage-scope validation to full preflight checks and Linux CI workflows.

* **Bug Fixes**
  * Improved handling of excluded files, missing coverage data, and scopes without matching files.

* **Documentation**
  * Clarified how aggregate coverage thresholds are enforced and which commands perform validation.

* **Tests**
  * Added comprehensive tests for passing, failing, boundary, exclusion, and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->