### PR TITLE
fix(admin-console): escape policy.version before it reaches innerHTML

### DIFF
--- a/packages/admin-console/src/render.test.ts
+++ b/packages/admin-console/src/render.test.ts
@@ -33,4 +33,37 @@ describe("render", () => {
     const html = renderOverview({ ...status, peers: [{ peerId: "<script>", reachable: true }] });
     expect(html).not.toContain("<script>");
   });
+
+  /**
+   * `policy.version` is the one interpolation in this renderer that esc() did
+   * not cover, and this string is assigned to `innerHTML` in main.ts — so it was
+   * a live DOM-XSS sink. Sonar flagged exactly this flow and it was closed as a
+   * false positive on the grounds that "every dynamic value reaching innerHTML
+   * is HTML-escaped via esc()", which was true of `policy.org` beside it and not
+   * of `policy.version`.
+   *
+   * The cast is the point: `version` is TYPED number, but `client.ts` only
+   * shape-checks the response (`"data" in body`) and never validates the field,
+   * so the type is an assumption about a remote JSON document, not a guarantee.
+   */
+  test("policy banner escapes version — the DOM-XSS sink, not just org", () => {
+    const payload = '<img src=x onerror="alert(1)">';
+    const html = renderPolicyBanner({
+      ...status.policy,
+      version: payload as unknown as number,
+    });
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain('onerror="');
+    expect(html).toContain("&lt;img");
+  });
+
+  test("policy banner escapes org too — the half that was already covered", () => {
+    const html = renderPolicyBanner({ ...status.policy, org: "<script>x</script>" });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  test("a numeric version still renders as a plain number", () => {
+    expect(renderPolicyBanner({ ...status.policy, version: 7 })).toContain("v7");
+  });
 });

--- a/packages/admin-console/src/render.ts
+++ b/packages/admin-console/src/render.ts
@@ -29,7 +29,14 @@ export function renderPolicyBanner(p: PolicyState): string {
     return `<div class="banner banner-warn">⚠ ungoverned — no valid org policy applied</div>`;
   }
   const restart = p.pendingRestart ? ' · <span class="warn">restart pending</span>' : "";
-  return `<div class="banner">policy <b>${esc(p.org ?? "")}</b> v${p.version ?? 0} ✓ signed${restart}</div>`;
+  // `p.version` is escaped for the same reason `p.org` beside it is: both come
+  // from the /v1/admin/status JSON, which `client.ts` shape-checks but does not
+  // validate per field — `version` is only TYPED number, never proven to be one.
+  // This string is assigned to `innerHTML` in main.ts, so an unescaped value
+  // here is a DOM-XSS sink. It was the one interpolation in this renderer that
+  // esc() did not cover; every other dynamic value goes through `card()`, which
+  // escapes. `restart` is a locally-built constant, deliberately raw HTML.
+  return `<div class="banner">policy <b>${esc(p.org ?? "")}</b> v${esc(String(p.version ?? 0))} ✓ signed${restart}</div>`;
 }
 
 export function renderOverview(s: GatewayStatus): string {


### PR DESCRIPTION
`renderPolicyBanner` interpolated `policy.version` **unescaped** into a string
that `main.ts` assigns to `innerHTML`. It was the only dynamic value in the
renderer that `esc()` did not cover.

```ts
`<div class="banner">policy <b>${esc(p.org ?? "")}</b> v${p.version ?? 0} …`
//                              ^^^ escaped              ^^^ NOT escaped
```

## This was reported and dismissed

SonarCloud raised it as a **BLOCKER** DOM-XSS (`tssecurity:S5696`), naming the
sink (`main.ts:136`), the propagation point (`render.ts:32`) and even the field
("a malicious value was previously assigned to field 'version'").

It was closed **FALSE-POSITIVE** with:

> every dynamic value reaching innerHTML is HTML-escaped via esc() in
> render.ts/views.ts (the only interpolation point)

That is true of `policy.org` — sitting on the same line — and false of
`policy.version`. A security suppression whose stated reason does not hold is
worse than an open issue, because nobody re-checks it.

I verified the claim rather than taking either side: every `${…}` in
`render.ts` and `views.ts` that is not `esc()`-wrapped is either routed through
`card()` (which escapes — lines 43–48), a locally-built constant (`restart`), or
a literal (`"yes"`/`"no"`). `policy.version` was the only untrusted value
reaching the sink raw.

## Why the type does not protect it

`version` is typed `number`, but `client.ts` only shape-checks the response —
`typeof body === "object" && "data" in body` — and then casts. The type is an
assumption about a remote JSON document, not a guarantee, which is exactly what
Sonar's taint analysis was pointing at.

Exploitability is bounded (it needs control of the gateway's
`/v1/admin/status` response), so this is hardening rather than an incident.

## Red-proved

With the fix reverted, the new test fails with the rendered output:

```
<div class="banner">policy <b>acme</b> v<img src=x onerror="alert(1)"> ✓ signed</div>
```

— an executable payload assigned to `innerHTML`. With the fix it renders
`&lt;img …` and the test passes.

Three tests added: version escaped, org escaped (the half already covered, so a
future edit cannot silently swap which one is protected), and a plain numeric
version still rendering as `v7` — so the fix cannot pass by mangling normal
output.

- `bun test packages/admin-console/src/render.test.ts` — 6 pass, 0 fail
- `bun run preflight:fast` — all 29 gates pass

Follow-up, not done here: the Sonar issue should be re-opened so it closes as
**fixed** rather than staying resolved as a false positive. I'd rather change
that triage state alongside the rest of the Sonar work than as a side effect of
this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for policy status banners by safely escaping policy version and organization values.
  * Prevented potentially malicious content from being rendered as executable HTML.

* **Tests**
  * Added coverage confirming that normal version values display correctly and unsafe values are safely encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->