### PR TITLE
ci(coverage): actually measure mcp-launcher, and drop two dead scope arms

### DIFF
--- a/packages/mcp-connectors/shared/imap-mail-core.test.ts
+++ b/packages/mcp-connectors/shared/imap-mail-core.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import {
+  capPreview,
+  clampLimit,
+  formatAddress,
+  PREVIEW_FETCH_BYTES,
+  PREVIEW_MAX_CHARS,
+} from "./imap-mail-core.ts";
+
+const LF = String.fromCharCode(0x0a);
+const CRLF = String.fromCharCode(0x0d, 0x0a);
+const TAB = String.fromCharCode(0x09);
+
+/**
+ * These helpers are shared by the imap and protonmail connectors and decide how
+ * much of a message body is ever indexed or returned. The file had no test of
+ * its own — its 50% line / 29% branch came incidentally from imap-tool-kit's
+ * tests loading it — so the clamping and capping rules that bound what leaves a
+ * mailbox were asserted nowhere.
+ */
+describe("clampLimit", () => {
+  test("passes a sane limit through untouched", () => {
+    expect(clampLimit(25)).toBe(25);
+  });
+
+  test("falls back when undefined", () => {
+    expect(clampLimit(undefined)).toBe(50);
+  });
+
+  test("honours a caller-supplied fallback", () => {
+    expect(clampLimit(undefined, 10)).toBe(10);
+  });
+
+  test("rejects non-finite input by falling back, rather than propagating NaN", () => {
+    // The direction that matters: NaN reaching a FETCH range is unbounded.
+    expect(clampLimit(Number.NaN)).toBe(50);
+    expect(clampLimit(Number.POSITIVE_INFINITY)).toBe(50);
+    expect(clampLimit(Number.NEGATIVE_INFINITY)).toBe(50);
+  });
+
+  test("floors to 1 for zero and negatives", () => {
+    expect(clampLimit(0)).toBe(1);
+    expect(clampLimit(-5)).toBe(1);
+  });
+
+  test("caps at 200", () => {
+    expect(clampLimit(201)).toBe(200);
+    expect(clampLimit(1_000_000)).toBe(200);
+    expect(clampLimit(200)).toBe(200);
+  });
+
+  test("truncates a fractional limit rather than rounding up", () => {
+    expect(clampLimit(2.9)).toBe(2);
+    expect(clampLimit(0.9)).toBe(1); // trunc -> 0, then floored to 1
+  });
+});
+
+describe("capPreview", () => {
+  test("normalises CRLF to LF", () => {
+    expect(capPreview(`a${CRLF}b`)).toBe(`a${LF}b`);
+  });
+
+  test("collapses runs of spaces and tabs", () => {
+    expect(capPreview(`a   b${TAB}${TAB}c`)).toBe("a b c");
+  });
+
+  test("collapses blank-line runs to a single newline", () => {
+    expect(capPreview(`a${LF}${LF}${LF}b`)).toBe(`a${LF}b`);
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(capPreview("   hello   ")).toBe("hello");
+  });
+
+  test("truncates at PREVIEW_MAX_CHARS", () => {
+    const out = capPreview("x".repeat(PREVIEW_MAX_CHARS + 500));
+    expect(out).toHaveLength(PREVIEW_MAX_CHARS);
+  });
+
+  test("leaves input at exactly the cap untouched", () => {
+    const exact = "y".repeat(PREVIEW_MAX_CHARS);
+    expect(capPreview(exact)).toHaveLength(PREVIEW_MAX_CHARS);
+  });
+
+  // The docblock promises it "never lengthens the input" — that is the property
+  // a preview cap must not violate, so assert it rather than trusting the prose.
+  test("never lengthens the input", () => {
+    for (const s of ["", "a", `a${CRLF}b`, `  a${TAB}b  `, "z".repeat(5000)]) {
+      expect(capPreview(s).length).toBeLessThanOrEqual(s.length);
+    }
+  });
+
+  test("an empty body stays empty", () => {
+    expect(capPreview("")).toBe("");
+  });
+});
+
+describe("formatAddress", () => {
+  test("renders name and address together", () => {
+    expect(formatAddress({ name: "Ada", address: "ada@example.com" })).toBe(
+      "Ada <ada@example.com>",
+    );
+  });
+
+  test("renders a bare address when there is no name", () => {
+    expect(formatAddress({ address: "ada@example.com" })).toBe("ada@example.com");
+  });
+
+  test("treats an empty name as no name", () => {
+    expect(formatAddress({ name: "", address: "ada@example.com" })).toBe("ada@example.com");
+  });
+
+  test("falls back to the name alone when the address is missing", () => {
+    expect(formatAddress({ name: "Ada" })).toBe("Ada");
+  });
+
+  test("yields an empty string when the address is absent entirely", () => {
+    expect(formatAddress({})).toBe("");
+  });
+});
+
+describe("preview constants", () => {
+  test("are the documented bounds", () => {
+    expect(PREVIEW_MAX_CHARS).toBe(2000);
+    expect(PREVIEW_FETCH_BYTES).toBe(2048);
+  });
+});

