### PR TITLE
test(security): close the I23(c) subdirectory blind spot and floor both D17 scans

### DIFF
--- a/packages/gateway/src/security-invariants.test.ts
+++ b/packages/gateway/src/security-invariants.test.ts
@@ -979,9 +979,18 @@ describe("I23 — ChatOps operational posts are bounded to originating / policy-
     expect(src).toMatch(/notifyChannelsFor\(target\.namespace\)/);
   });
 
-  test("(b) no chatops module outside reply-dispatcher/transport references the connector post tools (D17)", async () => {
-    const dir = resolve(import.meta.dir, "chatops");
-    const offenders: string[] = [];
+  /**
+   * Production `.ts` under `dir`, RECURSIVELY, as repo-relative-ish paths.
+   *
+   * Recursive on purpose, and shared on purpose. (b) walked subdirectories and (c) did not,
+   * for no reason either invariant states — same regex, same tool ids, same D17 rule. `tribal/`
+   * happens to be flat today, so (c) was complete by accident rather than by construction: one
+   * `tribal/<anything>/foo.ts` and a `slack_chat_post` there would have walked straight past the
+   * guard. A scan whose correctness depends on a directory staying flat is a scan that stops
+   * working the day someone tidies up.
+   */
+  async function productionTsUnder(dir: string): Promise<{ rel: string; abs: string }[]> {
+    const out: { rel: string; abs: string }[] = [];
     async function walk(d: string, rel: string): Promise<void> {
       for (const ent of await readdir(d, { withFileTypes: true })) {
         const childRel = rel === "" ? ent.name : `${rel}/${ent.name}`;
@@ -990,24 +999,39 @@ describe("I23 — ChatOps operational posts are bounded to originating / policy-
           continue;
         }
         if (!ent.name.endsWith(".ts") || ent.name.endsWith(".test.ts")) continue;
-        if (childRel === "reply-dispatcher.ts" || childRel.startsWith("transport/")) continue;
-        const c = await readFile(resolve(d, ent.name), "utf8");
-        if (/\b(?:slack_chat_post|teams_chat_post)\b/.test(c)) offenders.push(childRel);
+        out.push({ rel: childRel, abs: resolve(d, ent.name) });
       }
     }
     await walk(dir, "");
+    return out;
+  }
+
+  /** The two connector post tools D17 confines. */
+  const POST_TOOLS = /\b(?:slack_chat_post|teams_chat_post)\b/;
+
+  test("(b) no chatops module outside reply-dispatcher/transport references the connector post tools (D17)", async () => {
+    const files = (await productionTsUnder(resolve(import.meta.dir, "chatops"))).filter(
+      ({ rel }) => rel !== "reply-dispatcher.ts" && !rel.startsWith("transport/"),
+    );
+    const offenders: string[] = [];
+    for (const { rel, abs } of files) {
+      if (POST_TOOLS.test(await readFile(abs, "utf8"))) offenders.push(rel);
+    }
     expect(offenders).toEqual([]);
+    // Guard the guard, as I17's `toContain("query-gate.ts")` and D22's `_lib` floor already do:
+    // every exclusion here is a filter, and a filter that swallowed the whole directory would
+    // leave `offenders` empty and this test green while checking nothing.
+    expect(files.length).toBeGreaterThan(5);
   });
 
   test("(c) no tribal module references the connector post tools — suggestions only via the injected I23 send seam (D17)", async () => {
-    const dir = resolve(import.meta.dir, "tribal");
+    const files = await productionTsUnder(resolve(import.meta.dir, "tribal"));
     const offenders: string[] = [];
-    for (const ent of await readdir(dir, { withFileTypes: true })) {
-      if (!ent.name.endsWith(".ts") || ent.name.endsWith(".test.ts")) continue;
-      const c = await readFile(resolve(dir, ent.name), "utf8");
-      if (/\b(?:slack_chat_post|teams_chat_post)\b/.test(c)) offenders.push(ent.name);
+    for (const { rel, abs } of files) {
+      if (POST_TOOLS.test(await readFile(abs, "utf8"))) offenders.push(rel);
     }
     expect(offenders).toEqual([]);
+    expect(files.length).toBeGreaterThan(5);
   });
 });
 


### PR DESCRIPTION
Auditing whether the I1–I30 enforcement tests can actually fail. Most are in good shape — the file consistently guards its own guards (`I17` asserts `toContain("query-gate.ts")`; the D22 `_lib` scan carries an explicit *"Guard the guard: if the directory scan finds nothing, the assertion above is vacuous"*). **I23's two D17 scans were the exceptions**, and one of them had a real hole.

## I23(c) could not see a subdirectory

`(b)` and `(c)` enforce the same D17 rule with the same regex against the same two tool ids. `(b)` walked recursively. `(c)` called `readdir` once, flat.

`tribal/` has no subdirectories today, so `(c)` was complete **by accident, not by construction** — the moment anyone adds `tribal/<group>/foo.ts`, a direct `slack_chat_post` there walks straight past the invariant.

Proved rather than argued. With a planted `tribal/nested/leak.ts` exporting `slack_chat_post`:

```
OLD scan offenders: [] -> PASSES (violation missed)
NEW: (fail) I23 ... (c) no tribal module references the connector post tools
  +   "nested/leak.ts",
```

I ran the pre-fix scan verbatim against the planted file to get that first line — the old code, not a reconstruction of it. I23 is the invariant that keeps operational ChatOps posts bound to a server-derived `ReplyTarget`, so the blind spot was in a rule about **where the agent is allowed to send messages**.

## Both scans could have passed while checking nothing

Neither `(b)` nor `(c)` asserted it had scanned anything. `readdir` throws on a missing directory, so the wrong-path case already failed loudly — but every *exclusion* in `(b)` is a filter (`reply-dispatcher.ts`, `transport/`), and a filter that widened until it swallowed the directory would leave `offenders` empty and the test green.

Both now assert a floor, matching what the rest of the file already does.

## What changed

The recursive walk is now a shared `productionTsUnder()` helper, so the two siblings cannot drift apart again — the asymmetry existed for no reason either invariant states. The `POST_TOOLS` regex is likewise named once instead of written twice.

## Verified as still enforcing

Before changing anything I confirmed both scans genuinely catch a violation today, by planting `slack_chat_post` in `tribal/tribal-suggestion.ts` and in `chatops/intent-router.ts` — each failed the right test, naming the right file, and passed again on revert. This is a real gap being closed, not a dead guard being resuscitated.

## Verification

`bun test security-invariants.test.ts` — **115 pass, 0 fail** (348 assertions; the two new floors take I23 from 5 expectations to 7).
`bun run preflight:fast` — **PASSED**, all gates including `audit:any`, `audit:cross-platform`, `audit:exclusion-parity` and jscpd.