### PR TITLE
fix: `nimbus config set` on a fresh machine, and an unactionable brief footer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,46 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-15 — two defects found by actually running Nimbus against a local Ollama,
+  neither of which any test could have caught.** The whole point of the exercise: a fake
+  gateway agrees with the code, and a real one does not.
+
+  Setup was a fully isolated install — `APPDATA`/`LOCALAPPDATA`/`USERPROFILE`/`HOME` all
+  redirected to a temp root, not just `NIMBUS_CONFIG_DIR`, which moves the config dir only
+  and would have left a gateway writing to the REAL index. Verified afterwards that the
+  real config (untouched since 2026-08-10) and data dir were never written.
+
+  **`nimbus config set` fails on a fresh machine.** `writeUtf8FileAtomicReplace` calls
+  `mkdtempSync(join(dir, …))` without ensuring `dir` exists, so the very first command the
+  install guide gives — `nimbus config set llm.local_model llama3.2`, documented BEFORE
+  "Start the Gateway", which is what would otherwise create the directory — dies with
+  `ENOENT: no such file or directory, mkdtemp '<configDir>/.nimbus.toml.swap-XXXXXX'`.
+  An error naming a swap file the user never asked for, from step one of setup. One
+  `mkdirSync(dir, { recursive: true })`; red-proved (reverting fails the new test, and the
+  control confirms an existing directory and its other files are untouched).
+
+  **The deterministic-brief footer gave unactionable advice.** Every built-in brief ended
+  with `Rendered deterministically — configure an LLM for prose synthesis.` Configuring
+  one changes nothing: both production callers of `dispatchAgentsRpc`
+  (`ipc/server/dispatchers.ts`, `agent-runs/agent-http-invoke.ts`) omit `llm` — the latter
+  explicitly, in a comment — so `AgentsRpcContext.llm` is ALWAYS undefined in production,
+  and `briefs/brief-llm-adapter.ts` says the same from the other side, calling itself "the
+  first place an LLM is wired into a built-in gateway agent surface". Confirmed live: with
+  `local_model = "llama3.2"` and `prefer_local = true` and Ollama running — a configuration
+  `nimbus ask` used successfully in the same session — `nimbus why` still printed it. The
+  footer now states the mode instead of prescribing a fix: "built-in briefs do not use an
+  LLM, regardless of `[llm]` settings."
+
+  **What the run confirmed working**, worth recording because it is the local-first claim
+  end to end: `nimbus init` inside a git repo appended a `[[filesystem.roots]]` block,
+  detected the running gateway and told the user to restart (exit 0, no silent no-op),
+  indexed on the second run, and suggested a real command derived from the actual code
+  (`nimbus why src/resize.ts:1 # resizeToThumbnail`). `nimbus search` returned the indexed
+  `code_symbol`. `nimbus ask` routed to Ollama and answered from indexed context, citing
+  the repo's own commit message, in 24.7 s on a 3.2B model. `nimbus egress` reported
+  **0 outbound events** for the whole session with an honest scope label and its two boot
+  markers — the I29 zero-row claim, observed rather than asserted.
+
 - **2026-08-15 — maintenance sweep: the skills the agent loads were drifting, and one
   of them was structurally broken.** Batched deliberately into one PR rather than four,
   since each carries CI cost and none is independently interesting.

--- a/packages/cli/src/lib/nimbus-toml-config.test.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -250,5 +250,31 @@ describe("setTomlValueInFile", () => {
     expect(otherStart).toBeGreaterThan(llmStart);
     expect(newKey).toBeGreaterThan(llmStart);
     expect(newKey).toBeLessThan(otherStart);
+  });
+
+  test("creates the config directory when it does not exist yet (fresh machine)", () => {
+    // The install guide runs `nimbus config set llm.local_model …` BEFORE
+    // "Start the Gateway", so on a new machine nothing has created the config
+    // directory yet. Without the mkdir this threw
+    // `ENOENT: ... mkdtemp '<configDir>/.nimbus.toml.swap-XXXXXX'` — an error naming a
+    // swap file the user never asked for, from the very first documented setup command.
+    // Found by running that documented sequence against a real gateway, not by a test.
+    const freshDir = join(dir, "does", "not", "exist", "yet");
+    const freshPath = join(freshDir, "nimbus.toml");
+    expect(existsSync(freshDir)).toBe(false);
+
+    setTomlValueInFile(freshPath, "llm.local_model", "llama3.2");
+
+    expect(existsSync(freshPath)).toBe(true);
+    expect(readFileSync(freshPath, "utf8")).toContain(`local_model = "llama3.2"`);
+  });
+
+  test("leaves an existing config directory and its other files alone", () => {
+    // The mkdir is recursive and therefore idempotent; prove it does not disturb a
+    // directory that already holds unrelated state.
+    const sibling = join(dir, "unrelated.txt");
+    writeFileSync(sibling, "keep me");
+    setTomlValueInFile(tomlPath, "llm.remote_model", "sonnet");
+    expect(readFileSync(sibling, "utf8")).toBe("keep me");
   });
 });

