### PR TITLE
ci(org): bring create-nimbus-connector inside the org-drift gates

### DIFF
--- a/.github/rulesets/general-branch.json
+++ b/.github/rulesets/general-branch.json
@@ -33,8 +33,16 @@
       "nimbus-client": [],
       "nimbus-sdk": [],
       "nimbus-vscode": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
-      "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }]
+      "nimbus-web-clipper": [{ "actor_type": "OrganizationAdmin", "bypass_mode": "always" }],
+      "create-nimbus-connector": []
     }
   },
-  "repos": ["Nimbus", "nimbus-client", "nimbus-sdk", "nimbus-vscode", "nimbus-web-clipper"]
+  "repos": [
+    "Nimbus",
+    "nimbus-client",
+    "nimbus-sdk",
+    "nimbus-vscode",
+    "nimbus-web-clipper",
+    "create-nimbus-connector"
+  ]
 }

--- a/.github/workflows/org-drift-sweep.yml
+++ b/.github/workflows/org-drift-sweep.yml
@@ -29,6 +29,7 @@ jobs:
           - nimbus-sdk
           - nimbus-vscode
           - nimbus-web-clipper
+          - create-nimbus-connector
           - .github
           - linux-repo
           - homebrew-tap
@@ -74,7 +75,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
-          repositories: Nimbus,nimbus-client,nimbus-sdk,nimbus-vscode,nimbus-web-clipper
+          repositories: Nimbus,nimbus-client,nimbus-sdk,nimbus-vscode,nimbus-web-clipper,create-nimbus-connector
           # Administration:read is what `GET /repos/{o}/{r}/rulesets` needs. Note it
           # is NOT sufficient to read `bypass_actors` for org-level actors
           # (OrganizationAdmin comes back empty) — proven live that even adding
@@ -161,7 +162,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
-          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,awesome-nimbus,create-nimbus-connector
           # cla-coverage reads .github/workflows/cla.yml from each gated repo — contents:read.
           permission-contents: read
       - name: Audit CLA coverage
@@ -193,7 +194,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: nimbus-agent
-          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper
+          repositories: Nimbus,nimbus-sdk,nimbus-client,nimbus-vscode,nimbus-web-clipper,create-nimbus-connector
           # review-coverage reads .coderabbit.yaml from each gated repo — contents:read.
           permission-contents: read
       - name: Audit review coverage

