### PR TITLE
refactor: clear the nine cognitive-complexity findings

### DIFF
--- a/packages/cli/src/commands/doctor-core.ts
+++ b/packages/cli/src/commands/doctor-core.ts
@@ -509,6 +509,31 @@ async function doctorRunGatewayRpcs(client: IPCClient): Promise<number> {
   return exit;
 }
 
+/**
+ * Print diagnostic lines and return the exit code they imply: 2 when a `[fail]` is
+ * present, 1 when a `[warn]` is, 0 otherwise. The caller folds it in with `Math.max`, so
+ * severity only ever ratchets up.
+ *
+ * Lifted out of {@link runDoctor} — inline, the loop plus its if/else-if was worth about
+ * eight points of cognitive complexity (Sonar `S3776`) for one idea, and that idea is
+ * reusable by every future check emitting the same prefixed lines.
+ *
+ * (Prose in this file deliberately avoids the bare TypeScript escape-hatch keyword. The
+ * `audit:a-n-y` gate strips comments with a scanner that does not understand regex
+ * literals; the one near the top of this file defeats it, so comment prose below that
+ * point is counted as real usage. It over-counts only — a genuine occurrence appended
+ * here is still detected, verified — but it will fail the gate on a comment.)
+ */
+function printAndScoreLines(lines: readonly string[]): number {
+  let exit = 0;
+  for (const line of lines) {
+    console.log(line);
+    if (line.startsWith("[fail]")) exit = Math.max(exit, 2);
+    else if (line.startsWith("[warn]")) exit = Math.max(exit, 1);
+  }
+  return exit;
+}
+
 export async function runDoctor(args: string[], deps: DoctorCoreDeps): Promise<void> {
   // Strictly opt-in: a plain `nimbus doctor` never touches `fixKeyringDeps` and
   // stays read-only. Only an explicit `--fix-keyring` runs the fixer, and it
@@ -537,11 +562,7 @@ export async function runDoctor(args: string[], deps: DoctorCoreDeps): Promise<v
     which: (n) => Bun.which(n),
     platform: platform() as "win32" | "darwin" | "linux",
   });
-  for (const line of voiceLines) {
-    console.log(line);
-    if (line.startsWith("[fail]")) exit = Math.max(exit, 2);
-    else if (line.startsWith("[warn]")) exit = Math.max(exit, 1);
-  }
+  exit = Math.max(exit, printAndScoreLines(voiceLines));
 
   const state = await deps.readGatewayState(paths);
   if (state !== undefined && deps.isProcessAlive(state.pid)) {

--- a/packages/gateway/src/agents/negotiate.ts
+++ b/packages/gateway/src/agents/negotiate.ts
@@ -170,19 +170,29 @@ function laneFailureGap(laneName: string, r: SubTaskResult): GapNote {
  * the enrichment pass has run, hence `statsCoverage`: an aggregate over a partial subset
  * must disclose its own denominator rather than be printed as if it covered everything.
  */
-function laneAuthoredPrs(db: Database, personId: string, sinceMs: number): NegotiateAuthoredPrs {
-  const cutoff = Date.now() - sinceMs;
-  const rows = db
-    .query(
-      `SELECT i.metadata AS metadata
-         FROM graph_relation r
-         JOIN graph_entity pe  ON pe.id = r.from_id AND pe.type = 'person'
-         JOIN graph_entity pre ON pre.id = r.to_id  AND pre.type = 'pr'
-         JOIN item i           ON i.id = pre.external_id
-        WHERE r.type = 'authored' AND pe.external_id = ? AND i.modified_at >= ?`,
-    )
-    .all(personId, cutoff) as Array<{ metadata: string }>;
-
+/**
+ * Fold one person's authored-PR metadata rows into the five counters
+ * {@link laneAuthoredPrs} reports. Lifted out of that function to bring it back under the
+ * cognitive-complexity gate (Sonar `S3776`) — the loop and its five guards were the whole
+ * of its score.
+ *
+ * Unparseable metadata contributes to neither the merged count nor stats coverage — but it
+ * DOES stay in `count`/`statsCoverage.total` at the call site, because the PR itself is real
+ * evidence and dropping it would understate the headline number. The consequence is
+ * asymmetric disclosure: the stats half is self-disclosing (`statsCoverage` renders
+ * `covered/total`, so an unparseable row visibly widens the gap), while the `merged` half is
+ * not — `merged` carries no denominator of its own, so a PR whose metadata will not parse is
+ * silently absent from it. Only a genuinely corrupt `item.metadata` reaches here (every
+ * writer goes through `JSON.stringify`), so this is a never-in-practice edge rather than a
+ * live undercount; a `mergedCoverage` companion field is the fix if it ever stops being one.
+ */
+function accumulateAuthoredPrStats(rows: ReadonlyArray<{ metadata: string }>): {
+  merged: number;
+  covered: number;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+} {
   let merged = 0;
   let covered = 0;
   let additions = 0;
@@ -196,16 +206,6 @@ function laneAuthoredPrs(db: Database, personId: string, sinceMs: number): Negot
         meta = parsed as Record<string, unknown>;
       }
     } catch {
-      // Unparseable metadata contributes to neither the merged count nor stats coverage —
-      // but it DOES stay in `count`/`statsCoverage.total`, because the PR itself is real
-      // evidence and dropping it would understate the headline number. The consequence is
-      // asymmetric disclosure: the stats half is self-disclosing (`statsCoverage` renders
-      // `covered/total`, so an unparseable row visibly widens the gap), while the `merged`
-      // half is not — `merged` carries no denominator of its own, so a PR whose metadata
-      // will not parse is silently absent from it. Only a genuinely corrupt `item.metadata`
-      // reaches here (every writer goes through `JSON.stringify`), so this is a
-      // never-in-practice edge rather than a live undercount; a `mergedCoverage` companion
-      // field is the fix if it ever stops being one.
       continue;
     }
     if (meta["merged"] === true) merged += 1;
@@ -219,6 +219,24 @@ function laneAuthoredPrs(db: Database, personId: string, sinceMs: number): Negot
       if (typeof c === "number") changedFiles += c;
     }
   }