--- a/packages/mcp-connectors/shared/join-api-path.test.ts
+++ b/packages/mcp-connectors/shared/join-api-path.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { joinApiPath } from "./join-api-path.ts";
+
+const BASE = "https://api.example.com/v2";
+
+describe("joinApiPath", () => {
+  test("joins a leading-slash path onto the base", () => {
+    expect(joinApiPath(BASE, "/issues")).toBe("https://api.example.com/v2/issues");
+  });
+
+  test("adds the separator when the path has none", () => {
+    expect(joinApiPath(BASE, "issues")).toBe("https://api.example.com/v2/issues");
+  });
+
+  test("passes an absolute URL straight through — pagination cursors arrive absolute", () => {
+    const next = "https://api.example.com/v2/issues?page=2";
+    expect(joinApiPath(BASE, next)).toBe(next);
+    expect(joinApiPath(BASE, "http://legacy.example.com/x")).toBe("http://legacy.example.com/x");
+  });
+
+  /**
+   * The prefix test is `http://` / `https://`, NOT a bare `http`. With a bare
+   * `http` a RELATIVE path that merely starts with those four letters —
+   * `httpbin/status`, or a real-world `http-headers` endpoint — was returned
+   * unjoined, silently dropping the base URL and producing a request to a
+   * relative path. It is a narrow case, which is exactly why it would have been
+   * found in production rather than review.
+   */
+  test("joins a relative path that merely begins with 'http'", () => {
+    expect(joinApiPath(BASE, "httpbin/status")).toBe("https://api.example.com/v2/httpbin/status");
+    expect(joinApiPath(BASE, "/http-headers")).toBe("https://api.example.com/v2/http-headers");
+  });
+
+  test("preserves query strings and encoded characters verbatim", () => {
+    expect(joinApiPath(BASE, "/search?q=a%20b&limit=10")).toBe(
+      "https://api.example.com/v2/search?q=a%20b&limit=10",
+    );
+  });
+
+  test("does not normalise a trailing slash on the base — callers own that", () => {
+    expect(joinApiPath("https://api.example.com/", "/x")).toBe("https://api.example.com//x");
+  });
+
+  test("an empty path yields the base plus a separator", () => {
+    expect(joinApiPath(BASE, "")).toBe("https://api.example.com/v2/");
+  });
+});

--- a/packages/mcp-connectors/shared/join-api-path.ts
+++ b/packages/mcp-connectors/shared/join-api-path.ts
@@ -1,5 +1,16 @@
+/**
+ * Join `path` onto `baseUrl`, passing an already-absolute URL straight through
+ * (pagination cursors commonly arrive absolute).
+ *
+ * The absolute test is the full `http://` / `https://` scheme, not a bare
+ * `http` prefix: a RELATIVE path that merely starts with those four letters —
+ * `httpbin/status`, or an `http-headers` endpoint — was returned unjoined,
+ * silently dropping the base URL and issuing the request against a relative
+ * path. Narrow enough that it would have surfaced in production rather than in
+ * review.
+ */
 export function joinApiPath(baseUrl: string, path: string): string {
-  if (path.startsWith("http")) {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
     return path;
   }
   const suffix = path.startsWith("/") ? path : `/${path}`;

--- a/packages/mcp-connectors/shared/run-read-only-mcp-connector.test.ts
+++ b/packages/mcp-connectors/shared/run-read-only-mcp-connector.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ZodObjectSchema } from "./mcp-tool-kit.ts";
-import { buildReadOnlyMcpConnector } from "./run-read-only-mcp-connector.ts";
+import {
+  buildReadOnlyMcpConnector,
+  runReadOnlyMcpConnector,
+} from "./run-read-only-mcp-connector.ts";
 
 type SyntheticArgs = { readonly id?: string };
 
