### PR TITLE
fix(coverage): gate four runtime-bearing types files and give the sandbox harness a way to run

### DIFF
--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -45,7 +45,20 @@ cd packages/ui && bunx vitest run                     # UI components (Vitest, s
 cd packages/ui && bunx vitest run --coverage          # UI with coverage
 
 bun run test:ci                           # the TEST SUITE only — same sequence as .github/workflows/_test-suite.yml
+
+bun run test:sandbox                      # per-connector sandbox contract suite — OPT-IN, real network
+bun run test:sandbox packages/mcp-connectors/github/test/sandbox.test.ts   # scoped to one connector
 ```
+
+**`test:sandbox` is the only way those 79 tests run.** Each connector's
+`test/sandbox.test.ts` is gated on `describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])`,
+and nothing in the repo set that variable until this script existed — so a plain `bun test`
+reports them as skipped and always did. They are **not** part of any CI gate and should not
+be: `runSandboxContractTests` forks a probe that opens a **real** connection to the
+connector's first declared `permissions.network` host (plus, off Windows, one to an unlisted
+host that must be refused). A host that does not resolve on your network fails as an exit
+code, which is an environment result and not a manifest defect — check the host resolves
+before filing anything.
 
 ## Pre-flight (what to actually run before pushing)
 

--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -346,7 +346,7 @@ jobs:
             sed -i 's|^SF:src/|SF:packages/ui/src/|' packages/ui/coverage/lcov.info
           fi
 
-      - name: Coverage floor — per-file 80% gate
+      - name: Coverage floor — per-file 85% line / 80% branch gate
         if: runner.os == 'Linux'
         # The PR gate is Ubuntu-only (matches the pre-existing pr-quality
         # pattern). The 3-OS push matrix still runs `bun test --coverage`

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "audit:structure": "bun scripts/structure-audit/audit-structure.ts",
     "audit:boundaries": "bunx dependency-cruiser --config .dependency-cruiser.cjs --no-progress packages",
     "audit:coverage-floor": "bun scripts/coverage-floor/check.ts",
+    "test:sandbox": "bun scripts/run-sandbox-contract.ts",
     "audit:coverage-scopes": "bun scripts/coverage-floor/check-scopes.ts",
     "mutation": "stryker run",
     "mutation:diff": "bun scripts/mutation/run-mutation.ts --diff",

--- a/scripts/coverage-floor/exclusions.ts
+++ b/scripts/coverage-floor/exclusions.ts
@@ -304,6 +304,23 @@ const NEVER_EXEMPT_PATHS: readonly string[] = [
   // Four runtime declarations / 20 executable lines: `retryAfterDateFromHeader` (Retry-After
   // header parsing), `RateLimitError`, `UnauthenticatedError`, `syncNoopResult`.
   "packages/gateway/src/sync/types.ts",
+  // The four below were found by auditing the name-matched set rather than by a failure: each
+  // was inheriting the `-types.ts` exemption while carrying runtime declarations, which is the
+  // case the comment on that regex says must be listed here. All four measure 100/100 today, so
+  // adding them buys no debt — it buys the regression guard they were silently outside of.
+  //
+  // `<service>:<type>` source-type SSoT + a filter that BUILDS SQL (`{ sql, params }`), so an
+  // untested edit here reaches the query layer. Two runtime declarations each.
+  "packages/gateway/src/decisions/decision-source-types.ts",
+  "packages/gateway/src/glossary/glossary-source-types.ts",
+  // `ACTION_TYPE_AUTO_UPDATE` / `ACTION_TYPE_DOWNGRADE` — the action-type constants
+  // `extensions/auto-update-rpc.ts` puts on the action it sends to the executor's consent gate.
+  // Action-type strings are what I2/I3 match on, so they are not declaration-only in any sense
+  // that matters.
+  "packages/gateway/src/extensions/auto-update-types.ts",
+  // `S8_LENGTHS` / `S8_BATCHES` — runtime arrays the perf harness iterates to derive its surface
+  // ids; a typo here silently changes which benchmarks exist.
+  "packages/gateway/src/perf/types.ts",
 ];
 
 /**

--- a/scripts/run-sandbox-contract.test.ts
+++ b/scripts/run-sandbox-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findSandboxTests } from "./run-sandbox-contract.ts";
+
+describe("findSandboxTests", () => {
+  test("finds every connector's sandbox test in the real tree", async () => {
+    const files = await findSandboxTests();
+    // The point of the runner is that it discovers the set rather than carrying a list that
+    // goes stale as connectors are added, so this asserts the shape, not a count.
+    expect(files.length).toBeGreaterThan(50);
+    expect(files.every((f) => f.endsWith("/test/sandbox.test.ts"))).toBe(true);
+    expect(files.every((f) => f.startsWith("packages/mcp-connectors/"))).toBe(true);
+    // Sorted, so a failing run is diffable against a previous one.
+    expect(files).toEqual([...files].sort());
+  });
+
+  test("returns forward slashes on every platform", async () => {
+    // The paths are handed to `bun test` as argv. A Windows-separator path would still work
+    // there, but the assertions above and any caller filtering on "/test/" would not
+    // (Non-Negotiable 5: platform equality).
+    const files = await findSandboxTests();
+    expect(files.some((f) => f.includes("\\"))).toBe(false);
+  });
+
+  test("finds nothing in a tree with no connectors, rather than throwing", async () => {
+    // The runner treats empty as a hard error and exits 1; that only reads correctly if the
+    // discovery itself returns [] instead of blowing up.
+    const root = mkdtempSync(join(tmpdir(), "nimbus-sandbox-scan-"));
+    mkdirSync(join(root, "packages"), { recursive: true });
+    expect(await findSandboxTests(root)).toEqual([]);
+  });
+
+  test("matches only the sandbox test, not a connector's other tests", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nimbus-sandbox-scan-"));
+    const testDir = join(root, "packages", "mcp-connectors", "demo", "test");
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(join(testDir, "sandbox.test.ts"), "");
+    writeFileSync(join(testDir, "server.test.ts"), "");
+    writeFileSync(join(testDir, "sandbox-helpers.test.ts"), "");
+    expect(await findSandboxTests(root)).toEqual([
+      "packages/mcp-connectors/demo/test/sandbox.test.ts",
+    ]);
+  });
+});

--- a/scripts/run-sandbox-contract.ts
+++ b/scripts/run-sandbox-contract.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+import { relative, resolve } from "node:path";
+/**
+ * Run the per-connector sandbox contract suite.
+ *
+ * Every connector's `test/sandbox.test.ts` (see CONNECTOR_GLOB below) is gated on
+ * `describe.skipIf(!process.env["NIMBUS_TEST_HARNESS"])`. Before this script that variable
+ * was read in 79 places and set in none — no workflow, no script, no documented command —
+ * so the suite had no invocation path at all and the exclusion notes that credited it were
+ * describing something that never ran.
+ *
+ * It stays off by default for a real reason, not an oversight: `runSandboxContractTests`
+ * forks a probe that opens a REAL connection to the connector's first declared network host
+ * (`permissions.network[0]`) to prove the sandbox permits a listed host, and on non-Windows
+ * a second probe that proves an unlisted host is refused. That is live outbound traffic to
+ * ~79 vendor endpoints, so it belongs behind an explicit opt-in rather than in `bun test`.
+ *
+ * Consequences worth knowing before reading a red result:
+ *   - A host that does not resolve from your network fails as `exit 6` / `exit 2`, which is
+ *     an environment result, not a manifest defect. Check the host resolves before filing.
+ *   - The unlisted-host probe is skipped on win32 by the SDK, so a Windows-only green run
+ *     has proved the positive half of the contract only.
+ *
+ * Env passthrough is explicit because `NIMBUS_TEST_HARNESS=1 bun test …` is a POSIX-shell
+ * idiom that is a parse error in PowerShell (Non-Negotiable 5: platform equality).
+ */
+import { Glob } from "bun";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const CONNECTOR_GLOB = "packages/mcp-connectors/*/test/sandbox.test.ts";
+
+export async function findSandboxTests(root: string = REPO_ROOT): Promise<string[]> {
+  const hits: string[] = [];
+  for await (const file of new Glob(CONNECTOR_GLOB).scan({ cwd: root })) {
+    hits.push(file.replaceAll("\\", "/"));
+  }
+  return hits.sort();
+}
+
+if (import.meta.main) {
+  const files = await findSandboxTests();
+  if (files.length === 0) {
+    console.error(`No sandbox tests matched ${CONNECTOR_GLOB} under ${REPO_ROOT}.`);
+    process.exit(1);
+  }
+  console.error(
+    `Running ${String(files.length)} sandbox contract tests. These make real outbound ` +
+      `requests to each connector's declared host.`,
+  );
+  // Forward any extra argv (e.g. a single connector path) so this can be scoped down.
+  const extra = process.argv.slice(2);
+  const target =
+    extra.length > 0 ? extra : files.map((f) => relative(REPO_ROOT, resolve(REPO_ROOT, f)));
+  const proc = Bun.spawn(["bun", "test", ...target], {
+    cwd: REPO_ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env, NIMBUS_TEST_HARNESS: "1" },
+  });
+  process.exit(await proc.exited);
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -58,13 +58,17 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info,packages/ui/coverage/lcov.i
 # `packages/mcp-connectors/*/src/server.ts` — each MCP connector's
 # entry-point script ends with top-level `await mcp.connect(transport)`
 # against a `StdioServerTransport`. Same structural shape as
