### PR TITLE
ci(docs): correct the duplication-gate comment to the measured numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,10 +400,20 @@ jobs:
       - name: Detect code duplication (jscpd)
         # Reads .jscpd.json (min-lines 5 / min-tokens 50 / shared ignore set) so
         # the local `audit:duplication` script and CI measure identically. The
-        # threshold there is a RATCHET pinned just above the current strict
-        # duplication (~4.41% after the Stage-A/B + big-PR extraction program) —
-        # it fails on regression and is lowered as further dedup lands; the
-        # standing target remains < 3%. See docs/superpowers/specs/2026-06-17-jscpd-big-dedup-design.md.
+        # threshold there is a RATCHET: it fails on regression and is lowered as
+        # further dedup lands; the standing target remains < 3%.
+        #
+        # Current numbers, measured — the previous note here said "~4.41%", which
+        # matched neither the threshold nor the duplication:
+        #   threshold  4%   (.jscpd.json)
+        #   actual     3.48% duplicated LINES (6,122 of 176k) across 600 clones
+        # so there is 0.52pp of slack, not "just above".
+        #
+        # The threshold gates the LINE percentage, NOT the token percentage —
+        # which matters, because the token figure (4.19%) is ABOVE the threshold
+        # and reading the wrong column suggests this job should be failing.
+        # Verified by bisecting the config: threshold 3.6 passes, 3.4 fails.
+        # See docs/superpowers/specs/2026-06-17-jscpd-big-dedup-design.md.
         run: bunx jscpd packages
 
   # Structure audit — D1/D2/D3 boundaries, D8 any-count ratchet, D10/D11


### PR DESCRIPTION
The duplication job's comment claimed the ratchet was *"pinned just above the
current strict duplication (~4.41%)"*. That number matches **neither** figure:

| | value |
|---|---|
| threshold in `.jscpd.json` | **4** |
| actual duplicated lines | **3.48%** (6,122 of 176k, 600 clones) |
| the comment | ~4.41% |

So there is **0.52pp of slack**, not "just above".

## The part worth writing down

The threshold gates the **LINE** percentage, not the token percentage. That
matters because jscpd prints both, and the token figure is **4.19% — above the
4 threshold**. Anyone reading that column concludes this job should be failing
and goes looking for a broken gate.

Verified rather than assumed, by bisecting the config against the real run:

- `threshold: 3.6` (above lines 3.48, below tokens 4.19) → **exit 0**
- `threshold: 3.4` (below lines 3.48) → **exit 1**

Only line-gating explains both. Config restored afterwards; the only change in
this PR is the comment.

Comment-only — no behaviour change. `bun run audit:workflow-lint` OK.