+  return { merged, covered, additions, deletions, changedFiles };
+}
+
+function laneAuthoredPrs(db: Database, personId: string, sinceMs: number): NegotiateAuthoredPrs {
+  const cutoff = Date.now() - sinceMs;
+  const rows = db
+    .query(
+      `SELECT i.metadata AS metadata
+         FROM graph_relation r
+         JOIN graph_entity pe  ON pe.id = r.from_id AND pe.type = 'person'
+         JOIN graph_entity pre ON pre.id = r.to_id  AND pre.type = 'pr'
+         JOIN item i           ON i.id = pre.external_id
+        WHERE r.type = 'authored' AND pe.external_id = ? AND i.modified_at >= ?`,
+    )
+    .all(personId, cutoff) as Array<{ metadata: string }>;
+
+  const { merged, covered, additions, deletions, changedFiles } = accumulateAuthoredPrStats(rows);
+
   const refs = evidenceRefsFor(
     db,
     `SELECT i.title AS title, COALESCE(i.canonical_url, i.url) AS url
@@ -890,6 +908,32 @@ function detectMissingIncidentPersonEdges(db: Database): GapNote | null {
  * run a command that reports "graphed N" and changes nothing. State the actual cause
  * instead.
  */
+/**
+ * Push at most ONE gap note for a connector-backed lane: the missing-connector note if the
+ * connector is absent, otherwise the missing-edges note if it is present but has emitted
+ * none.
+ *
+ * Ordered more fundamental cause first, and deliberately exclusive: a missing connector
+ * structurally implies missing edges, so firing both would emit two notes for one root
+ * cause. Written once here because the PagerDuty and Sentry blocks it replaces were the
+ * same eleven lines twice, and were most of the caller's cognitive-complexity score
+ * (Sonar `S3776`).
+ */
+function pushConnectorOrEdgeGap(
+  db: Database,
+  service: string,
+  detectMissingEdges: (db: Database) => GapNote | null,
+  gaps: GapNote[],
+): void {
+  const missingConnector = detectMissingConnector(db, service);
+  if (missingConnector !== null) {
+    gaps.push(missingConnector);
+    return;
+  }
+  const missingEdges = detectMissingEdges(db);
+  if (missingEdges !== null) gaps.push(missingEdges);
+}
+
 function detectMissingErrorIssuePersonEdges(db: Database): GapNote | null {
   const missingEmit = detectMissingRelationToEntityType(db, "assigned", "error_issue");
   if (missingEmit === null) return null;
@@ -952,30 +996,15 @@ export async function runNegotiate(
     // `missing_user_identity` gap and must not also emit connector noise. Ordered more
     // fundamental cause first: no connector before no edges, since a missing connector
     // implies missing edges too and naming both would be redundant.
-    const missingPagerdutyConnector = detectMissingConnector(ctx.db, "pagerduty");
-    if (missingPagerdutyConnector !== null) {
-      gaps.push(missingPagerdutyConnector);
-    } else {
-      // `detectMissingIncidentPersonEdges` builds an honest, scoped `GapNote` rather
-      // than falling back to `detectMissingRelationToEntityType`'s shared default
-      // detail, which says the edges are "not yet emitted by the graph populator" —
-      // false since `syncIncidentPersonEdges` shipped.
-      const missingIncidentEdges = detectMissingIncidentPersonEdges(ctx.db);
-      if (missingIncidentEdges !== null) gaps.push(missingIncidentEdges);
-    }
-    // Same shape as the PagerDuty block above, for the same reason: no Sentry
-    // connector structurally implies no `person --assigned--> error_issue`
-    // edges, so firing both would emit two notes for one root cause.
-    const missingSentryConnector = detectMissingConnector(ctx.db, "sentry");
-    if (missingSentryConnector !== null) {
-      gaps.push(missingSentryConnector);
-    } else {
-      // `detectMissingErrorIssuePersonEdges` builds an honest, scoped `GapNote` — an
-      // unassigned Sentry issue is the NORM, so the shared default detail's
-      // `nimbus index regraph` remediation would be a no-op in the common case.
-      const missingErrorIssueEdges = detectMissingErrorIssuePersonEdges(ctx.db);
-      if (missingErrorIssueEdges !== null) gaps.push(missingErrorIssueEdges);
-    }
+    // `detectMissingIncidentPersonEdges` builds an honest, scoped `GapNote` rather than
+    // falling back to `detectMissingRelationToEntityType`'s shared default detail, which
+    // says the edges are "not yet emitted by the graph populator" — false since
+    // `syncIncidentPersonEdges` shipped.
+    pushConnectorOrEdgeGap(ctx.db, "pagerduty", detectMissingIncidentPersonEdges, gaps);
+    // `detectMissingErrorIssuePersonEdges` is scoped for its own reason — an unassigned
+    // Sentry issue is the NORM, so the shared default's `nimbus index regraph` remediation
+    // would be a no-op in the common case.
+    pushConnectorOrEdgeGap(ctx.db, "sentry", detectMissingErrorIssuePersonEdges, gaps);
     laneNames.push(
       "authoredPrs",
       "reviewedPrs",

--- a/packages/gateway/src/agents/premortem.ts
+++ b/packages/gateway/src/agents/premortem.ts
@@ -575,6 +575,79 @@ function buildWatcherProposals(
   };
 }
 
+/**
+ * The brief returned when the ref names a tracker other than Jira.
+ *
+ * Every measured field is empty and the single gap says why — pre-mortem is JIRA-ONLY, and
+ * an empty brief with no explanation would read as "nothing to worry about" rather than
+ * "nothing was looked at". Split out of {@link runPremortem} so that function's happy path
+ * is not preceded by a 20-line literal (Sonar `S3776`).
+ */
+function nonJiraTrackerBrief(
+  epicRef: string,
+  trackerPrefix: string,
+  now: number,
+  start: number,
+  query: PremortemBrief["query"],
+): PremortemBrief {
+  const gaps: GapNote[] = [
+    {
+      category: "missing_relation_emit",
+      detail: nonJiraTrackerDetail(epicRef, trackerPrefix),
+      remediation: "Pass a Jira epic key, e.g. `PROJ-120` or `jira:PROJ-120`.",
+    },
+  ];
+  pushUnconditionalGaps(gaps);
+  return {
+    kind: "premortem",
+    agentVersion: 1,
+    generatedAt: now,
+    latencyMs: Math.round(performance.now() - start),
+    gaps,
+    query,
+    epic: null,
+    services: [],
+    cohort: emptyCohort(),
+    risks: [],
+    themes: [],
+    watchers: [],
+  };
+}
+
+/**
+ * Resolve an epic key to its indexed Jira row, or throw explaining exactly which check
+ * failed.
+ *
+ * The two failures are deliberately distinct. A missing row is "not found". A row of the
+ * wrong type is NOT — an item exists at this key, and saying "not found" would assert a
+ * cause that is not true. `jira-sync.ts` stores the raw Jira issue-type name verbatim
+ * (admins rename types, non-English instances localize them), so the message states what
+ * was checked rather than guessing why.
+ *
+ * Split out of {@link runPremortem} to bring it under the cognitive-complexity gate
+ * (Sonar `S3776`); it is also a coherent step on its own — resolve, or refuse with a
+ * reason.
+ */
+function requireIndexedJiraEpic(
+  db: PremortemContext["db"],
+  epicRef: string,
+  key: string,
+): NonNullable<ReturnType<typeof lookupJiraItem>> {
+  const rawRow = lookupJiraItem(db, key);
+  if (rawRow === null) {
+    throw new Error(`pre-mortem: '${epicRef}' was not found in the local Jira index`);
+  }
+  if (rawRow.issue_type !== "Epic") {
+    const typeDesc =
+      rawRow.issue_type === null ? "no recorded issue type" : `type \`${rawRow.issue_type}\``;
+    throw new Error(
+      `pre-mortem: '${epicRef}' is indexed with ${typeDesc}, not the literal Jira type ` +
+        "`Epic` pre-mortem requires (a renamed or localized type name is not recognized)",
+    );
+  }
+  return rawRow;
+}
+
 export async function runPremortem(
   input: PremortemInput,
   ctx: PremortemContext,
@@ -590,47 +663,10 @@ export async function runPremortem(
   const { trackerPrefix, key } = parseEpicRef(input.epicRef);
 
   if (trackerPrefix !== null && trackerPrefix.toLowerCase() !== "jira") {
-    const gaps: GapNote[] = [
-      {
-        category: "missing_relation_emit",
-        detail: nonJiraTrackerDetail(input.epicRef, trackerPrefix),
-        remediation: "Pass a Jira epic key, e.g. `PROJ-120` or `jira:PROJ-120`.",
-      },
-    ];
-    pushUnconditionalGaps(gaps);
-    return {
-      kind: "premortem",
-      agentVersion: 1,
-      generatedAt: now,
-      latencyMs: Math.round(performance.now() - start),
-      gaps,
-      query,
-      epic: null,
-      services: [],
-      cohort: emptyCohort(),
-      risks: [],
-      themes: [],
-      watchers: [],
-    };
+    return nonJiraTrackerBrief(input.epicRef, trackerPrefix, now, start, query);
   }
 
-  const rawRow = lookupJiraItem(ctx.db, key);
-  if (rawRow === null) {
-    throw new Error(`pre-mortem: '${input.epicRef}' was not found in the local Jira index`);
-  }
-  if (rawRow.issue_type !== "Epic") {
-    // NOT "not found" — an item exists at this key. `jira-sync.ts` stores the
-    // raw Jira issue-type name verbatim (admins rename types, non-English
-    // instances localize them), so this states exactly what was checked
-    // rather than asserting a cause ("not found") that isn't true.
-    const typeDesc =
-      rawRow.issue_type === null ? "no recorded issue type" : `type \`${rawRow.issue_type}\``;
-    throw new Error(
-      `pre-mortem: '${input.epicRef}' is indexed with ${typeDesc}, not the literal Jira type ` +
-        "`Epic` pre-mortem requires (a renamed or localized type name is not recognized)",
-    );
-  }
-  const epicRow = rawRow;
+  const epicRow = requireIndexedJiraEpic(ctx.db, input.epicRef, key);
   const epic: PremortemEpicView = {
     itemId: epicRow.id,
     key: epicRow.external_id,

--- a/packages/gateway/src/connectors/github-sync.ts
+++ b/packages/gateway/src/connectors/github-sync.ts
@@ -67,6 +67,29 @@ export function shouldRefreshMergeableState(input: MergeableStateRefreshInput): 
   return refreshAge > MERGEABLE_STATE_REFRESH_FRESHNESS_MS;
 }
 
+/**
+ * The merged-only half of {@link extractPrMetadataForIndex}: fields that exist solely
+ * on a merged PR. Three levels of nesting on their own, which is most of why that
+ * function was over the cognitive-complexity gate (Sonar `S3776`).
+ *
+ * Both fields are written only when genuinely present and parseable — an unparseable
+ * `merged_at` writes nothing rather than `NaN`, since a NaN timestamp in the index reads
+ * as a real value everywhere downstream.
+ */
+function applyMergeFields(out: Record<string, unknown>, pr: Record<string, unknown>): void {
+  const mergedAtIso = stringField(pr, "merged_at");
+  if (mergedAtIso !== undefined) {
+    const ms = Date.parse(mergedAtIso);
+    if (Number.isFinite(ms)) {
+      out["merged_at"] = ms;
+    }
+  }
+  const sha = stringField(pr, "merge_commit_sha");
+  if (sha !== undefined && sha.length > 0) {
+    out["merge_commit_sha"] = sha;
+  }
+}
+
 export function extractPrMetadataForIndex(
   repoFull: string,
   pr: Record<string, unknown>,
@@ -100,17 +123,7 @@ export function extractPrMetadataForIndex(
     }
   }
   if (merged) {
-    const mergedAtIso = stringField(pr, "merged_at");
-    if (mergedAtIso !== undefined) {
-      const ms = Date.parse(mergedAtIso);
-      if (Number.isFinite(ms)) {
-        out["merged_at"] = ms;
-      }
-    }
-    const sha = stringField(pr, "merge_commit_sha");
-    if (sha !== undefined && sha.length > 0) {
-      out["merge_commit_sha"] = sha;
-    }
+    applyMergeFields(out, pr);
   }
   return out;
 }

--- a/packages/gateway/src/connectors/pagerduty-attribution.ts
+++ b/packages/gateway/src/connectors/pagerduty-attribution.ts
@@ -139,6 +139,30 @@ export function extractPagerdutyActors(
  * a `/users/{id}` request on. Service actors are excluded so an auto-resolving
  * tenant never burns the lookup budget.
  */
+/**
+ * Add every actor id from ONE incident's candidate list that still needs an email
+ * lookup. Lifted out of {@link pagerdutyUnresolvedActorIds} — it was the inner of two
+ * nested loops with four guards inside it, which is most of that function's
+ * cognitive-complexity score (Sonar `S3776`).
+ *
+ * An actor is skipped when it is a service rather than a person, when it already carries
+ * a usable email, when it has no id, or when `emailById` already knows the id. Only what
+ * survives all four needs fetching.
+ */
+function addUnresolvedActorIds(
+  candidates: readonly Record<string, unknown>[],
+  emailById: ReadonlyMap<string, string>,
+  into: Set<string>,
+): void {
+  for (const actor of candidates) {
+    if (isServiceActor(actor)) continue;
+    if (usableActorEmail(actor["email"]) !== null) continue;
+    const id = stringField(actor, "id");
+    if (id === undefined || id === "" || emailById.has(id)) continue;
+    into.add(id);
+  }
+}
+
 export function pagerdutyUnresolvedActorIds(
   incidents: readonly unknown[],
   emailById: ReadonlyMap<string, string>,
@@ -150,13 +174,7 @@ export function pagerdutyUnresolvedActorIds(
     const candidates = [...actorsOnIncident(row)];
     const resolver = resolverRef(row);
     if (resolver !== undefined) candidates.push(resolver);
-    for (const actor of candidates) {
-      if (isServiceActor(actor)) continue;
-      if (usableActorEmail(actor["email"]) !== null) continue;
-      const id = stringField(actor, "id");
-      if (id === undefined || id === "" || emailById.has(id)) continue;
-      ids.add(id);
-    }
+    addUnresolvedActorIds(candidates, emailById, ids);
   }
   return [...ids];
 }

--- a/packages/gateway/src/connectors/pagerduty-sync.ts
+++ b/packages/gateway/src/connectors/pagerduty-sync.ts
@@ -229,6 +229,46 @@ export type PagerdutySyncableOptions = {
   maxPagesPerSync?: number;
 };
 
+/**
+ * Merge a page's newly-discovered actor emails into the run-scoped map, first write
+ * wins. Lifted out of the sync loop: as an inline `for` with a nested `if` it was worth
+ * five points of cognitive complexity (Sonar `S3776`) for one line of intent.
+ *
+ * First write wins deliberately — `emailById` is run-scoped so a repeated actor is
+ * harvested once per SYNC, and a later page re-reporting the same id must not overwrite
+ * an email an explicit user lookup already resolved.
+ */
+function mergeNewEmails(into: Map<string, string>, page: ReadonlyMap<string, string>): void {
+  for (const [id, email] of page) {
+    if (!into.has(id)) into.set(id, email);
+  }
+}
+
+/**
+ * The result a run returns when a page cannot be read — an HTTP failure or an
+ * unparseable body. Identical in both cases: keep everything already upserted, park the
+ * cursor at the high-water mark so the next run resumes from there, and report
+ * `hasMore: false` so the scheduler does not immediately retry into the same wall.
+ *
+ * One helper rather than two byte-identical object literals, which is what the two early
+ * returns in the loop used to be.
+ */
+function partialSyncResult(
+  maxUpdated: string,
+  itemsUpserted: number,
+  bytesTransferred: number,
+  t0: number,
+): SyncResult {
+  return {
+    cursor: encodeCursor({ lastUpdated: maxUpdated }),
+    itemsUpserted,
+    itemsDeleted: 0,
+    hasMore: false,
+    durationMs: Math.round(performance.now() - t0),
+    bytesTransferred,
+  };
+}
+
 export function createPagerdutySyncable(options: PagerdutySyncableOptions): Syncable {
   const initialSyncDepthDays = 30;
   const maxPagesPerSync = Math.max(1, Math.min(100, options.maxPagesPerSync ?? 20));
@@ -296,28 +336,14 @@ export function createPagerdutySyncable(options: PagerdutySyncableOptions): Sync
             { serviceId: SERVICE_ID, status: res.status, page: pagesFetched },
             "pagerduty sync: list failed",
           );
-          return {
-            cursor: encodeCursor({ lastUpdated: maxUpdated }),
-            itemsUpserted: totalUpserted,
-            itemsDeleted: 0,
-            hasMore: false,
-            durationMs: Math.round(performance.now() - t0),
-            bytesTransferred: totalBytesTransferred,
-          };
+          return partialSyncResult(maxUpdated, totalUpserted, totalBytesTransferred, t0);
         }
         const parsed = parsePagerdutyListResponse(text);
         if (parsed === null) {
-          return {
-            cursor: encodeCursor({ lastUpdated: maxUpdated }),
-            itemsUpserted: totalUpserted,
-            itemsDeleted: 0,
-            hasMore: false,
-            durationMs: Math.round(performance.now() - t0),
-            bytesTransferred: totalBytesTransferred,
-          };
+          return partialSyncResult(maxUpdated, totalUpserted, totalBytesTransferred, t0);
         }
         const pageEmails = pagerdutyEmailMapFromIncidents(parsed.incidents);
-        for (const [k, v] of pageEmails) if (!emailById.has(k)) emailById.set(k, v);
+        mergeNewEmails(emailById, pageEmails);
         totalBytesTransferred += await resolveMissingActorEmails(
           ctx,
           token,

--- a/packages/gateway/src/connectors/sentry-issue-sync.ts
+++ b/packages/gateway/src/connectors/sentry-issue-sync.ts
@@ -102,6 +102,41 @@ function resolveNextUrl(
   return resolved.href;
 }
 
+/**
+ * Upsert one page of issues and return what it contributed: how many rows were written,
+ * and the running high-water mark after them.
+ *
+ * Lifted out of {@link syncSentryIssuePass}, which was more than 12 points over the
+ * cognitive-complexity gate (Sonar `S3776`); this loop and its four guards were most of
+ * it. Pure with respect to the walk — it reads no pagination state and decides nothing
+ * about whether to continue.
+ */
+function upsertSentryIssuePage(
+  input: SentryIssuePassInput,
+  list: readonly unknown[],
+  startingMaxMs: number | null,
+): { upserted: number; runningMaxMs: number | null } {
+  let upserted = 0;
+  let runningMaxMs = startingMaxMs;
+  for (const raw of list) {
+    const row = mapSentryIssueToItem(raw, { org: input.org, syncedAt: input.now });
+    if (row === null) continue;
+    // SKIP, not stop: newest-first pagination means one out-of-order row
+    // at/below the stored high-water mark does NOT mean everything after
+    // it is old too — a later row in the same page (or a later page) can
+    // still be newer and must still be reached.
+    if (input.cursorLastSeenMs !== null && row.modifiedAt <= input.cursorLastSeenMs) {
+      continue;
+    }
+    upsertIndexedItemForSync(input.ctx, row);
+    upserted += 1;
+    if (runningMaxMs === null || row.modifiedAt > runningMaxMs) {
+      runningMaxMs = row.modifiedAt;
+    }
+  }
+  return { upserted, runningMaxMs };
+}
+
 export async function syncSentryIssuePass(
   input: SentryIssuePassInput,
 ): Promise<SentryIssuePassResult> {
@@ -162,22 +197,9 @@ export async function syncSentryIssuePass(
     }
     const list = Array.isArray(root) ? root : [];
 
-    for (const raw of list) {
-      const row = mapSentryIssueToItem(raw, { org: input.org, syncedAt: input.now });
-      if (row === null) continue;
-      // SKIP, not stop: newest-first pagination means one out-of-order row
-      // at/below the stored high-water mark does NOT mean everything after
-      // it is old too — a later row in the same page (or a later page) can
-      // still be newer and must still be reached.
-      if (input.cursorLastSeenMs !== null && row.modifiedAt <= input.cursorLastSeenMs) {
-        continue;
-      }
-      upsertIndexedItemForSync(ctx, row);
-      upserted += 1;
-      if (runningMaxMs === null || row.modifiedAt > runningMaxMs) {
-        runningMaxMs = row.modifiedAt;
-      }
-    }
+    const page = upsertSentryIssuePage(input, list, runningMaxMs);
+    upserted += page.upserted;
+    runningMaxMs = page.runningMaxMs;
 
     pages += 1;
     url = resolveNextUrl(nextPageUrl(res.headers.get("Link")), requestUrl, input.apiRoot, ctx);

--- a/packages/gateway/src/graph/graph-populator.ts
+++ b/packages/gateway/src/graph/graph-populator.ts
@@ -954,6 +954,61 @@ function occurredAtForItem(db: Database, itemId: string): number {
   return row.modified_at;
 }
 
+/**
+ * Per-item-type graph writers, keyed by `item.type`.
+ *
+ * A table rather than the fifteen-arm `if` chain this replaces. That chain was over the
+ * cognitive-complexity gate (Sonar `S3776`) purely from the count of branches — every arm
+ * was the same shape, so there was nothing to understand fifteen times. A lookup also
+ * makes the set of handled types readable at a glance and makes adding one a single row.
+ *
+ * The two timeline types share `syncTimelineEventGraph`, differing only in the kind they
+ * record and in needing the item's occurrence time.
+ */
+const GRAPH_SYNC_BY_TYPE: Readonly<
+  Record<
+    string,
+    (
+      db: Database,
+      row: IndexedItemGraphInput,
+      now: number,
+      resolveServiceId?: ResolveServiceId,
+    ) => void
+  >
+> = Object.freeze({
+  pr: (db, row, now) => syncPrGraph(db, row, now),
+  review: (db, row, now) => syncReviewGraph(db, row, now),
+  issue: (db, row, now) => syncIssueGraph(db, row, now),
+  message: (db, row, now) => syncMessageGraph(db, row, now),
+  git_commit: (db, row, now) => syncGitCommitGraph(db, row, now),
+  dependency: (db, row, now) => syncDependencyGraph(db, row, now),
+  api_endpoint: (db, row, now) => syncApiEndpointGraph(db, row, now),
+  code_symbol: (db, row, now) => syncCodeSymbolGraph(db, row, now),
+  obsidian_note: (db, row, now) => syncObsidianNoteGraph(db, row, now),
+  data_model: (db, row, now) => syncDataModelGraph(db, row, now),
+  dashboard: (db, row, now) => syncDashboardGraph(db, row, now),
+  data_quality_test: (db, row, now) => syncDataQualityTestGraph(db, row, now),
+  error_issue: (db, row, now) => syncErrorIssueGraph(db, row, now),
+  incident: (db, row, now, resolveServiceId) =>
+    syncTimelineEventGraph(
+      db,
+      row,
+      "incident",
+      occurredAtForItem(db, row.id),
+      now,
+      resolveServiceId,
+    ),
+  deployment: (db, row, now, resolveServiceId) =>
+    syncTimelineEventGraph(
+      db,
+      row,
+      "deployment",
+      occurredAtForItem(db, row.id),
+      now,
+      resolveServiceId,
+    ),
+});
+
 export function syncGraphFromIndexedItem(
   db: Database,
   row: IndexedItemGraphInput,
@@ -965,80 +1020,10 @@ export function syncGraphFromIndexedItem(
   if (!isItemLinkedGraphType(row.type)) {
     return;
   }
-
-  const now = Date.now();
-
-  if (row.type === "pr") {
-    syncPrGraph(db, row, now);
+  // `Object.hasOwn`, not a bare index: `row.type` is a string off an indexed row, so a
+  // value like "constructor" would otherwise reach Object.prototype and be called.
+  if (!Object.hasOwn(GRAPH_SYNC_BY_TYPE, row.type)) {
     return;
   }
-  if (row.type === "review") {
-    syncReviewGraph(db, row, now);
-    return;
-  }
-  if (row.type === "issue") {
-    syncIssueGraph(db, row, now);
-    return;
-  }
-  if (row.type === "message") {
-    syncMessageGraph(db, row, now);
-    return;
-  }
-  if (row.type === "git_commit") {
-    syncGitCommitGraph(db, row, now);
-    return;
-  }
-  if (row.type === "dependency") {
-    syncDependencyGraph(db, row, now);
-    return;
-  }
-  if (row.type === "api_endpoint") {
-    syncApiEndpointGraph(db, row, now);
-    return;
-  }
-  if (row.type === "code_symbol") {
-    syncCodeSymbolGraph(db, row, now);
-    return;
-  }
-  if (row.type === "obsidian_note") {
-    syncObsidianNoteGraph(db, row, now);
-    return;
-  }
-  if (row.type === "data_model") {
-    syncDataModelGraph(db, row, now);
-    return;
-  }
-  if (row.type === "dashboard") {
-    syncDashboardGraph(db, row, now);
-    return;
-  }
-  if (row.type === "data_quality_test") {
-    syncDataQualityTestGraph(db, row, now);
-    return;
-  }
-  if (row.type === "error_issue") {
-    syncErrorIssueGraph(db, row, now);
-    return;
-  }
-  if (row.type === "incident") {
-    syncTimelineEventGraph(
-      db,
-      row,
-      "incident",
-      occurredAtForItem(db, row.id),
-      now,
-      resolveServiceId,
-    );
-    return;
-  }
-  if (row.type === "deployment") {
-    syncTimelineEventGraph(
-      db,
-      row,
-      "deployment",
-      occurredAtForItem(db, row.id),
-      now,
-      resolveServiceId,
-    );
-  }
+  GRAPH_SYNC_BY_TYPE[row.type]?.(db, row, Date.now(), resolveServiceId);
 }


### PR DESCRIPTION
Clears the last **9** open SonarCloud issues in this repo, all `S3776`. That takes the org to zero across all six repos.

Every change is an extraction of a block that already existed as a unit — no behaviour change, no signature change on anything exported.

| file | was | what moved |
|---|---|---|
| `graph/graph-populator.ts` | 17 | a **fifteen-arm `if` chain** on `row.type` → `GRAPH_SYNC_BY_TYPE` lookup table |
| `connectors/sentry-issue-sync.ts` | 27 | the per-page upsert loop → `upsertSentryIssuePage` |
| `agents/negotiate.ts` | 32 | two byte-identical connector-gap blocks → one `pushConnectorOrEdgeGap` |
| `agents/negotiate.ts` | 17 | the PR-metadata fold → `accumulateAuthoredPrStats` |
| `agents/premortem.ts` | 28 | epic resolve/validate → `requireIndexedJiraEpic`; the non-Jira brief → `nonJiraTrackerBrief` |
| `connectors/pagerduty-attribution.ts` | 16 | the inner actor loop → `addUnresolvedActorIds` |
| `connectors/pagerduty-sync.ts` | 16 | the email merge → `mergeNewEmails`; **two identical** early-return literals → `partialSyncResult` |
| `connectors/github-sync.ts` | 16 | the merged-only fields → `applyMergeFields` |
| `cli/commands/doctor-core.ts` | 16 | print-and-score → `printAndScoreLines` |

Two are worth more than a complexity number: the `graph-populator` chain was fifteen arms of identical shape, so a table makes the handled set readable at a glance and adding one a single row; and `negotiate` / `pagerduty-sync` each had genuinely duplicated blocks that are now written once.

The table uses `Object.hasOwn` rather than a bare index — `row.type` is a string off an indexed row, so `"constructor"` would otherwise reach `Object.prototype` and be invoked.

## A gate weakness found on the way, and why I did not "fix" it here

`audit:any` failed with `any count regressed: 5 > baseline 2`, blaming `doctor-core.ts` for **3**. I added no types — those were the English word in my new docblock.

`countAnyInSource` strips comments with a hand-rolled scanner that does not understand **regex literals**. The one at `doctor-core.ts:78` —

```ts
const OBJECT_PATH_PATTERN = /(?:^|\s)(?:object path|o)\s+"([^"]*)"/m;
```

— puts it into a string state it never leaves: only **1,177 of 25,554 bytes** get stripped, so comment prose from the top of the file onward is scanned as code.

**It over-counts only.** I checked the direction that would matter: appending a real `x: any` to that file still moves the count 3 → 5, so the non-negotiable "no `any`" gate is not missing violations. That is worth stating precisely rather than alarming — the failure mode is a false positive on prose, not a hole.

I reworded my comment instead of touching the scanner. Teaching it regex literals would change counts across the tree and force a baseline re-bank; that belongs in its own change with its own red-prove, not bundled into nine refactors. The comment in `doctor-core.ts` records the trap so the next person does not spend the same twenty minutes.

## Verification

- `bun test packages/gateway/src packages/cli/src` — **13452 pass, 0 fail**
- `bun run preflight:fast` — **29/29 gates PASSED**
- per-area suites green after each extraction (graph 162, negotiate 72, premortem 44, sentry 44, pagerduty 57+18, github-sync 32, doctor 83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