-# `github-actions/*/src/main.ts` and `sandbox-wrapper.ts` — only the
-# sandbox harness (gated on `NIMBUS_TEST_HARNESS`) can run it; the
+# `github-actions/*/src/main.ts` and `sandbox-wrapper.ts` — the
 # in-process unit-test layer reaches the pure helpers (`search-filter`
 # et al.) that the server.ts re-exports, never the connect() site. Each
 # MCP connector PR (Snyk #386, Bitrise #387, SonarQube #408) regressed
 # Sonar new-code coverage from this single file until the exclusion
-# landed.
+# landed. This note used to credit the per-connector sandbox harness
+# (`test/sandbox.test.ts`, gated on `NIMBUS_TEST_HARNESS`) as the layer
+# that does reach it. It does not, and cannot in CI: each of those 79
+# tests probes its connector's first declared network host over the REAL
+# network, so they are deliberately off by default and are not a
+# coverage layer for anything. Run them with `bun run test:sandbox`.
 #
 # All of the above are mirrored in
 # `scripts/coverage-floor/exclusions.ts`; the directional parity check


### PR DESCRIPTION
Findings from a coverage audit across all six repos, scored against the merged lcov from CI run `31945036362` using the repo's own `parseLcov` / `isExempt` / `checkScopes`. Only the cheap, verified items are acted on here; the rest are listed at the end for you to triage.