--- a/scripts/structure-audit/check-bypass-actors.test.ts
+++ b/scripts/structure-audit/check-bypass-actors.test.ts
@@ -86,10 +86,15 @@ describe("validateDeclaredBypass", () => {
 });
 
 describe("loadDeclaredBypass", () => {
-  test("the checked-in config is valid and covers all five active repos", () => {
+  test("the checked-in config is valid and covers all six active repos", () => {
     const file = loadDeclaredBypass(process.cwd());
     expect(validateDeclaredBypass(file)).toEqual([]);
-    expect(file.repos.length).toBe(5);
+    // The count is deliberately exact rather than a floor: adding a repo to the
+    // managed set must be a reviewed decision, not something that rides along.
+    // create-nimbus-connector was the sixth — it publishes to npm and had been
+    // outside every drift gate.
+    expect(file.repos.length).toBe(6);
+    expect(file.repos).toContain("create-nimbus-connector");
     expect(Object.keys(file.bypass.by_repo).sort()).toEqual([...file.repos].sort());
   });
 });

--- a/scripts/structure-audit/check-cla-coverage.ts
+++ b/scripts/structure-audit/check-cla-coverage.ts
@@ -27,6 +27,12 @@ const GATED_REPOS = [
   "nimbus-vscode",
   "nimbus-web-clipper",
   "awesome-nimbus",
+  // Publishes to npm and takes outside contributions like the rest, but was
+  // absent from every org-drift list — this one, review-coverage's, the
+  // ruleset baseline and the sha-pins matrix. Widening the workflow's App-token
+  // `repositories:` scope alone would NOT have gated it: this list is the one
+  // the audit actually iterates.
+  "create-nimbus-connector",
 ];
 
 /**

--- a/scripts/structure-audit/check-review-coverage.ts
+++ b/scripts/structure-audit/check-review-coverage.ts
@@ -53,6 +53,10 @@ const GATED_REPOS = [
   "nimbus-client",
   "nimbus-vscode",
   "nimbus-web-clipper",
+  // Has a source tree and takes PRs, so a review pass is worth asserting. It
+  // already carries a `.coderabbit.yaml` with `auto_review.enabled: true`;
+  // adding it here is what makes that a gated fact rather than a coincidence.
+  "create-nimbus-connector",
 ];
 
 export const EXEMPT_REPOS: Readonly<Record<string, string>> = {


### PR DESCRIPTION
`create-nimbus-connector` publishes to npm, has 9 workflows and a live `General`
ruleset — and sat outside **every** list that keeps the org consistent:

| gate | before |
|---|---|
| `general-branch.json` `repos` (ruleset drift) | absent |
| `general-branch.json` `bypass.by_repo` | absent |
| `org-drift-sweep.yml` sha-pins matrix | absent |
| `check-cla-coverage.ts` `GATED_REPOS` | absent |
| `check-review-coverage.ts` `GATED_REPOS` | absent |
| the three App-token `repositories:` scopes | absent |

So its branch protection, action pinning, CLA workflow and review config could
drift indefinitely without anything going red.

## The part that would have made this change fake

Adding it to the workflow's `repositories:` scopes is **necessary but not
sufficient** — that only widens the App token. `check-cla-coverage.ts` and
`check-review-coverage.ts` iterate their own hardcoded `GATED_REPOS` consts,
so the audits would have kept checking the old set and still reported green.
Only `check-ruleset-drift.ts` reads `general-branch.json`.

I caught that because the counts did not move: after the workflow-only edit the
audits still printed `OK (6 repos)` and `OK (5 repos, 1 exempt)`. With the
consts updated they print:

```
audit:ruleset-drift:   OK (6 repos)          # was 5
audit:cla-coverage:    OK (7 repos)          # was 6
audit:review-coverage: OK (6 repos, 1 exempt) # was 5
```

The count moving is the evidence the repo is actually being checked rather than
merely listed.

## Verified it does not red the weekly sweep

Checked against live GitHub **before** adding it, since a scheduled workflow
going red on Monday is the failure mode here:

- **Ruleset shape** — its `General` ruleset's comparable fields (name, target,
  enforcement, ref conditions, every `pull_request` parameter) are **byte-identical**
  to Nimbus's. It carries all three `required_rule_types`. The baseline
  deliberately does not diff `required_status_checks`/`code_quality`, which is
  where it legitimately differs (its contexts are `check`, `cla-assistant`,
  `Analyze (javascript-typescript)`).
- **Bypass actors** — genuinely empty, so `"create-nimbus-connector": []` is the
  honest entry rather than a placeholder.
- **Action pinning** — all 22 `uses:` refs across its 8 workflows are 40-hex
  SHA-pinned.
- **CLA** — `cla.yml` present, pinned to `contributor-assistant/github-action@ca4a40a7…`
  — the *same* SHA as Nimbus's.
- **Review config** — `.coderabbit.yaml` present with `reviews.auto_review.enabled: true`.

Then all three audits were run locally against the real API with it included:
all pass, counts as above.

- `bun test` over the three audits' test files — 44 pass, 0 fail
- `bun run preflight:fast` — all 29 gates pass

## Not included

The sha-pins matrix entry is added, but that job checks out each repo in CI, so
its verification happens on the next sweep rather than here. Its pinning is
already clean per the scan above, so it should pass; if it does not, it will
say which ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded repository governance coverage for additional projects.
  * Updated automated checks for branch protection, contributor agreement coverage, review coverage, and configuration consistency.
  * Added required workflow verification for newly covered repositories.

* **Impact**
  * Improves consistency and compliance across managed projects.
  * No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->