### PR TITLE
fix(release): make the drop-guard ask whether the release PR is complete, not whether one exists

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -371,3 +371,29 @@ jobs:
           echo "::error::Only then unstick it with a 'Release-As: X.Y.Z' trailer as the LAST line of a PR description. NEVER add that trailer while a release PR is pending — it cuts a second version on top of it, and tags are immutable (see CLAUDE.md)."
           grep -E '^(feat|fix)(\([^)]*\))?!?:' <<<"$subjects" | sed 's/^/  dropped-or-unreleased: /'
           exit 1
+
+      # The guard above is EXISTENCE-based: it passes the moment a release PR exists. That left a
+      # real hole, and v2.4.6 fell through it — release-please could not parse #1218's squash body
+      # (an unbalanced `(` inside a code span), the runs on #1218 and #1219 went red exactly as
+      # intended, then #1220 merged, a release PR covering #1220 and #1221 appeared, `prs_created`
+      # came back true, and this step went green with the security fix still missing from the
+      # changelog. This one asks the completeness question instead: does the PENDING release PR
+      # account for every user-facing commit since the tag?
+      # Checkout + bun are pulled in HERE rather than at the top of the job: every step above
+      # talks only to the API, so the job has never needed a working tree, and adding one earlier
+      # would put a checkout in front of the token mint and the release action for no reason.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: '1.3'
+      - name: Guard — the pending release PR must account for every user-facing commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        # No `bun install`: the script imports nothing outside the Bun runtime and shells out to
+        # `gh`, so the dependency-free surface is what keeps this cheap enough to sit in the
+        # release path.
+        run: bun scripts/release/release-pr-completeness.ts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Phase-level history before `v0.1.0` (Phases 1â€“4) lives in [`docs/roadmap.md` Â
 
   **Two defects were already in production.** `commands/data-delete.ts` ran two unwrapped
   `DELETE`s through `input.index.rawDb.run(...)` on the live `data.delete` IPC path: D12's
-  regex pinned the receiver to the literal name `db`, and `` cannot match between the `w`
+  regex pinned the receiver to the literal name `db`, and `\b` cannot match between the `w`
   and the `D` of `rawDb`, so the rule exited 0 for its entire life. `connectors/reindex.ts`
   wrote `hitlStatus: "approved"` on a path where the gate is structurally never entered
   (`reindex-rpc.ts` gates `depth === "full"` alone, and that branch returns

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,52 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-16 — an audit of I1–I30 found two live bugs, two defenses wired to nothing,
+  and a class of guard that reports clean without enforcing anything.** Six PRs (#1216,
+  #1217, #1218, #1219, #1220, #1221), shipped in `v2.4.6`.
+
+  **Two defects were already in production.** `commands/data-delete.ts` ran two unwrapped
+  `DELETE`s through `input.index.rawDb.run(...)` on the live `data.delete` IPC path: D12's
+  regex pinned the receiver to the literal name `db`, and `` cannot match between the `w`
+  and the `D` of `rawDb`, so the rule exited 0 for its entire life. `connectors/reindex.ts`
+  wrote `hitlStatus: "approved"` on a path where the gate is structurally never entered
+  (`reindex-rpc.ts` gates `depth === "full"` alone, and that branch returns
+  `itemsAffected: 0`), putting a consent decision that never happened inside the verified
+  hash chain — the S1-F5 / chain C6 shape.
+
+  **Two defenses were resolved and read by nothing.** `EnforcedPolicy.hitlRequired` was
+  computed as a monotonic union and `isHitlRequiredByPolicy` existed to read it, with zero
+  production callers: an org admin could sign `[policy.hitl] require`, watch it verify, and
+  get no gate. And the federation identity guard was wired for local IPC but absent from
+  `buildFederationLanServer`'s options, so `ctx.identity` was `undefined` for every
+  peer-facing answer and a deprovisioned operator kept answering `federation.query` /
+  `auditExport` / `invoke` / `preflight` instead of failing closed.
+
+  **The structural finding: a guard that short-circuits per FILE cannot see a per-SITE
+  regression.** I15 and D10 both passed on one `wrapServerSpec(` token anywhere in the
+  file, and `connector-spawns.ts` funnels 26 MCPClient spawns through a single `wrap`
+  helper — so dropping the sandbox wrapper from one connector left the token in place and
+  three gates green while that child ran with a live OAuth token and no landlock/seccomp/
+  seatbelt profile. Both are per-site now. The same shape recurred across rules written in
+  the same style: the subdirectory blind spot fixed for D17/I23 in #1216 was still live in
+  D22(d) one commit later.
+
+  Also: the static auditor gained a non-vacuity floor (#1217) after a broken glob was shown
+  to leave 179 files scanned, all fourteen D-rules silently no-op, and `exit 0`; five
+  enforcement tests that could not fail were made capable of failing (#1219); and four
+  drifted doc claims are now derived by `audit:status-drift` rather than hand-maintained
+  (#1221) — the write-route allowlist said twelve against a real fourteen, and I17 named two
+  LAN-admitted federation methods against a real thirteen.
+
+  **Not in the `v2.4.6` release notes:** #1218. release-please could not parse its squash
+  commit (`unexpected token '(' at 103:15` — the PR body contained `` `.run(` ``/`` `.exec(` ``,
+  code spans holding unbalanced parentheses, and the squash body IS the commit message), so
+  it was dropped from the generated changelog. Recorded here because the tag is immutable.
+  The drop-guard failed the runs on #1218 and #1219 exactly as designed, then went green
+  once a partial release PR existed — it asked whether a release PR appeared, not whether
+  that PR accounted for every user-facing commit. `scripts/release/release-pr-completeness.ts`
+  now asks the second question.
+
 - **2026-08-15 — eleven copies of the gateway-connect lifecycle became one, and a guard
   keeps it that way.** Every `nimbus` command that talks to the Gateway re-derived the
   same five steps: read gateway state, throw the not-running message, construct a client,

--- a/scripts/release/release-pr-completeness.test.ts
+++ b/scripts/release/release-pr-completeness.test.ts
@@ -4,6 +4,8 @@ import {
   checkCompleteness,
   descriptionOf,
   droppedFromChangelog,
+  flattenPrFilePages,
+  newestReleaseTag,
   userFacingSubjects,
 } from "./release-pr-completeness.ts";
 
@@ -89,6 +91,79 @@ describe("addedChangelogLines", () => {
 
   test("returns empty when the PR touches no changelog", () => {
     expect(addedChangelogLines([{ filename: "package.json", patch: "@@\n+x" }])).toBe("");
+  });
+});
+
+describe("newestReleaseTag", () => {
+  test("orders numerically, not lexically", () => {
+    // The classic: lexical ordering puts v2.10.0 before v2.9.0, which would baseline the whole
+    // guard against a tag that is not the newest and quietly shrink the range it checks.
+    expect(newestReleaseTag(["refs/tags/v2.9.0", "refs/tags/v2.10.0", "refs/tags/v2.4.6"])).toBe(
+      "v2.10.0",
+    );
+    expect(newestReleaseTag(["refs/tags/v1.9.0", "refs/tags/v1.20.0"])).toBe("v1.20.0");
+  });
+
+  test("ignores the other release lines the prefix match drags in", () => {
+    // `matching-refs/tags/v` is a PREFIX match, so it also returns the satellite release lines.
+    expect(
+      newestReleaseTag([
+        "refs/tags/v2.4.6",
+        "refs/tags/vscode-v9.9.9",
+        "refs/tags/client-v9.9.9",
+        "refs/tags/v2.4.5",
+      ]),
+    ).toBe("v2.4.6");
+  });
+
+  test("rejects prerelease and malformed tags, and reports nothing when there are none", () => {
+    expect(newestReleaseTag(["refs/tags/v2.5.0-rc.1", "refs/tags/v2.4.6"])).toBe("v2.4.6");
+    expect(newestReleaseTag([])).toBeUndefined();
+    expect(newestReleaseTag(["refs/tags/nightly"])).toBeUndefined();
+  });
+});
+
+describe("flattenPrFilePages", () => {
+  test("flattens the array-of-pages shape --slurp produces", () => {
+    const pages = [
+      [{ filename: "CHANGELOG.md", patch: "@@\n+a" }, { filename: "package.json" }],
+      [{ filename: "docs/CHANGELOG.md", patch: "@@\n+b" }],
+    ];
+    expect(flattenPrFilePages(pages).map((f) => f.filename)).toEqual([
+      "CHANGELOG.md",
+      "package.json",
+      "docs/CHANGELOG.md",
+    ]);
+  });
+
+  test("still handles a flat single-page array", () => {
+    // gh only nests when --slurp is in play; accepting both means a behaviour change upstream
+    // cannot silently empty this list.
+    expect(flattenPrFilePages([{ filename: "CHANGELOG.md", patch: "@@\n+a" }])).toHaveLength(1);
+  });
+
+  test("drops entries with no usable filename instead of trusting them", () => {
+    // The caller filters on `filename`; an undefined one would quietly shrink the changelog it
+    // reads, which is the failure this whole guard is about.
+    const got = flattenPrFilePages([
+      [{ patch: "@@\n+x" }, { filename: "" }, null, 42, { filename: "CHANGELOG.md" }],
+    ]);
+    expect(got).toEqual([{ filename: "CHANGELOG.md" }]);
+  });
+
+  test("returns empty for a non-array payload rather than throwing", () => {
+    expect(flattenPrFilePages(null)).toEqual([]);
+    expect(flattenPrFilePages({ message: "Not Found" })).toEqual([]);
+  });
+
+  test("a page beyond the first still reaches the changelog scan", () => {
+    // The bug this replaces: `--paginate` without `--slurp` emits one JSON array per page, so
+    // `JSON.parse` threw at the start of page 2 and the guard crashed instead of checking.
+    const paged = [
+      [{ filename: "package.json", patch: "@@\n+v" }],
+      [{ filename: "CHANGELOG.md", patch: "@@\n+* fix ([#1218](x/issues/1218))" }],
+    ];
+    expect(addedChangelogLines(flattenPrFilePages(paged))).toContain("#1218");
   });
 });
 

--- a/scripts/release/release-pr-completeness.test.ts
+++ b/scripts/release/release-pr-completeness.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import {
+  addedChangelogLines,
+  checkCompleteness,
+  descriptionOf,
+  droppedFromChangelog,
+  userFacingSubjects,
+} from "./release-pr-completeness.ts";
+
+/**
+ * The real v2.4.6 range. Reproduced verbatim rather than invented, because the whole point of this
+ * guard is a case that already happened and that every existing check reported as healthy.
+ */
+const V246_SUBJECTS = [
+  "fix(docs): derive four drifted invariant claims instead of hand-maintaining them (#1221)",
+  "fix(security): wire the two I22/I18 defenses that were resolved but never read (#1220)",
+  "test(security): make five invariant enforcement tests capable of failing (#1219)",
+  "fix(security): widen D12 past its receiver-name blind spot and D22(d) past its flat-path one (#1218)",
+  "test(security): floor the static structure auditor so a broken scan cannot report clean (#1217)",
+  "test(security): close the I23(c) subdirectory blind spot and floor both D17 scans (#1216)",
+  "refactor(cli): collapse eleven copies of the gateway-connect lifecycle into one (#1215)",
+  "test(perf): 🧪 add empty array edge case tests to poolTrimmedSamples (#1214)",
+] as const;
+
+/** What release-please actually generated for v2.4.6 — #1218 absent. */
+const V246_CHANGELOG_PATCH = [
+  "@@ -1,5 +1,13 @@",
+  " # Changelog",
+  "+## [2.4.6](https://github.com/nimbus-agent/Nimbus/compare/v2.4.5...v2.4.6) (2026-08-16)",
+  "+",
+  "+### Bug Fixes",
+  "+",
+  "+* **docs:** derive four drifted invariant claims instead of hand-maintaining them ([#1221](https://github.com/nimbus-agent/Nimbus/issues/1221)) ([6fc59e5](https://github.com/nimbus-agent/Nimbus/commit/6fc59e5))",
+  "+* **security:** wire the two I22/I18 defenses that were resolved but never read ([#1220](https://github.com/nimbus-agent/Nimbus/issues/1220)) ([84d3e62](https://github.com/nimbus-agent/Nimbus/commit/84d3e62))",
+].join("\n");
+
+const filesWith = (patch: string) => [
+  { filename: "CHANGELOG.md", patch },
+  {
+    filename: ".release-please-manifest.json",
+    patch: '@@ -1 +1 @@\n-  ".": "2.4.5"\n+  ".": "2.4.6"',
+  },
+];
+
+describe("userFacingSubjects", () => {
+  test("selects only feat/fix, with scope and bang variants", () => {
+    const got = userFacingSubjects([
+      "feat: a",
+      "feat(scope): b",
+      "fix!: c",
+      "fix(scope)!: d",
+      "test(security): e",
+      "refactor(cli): f",
+      "chore: release main",
+      "docs: g",
+    ]).map((c) => c.subject);
+    expect(got).toEqual(["feat: a", "feat(scope): b", "fix!: c", "fix(scope)!: d"]);
+  });
+
+  test("captures the squash PR reference", () => {
+    expect(userFacingSubjects(["fix(security): x (#1218)"])[0]?.pr).toBe("1218");
+    expect(userFacingSubjects(["fix(security): x"])[0]?.pr).toBeUndefined();
+  });
+
+  test("a BODY line that looks like a conventional header is not counted", () => {
+    // The caller passes subjects, but this pins the intent: over-counting makes the guard fire on
+    // healthy runs, and a guard that cries wolf gets deleted rather than obeyed. This very file
+    // contains `fix(security):` strings inside prose.
+    expect(userFacingSubjects(["  fix: indented, so not a subject"])).toEqual([]);
+  });
+});
+
+describe("descriptionOf", () => {
+  test("strips type, scope, bang and the PR reference", () => {
+    expect(descriptionOf("fix(security): widen D12 past its blind spot (#1218)")).toBe(
+      "widen D12 past its blind spot",
+    );
+    expect(descriptionOf("feat!: a thing")).toBe("a thing");
+  });
+});
+
+describe("addedChangelogLines", () => {
+  test("takes only added lines, only from CHANGELOG files", () => {
+    const added = addedChangelogLines(filesWith(V246_CHANGELOG_PATCH));
+    expect(added).toContain("#1221");
+    expect(added).not.toContain('".": "2.4.5"'); // a different file
+    expect(added).not.toContain("# Changelog"); // a context line, not an addition
+  });
+
+  test("returns empty when the PR touches no changelog", () => {
+    expect(addedChangelogLines([{ filename: "package.json", patch: "@@\n+x" }])).toBe("");
+  });
+});
+
+describe("droppedFromChangelog", () => {
+  test("matches on the PR number, so #121 cannot vouch for #1218", () => {
+    // Substring matching would let a shorter number match inside a longer one, or the reverse.
+    const commits = userFacingSubjects(["fix: a (#121)"]);
+    expect(droppedFromChangelog(commits, "* a ([#1218](x/issues/1218))")).toHaveLength(1);
+  });
+
+  test("falls back to the description for a commit with no PR reference", () => {
+    const commits = userFacingSubjects(["fix(security): a direct push with no ref"]);
+    expect(droppedFromChangelog(commits, "* **security:** a direct push with no ref")).toEqual([]);
+    expect(droppedFromChangelog(commits, "* **security:** something else")).toHaveLength(1);
+  });
+});
+
+describe("checkCompleteness — the v2.4.6 incident", () => {
+  test("catches #1218 being dropped from the real generated changelog", () => {
+    const result = checkCompleteness({
+      subjects: [...V246_SUBJECTS],
+      releasePrFiles: filesWith(V246_CHANGELOG_PATCH),
+      tag: "v2.4.5",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.checked).toBe(3); // three fix commits in the range
+    expect(result.errors.join("\n")).toContain("#1218");
+    // Names the one that is missing, and not the two that are present.
+    expect(result.errors.join("\n")).not.toContain("#1220");
+    expect(result.errors.join("\n")).not.toContain("#1221");
+  });
+
+  test("passes once the missing entry is added — the remedy actually clears it", () => {
+    // A guard nobody can satisfy is as bad as one nobody can trip.
+    const fixed = `${V246_CHANGELOG_PATCH}\n+* **security:** widen D12 ([#1218](https://github.com/nimbus-agent/Nimbus/issues/1218))`;
+    const result = checkCompleteness({
+      subjects: [...V246_SUBJECTS],
+      releasePrFiles: filesWith(fixed),
+      tag: "v2.4.5",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("the test/refactor/chore commits in the same range are never demanded", () => {
+    // #1216, #1217, #1219 are `test:` and #1215 is `refactor:` — release-please omits them by
+    // design, so demanding them would make this guard permanently red.
+    const complete = [
+      V246_CHANGELOG_PATCH,
+      "+* **security:** widen D12 ([#1218](x/issues/1218))",
+    ].join("\n");
+    const result = checkCompleteness({
+      subjects: [...V246_SUBJECTS],
+      releasePrFiles: filesWith(complete),
+      tag: "v2.4.5",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checked).toBe(3);
+  });
+});
+
+describe("checkCompleteness — the cases that must NOT fire", () => {
+  test("no release PR open: silent, because the existing drop-guard owns that case", () => {
+    const result = checkCompleteness({ subjects: [...V246_SUBJECTS], tag: "v2.4.5" });
+    expect(result.ok).toBe(true);
+  });
+
+  test("no user-facing commits: silent", () => {
+    const result = checkCompleteness({
+      subjects: ["test: a (#1)", "chore: release main (#2)"],
+      releasePrFiles: filesWith("@@\n+## [2.4.6]"),
+      tag: "v2.4.5",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checked).toBe(0);
+  });
+
+  test("a release PR that adds NO changelog lines fails loudly rather than passing", () => {
+    // The degenerate shape: the check reads an empty string and every `includes` would be false,
+    // so without this arm the message would blame each commit individually instead of the scan.
+    const result = checkCompleteness({
+      subjects: ["fix: a (#1)"],
+      releasePrFiles: [{ filename: "package.json", patch: "@@\n+x" }],
+      tag: "v2.4.5",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("adds no CHANGELOG lines");
+  });
+});

--- a/scripts/release/release-pr-completeness.ts
+++ b/scripts/release/release-pr-completeness.ts
@@ -84,6 +84,40 @@ export function droppedFromChangelog(
   });
 }
 
+/** One entry of the GitHub pull-request files listing. */
+export interface PrFile {
+  readonly filename: string;
+  readonly patch?: string;
+}
+
+/**
+ * Flatten `gh api --paginate --slurp` output into a single file list, validating as it goes.
+ *
+ * `--slurp` yields an array of PAGES, each itself an array of file objects, so the shape is
+ * nested and comes from outside the process — `unknown` in, validated out, never asserted. An
+ * entry without a usable `filename` is dropped rather than trusted: the caller filters on that
+ * field, and a silently-undefined filename would quietly shrink the changelog it reads.
+ */
+export function flattenPrFilePages(pages: unknown): PrFile[] {
+  const out: PrFile[] = [];
+  const visit = (entry: unknown): void => {
+    if (entry === null || typeof entry !== "object") return;
+    const rec = entry as Record<string, unknown>;
+    const filename = rec["filename"];
+    if (typeof filename !== "string" || filename === "") return;
+    const patch = rec["patch"];
+    out.push(typeof patch === "string" ? { filename, patch } : { filename });
+  };
+  if (!Array.isArray(pages)) return out;
+  for (const page of pages) {
+    // Tolerates both shapes: `--slurp` gives array-of-pages, a single un-slurped response gives
+    // a flat array. Accepting either means this cannot break on a gh behaviour change.
+    if (Array.isArray(page)) for (const entry of page) visit(entry);
+    else visit(page);
+  }
+  return out;
+}
+
 /** Added lines of every CHANGELOG patch in a PR's file list — what the release PR would land. */
 export function addedChangelogLines(
   files: readonly { readonly filename: string; readonly patch?: string }[],
@@ -95,6 +129,22 @@ export function addedChangelogLines(
     .split("\n")
     .filter((l) => l.startsWith("+"))
     .join("\n");
+}
+
+/**
+ * The newest `vX.Y.Z` tag from a list of refs — the baseline the whole check compares against.
+ *
+ * Two things it must get right, both of which have bitten this repo's release tooling before:
+ * `matching-refs/tags/v` is a PREFIX match, so it also returns `vscode-v*` and `client-v*`, which
+ * are separate release lines; and ordering must be NUMERIC, or `v2.9.0` sorts after `v2.10.0` and
+ * the guard baselines against a tag that is not the newest.
+ */
+export function newestReleaseTag(refs: readonly string[]): string | undefined {
+  return refs
+    .map((r) => r.replace(/^refs\/tags\//, "").trim())
+    .filter((r) => /^v\d+\.\d+\.\d+$/.test(r))
+    .sort((a, b) => a.localeCompare(b, "en", { numeric: true }))
+    .pop();
 }
 
 export interface CompletenessInput {
@@ -170,21 +220,22 @@ async function main(): Promise<void> {
     "--jq",
     ".[].ref",
   ]);
-  const tag = refs
-    .split("\n")
-    .map((r) => r.replace(/^refs\/tags\//, "").trim())
-    .filter((r) => /^v\d+\.\d+\.\d+$/.test(r))
-    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-    .pop();
+  const tag = newestReleaseTag(refs.split("\n"));
   if (tag === undefined) {
     console.log("release-pr-completeness: no release tag yet — nothing to compare against.");
     return;
   }
 
+  // `--paginate`, because `compare` returns at most 250 commits per page. Without it a release
+  // range longer than that silently loses its OLDEST commits — and this guard exists precisely so
+  // a dropped commit is not silent, so under-reading the range would reproduce the defect it is
+  // meant to catch, one layer down. Safe to combine with `--jq`: gh applies the filter per page
+  // and emits raw lines, so there is no JSON to concatenate (unlike the files call below).
   const subjects = (
     await gh([
       "api",
-      `repos/${repo}/compare/${tag}...main`,
+      `repos/${repo}/compare/${tag}...main?per_page=100`,
+      "--paginate",
       "--jq",
       '.commits[].commit.message | split("\\n")[0]',
     ])
@@ -211,11 +262,22 @@ async function main(): Promise<void> {
     .split("\n")
     .filter((s) => s.trim() !== "");
 
-  let releasePrFiles: { filename: string; patch?: string }[] | undefined;
+  let releasePrFiles: PrFile[] | undefined;
   if (prNumbers.length > 0) {
-    releasePrFiles = JSON.parse(
-      await gh(["api", `repos/${repo}/pulls/${prNumbers[0]}/files`, "--paginate"]),
-    ) as { filename: string; patch?: string }[];
+    // `--slurp` with `--paginate`. Without it gh emits one JSON array PER PAGE, back to back, and
+    // `JSON.parse` throws at the start of the second — so a release PR touching more than a page
+    // of files would crash this guard rather than check it. `--slurp` wraps the pages in a single
+    // array, which is then flattened and validated rather than asserted.
+    releasePrFiles = flattenPrFilePages(
+      JSON.parse(
+        await gh([
+          "api",
+          `repos/${repo}/pulls/${prNumbers[0]}/files?per_page=100`,
+          "--paginate",
+          "--slurp",
+        ]),
+      ),
+    );
   }
 
   const result = checkCompleteness({

--- a/scripts/release/release-pr-completeness.ts
+++ b/scripts/release/release-pr-completeness.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env bun
+
+/**
+ * Guard — a pending release PR must account for EVERY user-facing commit since the last tag.
+ *
+ * The existing drop-guard in `.github/workflows/release-please.yml` asks "did release-please
+ * produce a release, or a release PR?" and passes the moment one exists. That is existence, not
+ * completeness, and the gap is not theoretical:
+ *
+ *   v2.4.6 (2026-08-16). release-please failed to parse the squash commit for #1218
+ *   (`fix(security): widen D12 …`) — `Error: unexpected token '(' at 103:15` — because the PR
+ *   body, which becomes the squash commit body, contained `` `.run(` ``/`` `.exec(` ``: code spans
+ *   holding unbalanced parentheses. The runs on #1218 and #1219 went red on the drop-guard, exactly
+ *   as designed. Then #1220 merged, release-please opened a release PR covering #1220 and #1221,
+ *   `prs_created` came back true, and the guard went green — with #1218 still missing from the
+ *   changelog. A security fix shipped in v2.4.6 with no entry in its release notes.
+ *
+ * So this asks the other question: of the feat/fix commits since the newest tag, which ones does
+ * the pending release PR's CHANGELOG diff NOT mention? Anything it cannot find is reported and the
+ * run fails, because the remedy needs a human — the release PR's changelog has to be edited before
+ * it is merged, and once merged the tag is immutable (see CLAUDE.md).
+ *
+ * Deliberately narrow. It only runs when a release PR is actually pending; the "nothing was
+ * produced at all" case stays with the existing guard, which already handles it and says more.
+ */
+
+/** A commit release-please is expected to put in the changelog. */
+export interface UserFacingCommit {
+  /** The commit subject line, verbatim. */
+  readonly subject: string;
+  /** The `#NNNN` reference a squash merge appends, when present. */
+  readonly pr?: string;
+}
+
+/**
+ * `feat:` / `fix:` with an optional scope and an optional `!`.
+ *
+ * SUBJECTS ONLY — the caller must pass first lines. A body line can look like a conventional
+ * header (this very file contains several inside a doc comment), and counting those would make the
+ * guard fire on healthy runs, which is how a guard gets deleted.
+ */
+const USER_FACING_RE = /^(?:feat|fix)(?:\([^)]*\))?!?:/;
+/** The trailing `(#1234)` a squash merge appends to the subject. */
+const PR_REF_RE = /\(#(\d+)\)\s*$/;
+
+export function userFacingSubjects(subjects: readonly string[]): UserFacingCommit[] {
+  const out: UserFacingCommit[] = [];
+  for (const raw of subjects) {
+    // trimEnd only. Leading whitespace is the tell that this is a BODY line rather than a subject
+    // — conventional headers are column-anchored — and trimming it would let an indented example
+    // inside a commit body be counted as a commit, which is precisely how this guard would start
+    // firing on healthy runs.
+    const subject = raw.trimEnd();
+    if (!USER_FACING_RE.test(subject)) continue;
+    const pr = PR_REF_RE.exec(subject)?.[1];
+    out.push(pr === undefined ? { subject } : { subject, pr });
+  }
+  return out;
+}
+
+/** The human-readable part of a conventional subject, minus type, scope and PR ref. */
+export function descriptionOf(subject: string): string {
+  return subject
+    .replace(/^(?:feat|fix)(?:\([^)]*\))?!?:\s*/, "")
+    .replace(PR_REF_RE, "")
+    .trim();
+}
+
+/**
+ * Which user-facing commits the changelog does not mention.
+ *
+ * Matched on the PR number first — release-please writes `([#1221](…/issues/1221))`, and a number
+ * is exact where prose is not. A commit with no PR reference (a direct push to main) falls back to
+ * its description text, which is what release-please would have written verbatim.
+ */
+export function droppedFromChangelog(
+  commits: readonly UserFacingCommit[],
+  changelogAdded: string,
+): UserFacingCommit[] {
+  return commits.filter((c) => {
+    if (c.pr !== undefined) return !new RegExp(`#${c.pr}\\b`).test(changelogAdded);
+    const description = descriptionOf(c.subject);
+    return description !== "" && !changelogAdded.includes(description);
+  });
+}
+
+/** Added lines of every CHANGELOG patch in a PR's file list — what the release PR would land. */
+export function addedChangelogLines(
+  files: readonly { readonly filename: string; readonly patch?: string }[],
+): string {
+  return files
+    .filter((f) => /(^|\/)CHANGELOG\.md$/.test(f.filename))
+    .map((f) => f.patch ?? "")
+    .join("\n")
+    .split("\n")
+    .filter((l) => l.startsWith("+"))
+    .join("\n");
+}
+
+export interface CompletenessInput {
+  /** Commit SUBJECTS (first lines) since the newest release tag. */
+  readonly subjects: readonly string[];
+  /** The pending release PR's CHANGELOG file patches, or undefined when no release PR is open. */
+  readonly releasePrFiles?: readonly { readonly filename: string; readonly patch?: string }[];
+  /** The tag the comparison was baselined on, for the message. */
+  readonly tag: string;
+}
+
+export interface CompletenessResult {
+  readonly ok: boolean;
+  readonly errors: string[];
+  readonly checked: number;
+}
+
+export function checkCompleteness(input: CompletenessInput): CompletenessResult {
+  const commits = userFacingSubjects(input.subjects);
+  // No release PR open: the existing drop-guard owns that case and reports it better.
+  if (input.releasePrFiles === undefined) return { ok: true, errors: [], checked: commits.length };
+  if (commits.length === 0) return { ok: true, errors: [], checked: 0 };
+
+  const added = addedChangelogLines(input.releasePrFiles);
+  if (added.trim() === "") {
+    return {
+      ok: false,
+      checked: commits.length,
+      errors: [
+        `the pending release PR adds no CHANGELOG lines, but there ${commits.length === 1 ? "is" : "are"} ${commits.length} user-facing commit(s) since ${input.tag}`,
+      ],
+    };
+  }
+
+  const dropped = droppedFromChangelog(commits, added);
+  if (dropped.length === 0) return { ok: true, errors: [], checked: commits.length };
+
+  return {
+    ok: false,
+    checked: commits.length,
+    errors: [
+      `the pending release PR omits ${dropped.length} of ${commits.length} user-facing commit(s) since ${input.tag}:`,
+      ...dropped.map((c) => `  dropped: ${c.subject}`),
+      'release-please most likely could not PARSE one of these — open the release-please step of the run that FOLLOWED that merge and look for "error message: Error: unexpected token". An unbalanced `(` in a PR body does it, because the squash body IS the commit message.',
+      "Fix by editing the release PR's CHANGELOG.md to add the missing entries BEFORE merging it. Do not add a Release-As: trailer, and do not merge and re-tag — tags are immutable (see CLAUDE.md).",
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function gh(args: readonly string[]): Promise<string> {
+  const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`gh ${args.join(" ")} failed: ${err.trim() || out.trim()}`);
+  return out;
+}
+
+async function main(): Promise<void> {
+  const repo = process.env["REPO"];
+  if (repo === undefined || repo === "") throw new Error("REPO is required");
+
+  const refs = await gh([
+    "api",
+    `repos/${repo}/git/matching-refs/tags/v`,
+    "--paginate",
+    "--jq",
+    ".[].ref",
+  ]);
+  const tag = refs
+    .split("\n")
+    .map((r) => r.replace(/^refs\/tags\//, "").trim())
+    .filter((r) => /^v\d+\.\d+\.\d+$/.test(r))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .pop();
+  if (tag === undefined) {
+    console.log("release-pr-completeness: no release tag yet — nothing to compare against.");
+    return;
+  }
+
+  const subjects = (
+    await gh([
+      "api",
+      `repos/${repo}/compare/${tag}...main`,
+      "--jq",
+      '.commits[].commit.message | split("\\n")[0]',
+    ])
+  )
+    .split("\n")
+    .filter((s) => s.trim() !== "");
+
+  const prNumbers = (
+    await gh([
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--state",
+      "open",
+      "--label",
+      "autorelease: pending",
+      "--json",
+      "number",
+      "--jq",
+      ".[].number",
+    ])
+  )
+    .split("\n")
+    .filter((s) => s.trim() !== "");
+
+  let releasePrFiles: { filename: string; patch?: string }[] | undefined;
+  if (prNumbers.length > 0) {
+    releasePrFiles = JSON.parse(
+      await gh(["api", `repos/${repo}/pulls/${prNumbers[0]}/files`, "--paginate"]),
+    ) as { filename: string; patch?: string }[];
+  }
+
+  const result = checkCompleteness({
+    subjects,
+    tag,
+    ...(releasePrFiles === undefined ? {} : { releasePrFiles }),
+  });
+  if (!result.ok) {
+    for (const e of result.errors) console.error(`::error::${e}`);
+    process.exit(1);
+  }
+  console.log(
+    `release-pr-completeness: OK — ${result.checked} user-facing commit(s) since ${tag}${releasePrFiles === undefined ? " (no release PR open; the drop-guard owns that case)" : " all present in the pending release PR"}.`,
+  );
+}
+
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(
+      `::error::release-pr-completeness: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
`v2.4.6` shipped a security fix with no entry in its release notes. Every gate reported healthy.

## What happened

release-please could not parse the squash commit for #1218:

```
❯ error message: Error: unexpected token '(' at 103:15, valid tokens [)]
```

Line 103, column 15 of that commit message:

```
`.run(`/`.exec(` in this tree are asserted **not** to flag, …
 1    6 9    15
```

Code spans holding **unbalanced parentheses**. The parser opened a group at the first `(`, wanted `)`, and hit the second. Since a squash commit body *is* the PR description, a PR body broke the release tooling — and #1218 was dropped from the changelog.

## Why the existing guard let it through

The drop-guard did its job **twice**: the runs on #1218 and #1219 went red, and its own error text names this exact cause — *"release-please most likely could not PARSE a commit and skipped it."*

Then #1220 merged. release-please opened a release PR covering #1220 and #1221, `prs_created` came back `true`, and the guard went green — with #1218 still missing.

That is the gap. The guard is **existence-based**:

```bash
if [ "${RELEASES_CREATED:-false}" = "true" ] \
  || [ "${PRS_CREATED:-false}" = "true" ] \
  || [ "${RECONCILED:-false}" = "true" ] \
  || [ "$pending" -gt 0 ]; then
```

It asks *"did a release PR appear?"*, never *"does that PR account for every user-facing commit?"* A partially-generated release PR satisfies all four signals.

## The fix

`scripts/release/release-pr-completeness.ts` asks the second question: of the `feat`/`fix` commits since the newest tag, which does the **pending** release PR's CHANGELOG diff not mention? Anything missing fails the run, because the remedy needs a human — the changelog must be edited before the PR merges, and after that the tag is immutable.

Deliberately scoped so it cannot double-report or cry wolf:

- **Only when a release PR is pending.** The "nothing was produced at all" case stays with the existing guard, which handles it and says more.
- **Matches on the PR number**, not prose — release-please writes `([#1221](…/issues/1221))`, and a number is exact where a description is not. Commits with no PR ref (direct pushes) fall back to description text.
- **Reads the CHANGELOG patch, not the PR body.** Release-please collapses long bodies; the diff is authoritative.
- **`trimEnd` only, never `trim`.** Leading whitespace is the tell that a line is a body line rather than a subject, and counting indented examples would make this fire on healthy runs. My own test caught me trimming both ends.

Checkout and bun are added at that step rather than the top of the job — every earlier step is API-only, and putting a checkout in front of the token mint and the release action buys nothing. No `bun install`: the script imports nothing outside the Bun runtime and shells out to `gh`.

## Red-prove — against live data, not fixtures

Run against the real v2.4.6 range and the real files of release PR #1222 as it stood:

```
=== against the REAL #1222 as merged ===
  ok=false  checked=3
  the pending release PR omits 1 of 3 user-facing commit(s) since v2.4.5:
    dropped: fix(security): widen D12 past its receiver-name blind spot … (#1218)

=== with the #1218 entry added (the remedy) ===
  ok=true  errors=0

=== against the HEALTHY v2.4.5 release PR #1213 (must not fire) ===
  ok=true  checked=1
```

All three legs matter: it catches the real drop and names the right commit, it **clears when the remedy is applied** (a guard nobody can satisfy is as useless as one nobody can trip), and it stays silent on a healthy release. 14 unit tests cover the same ground from the real v2.4.6 subjects and generated patch, plus the cases that must not fire — `test`/`refactor`/`chore` in the same range are never demanded, since demanding them would leave this permanently red.

## Also here

`docs/CHANGELOG.md` — the canonical dated log — had no entry for any of #1216–#1221. It now records the audit, **including #1218**, which is where that fix's record lives given `v2.4.6`'s generated notes omit it and the tag cannot be changed.

`bun run preflight:fast` — 29/29 (`audit:workflow-lint` and `audit:action-sha-pins` both clean over the edited workflow). `bun test scripts/release` — 278 pass, 4 fail; the 4 are the pre-existing Windows GPG `nimbus-verify.ps1` failures, identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation to ensure user-facing changes are represented in pending release notes.
  * Release checks now flag missing changelog entries and incomplete release pull requests.

* **Documentation**
  * Added the v2.4.6 changelog entry, including recent fixes, safeguards, and release-validation improvements.

* **Tests**
  * Added comprehensive coverage for release-note completeness checks, including valid, missing, and ignored change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->