Headline for context, since it frames what is and isn't worth doing: Nimbus is at **97.46% lines / 92.73% branches** over 1,000 non-exempt files, all 24 scope gates pass with 7–27 points of slack, and the ratchet baseline carries **zero** debt entries. There is no coverage problem. There are exemption-hygiene problems, which is a different thing.

## 1. Four files were inheriting a name-pattern exemption they don't qualify for

`exclusions.ts` exempts `types.ts` / `-types.ts` by basename, and the comment on that regex is explicit about the deal:

> read them as "matched by name, not verified" — a new `types.ts` that grows runtime logic must be added to `NEVER_EXEMPT`, not left to inherit an exemption it does not deserve.

Auditing the 28 name-matched files found four that had grown exactly that, and none were listed:

| File | What it actually carries |
| --- | --- |
| `decisions/decision-source-types.ts` | `DECISION_SOURCE_TYPES` + `decisionSourceFilter()` — **builds SQL** (`{ sql, params }`) |
| `glossary/glossary-source-types.ts` | same shape, same SQL-building |
| `extensions/auto-update-types.ts` | `ACTION_TYPE_AUTO_UPDATE` / `ACTION_TYPE_DOWNGRADE` — the action-type strings `auto-update-rpc.ts` puts on the action it sends to the consent gate, i.e. what I2/I3 match on |
| `perf/types.ts` | `S8_LENGTHS` / `S8_BATCHES`, iterated to derive benchmark surface ids |

**All four measure 100 line / 100 branch on the CI lcov** (real records: LF=5, 5, 2, 2), so this buys no debt at all — it buys the regression guard they were silently outside of. Verified with `isExempt` before and after: the four now gate, and an arbitrary `some/other-types.ts` still inherits the exemption, so the general rule is intact.

