### PR TITLE
fix(cli): stop blocking gateway RPCs dying on the 30s client timeout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,70 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-15 — blocking CLI commands no longer die on the client's 30s request
+  timeout, and two HITL-gated commands get the consent handler they never had.**
+  `IPCClient` bounds every `call()` with `requestTimeoutMs` (default 30 s), armed at
+  send time and cleared only by the matching response — no notification resets it.
+  That is the right default for the hundreds of RPCs that answer in milliseconds, and
+  the wrong one for two classes of call, **both of which were shipping broken**.
+
+  (1) *The handler awaits the whole operation.* `connector.sync` (the scheduler's
+  `forceSync` settles only when the run finishes, queue wait included),
+  `connector.reindex`, `index.regraph`, `agent.invoke` (`nimbus ask` / `prove` /
+  `repl`), `workflow.run` (both `nimbus run <file>` and `nimbus workflow run`),
+  `data.export`, `data.import` and `updater.applyUpdate`. Past 30 s the CLI printed
+  `IPC request timed out after 30000ms: <method>` and exited 1 **while the operation
+  ran to completion server-side** — so the command reported failure for work that
+  succeeded, and a user who re-ran it queued the work twice. Eleven call sites, none
+  of which passed an options object; `requestTimeoutMs` is a per-CLIENT constructor
+  option, so the budget is opted into per command rather than raised globally, and
+  fast RPCs keep the tight default. New `packages/cli/src/lib/rpc-timeouts.ts` owns
+  the two budgets and the single constructor that applies them.
+
+  (2) *The call blocks on a HUMAN.* The CLI answers the Gateway's `consent.request`
+  from a `@clack` `confirm()` that runs **inside** the still-pending call's window, so
+  the bound doubled as the user's think time — answer the y/n prompt slower than 30 s
+  and the call it belonged to was already dead. This bit regardless of data volume, a
+  one-item index included, and is the failure mode
+  `lib/interactive-ipc-handlers.ts` already documented.
+
+  Two hard bugs found alongside, each a total failure rather than a slow one:
+  **`nimbus connector reindex <svc> --depth full`** is HITL-gated in
+  `ipc/reindex-rpc.ts` but registered no `consent.request` handler at all, so the
+  Gateway's gate never received `consent.respond` and the command failed **100 % of
+  the time** independent of index size — the same defect, and the same fix, as
+  `connector remove` in #1013. **`nimbus workflow run`** registered only the
+  agent-chunk handler, so a HITL step hung to the timeout **without ever showing the
+  user a prompt**; it now uses the same combined helper as its sibling `nimbus run
+  <file>`, which also gives it `NIMBUS_SCRIPT_CONSENT_SOURCE` support. The existing
+  `reindex --depth full` test could not have caught this: its mock resolves `call`
+  immediately and never raises the notification, so it passed while the command was
+  broken.
+
+  A **dead** Gateway never depended on these timers — `IPCClient.failAll` rejects
+  every pending `call()` on socket close or error — so a long budget still fails fast
+  when the socket dies. The timers backstop only a Gateway that is alive and silent,
+  which is why the new budgets are long but **finite**: `requestTimeoutMs: 0` disables
+  the timer outright and restores the hang-forever behaviour the transport's own
+  docblock records it was added to prevent.
+
+  The Tauri bridge had the same gap from the other side: `workflow.run` was in
+  `ALLOWED_METHODS` but not in `NO_TIMEOUT_METHODS`, so the desktop UI aborted the
+  identical call at 30 s; it joins the list (now six, with the count-pinned I7 tests
+  updated).
+
+  **Not** fixed here, and deliberately: the structurally correct end state is to
+  convert these methods to the `LongRunningJobRegistry` `{ jobId }` + notification
+  shape the repo already uses for `index.reembed`/`index.rebody` (and which
+  `commands/glossary.ts` documents this exact 30 s bound as the reason for). That is
+  a larger change with real constraints — `index.regraph` is a clean candidate, but
+  `connector.reindex` is in the I2 HITL frozen set and moving its gate inside the job
+  would return `{ jobId }` before the owner consents, and migrating `ask` to the
+  already-correct `engine.askStream` would drop the `--agent` selector its params do
+  not carry. Until then a timed-out command still leaves non-gated server-side work
+  running with no way to cancel it; HITL-gated steps do fail closed on client
+  disconnect (`ipc/consent.ts`), and that rejection is audit-logged.
+
 - **2026-08-14 — the one-liner install is documented again, and #1167 is closed
   (docs only).** The 2026-08-13 entry below held the `curl | sh` / `irm | iex`
   one-liner back from user-facing docs for two stated reasons; both are now

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -1,6 +1,6 @@
-import { IPCClient } from "../ipc-client/index.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
+import { createIpcClient, INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
 function parseAskArgs(args: string[]): { rest: string[]; sessionId?: string; agent?: string } {
@@ -62,7 +62,9 @@ export async function runAsk(args: string[]): Promise<void> {
     throw new Error("Gateway is not running. Start with: nimbus start");
   }
 
-  const client = new IPCClient(state.socketPath);
+  // `agent.invoke` below is awaited by the Gateway for the whole run, and the HITL
+  // prompt this client registers is answered from inside that pending call.
+  const client = createIpcClient(state.socketPath, INTERACTIVE_RPC_TIMEOUT_MS);
   await client.connect();
   registerInteractiveCliIpcHandlers(client);
 

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -17,6 +17,9 @@ import { BATCH_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 const connectorMod = await import("./connector.ts");
 const { runConnector } = connectorMod;
 
+/** Yield a macrotask so every pending microtask chain (connect → call → handler) settles. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
 const out = captureOutput();
 
 afterAll(() => {
@@ -414,10 +417,20 @@ describe("runConnector reindex", () => {
     expect(handlers.has("consent.request")).toBe(true);
   });
 
-  it("answers the Gateway's consent.request with a consent.respond", async () => {
+  it("answers consent WHILE the gated reindex is still in flight", async () => {
+    // Ordering is the property under test, not just registration. The Gateway raises
+    // `consent.request` from INSIDE the pending `connector.reindex` call and blocks on
+    // `consent.respond`, so a handler registered after the call was issued would never
+    // be reached. Emitting the notification after the command had already returned —
+    // as an earlier version of this test did — cannot tell those apart.
     const handlers = new Map<string, (params: unknown) => void>();
-    // Two responses: the reindex itself, plus the consent.respond the handler sends.
-    const ipc = createMockIpcClient([{ itemsAffected: 3, mode: "full" }, { ok: true }], handlers);
+    let releaseReindex = (): void => {};
+    const reindexPending = new Promise<{ itemsAffected: number; mode: string }>((resolve) => {
+      releaseReindex = () => {
+        resolve({ itemsAffected: 3, mode: "full" });
+      };
+    });
+    const ipc = createMockIpcClient([reindexPending, { ok: true }], handlers);
     setFixture({
       gatewayState: { socketPath: FAKE_SOCKET_PATH },
       clackAnswer: true,
@@ -428,15 +441,52 @@ describe("runConnector reindex", () => {
         onNotification: ipc.client.onNotification,
       },
     });
+
+    const done = runConnector(["reindex", "github", "--depth", "full"]);
+    // Drain to the in-flight `connector.reindex`. A macrotask tick, not a microtask:
+    // `withIpc` awaits `readGatewayState` and `connect()` before issuing the call, so a
+    // single `Promise.resolve()` lands before the call has been made at all.
+    await flush();
+    expect(ipc.calls.map((c) => c.method)).toEqual(["connector.reindex"]);
+
+    const onConsent = handlers.get("consent.request");
+    expect(onConsent).toBeDefined();
+    onConsent?.({ requestId: "req-1", prompt: "Reindex github at full depth?" });
+    // The handler awaits the clack confirm before responding.
+    await flush();
+
+    // The approval reached the Gateway BEFORE the gated call resolved — the ordering
+    // the Gateway's gate actually requires.
+    const respond = ipc.calls.find((c) => c.method === "consent.respond");
+    expect(respond?.params).toEqual({ requestId: "req-1", approved: true });
+
+    releaseReindex();
+    await done;
+    expect(out.stdout).toContain("3 items affected");
+  });
+
+  it("relays a DENIED consent decision rather than approving by default", async () => {
+    // `clackAnswer: false` is the user answering "n". The CLI must forward that, not
+    // silently approve — the auto-approve handler is a different, opt-in code path.
+    const handlers = new Map<string, (params: unknown) => void>();
+    const ipc = createMockIpcClient([{ itemsAffected: 0, mode: "full" }, { ok: true }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: false,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
     await runConnector(["reindex", "github", "--depth", "full"]);
-    ipc.emit("consent.request", { requestId: "req-1", prompt: "Reindex github at full depth?" });
-    // The handler awaits the clack prompt before responding, so let its microtasks run.
+    handlers.get("consent.request")?.({ requestId: "req-2", prompt: "Reindex?" });
     await Promise.resolve();
     await Promise.resolve();
-    expect(ipc.calls.map((c) => c.method)).toContain("consent.respond");
     expect(ipc.calls.find((c) => c.method === "consent.respond")?.params).toEqual({
-      requestId: "req-1",
-      approved: true,
+      requestId: "req-2",
+      approved: false,
     });
   });
 

--- a/packages/cli/src/commands/connector.test.ts
+++ b/packages/cli/src/commands/connector.test.ts
@@ -6,10 +6,13 @@ import {
   CLACK_CANCEL,
   clearFixture,
   FAKE_SOCKET_PATH,
+  type RecordedClientConstruction,
   setFixture,
 } from "../../test/helpers/cli-mocks.ts";
 import { captureOutput } from "../../test/helpers/cli-output.ts";
 import { createMockIpcClient } from "../../test/helpers/mock-ipc-client.ts";
+
+import { BATCH_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 
 const connectorMod = await import("./connector.ts");
 const { runConnector } = connectorMod;
@@ -388,6 +391,112 @@ describe("runConnector reindex", () => {
     await expect(runConnector(["reindex"])).rejects.toThrow(
       "Usage: nimbus connector reindex <name>",
     );
+  });
+
+  // `--depth full` is HITL-gated in `ipc/reindex-rpc.ts`, so the Gateway raises
+  // `consent.request` and blocks on `consent.respond`. The two tests above cannot
+  // catch a missing handler: their mock resolves `call` immediately and never raises
+  // the notification, so they passed while the command failed 100% of the time in
+  // production. These pin the handler itself.
+  it("registers a consent.request handler, so a HITL-gated reindex can be approved", async () => {
+    const handlers = new Map<string, (params: unknown) => void>();
+    const ipc = createMockIpcClient([{ itemsAffected: 0, mode: "full" }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
+    await runConnector(["reindex", "github", "--depth", "full"]);
+    expect(handlers.has("consent.request")).toBe(true);
+  });
+
+  it("answers the Gateway's consent.request with a consent.respond", async () => {
+    const handlers = new Map<string, (params: unknown) => void>();
+    // Two responses: the reindex itself, plus the consent.respond the handler sends.
+    const ipc = createMockIpcClient([{ itemsAffected: 3, mode: "full" }, { ok: true }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: true,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
+    await runConnector(["reindex", "github", "--depth", "full"]);
+    ipc.emit("consent.request", { requestId: "req-1", prompt: "Reindex github at full depth?" });
+    // The handler awaits the clack prompt before responding, so let its microtasks run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ipc.calls.map((c) => c.method)).toContain("consent.respond");
+    expect(ipc.calls.find((c) => c.method === "consent.respond")?.params).toEqual({
+      requestId: "req-1",
+      approved: true,
+    });
+  });
+
+  it("opts into the batch budget rather than the transport's 30s default", async () => {
+    const constructions: RecordedClientConstruction[] = [];
+    const ipc = createMockIpcClient([{ itemsAffected: 0, mode: "full" }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clientConstructions: constructions,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["reindex", "github", "--depth", "full"]);
+    expect(constructions[0]?.opts).toEqual({ requestTimeoutMs: BATCH_RPC_TIMEOUT_MS });
+  });
+});
+
+describe("runConnector sync — request budget", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+  afterEach(() => {
+    clearFixture();
+  });
+
+  it("opts into the batch budget, since the Gateway awaits the whole sync run", async () => {
+    const constructions: RecordedClientConstruction[] = [];
+    const ipc = createMockIpcClient([{ ok: true }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clientConstructions: constructions,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["sync", "github"]);
+    expect(constructions[0]?.opts).toEqual({ requestTimeoutMs: BATCH_RPC_TIMEOUT_MS });
+  });
+
+  it("leaves fast connector RPCs on the tight default", async () => {
+    // `requestTimeoutMs` is per-client, so the budget must be opted into per command.
+    // If a future refactor moves it onto the shared `withIpc` helper, this fails.
+    const constructions: RecordedClientConstruction[] = [];
+    const ipc = createMockIpcClient([[]]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clientConstructions: constructions,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+      },
+    });
+    await runConnector(["history", "github"]);
+    expect(constructions[0]?.opts).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -1,6 +1,6 @@
 import { confirm, isCancel } from "@clack/prompts";
 
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import {
   GOOGLE_OAUTH_CLIENT_ID_HELP,
   MICROSOFT_OAUTH_CLIENT_ID_HELP,
@@ -10,8 +10,12 @@ import {
   SLACK_OAUTH_CLIENT_ID_HELP,
 } from "../lib/connector-oauth-env-help.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
-import { registerAutoApproveConsentHandler } from "../lib/interactive-ipc-handlers.ts";
+import {
+  registerAutoApproveConsentHandler,
+  registerConsentPromptHandler,
+} from "../lib/interactive-ipc-handlers.ts";
 import { parseDurationToMs } from "../lib/parse-duration.ts";
+import { BATCH_RPC_TIMEOUT_MS, createIpcClient } from "../lib/rpc-timeouts.ts";
 import { stripTrailingSlashes } from "../lib/strip-trailing-slashes.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
@@ -80,13 +84,14 @@ type ConnectorFlags = {
 async function withIpc<T>(
   fn: (c: IPCClient) => Promise<T>,
   onConnect?: (c: IPCClient) => void,
+  requestTimeoutMs?: number,
 ): Promise<T> {
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) {
     throw new Error("Gateway is not running. Start with: nimbus start");
   }
-  const client = new IPCClient(state.socketPath);
+  const client = createIpcClient(state.socketPath, requestTimeoutMs);
   await client.connect();
   onConnect?.(client);
   try {
@@ -1093,7 +1098,10 @@ async function runConnectorSync(tail: string[]): Promise<void> {
   } else {
     syncParams = { serviceId: service };
   }
-  await withIpc((c) => c.call("connector.sync", syncParams));
+  // A sync run is awaited end-to-end by the Gateway (`forceSync` settles only when
+  // the job finishes, queue wait included), so this needs the batch budget — on the
+  // 30s default a first full sync reported failure for a sync that then completed.
+  await withIpc((c) => c.call("connector.sync", syncParams), undefined, BATCH_RPC_TIMEOUT_MS);
   const suffix = full === true ? " (full)" : "";
   console.log(`Sync requested: ${service}${suffix}`);
 }
@@ -1196,8 +1204,22 @@ async function runConnectorReindex(args: string[]): Promise<void> {
   }
   const depthIdx = args.indexOf("--depth");
   const depth = depthIdx >= 0 ? (args[depthIdx + 1] ?? "metadata_only") : "metadata_only";
-  const result = await withIpc((c) =>
-    c.call<{ itemsAffected: number; mode: string }>("connector.reindex", { service, depth }),
+  // `--depth full` is HITL-gated (`ipc/reindex-rpc.ts` gates on `connector.reindex`
+  // before doing any work), so this MUST register a `consent.request` handler: the
+  // Gateway blocks on `consent.respond`, and a client that never answers just times
+  // out. Without it `reindex --depth full` failed 100% of the time regardless of
+  // index size — same defect, and same fix, as `connector remove` (#1013).
+  //
+  // The prompt handler is the right one rather than auto-approve: unlike `remove`,
+  // reindex has no `--yes` flag, so no approval has been collected up front and the
+  // user must be the one to answer. The batch budget then covers both the human's
+  // think time at that prompt and the re-walk itself, which the Gateway awaits.
+  const result = await withIpc(
+    (c) => c.call<{ itemsAffected: number; mode: string }>("connector.reindex", { service, depth }),
+    (c) => {
+      registerConsentPromptHandler(c);
+    },
+    BATCH_RPC_TIMEOUT_MS,
   );
   console.log(
     `[ok] ${service} reindex ${result.mode} — ${String(result.itemsAffected)} items affected`,

--- a/packages/cli/src/commands/data.ts
+++ b/packages/cli/src/commands/data.ts
@@ -1,7 +1,8 @@
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import { assertDestructiveDeleteAllowed, parseScriptConsentSource } from "../lib/data-helpers.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { selectConsentHandler } from "../lib/interactive-ipc-handlers.ts";
+import { BATCH_RPC_TIMEOUT_MS, createIpcClient } from "../lib/rpc-timeouts.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
 export { assertDestructiveDeleteAllowed, parseScriptConsentSource } from "../lib/data-helpers.ts";
@@ -32,7 +33,11 @@ async function withClient<T>(
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) throw new Error("Gateway is not running. Start with: nimbus start");
-  const client = new IPCClient(state.socketPath);
+  // Every `withClient` caller issues a HITL-gated bundle export/import that the
+  // Gateway awaits end to end, and whose consent prompt is answered from inside the
+  // pending call — so the batch budget applies to the whole helper rather than being
+  // opted into per call site.
+  const client = createIpcClient(state.socketPath, BATCH_RPC_TIMEOUT_MS);
   await client.connect();
   selectConsentHandler(client, opts);
   try {

--- a/packages/cli/src/commands/index-cmd.ts
+++ b/packages/cli/src/commands/index-cmd.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { IPCClient } from "../ipc-client/index.ts";
+import { BATCH_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 
 type ReembedSummary = {
@@ -507,7 +508,14 @@ type RegraphSummary = { scanned: number; graphed: number; skipped: number };
 
 async function runRegraph(args: string[]): Promise<void> {
   const json = args.includes("--json");
-  const result = await withGatewayIpc((c) => c.call<RegraphSummary>("index.regraph", null));
+  // Unlike `reembed`/`rebody` above, `index.regraph` is NOT job-registry backed: the
+  // handler awaits `regraphAllItems` over every indexed item, so the whole re-walk
+  // happens inside this one call and needs the batch budget.
+  const result = await withGatewayIpc(
+    (c) => c.call<RegraphSummary>("index.regraph", null),
+    undefined,
+    { requestTimeoutMs: BATCH_RPC_TIMEOUT_MS },
+  );
   if (json) {
     console.log(JSON.stringify(result));
   } else {

--- a/packages/cli/src/commands/prove.ts
+++ b/packages/cli/src/commands/prove.ts
@@ -1,7 +1,8 @@
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { registerConsentPromptHandler } from "../lib/interactive-ipc-handlers.ts";
 import { parseSinceDurationToMs } from "../lib/parse-since.ts";
+import { createIpcClient, INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
 type VerifyResult = { ok: boolean; verifiedRows: number; brokenAt?: number; reason?: string };
@@ -100,12 +101,12 @@ export function formatProveResult(input: {
   return lines.join("\n");
 }
 
-async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
+async function withIpc<T>(fn: (c: IPCClient) => Promise<T>, requestTimeoutMs?: number): Promise<T> {
   const state = await readGatewayState(getCliPlatformPaths());
   if (state === undefined) {
     throw new Error("Gateway is not running. Start with: nimbus start");
   }
-  const client = new IPCClient(state.socketPath);
+  const client = createIpcClient(state.socketPath, requestTimeoutMs);
   await client.connect();
   try {
     return await fn(client);
@@ -118,13 +119,19 @@ async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
  * Like {@link withIpc} but registers the interactive consent prompt handler first, so an inline
  * `consent.request` (egress.prune's owner-HITL gate, or any HITL action triggered by a proved
  * query) reaches the user as a y/n prompt instead of hanging. Without it the gateway's consent
- * gate would wait indefinitely for an answer the CLI never sends.
+ * gate never receives an answer and the call dies on the client's request timeout.
+ *
+ * That prompt is awaited INSIDE the pending call, so the caller's `requestTimeoutMs` is also the
+ * user's think time — pass a budget sized for a human, not for an RPC.
  */
-async function withConsentIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
+async function withConsentIpc<T>(
+  fn: (c: IPCClient) => Promise<T>,
+  requestTimeoutMs?: number,
+): Promise<T> {
   return withIpc(async (client) => {
     registerConsentPromptHandler(client);
     return fn(client);
-  });
+  }, requestTimeoutMs);
 }
 
 /**
@@ -239,6 +246,8 @@ export async function runEgressReport(
 export async function runProve(args: string[]): Promise<void> {
   const sign = args.includes("--receipt") || args.includes("--sign");
   const query = args.find((a) => !a.startsWith("--"));
+  // `agent.invoke` below is `stream: false`, so unlike `nimbus ask` there are no tokens
+  // already on stdout to salvage: a timeout here loses the whole answer AND the proof.
   await withConsentIpc(async (client) => {
     const since = Date.now();
     if (query !== undefined && query !== "") {
@@ -281,7 +290,7 @@ export async function runProve(args: string[]): Promise<void> {
       // different number over a different scope.
       await runEgressReport(client, { json: false, sign });
     }
-  });
+  }, INTERACTIVE_RPC_TIMEOUT_MS);
 }
 
 /**
@@ -309,7 +318,7 @@ export async function runEgress(args: string[]): Promise<void> {
           ? `[ok] pruned ${String(out.prunedCount)} egress rows (tombstone written)`
           : "[denied] prune not approved — nothing removed",
       );
-    });
+    }, INTERACTIVE_RPC_TIMEOUT_MS);
     return;
   }
   const since = parseSince(args, Date.now());

--- a/packages/cli/src/commands/repl.ts
+++ b/packages/cli/src/commands/repl.ts
@@ -1,6 +1,6 @@
-import { IPCClient } from "../ipc-client/index.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
+import { createIpcClient, INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
 import { runRepl as coreRunRepl, type ReplCoreDeps } from "./repl-core.ts";
@@ -8,7 +8,10 @@ import { runRepl as coreRunRepl, type ReplCoreDeps } from "./repl-core.ts";
 const productionDeps: ReplCoreDeps = {
   readGatewayState,
   getCliPlatformPaths,
-  makeClient: (socketPath) => new IPCClient(socketPath),
+  // The REPL holds one client for the whole session and issues a blocking
+  // `agent.invoke` per turn, each of which can raise a HITL prompt answered from
+  // inside the pending call.
+  makeClient: (socketPath) => createIpcClient(socketPath, INTERACTIVE_RPC_TIMEOUT_MS),
   registerHandlers: (client) => {
     registerInteractiveCliIpcHandlers(client);
   },

--- a/packages/cli/src/commands/run-workflow.ts
+++ b/packages/cli/src/commands/run-workflow.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "node:fs";
 
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import { hasFlag, shiftFlag } from "../lib/flag-parsing.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
 import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
+import { createIpcClient, INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { parseWorkflowFileContent } from "../lib/workflow-parse.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
@@ -96,7 +97,9 @@ export async function runWorkflowFromFile(args: string[]): Promise<void> {
     throw new Error("Gateway is not running. Start with: nimbus start");
   }
 
-  const client = new IPCClient(state.socketPath);
+  // `workflow.run` is awaited by the Gateway for the whole run, and a HITL step is
+  // answered at a prompt that runs inside that pending call.
+  const client = createIpcClient(state.socketPath, INTERACTIVE_RPC_TIMEOUT_MS);
   await client.connect();
   try {
     await runWorkflowFromFileWithClient(client, file, opts);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -4,6 +4,7 @@ import {
   resolveDistributionChannel,
 } from "@nimbus-dev/sdk";
 import type { IPCClient } from "../ipc-client/index.ts";
+import { BATCH_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 
 export type UpdateArgs = { mode: "check" | "apply"; yes: boolean };
@@ -98,9 +99,16 @@ export async function runUpdate(argv: string[], opts: RunUpdateOptions = {}): Pr
     }
   }
 
-  await withGatewayIpc(async (c) => {
-    await runUpdateApply(c);
-  });
+  // `updater.applyUpdate` downloads, verifies the signature and installs before it
+  // returns — the Tauri bridge already exempts it from its own 30s bound via
+  // NO_TIMEOUT_METHODS; the CLI was still applying one.
+  await withGatewayIpc(
+    async (c) => {
+      await runUpdateApply(c);
+    },
+    undefined,
+    { requestTimeoutMs: BATCH_RPC_TIMEOUT_MS },
+  );
 }
 
 async function readLine(): Promise<string> {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3,9 +3,16 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { clearFixture, FAKE_SOCKET_PATH, setFixture } from "../../test/helpers/cli-mocks.ts";
+import {
+  clearFixture,
+  FAKE_SOCKET_PATH,
+  type RecordedClientConstruction,
+  setFixture,
+} from "../../test/helpers/cli-mocks.ts";
 import { captureOutput } from "../../test/helpers/cli-output.ts";
 import { createMockIpcClient } from "../../test/helpers/mock-ipc-client.ts";
+
+import { INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 
 const mod = await import("./workflow.ts");
 const { runWorkflowCli, runWorkflowList, runWorkflowDelete, runWorkflowSave, runWorkflowRun } = mod;
@@ -218,5 +225,64 @@ describe("runWorkflowCli (dispatcher)", () => {
     });
     await runWorkflowCli([]);
     expect(ipc.calls[0]?.method).toBe("workflow.list");
+  });
+
+  // A workflow step can trip a HITL gate, and the Gateway then blocks on
+  // `consent.respond`. Without a `consent.request` handler this command hung to the
+  // client timeout without ever prompting the user — the failure mode
+  // `interactive-ipc-handlers.ts` documents.
+  it("registers a consent.request handler for 'run', so a HITL step can be approved", async () => {
+    const handlers = new Map<string, (params: unknown) => void>();
+    const ipc = createMockIpcClient([{ ok: true }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
+    await runWorkflowCli(["run", "deploy"]);
+    expect(handlers.has("consent.request")).toBe(true);
+  });
+
+  it("still streams agent chunks for 'run'", async () => {
+    // The consent handler was added ALONGSIDE the chunk handler, not instead of it.
+    const handlers = new Map<string, (params: unknown) => void>();
+    const ipc = createMockIpcClient([{ ok: true }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
+    await runWorkflowCli(["run", "deploy"]);
+    expect(handlers.has("agent.chunk")).toBe(true);
+  });
+
+  it("gives 'run' the interactive budget and leaves 'list' on the tight default", async () => {
+    const runConstructions: RecordedClientConstruction[] = [];
+    const runIpc = createMockIpcClient([{ ok: true }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clientConstructions: runConstructions,
+      ipcClient: { call: runIpc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runWorkflowCli(["run", "deploy"]);
+    expect(runConstructions[0]?.opts).toEqual({ requestTimeoutMs: INTERACTIVE_RPC_TIMEOUT_MS });
+
+    const listConstructions: RecordedClientConstruction[] = [];
+    const listIpc = createMockIpcClient([{ workflows: [] }]);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clientConstructions: listConstructions,
+      ipcClient: { call: listIpc.client.call, connect: () => {}, disconnect: () => {} },
+    });
+    await runWorkflowCli(["list"]);
+    expect(listConstructions[0]?.opts).toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -17,6 +17,9 @@ import { INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 const mod = await import("./workflow.ts");
 const { runWorkflowCli, runWorkflowList, runWorkflowDelete, runWorkflowSave, runWorkflowRun } = mod;
 
+/** Yield a macrotask so every pending microtask chain (connect → call → handler) settles. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
 const out = captureOutput();
 
 afterAll(() => {
@@ -245,6 +248,46 @@ describe("runWorkflowCli (dispatcher)", () => {
     });
     await runWorkflowCli(["run", "deploy"]);
     expect(handlers.has("consent.request")).toBe(true);
+  });
+
+  it("answers consent WHILE workflow.run is still in flight", async () => {
+    // The ordering the Gateway's gate requires: a HITL step raises `consent.request`
+    // from inside the pending `workflow.run` and blocks on `consent.respond`, so the
+    // approval has to reach it before the call resolves — not merely at some point.
+    const handlers = new Map<string, (params: unknown) => void>();
+    let releaseRun = (): void => {};
+    const runPending = new Promise<{ ok: boolean }>((resolve) => {
+      releaseRun = () => {
+        resolve({ ok: true });
+      };
+    });
+    const ipc = createMockIpcClient([runPending, { ok: true }], handlers);
+    setFixture({
+      gatewayState: { socketPath: FAKE_SOCKET_PATH },
+      clackAnswer: true,
+      ipcClient: {
+        call: ipc.client.call,
+        connect: () => {},
+        disconnect: () => {},
+        onNotification: ipc.client.onNotification,
+      },
+    });
+
+    const done = runWorkflowCli(["run", "deploy"]);
+    await flush();
+    expect(ipc.calls.map((c) => c.method)).toEqual(["workflow.run"]);
+
+    handlers.get("consent.request")?.({ requestId: "req-1", prompt: "Deploy to prod?" });
+    await flush();
+
+    // Approved before the gated run resolved.
+    expect(ipc.calls.find((c) => c.method === "consent.respond")?.params).toEqual({
+      requestId: "req-1",
+      approved: true,
+    });
+
+    releaseRun();
+    await done;
   });
 
   it("still streams agent chunks for 'run'", async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "node:fs";
 
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import { hasFlag, shiftFlag } from "../lib/flag-parsing.ts";
 import { readGatewayState } from "../lib/gateway-process.ts";
-import { registerAgentChunkStdout } from "../lib/interactive-ipc-handlers.ts";
+import { registerInteractiveCliIpcHandlers } from "../lib/interactive-ipc-handlers.ts";
+import { createIpcClient, INTERACTIVE_RPC_TIMEOUT_MS } from "../lib/rpc-timeouts.ts";
 import { parseWorkflowFileContent } from "../lib/workflow-parse.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 
@@ -66,7 +67,12 @@ export async function runWorkflowRun(client: IPCClient, rest: string[]): Promise
     agent = agentArg;
   }
 
-  registerAgentChunkStdout(client);
+  // Not just the chunk handler: a workflow step can trip a HITL gate, and the Gateway
+  // then blocks on `consent.respond`. With no `consent.request` handler registered
+  // here, `nimbus workflow run` hung to the client timeout without ever showing the
+  // user a prompt. This is the same helper `nimbus run <file>` uses, so both entry
+  // points now prompt identically and both honour NIMBUS_SCRIPT_CONSENT_SOURCE.
+  registerInteractiveCliIpcHandlers(client);
 
   if (noTtv && !dryRun) {
     const preview = await client.call("workflow.run", {
@@ -96,13 +102,13 @@ export async function runWorkflowRun(client: IPCClient, rest: string[]): Promise
   console.log(`\n${JSON.stringify(out, undefined, 2)}`);
 }
 
-async function withIpc<T>(fn: (c: IPCClient) => Promise<T>): Promise<T> {
+async function withIpc<T>(fn: (c: IPCClient) => Promise<T>, requestTimeoutMs?: number): Promise<T> {
   const paths = getCliPlatformPaths();
   const state = await readGatewayState(paths);
   if (state === undefined) {
     throw new Error("Gateway is not running. Start with: nimbus start");
   }
-  const client = new IPCClient(state.socketPath);
+  const client = createIpcClient(state.socketPath, requestTimeoutMs);
   await client.connect();
   try {
     return await fn(client);
@@ -128,7 +134,12 @@ export async function runWorkflowCli(args: string[]): Promise<void> {
     return;
   }
   if (sub === "run") {
-    await withIpc((c) => runWorkflowRun(c, rest));
+    // Only `run` gets the long budget: the Gateway awaits the whole run, and a HITL
+    // step waits on the user. `list`/`delete`/`save` are fast RPCs and keep the tight
+    // 30s default, which is why this is opt-in per subcommand rather than set on the
+    // helper — `requestTimeoutMs` is per-client, so raising it here would slacken the
+    // bound for all four.
+    await withIpc((c) => runWorkflowRun(c, rest), INTERACTIVE_RPC_TIMEOUT_MS);
     return;
   }
 

--- a/packages/cli/src/lib/rpc-timeouts.test.ts
+++ b/packages/cli/src/lib/rpc-timeouts.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+  clearFixture,
+  FAKE_SOCKET_PATH,
+  type RecordedClientConstruction,
+  setFixture,
+} from "../../test/helpers/cli-mocks.ts";
+
+const { BATCH_RPC_TIMEOUT_MS, INTERACTIVE_RPC_TIMEOUT_MS, createIpcClient } = await import(
+  "./rpc-timeouts.ts"
+);
+
+describe("createIpcClient", () => {
+  let constructions: RecordedClientConstruction[];
+
+  beforeEach(() => {
+    constructions = [];
+    setFixture({ clientConstructions: constructions });
+  });
+
+  afterEach(() => {
+    clearFixture();
+  });
+
+  it("passes NO options object when no timeout is supplied, leaving the transport default", () => {
+    createIpcClient(FAKE_SOCKET_PATH);
+    expect(constructions).toHaveLength(1);
+    expect(constructions[0]?.opts).toBeUndefined();
+  });
+
+  it("passes requestTimeoutMs through when one is supplied", () => {
+    createIpcClient(FAKE_SOCKET_PATH, 1234);
+    expect(constructions[0]?.opts).toEqual({ requestTimeoutMs: 1234 });
+  });
+
+  it("omits the key rather than passing it as undefined", () => {
+    // `exactOptionalPropertyTypes` makes `{ requestTimeoutMs: undefined }` a type
+    // error, but the runtime distinction matters independently: the transport reads
+    // `opts?.requestTimeoutMs ?? DEFAULT`, so a present-but-undefined key would still
+    // fall back — while any future strict read (`"requestTimeoutMs" in opts`) would
+    // not. Pin the shape, not just the resolved value.
+    createIpcClient(FAKE_SOCKET_PATH, undefined);
+    expect(constructions[0]?.opts).toBeUndefined();
+  });
+
+  it("forwards the socket path unchanged", () => {
+    createIpcClient(FAKE_SOCKET_PATH, BATCH_RPC_TIMEOUT_MS);
+    expect(constructions[0]?.socketPath).toBe(FAKE_SOCKET_PATH);
+  });
+});
+
+describe("timeout budgets", () => {
+  // The whole point of these constants is to be materially longer than the 30s
+  // transport default that was cutting off work in progress. Pin that relationship
+  // rather than the literals, so a future tuning change stays honest but a
+  // regression to a ~30s value fails.
+  const TRANSPORT_DEFAULT_MS = 30_000;
+
+  it("are both far longer than the transport's 30s default", () => {
+    expect(INTERACTIVE_RPC_TIMEOUT_MS).toBeGreaterThan(TRANSPORT_DEFAULT_MS * 10);
+    expect(BATCH_RPC_TIMEOUT_MS).toBeGreaterThan(TRANSPORT_DEFAULT_MS * 10);
+  });
+
+  it("give machine-bound work a larger budget than human-bound work", () => {
+    // Batch work is bounded by the user's data volume, which the CLI cannot predict;
+    // an interactive run is bounded by a person's attention span. If these ever
+    // invert, the rationale in the module docblock has stopped matching the values.
+    expect(BATCH_RPC_TIMEOUT_MS).toBeGreaterThan(INTERACTIVE_RPC_TIMEOUT_MS);
+  });
+
+  it("stay finite — `0` would disable the timer and restore the hang-forever bug", () => {
+    // The transport documents `0` as "disables the timeout (a wedged gateway then
+    // hangs the call forever)". A dead socket is covered by `failAll`; an alive-but-
+    // silent gateway is covered only by these timers, so neither may be 0.
+    expect(BATCH_RPC_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(INTERACTIVE_RPC_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(BATCH_RPC_TIMEOUT_MS)).toBe(true);
+    expect(Number.isFinite(INTERACTIVE_RPC_TIMEOUT_MS)).toBe(true);
+  });
+});

--- a/packages/cli/src/lib/rpc-timeouts.ts
+++ b/packages/cli/src/lib/rpc-timeouts.ts
@@ -1,0 +1,73 @@
+import { IPCClient } from "../ipc-client/index.ts";
+
+/**
+ * Request-timeout budgets for the CLI's IPC clients, and the single constructor
+ * that applies them.
+ *
+ * `IPCClient` bounds EVERY `call()` with `requestTimeoutMs` (default 30_000). The
+ * timer is armed at send time and cleared only by the matching response — no
+ * incoming notification resets it, so a method that streams progress for minutes
+ * still dies at the bound. Nearly every Gateway method answers in milliseconds, so
+ * 30s is the right default: it surfaces an alive-but-wedged Gateway quickly.
+ *
+ * It is the wrong bound for two classes of call, and both were shipping broken:
+ *
+ *   1. The handler awaits the WHOLE operation. `connector.sync` awaits a full sync
+ *      run, `index.regraph` re-walks every indexed item, `data.export` packs and
+ *      encrypts a bundle. Past 30s the CLI printed
+ *      `IPC request timed out after 30000ms: <method>` and exited 1 while the
+ *      operation ran to completion server-side — so the command reported failure
+ *      for work that succeeded, and a user who re-ran it queued the work twice.
+ *
+ *   2. The call can block on a HUMAN. A HITL gate raises `consent.request`, and the
+ *      CLI answers from a `@clack` `confirm()` that runs INSIDE the still-pending
+ *      call's window (see `interactive-ipc-handlers.ts`). The bound therefore became
+ *      the user's think time: answer the y/n prompt slower than 30s and the call it
+ *      belonged to was already dead. This bit regardless of data volume — a
+ *      one-item index included.
+ *
+ * A DEAD Gateway does not depend on these timers. `IPCClient.failAll` rejects every
+ * pending `call()` on socket close or error, so a long budget still fails fast when
+ * the socket dies. The timeout backstops only a Gateway that is alive and silent,
+ * which is why these values are long but FINITE: `requestTimeoutMs: 0` disables the
+ * timer outright and restores the hang-forever behaviour the transport's own
+ * docblock records it was added to prevent. (The Tauri bridge takes the opposite
+ * side of that trade for its five `NO_TIMEOUT_METHODS`; the CLI does not follow it.)
+ *
+ * These are opt-in per construction site rather than raised globally because
+ * `requestTimeoutMs` is a per-CLIENT constructor option, not per-call. A client that
+ * issues one long call and a dozen fast ones would otherwise lose the tight bound on
+ * all of them.
+ */
+
+/**
+ * Machine-bound work: a full connector sync, a whole-index regraph or reindex, a
+ * bundle export/import, an update download + signature verify + install. Larger than
+ * {@link INTERACTIVE_RPC_TIMEOUT_MS} because the ceiling is the user's data volume,
+ * which the CLI cannot predict — a first full sync of a large mailbox is legitimately
+ * slow, and cutting it off is exactly the bug this replaces.
+ */
+export const BATCH_RPC_TIMEOUT_MS = 6 * 60 * 60 * 1_000;
+
+/**
+ * Human-bound work: an agent or workflow run that can raise a HITL prompt the user
+ * answers at a `confirm()`. The ceiling here is a person's attention span, not a
+ * data volume, so it is the shorter of the two — a run still pending an hour after
+ * the prompt appeared is one the user has walked away from.
+ */
+export const INTERACTIVE_RPC_TIMEOUT_MS = 60 * 60 * 1_000;
+
+/**
+ * Build an `IPCClient`, applying `requestTimeoutMs` only when one is supplied.
+ *
+ * The conditional matters under `exactOptionalPropertyTypes`: passing
+ * `{ requestTimeoutMs: undefined }` is a type error, and passing it as a present-but-
+ * undefined key would in any case defeat the transport's own `?? DEFAULT` fallback.
+ * Routing every timeout-aware construction through here keeps that detail in one
+ * place instead of at each call site.
+ */
+export function createIpcClient(socketPath: string, requestTimeoutMs?: number): IPCClient {
+  return requestTimeoutMs === undefined
+    ? new IPCClient(socketPath)
+    : new IPCClient(socketPath, { requestTimeoutMs });
+}

--- a/packages/cli/src/lib/with-gateway-ipc.ts
+++ b/packages/cli/src/lib/with-gateway-ipc.ts
@@ -1,7 +1,8 @@
-import { IPCClient } from "../ipc-client/index.ts";
+import type { IPCClient } from "../ipc-client/index.ts";
 import type { CliPlatformPaths } from "../paths.ts";
 import { getCliPlatformPaths } from "../paths.ts";
 import { readGatewayState } from "./gateway-process.ts";
+import { createIpcClient } from "./rpc-timeouts.ts";
 
 /**
  * Thrown by `withGatewayIpc` when no gateway is running. A distinct subclass
@@ -19,15 +20,26 @@ export class GatewayNotRunningError extends Error {
   }
 }
 
+export interface WithGatewayIpcOptions {
+  /**
+   * Overrides `IPCClient`'s 30s per-request bound for this client only. Supply one
+   * of the named budgets in `rpc-timeouts.ts` when the call being made is answered
+   * by a Gateway handler that awaits the whole operation, or can block on a HITL
+   * prompt; leave unset for ordinary fast RPCs, which want the tight default.
+   */
+  readonly requestTimeoutMs?: number;
+}
+
 export async function withGatewayIpc<T>(
   fn: (c: IPCClient) => Promise<T>,
   paths: CliPlatformPaths = getCliPlatformPaths(),
+  opts: WithGatewayIpcOptions = {},
 ): Promise<T> {
   const state = await readGatewayState(paths);
   if (state === undefined) {
     throw new GatewayNotRunningError();
   }
-  const client = new IPCClient(state.socketPath);
+  const client = createIpcClient(state.socketPath, opts.requestTimeoutMs);
   await client.connect();
   try {
     return await fn(client);

--- a/packages/cli/test/helpers/cli-mocks.ts
+++ b/packages/cli/test/helpers/cli-mocks.ts
@@ -20,6 +20,20 @@ export const FAKE_GATEWAY_STATE_PATH: string = join(FAKE_GATEWAY_ROOT, "fake-gat
  */
 export const fakePath = (name: string): string => join(FAKE_GATEWAY_ROOT, name);
 
+/**
+ * One `new IPCClient(socketPath, opts)` the code under test performed.
+ *
+ * `opts` is what distinguishes a command that opted into a long request budget from
+ * one that silently took the transport's 30s default, so a test asserting a blocking
+ * RPC is not bounded at 30s has to be able to see it. `undefined` means the site
+ * passed no options object at all — which is the pre-fix behaviour, not a synonym
+ * for "default": the two are only equivalent by the transport's own `?? DEFAULT`.
+ */
+export interface RecordedClientConstruction {
+  readonly socketPath: string;
+  readonly opts: { requestTimeoutMs?: number } | undefined;
+}
+
 export interface CliTestFixture {
   gatewayState?: { socketPath: string; pid?: number };
   processAlive?: boolean;
@@ -30,6 +44,12 @@ export interface CliTestFixture {
     disconnect: unknown;
     onNotification?: unknown;
   };
+  /**
+   * Populated by the fake client's constructor when present. Tests that care opt in
+   * by passing an empty array; leaving it unset keeps the fake allocation-free for
+   * the many tests that do not.
+   */
+  clientConstructions?: RecordedClientConstruction[];
 }
 
 declare global {
@@ -67,6 +87,9 @@ export function installCliMocks(): void {
 
   mock.module("../../src/ipc-client/index.ts", () => ({
     IPCClient: class FakeIPCClient {
+      constructor(socketPath: string, opts?: { requestTimeoutMs?: number }) {
+        globalThis.__nimbusCliFixture?.clientConstructions?.push({ socketPath, opts });
+      }
       async connect(): Promise<void> {
         const ipc = globalThis.__nimbusCliFixture?.ipcClient;
         const connectFn = ipc?.connect as (() => Promise<void>) | undefined;

--- a/packages/ui/src-tauri/src/gateway_bridge.rs
+++ b/packages/ui/src-tauri/src/gateway_bridge.rs
@@ -169,12 +169,19 @@ pub fn is_method_allowed(method: &str) -> bool {
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Allowlisted methods whose Gateway handler awaits the whole operation, so the
+/// 30s default above would abort work that is progressing normally.
+///
+/// `workflow.run` belongs here for two reasons, not one: the handler resolves only
+/// when the run ends, AND a step can trip a HITL gate whose approval the user
+/// supplies mid-call — so the bound would double as the user's think time.
 pub const NO_TIMEOUT_METHODS: &[&str] = &[
     "data.export",
     "data.import",
     "identity.login",
     "llm.pullModel",
     "updater.applyUpdate",
+    "workflow.run",
 ];
 
 pub fn is_no_timeout_method(method: &str) -> bool {
@@ -612,19 +619,20 @@ mod tests {
     }
 
     #[test]
-    fn no_timeout_methods_contains_expected_five() {
+    fn no_timeout_methods_contains_expected_six() {
         assert!(is_no_timeout_method("data.export"));
         assert!(is_no_timeout_method("data.import"));
         assert!(is_no_timeout_method("identity.login"));
         assert!(is_no_timeout_method("llm.pullModel"));
         assert!(is_no_timeout_method("updater.applyUpdate"));
+        assert!(is_no_timeout_method("workflow.run"));
         assert!(!is_no_timeout_method("profile.list"));
         assert!(!is_no_timeout_method("audit.list"));
     }
 
     #[test]
     fn no_timeout_methods_exact_size() {
-        assert_eq!(NO_TIMEOUT_METHODS.len(), 5);
+        assert_eq!(NO_TIMEOUT_METHODS.len(), 6);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`IPCClient` bounds every `call()` with `requestTimeoutMs` (default **30 s**). The timer is armed at send time and cleared only by the matching response — no incoming notification resets it. That is the right default for the hundreds of RPCs that answer in milliseconds, and the wrong one for two classes of call. **Both were shipping broken.**

### 1. The handler awaits the whole operation

`connector.sync` (the scheduler's `forceSync` settles only when the run finishes, queue wait included), `connector.reindex`, `index.regraph`, `agent.invoke` (`nimbus ask` / `prove` / `repl`), `workflow.run` (both `nimbus run <file>` and `nimbus workflow run`), `data.export`, `data.import`, `updater.applyUpdate`.

Past 30 s the CLI printed `IPC request timed out after 30000ms: <method>` and exited 1 **while the operation ran to completion server-side**. The command reported failure for work that succeeded — and a user who re-ran it queued the work twice.

Eleven call sites, none passing an options object. `requestTimeoutMs` is a per-**client** constructor option, not per-call, so the budget is opted into per command rather than raised globally; fast RPCs keep the tight default. Tests pin both directions (`connector sync` opts in, `connector history` does not).

### 2. The call blocks on a HUMAN — the stronger half

The CLI answers the Gateway's `consent.request` from a `@clack` `confirm()` that runs **inside** the still-pending call's window. So the bound doubled as the user's think time: answer the y/n prompt slower than 30 s and the call it belonged to was already dead. This bit **regardless of data volume** — a one-item index included. `lib/interactive-ipc-handlers.ts` already documented this failure mode.

## Two hard bugs found alongside

Total failures, not slow ones:

- **`nimbus connector reindex <svc> --depth full`** is HITL-gated in `ipc/reindex-rpc.ts` but registered **no `consent.request` handler at all**, so the gate never received `consent.respond`. It failed **100% of the time**, independent of index size — same defect and same fix as `connector remove` (#1013).
- **`nimbus workflow run`** registered only the agent-chunk handler, so a HITL step hung to the timeout **without ever showing the user a prompt**. It now uses the same combined helper as its sibling `nimbus run <file>`, which also gives it `NIMBUS_SCRIPT_CONSENT_SOURCE` support.

The existing `reindex --depth full` test could not have caught this: its mock resolves `call` immediately and never raises the notification, so it passed while the command was broken. The new tests drive the notification.

## Why long-but-finite, and why no `onClose`

A **dead** Gateway never depended on these timers — `IPCClient.failAll` rejects every pending `call()` on socket close or error, so a long budget still fails fast when the socket dies. The timers backstop only a Gateway that is **alive and silent**.

That is also why the budgets are finite: `requestTimeoutMs: 0` disables the timer outright and restores the hang-forever behaviour the transport's own docblock records it was added to prevent. The Tauri bridge takes the opposite side of that trade for its `NO_TIMEOUT_METHODS`; the CLI deliberately does not follow it.

## Tauri

`workflow.run` was in `ALLOWED_METHODS` but not `NO_TIMEOUT_METHODS`, so the desktop UI aborted the identical call at its own 30 s bound. It joins the list — now six, with the count-pinned I7 tests updated (`no_timeout_methods_contains_expected_six`, `exact_size` 5→6).

## Verification

- `bun test packages/cli/src` — **2281 pass, 0 fail**
- `cargo test --lib gateway_bridge` — **30 pass, 0 fail**
- `bun run preflight:fast` — **29/29 gates PASSED**
- **Red-proved**: reverting each fix fails exactly the intended tests and nothing else — 3 fail for reindex (consent handler, consent round-trip, batch budget), 2 for workflow run (consent handler, interactive budget). The "still streams agent chunks" test passes both ways by design: it guards that the consent handler was added *alongside* the chunk handler, not instead of it.

## Deliberately NOT in scope

The structurally correct end state is converting these methods to the `LongRunningJobRegistry` `{ jobId }` + notification shape the repo already uses for `index.reembed`/`index.rebody` — and which `commands/glossary.ts` cites this exact 30 s bound as the reason for. That is a larger change with real constraints:

- `index.regraph` is a clean candidate (ungated pure batch work).
- `connector.reindex` is **not**: it is in the I2 HITL frozen set, and moving its gate inside the job would return `{ jobId }` before the owner consents — a contract change on a gated action.
- Migrating `ask` to the already-correct `engine.askStream` would silently drop the `--agent` selector, which `AskStreamParams` does not carry, and cannot express `prove`'s `stream: false`.

Until then a timed-out command still leaves **non-gated** server-side work running with no way to cancel it. HITL-gated steps do fail closed on client disconnect (`ipc/consent.ts` rejects pending consents; the executor records `hitlStatus='rejected'` and audit-logs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running CLI operations now support extended timeout periods.
  * Interactive commands can display and handle consent prompts during reindexing, workflow execution, and other approval-gated actions.
  * Workflow runs can wait for completion beyond the previous 30-second limit.
* **Bug Fixes**
  * Socket failures continue to be reported immediately.
  * Updated CLI behavior preserves shorter default timeouts for quick requests.
* **Documentation**
  * Added changelog notes covering timeout behavior, consent handling, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->