### PR TITLE
ci(release): fail when the manifest names a version that was never tagged

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -260,10 +260,29 @@ jobs:
           # for `prs_created` below). Those two outputs come straight back from the action, so
           # they cannot race with themselves.
           if [ "${RELEASES_CREATED:-false}" != "true" ] && [ "${RECONCILED:-false}" != "true" ]; then
-            manifest_ver=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${HEAD_SHA}" \
-                             --jq '.content' | tr -d '\n' | base64 -d | jq -r '."."')
+            # Read and decode are separate, each with its own status check, so an
+            # auth/network failure is distinguishable from a manifest that is
+            # present but unreadable. Under `set -euo pipefail` a failed `gh api`
+            # aborts the step AT THE ASSIGNMENT, so a single combined pipeline
+            # would skip the guard below entirely and leave the operator a bare
+            # exit code. Fail-closed either way — this is about being able to
+            # tell the two apart.
+            #
+            # stderr is deliberately NOT folded into the value here, unlike the
+            # tag read below whose capture is only ever printed: this one is
+            # base64 that gets decoded, and a warning line prepended to it would
+            # corrupt the decode. gh's stderr still reaches the job log.
+            set +e
+            manifest_b64=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${HEAD_SHA}" --jq '.content')
+            manifest_rc=$?
+            set -e
+            if [ "$manifest_rc" -ne 0 ]; then
+              echo "::error::could not read .release-please-manifest.json at ${HEAD_SHA} (see the gh error above); refusing to guess."
+              exit 1
+            fi
+            manifest_ver=$(tr -d '\n' <<<"$manifest_b64" | base64 -d 2>/dev/null | jq -r '."."' 2>/dev/null || true)
             if [ -z "$manifest_ver" ] || [ "$manifest_ver" = "null" ]; then
-              echo "::error::could not read the manifest version at ${HEAD_SHA}; refusing to guess."
+              echo "::error::could not decode a version from the manifest at ${HEAD_SHA}; refusing to guess."
               exit 1
             fi
             set +e

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -218,6 +218,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
+          # Read explicitly rather than leaning on the runner's implicit GITHUB_SHA:
+          # this step runs under `set -u`, where an unset name is a hard error.
+          HEAD_SHA: ${{ github.sha }}
           RELEASES_CREATED: ${{ steps.release-please.outputs.releases_created }}
           PRS_CREATED: ${{ steps.release-please.outputs.prs_created }}
           RECONCILED: ${{ steps.reconcile.outputs.reconciled }}
@@ -234,6 +237,49 @@ jobs:
           if [ "${UNACCOUNTED:-0}" -gt 0 ]; then
             echo "::error::${UNACCOUNTED} merged release PR(s) left unaccounted for by the reconcile step above — read its warnings. A tag pointing at the wrong tree must be resolved by hand; tags are immutable (see CLAUDE.md), so the fix is to cut the next version, never to move the tag."
             exit 1
+          fi
+
+          # ANCHOR CHECK — the manifest version must exist as a tag.
+          #
+          # Checked here, ABOVE the commit comparison, because the comparison cannot see this
+          # failure: it baselines off the newest TAG, and the whole problem is that the manifest
+          # has moved on while the tag has not. On the run that started the #1183 -> #1184
+          # outage the merge commit was a `chore: release` — so `facing` was 0 and the guard
+          # exited "release-please correctly produced nothing" a few lines below, while the
+          # manifest had just advanced to a version that was never tagged.
+          #
+          # Why that is fatal rather than cosmetic: release-please finds its place by matching
+          # the manifest version to a tag. With no `v2.5.0` tag to anchor to, the next run
+          # re-walked all 915 commits, regenerated the entire changelog, picked up a months-old
+          # `Release-As:` trailer that only came back into range BECAUSE the anchor was lost,
+          # and wrote the manifest BACKWARDS to 1.12.0 — over a published 2.4.1. Every push
+          # after that failed, and no release could be cut at all.
+          #
+          # Skipped when this run cut or reconciled a release: the tag was created moments ago
+          # and a read issued seconds after a write can still miss it (the same race documented
+          # for `prs_created` below). Those two outputs come straight back from the action, so
+          # they cannot race with themselves.
+          if [ "${RELEASES_CREATED:-false}" != "true" ] && [ "${RECONCILED:-false}" != "true" ]; then
+            manifest_ver=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${HEAD_SHA}" \
+                             --jq '.content' | tr -d '\n' | base64 -d | jq -r '."."')
+            if [ -z "$manifest_ver" ] || [ "$manifest_ver" = "null" ]; then
+              echo "::error::could not read the manifest version at ${HEAD_SHA}; refusing to guess."
+              exit 1
+            fi
+            set +e
+            tag_out=$(gh api "repos/${REPO}/git/ref/tags/v${manifest_ver}" 2>&1)
+            tag_rc=$?
+            set -e
+            if [ "$tag_rc" -ne 0 ]; then
+              if grep -qi 'not found' <<<"$tag_out"; then
+                echo "::error::the manifest declares ${manifest_ver} but tag v${manifest_ver} does not exist — a release was consumed without being cut. release-please has lost its anchor and the NEXT run will re-walk the whole history."
+                echo "::error::Do NOT create the tag by hand to silence this, and do NOT add a Release-As: trailer. Reconcile the manifest to the newest tag that IS published (see CLAUDE.md on immutable tags), then let the next user-facing commit cut the following version."
+              else
+                echo "::error::could not verify tag v${manifest_ver}, refusing to guess: ${tag_out}"
+              fi
+              exit 1
+            fi
+            echo "Anchor ok: manifest ${manifest_ver} has tag v${manifest_ver}."
           fi
 
           # Baseline off the newest `vX.Y.Z` TAG, not `releases/latest`. The tag is what marks