## 2. A harness cited as a coverage layer, which had no way to run

`sonar-project.properties` justified excluding every connector's `src/server.ts` partly like this:

> only the sandbox harness (gated on `NIMBUS_TEST_HARNESS`) can run it

`NIMBUS_TEST_HARNESS` is read in **79** places — one `describe.skipIf` per connector — and was set in **none**. No workflow, no script, no documented command. A plain `bun test` reported all 79 as skipped, and always had.

**My first read of this was wrong and worth recording**, because the correction is the useful part. I assumed the fix was to enable them in CI, and started down that road. Running all 79 locally gives 78 pass / 1 fail, and chasing the failure is what showed why that would have been a bad change: `runSandboxContractTests` forks a probe that opens a **real network connection** to the connector's first declared `permissions.network` host. The one failure is `wiz`, and it is environmental — `api.app.wiz.io` does not resolve from here (`curl` exit 6) while `api.github.com` returns 200. The manifest is fine.

So gating these off by default is **correct**, not an oversight: they are live outbound traffic to ~79 vendor endpoints. What was missing was any way to run them at all, and a Sonar note that claimed they were doing work they were not.

Added `bun run test:sandbox`, which sets the variable and discovers the set (so it does not carry a list that goes stale as connectors are added), and accepts a path to scope to one connector. Env passthrough is explicit because `NIMBUS_TEST_HARNESS=1 bun test …` is a POSIX-shell idiom and a parse error in PowerShell (Non-Negotiable 5).

**Red-proved** — the same file, two ways:

```
plain bun test  ->  0 pass  1 skip  0 fail
bun run test:sandbox  ->  1 pass  0 fail
```

That difference is the entire claim, so it is the thing I checked. The Sonar note now says what is true, including that a non-resolving host is an environment result rather than a manifest defect.

## 3. A CI step label that misstates the gate it runs

`_test-suite.yml` named the step **"Coverage floor — per-file 80% gate"**. It has been `FLOOR_PCT = 85` line / `BRANCH_FLOOR_PCT = 80` branch since those constants landed. The label is what people read in the checks list when deciding whether a red gate applies to them.

## Verification

`preflight:fast` — 29 of 29, exit 0, run again after rebasing onto `main` at 2.4.8. `audit:exclusion-parity` green (it is the gate that would catch a Sonar/registry mismatch from §1 and §2). New discovery helper has four tests, including that it matches `sandbox.test.ts` but not `sandbox-helpers.test.ts`, and returns forward slashes on every platform.

## Not done — findings that need a decision, not a drive-by

- **The `Vault ≥90%` scope gate is close to vacuous.** It is computed over **4 files / 31 executable lines** — `darwin-keychain-status.ts` (11), `index.ts` (0), `key-format.ts` (8), `mock.ts` (12) — and one of the four is a test double. The vault directory is 887 lines. `vault/win32.ts`, which carries **I12**, has **no lcov record at all**, and `check-scopes.ts` already says so in a comment. Reaching 100% there proves very little. Worth reshaping, but that is a real piece of work and it changes what a headline number in `CLAUDE.md` means.
- **`expectNoRejectedDiagnostics`** is published from `@nimbus-dev/sdk/testing`, documented, exported and untested — but has **zero** consumers anywhere in `packages/`, so it is an unused published API rather than a live risk. (An earlier draft of this audit called it "the mechanism every connector uses to fail its own suite". It is not; that claim was checked against the consumers and dropped.)
- **Four satellite repos guard their Sonar step with `if: env.SONAR_TOKEN != ''`**, which makes the workflow green while analysing nothing. `create-nimbus-connector` deliberately refuses that guard and documents why, skipping only on fork PRs where GitHub withholds secrets. That is the pattern the other four should copy — the fix already exists in the fleet.
- **86 connector shell files / ~11,189 lines carry no lcov data**, which is the intended consequence of the `server.ts` + `tools.ts` exclusions, not a regression.
- **Nimbus is the only repo in the fleet with a per-file branch floor.** `create-nimbus-connector` gates lines+functions, the three vitest repos gate nothing per-file, and Sonar's gate is new-code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)