### PR TITLE
ci(audit): make audit:doc-refs actually scan the skill files

### DIFF
--- a/.claude/commands/nimbus-architecture.md
+++ b/.claude/commands/nimbus-architecture.md
@@ -177,7 +177,7 @@ Full walkthrough: `docs/contributors/extension-author-walkthrough.md`
 | New CLI subcommand | `packages/cli/src/commands/<name>.ts` |
 | New IPC method | `packages/gateway/src/ipc/<namespace>-rpc.ts` |
 | New connector | `packages/mcp-connectors/<service>/` |
-| New DB table / migration | `packages/gateway/src/db/migrations/` |
+| New DB table / migration | `packages/gateway/src/index/migrations/` |
 | New engine capability | `packages/gateway/src/engine/` |
 | New Vault backend | `packages/gateway/src/vault/<platform>.ts` |
 | New Tauri UI page | `packages/ui/src/pages/<Name>.tsx` |

--- a/scripts/structure-audit/check-doc-references.test.ts
+++ b/scripts/structure-audit/check-doc-references.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+import { DOCS_GLOBS, extractMarkdownLinks, maskInlineCode } from "./check-doc-references.ts";
+
+const REPO_ROOT = new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+
+/**
+ * The bug this file exists for: every `DOCS_GLOBS` pattern lives under
+ * `.claude/`, and `Bun.Glob.scan` skips dot-directories unless `dot: true` is
+ * passed. The glob was declared, matched nothing, and the gate reported "all
+ * resolve" over only its hardcoded list — so 21 skill files went unchecked for
+ * as long as the glob existed.
+ */
+describe("DOCS_GLOBS — dot-directory scanning", () => {
+  test("every glob targets a dot-directory, which is why dot:true is required", () => {
+    expect(DOCS_GLOBS.length).toBeGreaterThan(0);
+    for (const pattern of DOCS_GLOBS) expect(pattern.startsWith(".")).toBe(true);
+  });
+
+  test("scanning WITHOUT dot:true finds nothing — the original defect", () => {
+    for (const pattern of DOCS_GLOBS) {
+      const hits = [...new Glob(pattern).scanSync({ cwd: REPO_ROOT })];
+      expect(hits).toHaveLength(0);
+    }
+  });
+
+  test("scanning WITH dot:true finds the skill files", () => {
+    let total = 0;
+    for (const pattern of DOCS_GLOBS) {
+      total += [...new Glob(pattern).scanSync({ cwd: REPO_ROOT, dot: true })].length;
+    }
+    // Deliberately a floor, not an equality: skills get added and removed, and a
+    // brittle count would fail for the wrong reason. Zero is the failure mode
+    // that matters.
+    expect(total).toBeGreaterThan(10);
+  });
+});
+
+describe("maskInlineCode", () => {
+  test("blanks span contents", () => {
+    const span = "`foo/bar.ts`";
+    expect(maskInlineCode(`see ${span} now`)).toBe(`see ${" ".repeat(span.length)} now`);
+  });
+
+  test("preserves length exactly, so byte offsets still map to the right line", () => {
+    const text = "a `b` c\n`d`\nplain";
+    expect(maskInlineCode(text)).toHaveLength(text.length);
+    // Newlines outside spans must survive, or the line reporter drifts.
+    expect(maskInlineCode(text).split("\n")).toHaveLength(3);
+  });
+
+  test("leaves text outside spans untouched", () => {
+    expect(maskInlineCode("[real](docs/a.md)")).toBe("[real](docs/a.md)");
+  });
+});
+
+describe("extractMarkdownLinks", () => {
+  test("finds a real markdown link", () => {
+    const found = [...extractMarkdownLinks("see [docs](docs/roadmap.md) here")];
+    expect(found.map((f) => f.raw)).toEqual(["docs/roadmap.md"]);
+  });
+
+  /**
+   * `nimbus-file-map.md` describes this very gate as catching "broken
+   * `[text](path)` and backtick path refs". Read literally that is a link to a
+   * file named `path`, and the gate reported it as a broken reference.
+   */
+  test("ignores a link that is quoted inside an inline code span", () => {
+    const line = "Doc-ref drift audit (broken `[text](path)` and backtick path refs)";
+    expect([...extractMarkdownLinks(line)]).toHaveLength(0);
+  });
+
+  test("still finds a real link on a line that also quotes syntax", () => {
+    const line = "syntax is `[text](path)` — see [the map](docs/architecture.md)";
+    expect([...extractMarkdownLinks(line)].map((f) => f.raw)).toEqual(["docs/architecture.md"]);
+  });
+
+  test("reports an offset that lands on the right line", () => {
+    const text = "line one\nline two\nsee [x](docs/a.md)";
+    const [hit] = [...extractMarkdownLinks(text)];
+    expect(hit).toBeDefined();
+    expect(text.slice(0, hit?.offset ?? 0).split("\n")).toHaveLength(3);
+  });
+});

--- a/scripts/structure-audit/check-doc-references.ts
+++ b/scripts/structure-audit/check-doc-references.ts
@@ -94,7 +94,18 @@ const DOCS_FILES = [
   "docs/license-policy.md",
 ];
 