### PR DESCRIPTION
Adds the one check that would have caught the #1183 → #1184 release outage on
the run it started, rather than two releases later with the pipeline already
dead.

## What the guard could not see

release-please finds its place by matching the manifest version to a tag. When
a release PR merges, the merge writes the new version into
`.release-please-manifest.json` and the run is supposed to create the matching
tag. On #1183 the manifest advanced to `2.5.0` and **no `v2.5.0` tag was ever
created**.

Every existing signal read healthy:

- the merge commit was `chore: release main`, so `facing` was **0** and the
  guard exited a few lines later with *"No feat/fix since v2.4.1 —
  release-please correctly produced nothing"*;
- `prs_created` was **true**, because the run had opened the *next* release PR;
- `unaccounted` was **0**, because the reconcile step keys off the
  `autorelease: pending` label, which that PR did not carry.

The commit comparison structurally cannot catch this: it baselines off the
newest **tag**, and the entire failure is that the manifest moved on while the
tag did not.

## Why that is fatal rather than cosmetic

With no `v2.5.0` to anchor to, the next run re-walked the whole history —
`commits: 915` in its own log — regenerated the entire changelog, and picked up
a `Release-As: 1.12.0` trailer from 2026-08-11 that was **only back in range
because the anchor was lost**. It then wrote the manifest *backwards* to
`1.12.0`, over a published `2.4.1`, and took `package.json` and
`GATEWAY_VERSION` with it. Every subsequent push failed and no release could be
cut at all until #1188.

## The check

Placed **above** the commit comparison, next to the `unaccounted` check, for
exactly the reason above — below it, `facing == 0` short-circuits first.

> the manifest declares 2.5.0 but tag v2.5.0 does not exist — a release was
> consumed without being cut. release-please has lost its anchor and the NEXT
> run will re-walk the whole history.

It also says what *not* to do, because both obvious reflexes make it worse:
hand-creating the tag silences the symptom while leaving the tag pointing at
whatever tree is current, and a `Release-As:` trailer cuts a second version on
top. The message points at reconciling the manifest to the newest published tag
instead.

Skipped when `releases_created` or `reconciled` is true — the tag was created
moments earlier and a read issued seconds after a write can still miss it. Both
come straight back from the action, so they cannot race with themselves; this
is the same discipline the `prs_created` note below already documents.

## Verification

The block was **executed**, not eyeballed — lifted verbatim into a container
with a stubbed `gh`, across all four states:

| scenario | result |
|---|---|
| healthy: manifest 2.4.1, tag exists | `exit 0` — `Anchor ok` |
| **the #1183 failure: manifest 2.5.0, no tag** | **`exit 1`** with the anchor error |
| release cut this run (`releases_created=true`), tag not yet readable | `exit 0` — skipped, no race |
| reconcile created it this run (`reconciled=true`) | `exit 0` — skipped |

`HEAD_SHA` is passed explicitly rather than leaning on the runner's implicit
`GITHUB_SHA`, because this step runs under `set -u` where an unset name is a
hard error.

- `bun run audit:workflow-lint` — OK (25 workflows)
- `bun run preflight:fast` — all 29 gates pass

Against `main` as it stands today (manifest `2.4.1`, tag `v2.4.1` published)
this guard passes, so it does not red the branch on landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation by confirming the workflow commit matches a corresponding version tag.
  * Added clear failure handling for missing release manifests, tags, and tag lookup errors.
  * Added confirmation logging when release verification succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->