--- a/packages/cli/src/lib/nimbus-toml-config.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.ts
@@ -1,4 +1,5 @@
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   renameSync,
@@ -63,6 +64,13 @@ function parseSectionKey(source: string, section: string, key: string): string |
 
 function writeUtf8FileAtomicReplace(path: string, content: string): void {
   const dir = dirname(path);
+  // The config directory may not exist yet, and `nimbus config set` is the FIRST command
+  // the install guide gives — it is documented before "Start the Gateway", which is what
+  // would otherwise have created it. Without this, a brand-new machine gets a raw
+  // `ENOENT: ... mkdtemp '<configDir>/.nimbus.toml.swap-XXXXXX'` from the line below,
+  // which names a swap file the user never asked for and does not mention the real
+  // problem. Recursive + idempotent, so the already-exists path is unchanged.
+  mkdirSync(dir, { recursive: true });
   const swap = mkdtempSync(join(dir, `.${basename(path)}.swap-`));
   const tmp = join(swap, "content");
   try {

--- a/packages/gateway/src/agents/_lib/synthesize.test.ts
+++ b/packages/gateway/src/agents/_lib/synthesize.test.ts
@@ -339,6 +339,17 @@ describe("no-LLM labelling", () => {
     expect(out).toContain("Rendered deterministically");
   });
 
+  test("the footer does not tell the user to configure an LLM", async () => {
+    // It used to, and that was unactionable: both production callers of
+    // `dispatchAgentsRpc` omit `llm`, so every built-in brief takes this path no matter
+    // what `[llm]` says. Confirmed live — with `local_model` + `prefer_local` set and
+    // Ollama running (a config `nimbus ask` used successfully), `nimbus why` still
+    // printed the old text.
+    const out = await synthesize(EXPERT_FIXTURE);
+    expect(out).not.toMatch(/configure an LLM/i);
+    expect(out).toContain("regardless of");
+  });
+
   test("an LLM-backed render carries no such footer", async () => {
     const out = await synthesize(EXPERT_FIXTURE, {
       llm: { generateMarkdown: mock(async () => "# polished") },

--- a/packages/gateway/src/agents/_lib/synthesize.ts
+++ b/packages/gateway/src/agents/_lib/synthesize.ts
@@ -121,14 +121,28 @@ function toolNameFor(brief: SynthInput): string {
   return assertNeverBrief(brief);
 }
 
-const DETERMINISTIC_FOOTER = "_Rendered deterministically — configure an LLM for prose synthesis._";
+const DETERMINISTIC_FOOTER =
+  "_Rendered deterministically — built-in briefs do not use an LLM, regardless of `[llm]` settings._";
 
 /**
  * Label the no-LLM path so it reads as a supported mode rather than breakage.
  *
- * The fallback branches below (empty / throwing LLM) deliberately do NOT get
- * this footer: there the user HAS configured an LLM, and telling them to
- * configure one would send them to fix a setting that is already correct.
+ * WHY IT NO LONGER SAYS "configure an LLM": that was unactionable advice. Both production
+ * callers of `dispatchAgentsRpc` — `ipc/server/dispatchers.ts` and
+ * `agent-runs/agent-http-invoke.ts` — omit `llm`, the latter explicitly ("omitting `llm`,
+ * which that path also omits, so an HTTP brief and a socket brief are the same"), so
+ * `AgentsRpcContext.llm` is ALWAYS undefined in production and every built-in brief takes
+ * this path. `briefs/brief-llm-adapter.ts` says the same thing from the other side: it is
+ * "the first place an LLM is wired into a built-in gateway agent surface".
+ *
+ * Verified live rather than by reading: with `[llm].local_model = "llama3.2"` and
+ * `prefer_local = true` set and a running Ollama — a configuration `nimbus ask` used
+ * successfully in the same session — `nimbus why` still emitted this footer. So the old
+ * text sent a user who had done everything right to go and do it again.
+ *
+ * The fallback branches below (empty / throwing LLM) deliberately do NOT get this footer:
+ * there an LLM genuinely was supplied and simply did not produce usable output, so
+ * describing the render as LLM-free would be the inverse error.
  */
 function withDeterministicFooter(markdown: string): string {
   return `${markdown.trimEnd()}\n\n${DETERMINISTIC_FOOTER}\n`;


### PR DESCRIPTION
Two defects found by **actually running Nimbus against a local Ollama**, neither reachable by any test in the suite. That was the point of the exercise — a fake gateway agrees with the code; a real one does not.

Setup was a fully isolated install: `APPDATA` / `LOCALAPPDATA` / `USERPROFILE` / `HOME` all redirected to a temp root — **not** just `NIMBUS_CONFIG_DIR`, which moves the config dir only and would have left the gateway writing to the real index. Confirmed afterwards that the real config (untouched since 2026-08-10) and data dir were never written.

## 1. `nimbus config set` fails on a fresh machine

`writeUtf8FileAtomicReplace` calls `mkdtempSync(join(dir, …))` without ensuring `dir` exists. The install guide runs

```bash
nimbus config set llm.local_model llama3.2
```

**before** "Start the Gateway" — which is the thing that would otherwise create the directory. So step one of setup on a new machine dies with:

```
ENOENT: no such file or directory, mkdtemp '<configDir>/.nimbus.toml.swap-XXXXXX'
```

An error naming a swap file the user never asked for, with no hint that the real problem is a missing directory.

Fix is one `mkdirSync(dir, { recursive: true })`. **Red-proved**: reverting it fails the new test, and a control test confirms an existing directory and its other files are left alone (the mkdir is recursive and idempotent).

## 2. The deterministic-brief footer told users to fix something that changes nothing

Every built-in brief ended with:

> _Rendered deterministically — configure an LLM for prose synthesis._

Configuring one does nothing. Both production callers of `dispatchAgentsRpc` omit `llm`:

- `ipc/server/dispatchers.ts`
- `agent-runs/agent-http-invoke.ts` — explicitly, in a comment: *"omitting `llm`, which that path also omits, so an HTTP brief and a socket brief are the same"*

So `AgentsRpcContext.llm` is **always** undefined in production. `briefs/brief-llm-adapter.ts` states the same from the other side, describing itself as *"the first place an LLM is wired into a built-in gateway agent surface (`AgentsRpcContext.llm` has always been left undefined in production, so every other brief is deterministic Markdown)"*.

**Confirmed live, not by reading**: with `local_model = "llama3.2"`, `prefer_local = true`, and Ollama running — a configuration `nimbus ask` used successfully in the same session — `nimbus why` still printed the old footer. The advice sent a user who had done everything right to go and do it again.

The footer now states the mode instead of prescribing a fix:

> _Rendered deterministically — built-in briefs do not use an LLM, regardless of `[llm]` settings._

The empty/throwing-LLM fallback branches deliberately still do **not** get this footer: there an LLM genuinely was supplied and just produced nothing usable, so calling the render LLM-free would be the inverse error.

## What the run confirmed working

Worth recording, because it is the local-first claim end to end with zero cloud calls:

- `nimbus init` inside a git repo appended a `[[filesystem.roots]]` block, **detected the running gateway** and said to restart rather than silently indexing nothing, then indexed on the second run — and suggested a real command derived from the actual code: `nimbus why src/resize.ts:1 # resizeToThumbnail`.
- `nimbus search "thumbnail"` returned the indexed `code_symbol`.
- `nimbus ask` routed to Ollama and answered **from indexed context**, citing the repo's own commit message, in 24.7 s on a 3.2B model.
- `nimbus why` produced real git-blame attribution and listed its gaps honestly.
- `nimbus egress` reported **0 outbound events** for the entire session, with an accurate scope label and its two boot markers — the I29 zero-row claim observed rather than asserted.

## Verification

- `bun test packages/cli/src/lib/nimbus-toml-config.test.ts packages/gateway/src/agents/_lib` — **201 pass, 0 fail**
- `bun test packages/gateway/src/agents` — 436 pass, 0 fail
- `bun run preflight:fast` — **29/29 gates PASSED**
- New footer verified **live** against a restarted gateway, not just in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