-const DOCS_GLOBS = [".claude/commands/*.md"];
+/**
+ * Globbed doc sources, in ADDITION to the explicit list above.
+ *
+ * These live under a dot-directory, and `Bun.Glob.scan` skips dot-directories
+ * unless `dot: true` is passed — so for as long as this glob has existed it
+ * matched ZERO files and every skill went unchecked. Measured:
+ * `new Glob(".claude/commands/*.md").scanSync({cwd})` yields 0, the same call
+ * with `{dot: true}` yields 21. The gate reported "all resolve" across 16 docs
+ * — the hardcoded list — while the 21 files it was added to cover were never
+ * opened. See `gatherDocs`, which now passes `dot: true`.
+ */
+export const DOCS_GLOBS = [".claude/commands/*.md", ".claude/agents/*.md"];
 
 function hasRejectChar(s: string): boolean {
   for (const ch of PATH_REJECT_CHARS) if (s.includes(ch)) return true;
@@ -134,9 +145,27 @@ function offsetToLine(text: string, offset: number): number {
   return line;
 }
 
-function* extractMarkdownLinks(text: string): Generator<{ raw: string; offset: number }> {
+/**
+ * Blank the CONTENTS of inline code spans, preserving length (and therefore
+ * every byte offset, which the line reporter depends on).
+ *
+ * A doc that documents link syntax writes it in backticks — this gate's own
+ * entry in `nimbus-file-map.md` describes itself as catching "broken
+ * `[text](path)` and backtick path refs". Read literally, that is a link to a
+ * file named `path`, and the gate reported it as broken. Quoted syntax is not
+ * a reference.
+ *
+ * Only the markdown-LINK pass masks: `extractBacktickPaths` deliberately reads
+ * inside backticks, since a backticked path IS a reference there.
+ */
+export function maskInlineCode(text: string): string {
+  return text.replace(/`([^`\n]*)`/g, (whole) => " ".repeat(whole.length));
+}
+
+export function* extractMarkdownLinks(text: string): Generator<{ raw: string; offset: number }> {
   const re = /\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
-  for (const m of text.matchAll(re)) {
+  const masked = maskInlineCode(text);
+  for (const m of masked.matchAll(re)) {
     if (m[1] !== undefined && m.index !== undefined) {
       yield { raw: m[1], offset: m.index };
     }
@@ -268,7 +297,9 @@ async function gatherDocs(): Promise<string[]> {
     if (existsSync(join(REPO_ROOT, d))) docs.push(d);
   }
   for (const pattern of DOCS_GLOBS) {
-    for await (const rel of new Glob(pattern).scan({ cwd: REPO_ROOT })) {
+    // `dot: true` is load-bearing: every DOCS_GLOBS pattern is under `.claude/`,
+    // and without it Glob.scan silently matches nothing.
+    for await (const rel of new Glob(pattern).scan({ cwd: REPO_ROOT, dot: true })) {
       docs.push(rel.replaceAll("\\", "/"));
     }
   }
@@ -311,4 +342,8 @@ async function run(): Promise<void> {
   process.exit(1);
 }
 
-await run();
+// Guarded so the module can be imported by tests. Without it, `import` runs the
+// whole audit as a side effect — and `run()` calls `process.exit(1)` on a broken
+// reference, which would kill the importing test process. `bun run audit:doc-refs`
+// still executes it: `import.meta.main` is true when the file is the entry point.
+if (import.meta.main) await run();


### PR DESCRIPTION
`audit:doc-refs` declares `.claude/commands/*.md` as a doc source. It has been
matching **zero files** for as long as that glob has existed.

`Bun.Glob.scan` skips dot-directories unless `dot: true` is passed, and every
`DOCS_GLOBS` pattern lives under `.claude/`. Measured directly:

```
new Glob(".claude/commands/*.md").scanSync({cwd})              → 0
new Glob(".claude/commands/*.md").scanSync({cwd, dot: true})   → 21
```

So the gate reported *"688 refs across 16 docs — all resolve"* — the hardcoded
list only — while the 21 files the glob was added to cover were never opened.
Every path, command and count in the skills was unchecked, which is why the
drift below survived.

**After:** `1172 refs across 41 docs` — a 70% increase in what is actually
verified. `.claude/agents/*.md` is added too; it was not in `DOCS_GLOBS` at all.

## What turning it on immediately caught

**1. A real defect in `nimbus-architecture.md`.** Its "where does new code go"
table sent every new migration to `packages/gateway/src/db/migrations/` — a
directory that does not exist. The real location is
`packages/gateway/src/index/migrations/`, which is also what the
`nimbus-db-migrations` skill says, so the two skills contradicted each other and
an agent following the architecture table would create a file the migration
runner never reads.

**2. A false positive in the gate itself.** `nimbus-file-map.md` describes this
very gate as catching "broken `` `[text](path)` `` and backtick path refs".
Read literally that is a link to a file named `path`. Quoted syntax is not a
reference, so the markdown-link pass now masks inline code spans first —
preserving length, so byte offsets still map to the correct line.
`extractBacktickPaths` deliberately does **not** mask, because a backticked
path *is* a reference there.

## Making it testable

The module had **no exports and no tests** — it ended in a bare top-level
`await run()`, so importing it executed the whole audit and could
`process.exit(1)` in the importing process. That is precisely why a gate this
load-bearing had no cover. It is now `if (import.meta.main) await run()`, which
leaves `bun run audit:doc-refs` unchanged (`import.meta.main` is true when it is
the entry point) and makes the helpers importable.

## Verification

10 new tests, including the direct red-prove of the defect: scanning each glob
**without** `dot: true` asserts zero hits, and **with** it asserts a non-zero
floor. The false-positive fix is pinned by the real `nimbus-file-map.md` line,
plus a case proving a genuine link on the *same* line is still found — masking
must not blind the pass.

- `bun test ./scripts/structure-audit/check-doc-references.test.ts` — 10 pass, 0 fail
- `bun run audit:doc-refs` — 1172 refs across 41 docs, all resolve
- `bun run preflight:fast` — all 29 gates pass

The skill-file count assertion is a floor rather than an equality on purpose:
skills get added and removed, and a brittle count would fail for the wrong
reason. Zero is the failure mode that matters.