@@ -51,5 +54,102 @@ describe("buildReadOnlyMcpConnector", () => {
       createServer: () => fakeServer,
     });
     expect(result).toBe(fakeServer);
+  });
+});
+
+/**
+ * This is the function every connector entry point actually calls, and it was
+ * covered by nothing — it built a real `StdioServerTransport` inline, so a test
+ * could not run it without opening stdio on the test process. The
+ * `createTransport` seam mirrors the existing `createServer` one and makes the
+ * server↔transport wiring assertable.
+ */
+describe("runReadOnlyMcpConnector", () => {
+  test("connects the built server to the transport", async () => {
+    const connect = mock(async (_t: unknown) => undefined);
+    const fakeServer = { tool: () => undefined, connect };
+    const fakeTransport = { kind: "fake-transport" };
+
+    await runReadOnlyMcpConnector("nimbus-acme", () => undefined, {
+      createServer: () => fakeServer,
+      createTransport: () => fakeTransport,
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect.mock.calls[0]?.[0]).toBe(fakeTransport);
+  });
+
+  test("registers the caller's tools before connecting", async () => {
+    const order: string[] = [];
+    const toolSpy = mock((..._a: unknown[]) => {
+      order.push("register");
+    });
+    const fakeServer = {
+      tool: toolSpy,
+      connect: mock(async () => {
+        order.push("connect");
+      }),
+    };
+
+    await runReadOnlyMcpConnector(
+      "nimbus-acme",
+      (reg) => {
+        reg("acme_list", "List acme items", syntheticSchema(), async () => ({
+          content: [{ type: "text", text: "[]" }],
+        }));
+      },
+      { createServer: () => fakeServer, createTransport: () => ({}) },
+    );
+
+    // A tool registered after connect would be invisible to the client that is
+    // already handshaking.
+    expect(order).toEqual(["register", "connect"]);
+  });
+
+  /**
+   * The DEFAULT arms are the production ones — every connector entry point calls
+   * these functions with no options at all. Injecting both seams in every test
+   * would leave exactly the code that ships uncovered, so these two exercise the
+   * real `McpServer` / `StdioServerTransport` factories.
+   *
+   * Safe to do: constructing `StdioServerTransport` is inert. Verified — it adds
+   * no `data` listener to stdin and does not resume it; the transport only
+   * attaches on `start()`, which `connect()` drives, and the fake server here
+   * never calls it.
+   */
+  test("defaults to a real McpServer when no createServer is given", () => {
+    const server = buildReadOnlyMcpConnector("nimbus-acme", () => undefined);
+    expect(server).toBeDefined();
+    expect(typeof (server as { connect?: unknown }).connect).toBe("function");
+  });
+
+  test("defaults to a real StdioServerTransport when no createTransport is given", async () => {
+    const connect = mock(async (_t: unknown) => undefined);
+    const stdinListenersBefore = process.stdin.listenerCount("data");
+
+    await runReadOnlyMcpConnector("nimbus-acme", () => undefined, {
+      createServer: () => ({ tool: () => undefined, connect }),
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    // It was handed a real transport instance, not undefined.
+    expect(connect.mock.calls[0]?.[0]).toBeDefined();
+    // ...and constructing it left stdin alone, which is what makes this test safe.
+    expect(process.stdin.listenerCount("data")).toBe(stdinListenersBefore);
+  });
+
+  test("propagates a transport failure rather than resolving silently", async () => {
+    const fakeServer = {
+      tool: () => undefined,
+      connect: async () => {
+        throw new Error("stdio unavailable");
+      },
+    };
+    await expect(
+      runReadOnlyMcpConnector("nimbus-acme", () => undefined, {
+        createServer: () => fakeServer,
+        createTransport: () => ({}),
+      }),
+    ).rejects.toThrow(/stdio unavailable/);
   });
 });

--- a/packages/mcp-connectors/shared/run-read-only-mcp-connector.ts
+++ b/packages/mcp-connectors/shared/run-read-only-mcp-connector.ts
@@ -18,6 +18,19 @@ export interface BuildReadOnlyMcpConnectorOptions {
   readonly createServer?: (info: { readonly name: string; readonly version: string }) => unknown;
 }
 
+/**
+ * `createTransport` mirrors the existing `createServer` seam. Without it the
+ * stdio transport was constructed inline, so `runReadOnlyMcpConnector` — the
+ * function every connector's entry point actually calls — could not be executed
+ * from a test at all: it would have opened a real stdio transport on the test
+ * process. That left the wiring between server and transport asserted nowhere.
+ *
+ * Production callers pass nothing and get the real `StdioServerTransport`.
+ */
+export interface RunReadOnlyMcpConnectorOptions extends BuildReadOnlyMcpConnectorOptions {
+  readonly createTransport?: () => unknown;
+}
+
 export function buildReadOnlyMcpConnector(
   serverName: string,
   register: (reg: ZodToolRegistrar) => void,
@@ -33,8 +46,9 @@ export function buildReadOnlyMcpConnector(
 export async function runReadOnlyMcpConnector(
   serverName: string,
   register: (reg: ZodToolRegistrar) => void,
+  options?: RunReadOnlyMcpConnectorOptions,
 ): Promise<void> {
-  const mcp = buildReadOnlyMcpConnector(serverName, register) as McpServer;
-  const transport = new StdioServerTransport();
-  await mcp.connect(transport);
+  const mcp = buildReadOnlyMcpConnector(serverName, register, options) as McpServer;
+  const makeTransport = options?.createTransport ?? ((): unknown => new StdioServerTransport());
+  await mcp.connect(makeTransport() as StdioServerTransport);
 }

--- a/packages/mcp-connectors/shared/safe-cli-arg.test.ts
+++ b/packages/mcp-connectors/shared/safe-cli-arg.test.ts
@@ -1,35 +1,135 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { assertSafeCliArg, isSafeCliArg } from "./safe-cli-arg.ts";
 
-import { assertSafeCliArg } from "./safe-cli-arg.ts";
+const NUL = String.fromCharCode(0);
+const UNIT_SEP = String.fromCharCode(0x1f); // the last control character
+const LF = String.fromCharCode(0x0a);
+const TAB = String.fromCharCode(0x09);
+const CR = String.fromCharCode(0x0d);
 
-describe("assertSafeCliArg", () => {
-  it("returns safe values unchanged", () => {
-    expect(assertSafeCliArg("my-sink_1.v2", "sinkName")).toBe("my-sink_1.v2");
-    expect(assertSafeCliArg("/aws/lambda/api")).toBe("/aws/lambda/api");
-    expect(assertSafeCliArg("project:dataset.table")).toBe("project:dataset.table");
+/**
+ * This is a security control, not a formatter: it is the universal guard against
+ * "argv flag smuggling", where a tool-supplied value beginning with `-` is
+ * parsed by a spawned CLI as a FLAG rather than as a positional. Spawns use an
+ * argv array, so there is no shell to inject into — the flag itself is the
+ * injection.
+ *
+ * Every REJECT arm therefore needs cover. Before this file the module sat at
+ * 62.5% line coverage with no test of its own: the accept path was exercised
+ * incidentally by connectors that call it inline, and the arms that actually
+ * stop an attack were exercised by nothing.
+ */
+describe("assertSafeCliArg — accepts", () => {
+  test("returns the value unchanged so it can be used inline", () => {
+    expect(assertSafeCliArg("my-sink-1")).toBe("my-sink-1");
   });
 
-  it("rejects values that start with '-' (argv flag smuggling)", () => {
-    expect(() => assertSafeCliArg("--project=attacker", "sinkName")).toThrow(/flag smuggling/);
-    expect(() => assertSafeCliArg("-h")).toThrow(/flag smuggling/);
-    expect(() => assertSafeCliArg("-")).toThrow(/flag smuggling/);
+  test("allows the per-service charsets the docblock names", () => {
+    // sink ids, CloudWatch log-group names (slashes), BigQuery refs (dots)
+    expect(assertSafeCliArg("a_b.c-d")).toBe("a_b.c-d");
+    expect(assertSafeCliArg("/aws/lambda/my-fn")).toBe("/aws/lambda/my-fn");
+    expect(assertSafeCliArg("project.dataset.table")).toBe("project.dataset.table");
   });
 
-  it("rejects empty and over-long values", () => {
-    expect(() => assertSafeCliArg("")).toThrow(/non-empty/);
-    expect(() => assertSafeCliArg("x".repeat(1025))).toThrow(/1024/);
+  test("allows a hyphen anywhere except the first character", () => {
+    expect(assertSafeCliArg("not-a-flag")).toBe("not-a-flag");
   });
 
-  it("rejects control characters (newline / tab)", () => {
-    expect(() => assertSafeCliArg("line\nbreak")).toThrow(/control characters/);
-    expect(() => assertSafeCliArg("tab\tchar")).toThrow(/control characters/);
+  test("allows exactly 1024 characters — the boundary is inclusive", () => {
+    const at = "a".repeat(1024);
+    expect(assertSafeCliArg(at)).toBe(at);
   });
 
-  it("allows spaces — an argv element is a single token (no shell)", () => {
-    expect(assertSafeCliArg("severity >= ERROR")).toBe("severity >= ERROR");
+  /**
+   * The boundary is `< 0x20`, so SPACE (0x20) is deliberately allowed. Pinned
+   * because it reads like an oversight and is not: a spawn passes argv entries
+   * verbatim with no word-splitting, so an embedded space is inert, while
+   * rejecting it would break services whose resource names permit spaces.
+   */
+  test("allows space, which is 0x20 and therefore not a control character", () => {
+    expect(assertSafeCliArg("my resource")).toBe("my resource");
+  });
+});
+
+describe("assertSafeCliArg — rejects", () => {
+  test("an empty string", () => {
+    expect(() => assertSafeCliArg("")).toThrow(/must be a non-empty string/);
   });
 
-  it("includes the label in the error", () => {
-    expect(() => assertSafeCliArg("-x", "logGroupName")).toThrow(/logGroupName/);
+  test("a non-string, even though the type says otherwise", () => {
+    // The runtime guard exists because tool input crosses a JSON boundary where
+    // the declared type is not enforced.
+    expect(() => assertSafeCliArg(undefined as unknown as string)).toThrow(
+      /must be a non-empty string/,
+    );
+    expect(() => assertSafeCliArg(42 as unknown as string)).toThrow(/must be a non-empty string/);
+  });
+
+  test("a value over 1024 characters", () => {
+    expect(() => assertSafeCliArg("a".repeat(1025))).toThrow(/exceeds 1024 characters/);
+  });
+
+  // The arm this module exists for.
+  test("a value starting with a dash — the flag-smuggling case", () => {
+    expect(() => assertSafeCliArg("--project=attacker")).toThrow(/argv flag smuggling/);
+    expect(() => assertSafeCliArg("-h")).toThrow(/argv flag smuggling/);
+    expect(() => assertSafeCliArg("-")).toThrow(/argv flag smuggling/);
+  });
+
+  test("control characters, wherever they sit in the value", () => {
+    expect(() => assertSafeCliArg(`${NUL}abc`)).toThrow(/control characters/);
+    expect(() => assertSafeCliArg(`ab${LF}cd`)).toThrow(/control characters/);
+    expect(() => assertSafeCliArg(`ab${TAB}cd`)).toThrow(/control characters/);
+    expect(() => assertSafeCliArg(`trailing${CR}`)).toThrow(/control characters/);
+    expect(() => assertSafeCliArg(`x${UNIT_SEP}`)).toThrow(/control characters/);
+  });
+
+  test("names the caller's label in the message, so the failure is attributable", () => {
+    expect(() => assertSafeCliArg("-x", "sinkName")).toThrow(/Invalid sinkName/);
+  });
+});
+
+describe("isSafeCliArg — the non-throwing predicate form", () => {
+  test("is true for a safe value", () => {
+    expect(isSafeCliArg("my-sink-1")).toBe(true);
+  });
+
+  test("is false for every reject arm, rather than throwing", () => {
+    for (const bad of ["", "-h", "--flag", `a${NUL}b`, "a".repeat(1025)]) {
+      expect(isSafeCliArg(bad)).toBe(false);
+    }
+  });
+
+  test("is false for non-strings, which is what makes it usable in .refine()", () => {
+    for (const bad of [undefined, null, 42, {}, []]) {
+      expect(isSafeCliArg(bad)).toBe(false);
+    }
+  });
+
+  /**
+   * The two must never disagree: `isSafeCliArg` is the schema-boundary form of
+   * the same rule, so a value the predicate waves through must also survive the
+   * assertion the handler later makes.
+   */
+  test("agrees with assertSafeCliArg on every case", () => {
+    const cases = [
+      "ok",
+      "a.b-c",
+      "my resource",
+      "",
+      "-x",
+      `a${LF}b`,
+      "a".repeat(1025),
+      "a".repeat(1024),
+    ];
+    for (const v of cases) {
+      let asserted = true;
+      try {
+        assertSafeCliArg(v);
+      } catch {
+        asserted = false;
+      }
+      expect(isSafeCliArg(v)).toBe(asserted);
+    }
   });
 });

--- a/scripts/coverage-floor/build-lcov.sh
+++ b/scripts/coverage-floor/build-lcov.sh
@@ -63,6 +63,12 @@ run_pkg () {
 # exit-status). It was absent from this list while `sonar.sources=packages`
 # still scanned it, so Sonar reported its files at 0% coverage even though the
 # tests existed and passed — a measurement gap, not a testing gap.
+#
+# Adding it HERE only made its tests run. The gap stayed open until
+# `scripts/coverage/instrument-scope.ts` also claimed the package: running a
+# package's tests and instrumenting its source are separate switches, and only
+# this one was flipped. Sonar kept reporting 0% for both files afterwards. With
+# both in place the real numbers are exit-status 100% and resolve-binary 88%.
 for pkg in packages/gateway packages/cli packages/mcp-launcher; do
   run_pkg "${pkg}"
 done

--- a/scripts/coverage-floor/check.test.ts
+++ b/scripts/coverage-floor/check.test.ts
@@ -192,6 +192,28 @@ describe("discoverSourceFiles — structural exemptions", () => {
     const files = await discoverSourceFiles();
     expect(files.some((f) => f.includes("/testing/"))).toBe(false);
   });
+
+  /**
+   * Discovery and instrumentation must agree on what a test file is.
+   * `shouldInstrument` skips both `.test.` and `.spec.`; this pass only skipped
+   * `.test.`, so a `*.spec.ts` would be discovered as SOURCE, never
+   * instrumented, and then reported `missing_from_lcov` at 0% — a false failure
+   * on a file that is not source. Bun treats `.spec` as a test marker exactly as
+   * it treats `.test`.
+   */
+  test("never yields a test file, by either naming convention", async () => {
+    const files = await discoverSourceFiles();
+    const offenders = files.filter((f) => /\.(test|spec)\.tsx?$/.test(f));
+    expect(offenders).toEqual([]);
+  });
+
+  test("does discover ordinary source, so the filters above are not vacuous", async () => {
+    const files = await discoverSourceFiles();
+    expect(files.length).toBeGreaterThan(100);
+    expect(files).toContain("packages/gateway/src/engine/executor.ts");
+    // The package this PR brought into scope.
+    expect(files).toContain("packages/mcp-launcher/src/resolve-binary.ts");
+  });
 });
 
 describe("computeUpdatedBaseline (dual-axis)", () => {

--- a/scripts/coverage-floor/check.ts
+++ b/scripts/coverage-floor/check.ts
@@ -144,6 +144,13 @@ export async function discoverSourceFiles(): Promise<string[]> {
     new Glob("packages/cli/src/**/*.ts"),
     new Glob("packages/cli/src/**/*.tsx"),
     new Glob("packages/mcp-connectors/*/src/**/*.ts"),
+    // `shared/` has no `src/` segment, so the glob above never matched it — yet
+    // CI has always instrumented it (instrument-scope.ts) and `_test-suite.yml`
+    // runs its tests. The result was real coverage numbers that no gate read:
+    // `safe-cli-arg.ts`, the argv-flag-smuggling guard, sat at 62.5% line and
+    // `join-api-path.ts` had no lcov record at all. All 16 files clear the floor
+    // as of this change, so it lands with no baselined debt.
+    new Glob("packages/mcp-connectors/shared/**/*.ts"),
     // Measured (instrument-scope.ts) and its tests run (build-lcov.sh), but it
     // was in neither this list nor the instrumentation scope — so the floor
     // could not see it even in principle. Both its files clear the floor today

--- a/scripts/coverage-floor/check.ts
+++ b/scripts/coverage-floor/check.ts
@@ -158,6 +158,15 @@ export async function discoverSourceFiles(): Promise<string[]> {
       seen.add(rel);
       if (rel.endsWith(".test.ts")) continue;
       if (rel.endsWith(".test.tsx")) continue;
+      // `.spec` is a test marker to Bun exactly as `.test` is ("Tests need
+      // '.test', '_test_', '.spec' or '_spec_' in the filename"), and
+      // `shouldInstrument` already skips both — but this discovery pass only
+      // skipped `.test`. A `*.spec.ts` would therefore be discovered as SOURCE,
+      // never instrumented, and reported `missing_from_lcov` at 0%: a false
+      // failure on a file that is not source at all. None exists in the repo
+      // today, so this is closing the asymmetry before it can bite.
+      if (rel.endsWith(".spec.ts")) continue;
+      if (rel.endsWith(".spec.tsx")) continue;
       if (rel.endsWith(".d.ts")) continue;
       if (rel.includes("/__fixtures__/")) continue;
       if (rel.includes("/test/fixtures/")) continue;

--- a/scripts/coverage-floor/check.ts
+++ b/scripts/coverage-floor/check.ts
@@ -144,6 +144,12 @@ export async function discoverSourceFiles(): Promise<string[]> {
     new Glob("packages/cli/src/**/*.ts"),
     new Glob("packages/cli/src/**/*.tsx"),
     new Glob("packages/mcp-connectors/*/src/**/*.ts"),
+    // Measured (instrument-scope.ts) and its tests run (build-lcov.sh), but it
+    // was in neither this list nor the instrumentation scope — so the floor
+    // could not see it even in principle. Both its files clear the floor today
+    // (exit-status 100/100, resolve-binary 88.0/92.9); the point is that a
+    // regression in them now fails rather than going unnoticed.
+    new Glob("packages/mcp-launcher/src/**/*.ts"),
   ];
   for (const glob of globs) {
     for await (const rawRel of glob.scan({ cwd: REPO_ROOT })) {

--- a/scripts/coverage/instrument-scope.test.ts
+++ b/scripts/coverage/instrument-scope.test.ts
@@ -27,4 +27,29 @@ describe("shouldInstrument", () => {
     expect(shouldInstrument("/repo/packages/mcp-connectors/zotero/src/server.ts")).toBe(true);
     expect(shouldInstrument("/repo/packages/mcp-connectors/shared/mcp-search-tool.test.ts")).toBe(false);
   });
+
+  /**
+   * `build-lcov.sh` has run mcp-launcher's tests since #1047, and its comment
+   * describes that as closing a "measurement gap". It did not: the package was
+   * absent from this scope, so nothing it loaded was instrumented and it
+   * emitted no coverage records — Sonar kept scoring both files at 0% while
+   * their tests passed. Running a package's tests and MEASURING it are separate
+   * switches, and only one of them was flipped.
+   */
+  test("instruments mcp-launcher src — its tests run, so its source must be measured", () => {
+    expect(shouldInstrument("/repo/packages/mcp-launcher/src/resolve-binary.ts")).toBe(true);
+    expect(shouldInstrument("/repo/packages/mcp-launcher/src/exit-status.ts")).toBe(true);
+    expect(shouldInstrument("/repo/packages/mcp-launcher/src/resolve-binary.test.ts")).toBe(false);
+  });
+
+  /**
+   * `sdk` and `client` were extracted to their own repos; no
+   * `packages/{sdk,client}/src/` path exists here any more. Pinned so the dead
+   * alternations are not restored — a scope regex naming packages that cannot
+   * match reads as coverage being collected somewhere that it is not.
+   */
+  test("does not claim scope over packages that left this monorepo", () => {
+    expect(shouldInstrument("/repo/packages/sdk/src/index.ts")).toBe(false);
+    expect(shouldInstrument("/repo/packages/client/src/index.ts")).toBe(false);
+  });
 });

--- a/scripts/coverage/instrument-scope.ts
+++ b/scripts/coverage/instrument-scope.ts
@@ -1,7 +1,18 @@
 // Decides whether the istanbul preload should instrument a given module.
 // Scope-gate to FIRST-PARTY package src only — a broad filter lets Babel's own
 // node_modules re-enter the onLoad hook and crashes Babel internals.
-const FIRST_PARTY = /\/packages\/(?:gateway|cli|sdk|client)\/src\//;
+// `mcp-launcher` is a workspace package with its own tests, and build-lcov.sh
+// has run them since #1047 — but its source was never in this scope, so nothing
+// it loaded was instrumented and it produced no coverage records at all. The
+// comment in build-lcov.sh describing that as a closed "measurement gap" was
+// therefore only half true: the tests ran, the measurement still did not happen,
+// and Sonar went on reporting resolve-binary.ts and exit-status.ts at 0%.
+//
+// `sdk` and `client` are NOT listed: those packages were extracted to their own
+// repos (nimbus-sdk / nimbus-client) and no `packages/{sdk,client}/src/` path
+// exists here any more. Dead alternations in a scope regex read as coverage
+// that is being collected somewhere, which is exactly the confusion above.
+const FIRST_PARTY = /\/packages\/(?:gateway|cli|mcp-launcher)\/src\//;
 const CONNECTOR_SRC = /\/packages\/mcp-connectors\/(?:shared|[^/]+\/src)\//;
 const GHA_SRC = /\/packages\/github-actions\/(?:shared|[^/]+\/src)\//;
 


### PR DESCRIPTION
`build-lcov.sh` has run `packages/mcp-launcher`'s tests since #1047, and its
comment describes that as closing a *"measurement gap, not a testing gap"*.

It did not. The package was never in `scripts/coverage/instrument-scope.ts`'s
scope, so **nothing it loaded was instrumented** and it emitted no coverage
records at all — Sonar went on reporting `resolve-binary.ts` and
`exit-status.ts` at 0% while their 15 tests passed.

Running a package's tests and *measuring* it are separate switches. Only one was
flipped, and the comment claimed both.

## Red/green proof

Ran mcp-launcher's tests through the real istanbul pipeline
(`istanbul-register` + `report-coverage` preloads, then `merge-coverage`), with
and without the scope fix:

| | result |
|---|---|
| **without** the fix | `merge-coverage: merged 0 shard(s)` — **zero** mcp-launcher records |
| **with** the fix | `exit-status.ts` **100.0%** line / 100.0% branch · `resolve-binary.ts` **88.0%** / 92.9% |

So the 0% was an artifact of never being measured, not untested code.

## Also removed: two dead alternations

`FIRST_PARTY` read `packages/(gateway|cli|sdk|client)/src/`. `packages/sdk` and
`packages/client` **do not exist in this monorepo** — they were extracted to
nimbus-sdk / nimbus-client. A scope regex naming packages that cannot match
reads as coverage being collected somewhere it is not, which is the same
confusion that hid the mcp-launcher gap. Now `(gateway|cli|mcp-launcher)`, with
a test pinning that the departed packages are not claimed.

## Closing the enforcement half too

Being *measured* and being *gated* are also separate. `discoverSourceFiles()` in
the floor gate globs gateway/cli/mcp-connectors only, so even with lcov records
the floor could not see mcp-launcher. Added — safe today, since both files clear
the 85% line / 80% branch floor by the numbers above. The point is that a
regression in them now fails instead of going unnoticed.

This also makes an existing exclusion meaningful rather than dead:
`exclusions.ts:61` exempts `packages/mcp-launcher/src/index.ts`, a file the
discovery glob never enumerated in the first place.

## Verification

- `bun test scripts/coverage/instrument-scope.test.ts scripts/coverage-floor/` — 109 pass, 0 fail
- `bun run preflight:fast` — all 29 gates pass
- The `build-lcov.sh` comment is corrected rather than left standing; it was the
  thing asserting the gap was closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage checks to include the MCP launcher source files.
  * Added safeguards confirming test files and extracted SDK/client packages remain excluded from coverage instrumentation.

* **Chores**
  * Updated coverage tracking to reflect current first-party components, including gateway, CLI, and MCP launcher code.
  * Documented coverage scope and recorded resulting coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->