### PR TITLE
test(security): floor the static structure auditor so a broken scan cannot report clean

### DIFF
--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
+import { join } from "node:path";
 import { CONNECTOR_VAULT_SECRET_KEYS } from "../../packages/gateway/src/connectors/connector-secrets-manifest.ts";
 import {
   assertScanIsMeaningful,
@@ -642,7 +642,11 @@ describe("the scan floor (every rule below it reports clean on an empty scan)", 
     // how a floor quietly becomes shorter than the rule set it protects.
     const missing: string[] = [];
     for (const anchor of RULE_ANCHORS) {
-      if (!(await Bun.file(resolve(REPO_ROOT, anchor)).exists())) missing.push(anchor);
+      // Split before joining: the `/` in an anchor is not a path separator choice, it is the
+      // scan-key format — `iterateSourceFiles` normalizes every relPath to `/` so the floor
+      // can compare against it by string. This is the one place that key becomes a real
+      // filesystem path, so it is the place to hand the components to `join`.
+      if (!(await Bun.file(join(REPO_ROOT, ...anchor.split("/"))).exists())) missing.push(anchor);
     }
     expect(missing).toEqual([]);
   });
@@ -654,7 +658,7 @@ describe("the scan floor (every rule below it reports clean on an empty scan)", 
     // to prevent, so the test for it must not be the kind that cannot fail.
     const src = stripComments(
       await Bun.file(
-        resolve(REPO_ROOT, "scripts/structure-audit/check-nimbus-invariants.ts"),
+        join(REPO_ROOT, "scripts", "structure-audit", "check-nimbus-invariants.ts"),
       ).text(),
     );
     // Slice from `run()` so the export declaration of the same name, which sits above it,

--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import { CONNECTOR_VAULT_SECRET_KEYS } from "../../packages/gateway/src/connectors/connector-secrets-manifest.ts";
 import {
+  assertScanIsMeaningful,
   checkAgentEmitterImportConfinement,
   checkConnectorWriteConfinement,
   checkEgressChokepointConfinement,
@@ -13,8 +15,10 @@ import {
   DB_RUN_EXEC_ALLOW_LIST,
   type FileEntry,
   findDirectDbRunExec,
+  RULE_ANCHORS,
   VAULT_KEY_ALLOW_LIST,
 } from "./check-nimbus-invariants.ts";
+import { REPO_ROOT, stripComments } from "./lib.ts";
 
 describe("D10 — checkSpawnInvariant (under connectors/)", () => {
   test("flags `Bun.spawn` not via extensionProcessEnv", () => {
@@ -594,5 +598,81 @@ describe("D22(d) — agent emitter import confinement", () => {
         },
       ]),
     ).toBe(false);
+  });
+});
+
+describe("the scan floor (every rule below it reports clean on an empty scan)", () => {
+  // Every check in this file has the same shape: scan `files`, report what is out of place.
+  // That shape reports "clean" when `files` is empty or has lost the subtree it polices, and
+  // this auditor runs BEFORE the test suite precisely so it fails first. Proven, not assumed:
+  // pointing `iterateSourceFiles`'s package glob at a directory that does not exist left 179
+  // files scanned (the mcp-connectors glob still matched) and the pre-fix auditor exited 0
+  // with zero errors, all fourteen D-rules silently no-op.
+  const entry = (relPath: string): FileEntry => ({ relPath, contents: "" });
+
+  test("passes when every policed file is in the scanned set", () => {
+    expect(assertScanIsMeaningful(RULE_ANCHORS.map(entry))).toEqual([]);
+  });
+
+  test("reports every anchor when the scan is empty", () => {
+    expect(assertScanIsMeaningful([])).toEqual([...RULE_ANCHORS]);
+  });
+
+  test("a large scan that lost the gateway subtree still fails", () => {
+    // The case a raw `files.length > 0` floor cannot catch, and the reason the floor is the
+    // anchors rather than a count: 500 real files, none of them the ones the rules confine.
+    const connectorsOnly = Array.from({ length: 500 }, (_, i) =>
+      entry(`packages/mcp-connectors/c${String(i)}/src/index.ts`),
+    );
+    expect(assertScanIsMeaningful(connectorsOnly)).toEqual([...RULE_ANCHORS]);
+  });
+
+  test("names exactly the anchor that went missing, not all of them", () => {
+    const allButExecutor = RULE_ANCHORS.filter(
+      (a) => a !== "packages/gateway/src/engine/executor.ts",
+    ).map(entry);
+    expect(assertScanIsMeaningful(allButExecutor)).toEqual([
+      "packages/gateway/src/engine/executor.ts",
+    ]);
+  });
+
+  test("every anchor is a file that actually exists", async () => {
+    // The floor is only as honest as its list: an anchor naming a file that was deleted or
+    // renamed would fail the audit forever and get "fixed" by deleting the anchor, which is
+    // how a floor quietly becomes shorter than the rule set it protects.
+    const missing: string[] = [];
+    for (const anchor of RULE_ANCHORS) {
+      if (!(await Bun.file(resolve(REPO_ROOT, anchor)).exists())) missing.push(anchor);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("run() consults the floor, and exits, before the first rule block", async () => {
+    // The five assertions above prove the function; this one proves it is WIRED. Without it,
+    // deleting the call from `run()` leaves all of them green — the auditor would go back to
+    // exiting 0 on a scan that enforces nothing, which is the exact defect this floor exists
+    // to prevent, so the test for it must not be the kind that cannot fail.
+    const src = stripComments(
+      await Bun.file(
+        resolve(REPO_ROOT, "scripts/structure-audit/check-nimbus-invariants.ts"),
+      ).text(),
+    );
+    // Slice from `run()` so the export declaration of the same name, which sits above it,
+    // cannot satisfy the call-site match.
+    const runAt = src.indexOf("async function run(");
+    expect(runAt).toBeGreaterThan(-1);
+    const runBody = src.slice(runAt);
+
+    const floorAt = runBody.indexOf("assertScanIsMeaningful(files)");
+    const bailAt = runBody.indexOf("process.exit(2)");
+    // Every rule block in `run()` opens with this mode test; the first one is where enforcement
+    // begins, so the floor and its bail-out both have to land ahead of it.
+    const firstRuleAt = runBody.indexOf("if (mode ===");
+
+    expect(floorAt).toBeGreaterThan(-1);
+    expect(bailAt).toBeGreaterThan(-1);
+    expect(firstRuleAt).toBeGreaterThan(-1);
+    expect(floorAt).toBeLessThan(bailAt);
+    expect(bailAt).toBeLessThan(firstRuleAt);
   });
 });

--- a/scripts/structure-audit/check-nimbus-invariants.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.ts
@@ -751,9 +751,60 @@ async function loadFiles(): Promise<FileEntry[]> {
   return out;
 }
 
+/**
+ * The production site each static rule below confines something TO.
+ *
+ * Every check in `run()` has the same shape — scan `files`, report what is out of place — so
+ * every one of them reports "clean" when `files` is empty or has lost the package it polices.
+ * There is no floor anywhere in this file, which means a single upstream breakage (a moved
+ * package, a widened exclusion in `iterateGlob`, a glob that stops matching after a layout
+ * change) would silently turn D10 through D22 into fourteen no-ops that exit 0 — and this
+ * auditor runs BEFORE the test suite specifically so it fails first.
+ *
+ * A raw file count would catch the empty case but not the interesting one: a scan that still
+ * finds a thousand files while the gateway subtree it is policing has dropped out. So the floor
+ * is the anchors themselves. If the file a rule confines `connectors.dispatch` to is not in the
+ * scanned set, that rule is not enforcing anything, whatever it reports.
+ */
+export const RULE_ANCHORS: readonly string[] = [
+  "packages/gateway/src/engine/executor.ts", // D22 — connectors.dispatch chokepoint
+  "packages/gateway/src/ipc/agents-rpc.ts", // D22(d) — agent emitter confinement
+  "packages/gateway/src/db/write.ts", // D12 — bound-param SQL writes
+  "packages/gateway/src/federation/query-gate.ts", // D13
+  "packages/gateway/src/federation/invoke-gate.ts", // D15, D20
+  "packages/gateway/src/federation/preflight-gate.ts", // D18
+  "packages/gateway/src/identity/verifier.ts", // D14
+  "packages/gateway/src/policy/policy-gate.ts", // D16
+  "packages/gateway/src/chatops/reply-dispatcher.ts", // D17
+  "packages/gateway/src/tribal/tribal-write-gate.ts", // D19
+  "packages/gateway/src/connectors/connector-write-registry.ts", // D20
+  "packages/gateway/src/share/share-gate.ts", // D21
+  "packages/gateway/src/share/share-forward.ts", // D21 second emit path
+];
+
+/** Fail loudly when the scanned set cannot support the rules about to run. */
+export function assertScanIsMeaningful(files: readonly FileEntry[]): string[] {
+  const present = new Set(files.map((f) => f.relPath));
+  return RULE_ANCHORS.filter((a) => !present.has(a));
+}
+
 async function run(): Promise<void> {
   const mode = parseArgs(Bun.argv);
   const files = await loadFiles();
+
+  // Before any rule runs, not after: a rule that examined nothing must not get the chance to
+  // report clean. Exits 2 rather than 1 so "this auditor is broken" stays distinguishable from
+  // "this auditor found a violation" — the same split `--db-run`'s exit codes already make.
+  const missing = assertScanIsMeaningful(files);
+  if (missing.length > 0) {
+    console.error(
+      `::error::structure audit scanned ${String(files.length)} file(s) but ${String(missing.length)} rule anchor(s) are absent, so D10-D22 would report clean without enforcing anything: ${missing.join(", ")}`,
+    );
+    console.error(
+      "::error::Either a policed file moved (update RULE_ANCHORS in the same commit) or iterateSourceFiles() stopped reaching it (fix the glob/exclusions in scripts/structure-audit/lib.ts).",
+    );
+    process.exit(2);
+  }
 
   let exit = 0;
 

--- a/scripts/structure-audit/lib.test.ts
+++ b/scripts/structure-audit/lib.test.ts
@@ -1,13 +1,55 @@
 import { describe, expect, test } from "bun:test";
-import { iterateSourceFiles } from "./lib.ts";
+import { iterateSourceFiles, REPO_ROOT } from "./lib.ts";
 
 describe("iterateSourceFiles", () => {
+  // Collected once: the walk reads every production source file in the monorepo, so doing it
+  // per-test would multiply the slowest part of this file by the number of assertions.
+  const visited: string[] = [];
+  const collected = (async (): Promise<void> => {
+    for await (const f of iterateSourceFiles()) visited.push(f.relPath);
+  })();
+
+  test("visits the production source tree at all", async () => {
+    await collected;
+    // The floor the exclusion test below needs to mean anything. `expect(testingPaths)
+    // .toEqual([])` is satisfied just as well by visiting NOTHING, and this generator is the
+    // single source of files for every D10-D22 rule in check-nimbus-invariants.ts — so a walk
+    // that silently stopped matching would leave those rules scanning an empty set and
+    // reporting clean. That is not hypothetical: pointing the package glob at a directory
+    // that does not exist still yields ~179 files from the mcp-connectors glob, which is why
+    // the auditor's own floor keys on specific files rather than a count.
+    expect(visited.length).toBeGreaterThan(500);
+    expect(visited).toContain("packages/gateway/src/engine/executor.ts");
+  });
+
   test("excludes paths under */testing/*", async () => {
-    const visited: string[] = [];
-    for await (const f of iterateSourceFiles()) {
-      visited.push(f.relPath);
-    }
+    await collected;
     const testingPaths = visited.filter((p) => p.includes("/testing/"));
     expect(testingPaths).toEqual([]);
+  });
+
+  test("the */testing/* exclusion is actually doing work", async () => {
+    await collected;
+    // Guard the guard from the other side: if no such directory existed, the exclusion test
+    // above would pass without the exclusion being written at all. Five exist today
+    // (gateway/src/testing, gateway/src/identity/testing, gateway/src/updater/testing,
+    // cli/src/commands/testing, cli/src/tui/testing), and each holds test-only scaffolding
+    // that no production module imports.
+    const glob = new Bun.Glob("packages/*/src/**/testing/**/*.ts");
+    const onDisk: string[] = [];
+    // REPO_ROOT, not `new URL(...).pathname` — a pathname is percent-encoded and carries a
+    // leading slash on Windows, so it names a directory that is not there and the scan throws
+    // ENOENT. lib.ts derives REPO_ROOT from import.meta.dir for exactly this reason.
+    for await (const p of glob.scan({ cwd: REPO_ROOT })) {
+      onDisk.push(p);
+    }
+    expect(onDisk.length).toBeGreaterThan(0);
+  });
+
+  test("excludes test files, declarations and fixtures", async () => {
+    await collected;
+    expect(visited.filter((p) => p.endsWith(".test.ts"))).toEqual([]);
+    expect(visited.filter((p) => p.endsWith(".d.ts"))).toEqual([]);
+    expect(visited.filter((p) => p.includes("/__fixtures__/"))).toEqual([]);
   });
 });


### PR DESCRIPTION
## The defect

`scripts/structure-audit/check-nimbus-invariants.ts` enforces fourteen static rules (D10–D22) and runs **before** the test suite precisely so it fails first. Every check in it has the same shape — scan `files`, report what is out of place — so every one of them reports *clean* when `files` is empty or has lost the subtree it polices. There was no floor anywhere in the file.

**Proven, not assumed.** Pointing `iterateSourceFiles`'s package glob at a directory that does not exist:

```
-  yield* iterateGlob(new Glob("packages/*/src/**/*.ts"), seen);
+  yield* iterateGlob(new Glob("packages/*/srcTYPO/**/*.ts"), seen);
```

leaves **179 files still scanned** — the second `packages/mcp-connectors/*/src/**/*.ts` glob keeps matching — and the pre-fix auditor **exits 0 with zero errors**, `db-run census: 0 hits`. All fourteen D-rules silently no-op, and CI is green.

That 179 is why a naive `files.length > 0` floor would not have caught it.

## The fix

The floor keys on `RULE_ANCHORS` — the thirteen production files the rules actually confine something *to* (`engine/executor.ts` for D22, `db/write.ts` for D12, `federation/query-gate.ts` for D13, …). If the file a rule confines `connectors.dispatch` to is not in the scanned set, that rule is not enforcing anything, whatever it reports.

`assertScanIsMeaningful(files)` runs in `run()` before the first rule block and exits **2**, not 1, so *"this auditor is broken"* stays distinguishable from *"this auditor found a violation"* — the same split `--db-run` already makes.

Same run, with the floor in place:

```
::error::structure audit scanned 179 file(s) but 13 rule anchor(s) are absent, so D10-D22
would report clean without enforcing anything: packages/gateway/src/engine/executor.ts, …
::error::Either a policed file moved (update RULE_ANCHORS in the same commit) or
iterateSourceFiles() stopped reaching it (fix the glob/exclusions in scripts/structure-audit/lib.ts).
exit 2
```

## Tests

`lib.test.ts` was vacuous: its single test asserted `expect(testingPaths).toEqual([])`, which a walk that visited **nothing** satisfies just as well. Rewritten — the walk is collected once and now carries a non-vacuity floor (>500 files, and `executor.ts` specifically), a guard-the-guard test proving `*/testing/*` directories exist on disk for the exclusion to exclude, and coverage of the `.test.ts` / `.d.ts` / `__fixtures__` exclusions.

Six new tests in `check-nimbus-invariants.test.ts` cover the floor: the empty scan, the 500-file scan that lost the gateway subtree, single-anchor precision, and that every anchor names a file that still exists — because an anchor pointing at a deleted file fails forever and gets "fixed" by deleting the anchor, which is how a floor quietly becomes shorter than the rule set it protects.

The sixth is a **wiring** test. The other five pass just fine if the call is deleted from `run()`, which would put the auditor straight back to exiting 0 on a scan that enforces nothing — the exact defect this floor exists to prevent. It asserts the call and its `process.exit(2)` both land ahead of the first `if (mode ===` rule block.

## Red-prove

Each guard was reverted and confirmed to fail naming the right thing:

| Mutation | Result |
| --- | --- |
| Break the package glob, run pre-fix auditor from `origin/main` | **exit 0**, zero errors (the defect) |
| Break the package glob, run patched auditor | **exit 2**, 13 anchors named |
| Break the package glob, run `lib.test.ts` | fails `visits the production source tree at all` — `Expected: > 500, Received: 179` |
| Delete `assertScanIsMeaningful(files)` from `run()` | fails `run() consults the floor, and exits, before the first rule block` |

`bun run preflight:fast` — 29/29 gates pass. `bun test scripts/structure-audit/` — 585 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structure validation to detect incomplete or invalid scans before enforcing rules.
  * Added clear diagnostics when required project files are missing from validation.
  * Prevented false confidence from scans that omit production files.

* **Tests**
  * Expanded coverage for empty scans, missing files, scan ordering, and required file detection.
  * Improved verification that source scanning includes production files while excluding tests, fixtures, and declaration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->