### PR TITLE
feat(clips): related answers about the resolved item, and its snippets come from the body

### DIFF
--- a/packages/gateway/src/clips/clip-e2e.test.ts
+++ b/packages/gateway/src/clips/clip-e2e.test.ts
@@ -246,4 +246,72 @@ describe("web clipper E2E", () => {
       expect(r.status).toBe(400);
     }
   });
+
+  test("related snippet is an extract of the BODY, not an echo of the title", async () => {
+    const base = `http://127.0.0.1:${handle.port}`;
+    const { code } = pairing.open("e2e-snippet-column", ["clip"]);
+    const confirmRes = await fetch(`${base}/v1/clips/pair/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const { token } = (await confirmRes.json()) as { token: string };
+
+    // Title and body share NO tokens, so the snippet's source column is provable.
+    await fetch(`${base}/v1/clips`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        url: "https://example.com/snippet-column",
+        title: "Zzalphatitleword",
+        mode: "article",
+        body: "Zzbetabodyword one two three four five six seven eight nine ten.",
+        capturedAt: Date.now(),
+      }),
+    });
+
+    const relRes = await fetch(`${base}/v1/clips/related`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ title: "Zzalphatitleword" }),
+    });
+    expect(relRes.status).toBe(200);
+    const rel = (await relRes.json()) as { items: Array<{ snippet: string }> };
+    const hit = rel.items.find((i) => i.snippet.includes("Zzbetabodyword"));
+    expect(hit).toBeDefined();
+    // The defect this pins: the snippet must not be the title read back.
+    expect(hit?.snippet).not.toContain("Zzalphatitleword");
+  });
+
+  test("an item with no body yields an empty-string snippet, never null", async () => {
+    const base = `http://127.0.0.1:${handle.port}`;
+    const { code } = pairing.open("e2e-null-body", ["clip"]);
+    const confirmRes = await fetch(`${base}/v1/clips/pair/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const { token } = (await confirmRes.json()) as { token: string };
+
+    // Write a title-only row directly: the clip route always supplies a body.
+    const writeDb = new Database(dbPath, { create: false, readwrite: true });
+    try {
+      writeDb.run(
+        `INSERT INTO item (id, service, type, external_id, title, url, modified_at, synced_at)
+         VALUES ('t:nullbody', 'test', 'page', 'nullbody', 'Zzgammatitleword', NULL, 1, 1)`,
+      );
+    } finally {
+      writeDb.close();
+    }
+
+    const relRes = await fetch(`${base}/v1/clips/related`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ title: "Zzgammatitleword" }),
+    });
+    const rel = (await relRes.json()) as { items: Array<{ id: string; snippet: unknown }> };
+    const hit = rel.items.find((i) => i.id === "t:nullbody");
+    expect(hit).toBeDefined();
+    expect(hit?.snippet).toBe("");
+  });
 });

--- a/packages/gateway/src/clips/clip-e2e.test.ts
+++ b/packages/gateway/src/clips/clip-e2e.test.ts
@@ -315,6 +315,43 @@ describe("web clipper E2E", () => {
     expect(hit?.snippet).toBe("");
   });
 
+  // Every unit test in clip-related.test.ts injects a FAKE lookupItem, so the
+  // production adapter (http-server.ts's inline single-row read, including its
+  // no-row branch) was exercised by nothing. This pins it end to end: an
+  // itemId naming no row must fall through to the title query rather than
+  // erroring, through the REAL lookupItem wired into the real HTTP server.
+  test("related with an itemId that names no row falls through to the title query", async () => {
+    const base = `http://127.0.0.1:${handle.port}`;
+    const { code } = pairing.open("e2e-unknown-itemid", ["clip"]);
+    const confirmRes = await fetch(`${base}/v1/clips/pair/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const { token } = (await confirmRes.json()) as { token: string };
+
+    await fetch(`${base}/v1/clips`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        url: "https://example.com/unknown-itemid",
+        title: "Zzepsilontitleword",
+        mode: "article",
+        body: "Zzepsilonbody prose here.",
+        capturedAt: Date.now(),
+      }),
+    });
+
+    const relRes = await fetch(`${base}/v1/clips/related`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ title: "Zzepsilontitleword", itemId: "does:not:exist" }),
+    });
+    expect(relRes.status).toBe(200);
+    const rel = (await relRes.json()) as { items: Array<{ title: string }> };
+    expect(rel.items.some((i) => i.title === "Zzepsilontitleword")).toBe(true);
+  });
+
   test("related hits carry type and modified_at (epoch ms)", async () => {
     const base = `http://127.0.0.1:${handle.port}`;
     const { code } = pairing.open("e2e-new-fields", ["clip"]);

--- a/packages/gateway/src/clips/clip-e2e.test.ts
+++ b/packages/gateway/src/clips/clip-e2e.test.ts
@@ -314,4 +314,44 @@ describe("web clipper E2E", () => {
     expect(hit).toBeDefined();
     expect(hit?.snippet).toBe("");
   });
+
+  test("related hits carry type and modified_at (epoch ms)", async () => {
+    const base = `http://127.0.0.1:${handle.port}`;
+    const { code } = pairing.open("e2e-new-fields", ["clip"]);
+    const confirmRes = await fetch(`${base}/v1/clips/pair/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const { token } = (await confirmRes.json()) as { token: string };
+
+    const before = Date.now();
+    await fetch(`${base}/v1/clips`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        url: "https://example.com/new-fields",
+        title: "Zzdeltatitleword",
+        mode: "article",
+        body: "Zzdeltabody prose here.",
+        capturedAt: Date.now(),
+      }),
+    });
+
+    const relRes = await fetch(`${base}/v1/clips/related`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ title: "Zzdeltatitleword" }),
+    });
+    const rel = (await relRes.json()) as {
+      items: Array<{ type: string; modified_at: number }>;
+    };
+    expect(rel.items.length).toBeGreaterThan(0);
+    const hit = rel.items[0];
+    expect(typeof hit?.type).toBe("string");
+    expect(hit?.type.length).toBeGreaterThan(0);
+    // Milliseconds, not seconds: a seconds value would sit in 1970 in JS.
+    expect(hit?.modified_at).toBeGreaterThanOrEqual(before - 60_000);
+    expect(hit?.modified_at).toBeLessThan(before + 60 * 60_000);
+  });
 });

--- a/packages/gateway/src/clips/clip-related.test.ts
+++ b/packages/gateway/src/clips/clip-related.test.ts
@@ -6,24 +6,76 @@ import {
   runClipRelated,
 } from "./clip-related.ts";
 
+const NO_ITEMS = (): null => null;
+function hit(id: string, service = "github"): RelatedHit {
+  return {
+    id,
+    title: id,
+    service,
+    type: "pr",
+    snippet: "",
+    url: `https://ex.com/${id}`,
+    modified_at: 1,
+  };
+}
+
 describe("buildRelatedQuery", () => {
   test("selection present → selection is the query", () => {
-    expect(buildRelatedQuery({ title: "Docs", selection: "vector index" }).query).toBe(
+    expect(buildRelatedQuery({ title: "Docs", selection: "vector index" }, NO_ITEMS).query).toBe(
       "vector index",
     );
   });
   test("no selection → title is the query", () => {
-    expect(buildRelatedQuery({ title: "Vector indexes" }).query).toBe("Vector indexes");
+    expect(buildRelatedQuery({ title: "Vector indexes" }, NO_ITEMS).query).toBe("Vector indexes");
   });
   test("canonicalUrl host is parsed into excludeHost", () => {
-    expect(buildRelatedQuery({ title: "x", canonicalUrl: "https://ex.com/p" }).excludeHost).toBe(
-      "ex.com",
-    );
+    expect(
+      buildRelatedQuery({ title: "x", canonicalUrl: "https://ex.com/p" }, NO_ITEMS).excludeHost,
+    ).toBe("ex.com");
   });
   test("empty inputs → empty query, no host", () => {
-    const q = buildRelatedQuery({});
+    const q = buildRelatedQuery({}, NO_ITEMS);
     expect(q.query).toBe("");
     expect(q.excludeHost).toBeUndefined();
+  });
+});
+
+describe("buildRelatedQuery with itemId", () => {
+  const lookup = (id: string): { title: string } | null =>
+    id === "gh:1" ? { title: "Fix the flaky retry" } : null;
+
+  test("itemId supplies the query text when there is no selection", () => {
+    const q = buildRelatedQuery(
+      { title: "Fix … · Pull Request #482 · acme/web", itemId: "gh:1" },
+      lookup,
+    );
+    expect(q.query).toBe("Fix the flaky retry");
+  });
+
+  test("selection still beats itemId for the query text", () => {
+    const q = buildRelatedQuery({ selection: "vector index", itemId: "gh:1" }, lookup);
+    expect(q.query).toBe("vector index");
+  });
+
+  test("selection wins the query, and the item is STILL excluded", () => {
+    const q = buildRelatedQuery({ selection: "vector index", itemId: "gh:1" }, lookup);
+    expect(q.excludeId).toBe("gh:1");
+  });
+
+  test("an unknown itemId falls through to title rather than erroring", () => {
+    const q = buildRelatedQuery({ title: "Page title", itemId: "gh:missing" }, lookup);
+    expect(q.query).toBe("Page title");
+    expect(q.excludeId).toBeUndefined();
+  });
+
+  test("no itemId → no exclusion", () => {
+    expect(buildRelatedQuery({ title: "x" }, NO_ITEMS).excludeId).toBeUndefined();
+  });
+
+  test("a non-string itemId is coerced away, not thrown on", () => {
+    const q = buildRelatedQuery({ title: "x", itemId: 7 } as unknown as RelatedInput, NO_ITEMS);
+    expect(q.query).toBe("x");
+    expect(q.excludeId).toBeUndefined();
   });
 });
 
@@ -34,18 +86,9 @@ describe("runClipRelated", () => {
       {
         search: async (query, limit) => {
           calls.push({ query, limit });
-          return [
-            {
-              id: "drive:1",
-              title: "Hit",
-              service: "drive",
-              type: "page",
-              snippet: "s",
-              url: "u",
-              modified_at: 1,
-            },
-          ];
+          return [hit("drive:1", "drive")];
         },
+        lookupItem: NO_ITEMS,
       },
       { selection: "vector index", limit: 5 },
     );
@@ -61,6 +104,7 @@ describe("runClipRelated", () => {
           called = true;
           return [];
         },
+        lookupItem: NO_ITEMS,
       },
       {},
     );
@@ -91,6 +135,7 @@ describe("runClipRelated", () => {
             modified_at: 2,
           },
         ],
+        lookupItem: NO_ITEMS,
       },
       { title: "x", canonicalUrl: "https://ex.com/p" },
     );
@@ -103,7 +148,7 @@ describe("runClipRelated", () => {
       called = true;
       return [];
     };
-    const out = await runClipRelated({ search }, {
+    const out = await runClipRelated({ search, lookupItem: NO_ITEMS }, {
       title: 123,
       selection: { x: 1 },
     } as unknown as RelatedInput);
@@ -117,7 +162,7 @@ describe("runClipRelated", () => {
       seen.push(limit);
       return [];
     };
-    await runClipRelated({ search }, {
+    await runClipRelated({ search, lookupItem: NO_ITEMS }, {
       title: "hi",
       limit: "abc",
     } as unknown as RelatedInput);
@@ -125,7 +170,42 @@ describe("runClipRelated", () => {
   });
 
   test("null input → empty, no throw", async () => {
-    const out = await runClipRelated({ search: async () => [] }, null as unknown as RelatedInput);
+    const out = await runClipRelated(
+      { search: async () => [], lookupItem: NO_ITEMS },
+      null as unknown as RelatedInput,
+    );
     expect(out.items).toEqual([]);
+  });
+});
+
+describe("runClipRelated self-exclusion", () => {
+  test("the item excludes itself from its own related list", async () => {
+    const out = await runClipRelated(
+      {
+        search: async () => [hit("gh:1"), hit("gh:2")],
+        lookupItem: (id) => (id === "gh:1" ? { title: "Fix the flaky retry" } : null),
+      },
+      { itemId: "gh:1" },
+    );
+    expect(out.items.map((i) => i.id)).toEqual(["gh:2"]);
+  });
+
+  test("self-exclusion applies even when a selection drove the query", async () => {
+    const out = await runClipRelated(
+      {
+        search: async () => [hit("gh:1"), hit("gh:2")],
+        lookupItem: (id) => (id === "gh:1" ? { title: "Fix the flaky retry" } : null),
+      },
+      { selection: "flaky", itemId: "gh:1" },
+    );
+    expect(out.items.map((i) => i.id)).toEqual(["gh:2"]);
+  });
+
+  test("a selection on an unresolved page searches normally and excludes nothing", async () => {
+    const out = await runClipRelated(
+      { search: async () => [hit("gh:1"), hit("gh:2")], lookupItem: NO_ITEMS },
+      { selection: "flaky" },
+    );
+    expect(out.items.map((i) => i.id)).toEqual(["gh:1", "gh:2"]);
   });
 });

--- a/packages/gateway/src/clips/clip-related.test.ts
+++ b/packages/gateway/src/clips/clip-related.test.ts
@@ -34,7 +34,17 @@ describe("runClipRelated", () => {
       {
         search: async (query, limit) => {
           calls.push({ query, limit });
-          return [{ id: "drive:1", title: "Hit", service: "drive", snippet: "s", url: "u" }];
+          return [
+            {
+              id: "drive:1",
+              title: "Hit",
+              service: "drive",
+              type: "page",
+              snippet: "s",
+              url: "u",
+              modified_at: 1,
+            },
+          ];
         },
       },
       { selection: "vector index", limit: 5 },
@@ -62,8 +72,24 @@ describe("runClipRelated", () => {
     const out = await runClipRelated(
       {
         search: async () => [
-          { id: "a", title: "self", service: "nimbus", snippet: "", url: "https://ex.com/self" },
-          { id: "b", title: "other", service: "drive", snippet: "", url: "https://other.com/x" },
+          {
+            id: "a",
+            title: "self",
+            service: "nimbus",
+            type: "page",
+            snippet: "",
+            url: "https://ex.com/self",
+            modified_at: 1,
+          },
+          {
+            id: "b",
+            title: "other",
+            service: "drive",
+            type: "page",
+            snippet: "",
+            url: "https://other.com/x",
+            modified_at: 2,
+          },
         ],
       },
       { title: "x", canonicalUrl: "https://ex.com/p" },

--- a/packages/gateway/src/clips/clip-related.ts
+++ b/packages/gateway/src/clips/clip-related.ts
@@ -2,6 +2,10 @@ export interface RelatedInput {
   readonly title?: string;
   readonly canonicalUrl?: string;
   readonly selection?: string;
+  /** An indexed item id — the page the caller has already resolved. When it
+   *  names a real row, its title becomes the query and the item is dropped from
+   *  its own results. */
+  readonly itemId?: string;
   readonly limit?: number;
 }
 
@@ -21,6 +25,8 @@ export interface RelatedHit {
 export interface ClipRelatedDeps {
   /** Injected hybrid-search adapter (text query + limit → ranked hits). */
   readonly search: (query: string, limit: number) => Promise<RelatedHit[]>;
+  /** Injected metadata read for `itemId`. Null when the id names no row. */
+  readonly lookupItem: (id: string) => { title: string } | null;
 }
 
 const DEFAULT_LIMIT = 10;
@@ -40,26 +46,42 @@ function asStr(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
 }
 
-export function buildRelatedQuery(input: RelatedInput): { query: string; excludeHost?: string } {
-  // `input` arrives from req.json() — fields may be any type; coerce defensively so a non-string
-  // title/selection can't throw (TypeError → 500) at `.trim()`.
+export function buildRelatedQuery(
+  input: RelatedInput,
+  lookupItem: (id: string) => { title: string } | null,
+): { query: string; excludeHost?: string; excludeId?: string } {
   const o = (input ?? {}) as RelatedInput;
-  const query = (asStr(o.selection) ?? asStr(o.title) ?? "").trim();
+  const itemId = asStr(o.itemId)?.trim();
+  // Looked up BEFORE precedence is applied: a selection wins the query text, but
+  // the item you are standing on is still the one answer that cannot tell you
+  // anything new, so the exclusion is keyed on the id existing — not on it having
+  // won. Keeping these two rules independent is the whole point.
+  const item = itemId === undefined || itemId === "" ? null : lookupItem(itemId);
+  // The item's TITLE, never its body: ftsMatchQuery AND-joins every token, so a
+  // 16 KiB body becomes thousands of required terms and matches nothing.
+  const query = (asStr(o.selection) ?? item?.title ?? asStr(o.title) ?? "").trim();
   const excludeHost = hostOf(asStr(o.canonicalUrl));
-  return excludeHost === undefined ? { query } : { query, excludeHost };
+  return {
+    query,
+    ...(excludeHost === undefined ? {} : { excludeHost }),
+    ...(item === null || itemId === undefined ? {} : { excludeId: itemId }),
+  };
 }
 
 export async function runClipRelated(
   deps: ClipRelatedDeps,
   input: RelatedInput,
 ): Promise<{ items: RelatedHit[] }> {
-  const { query, excludeHost } = buildRelatedQuery(input);
+  const { query, excludeHost, excludeId } = buildRelatedQuery(input, deps.lookupItem);
   if (query === "") return { items: [] };
   const rawLimit =
     typeof input?.limit === "number" && Number.isFinite(input.limit) ? input.limit : DEFAULT_LIMIT;
   const limit = Math.min(MAX_LIMIT, Math.max(1, rawLimit));
   const hits = await deps.search(query, limit);
-  const items =
-    excludeHost === undefined ? hits : hits.filter((h) => hostOf(h.url) !== excludeHost);
+  const items = hits.filter(
+    (h) =>
+      (excludeHost === undefined || hostOf(h.url) !== excludeHost) &&
+      (excludeId === undefined || h.id !== excludeId),
+  );
   return { items };
 }

--- a/packages/gateway/src/clips/clip-related.ts
+++ b/packages/gateway/src/clips/clip-related.ts
@@ -9,8 +9,13 @@ export interface RelatedHit {
   readonly id: string;
   readonly title: string;
   readonly service: string;
+  /** The connector's item kind — `pr`, `issue`, `ci_run`, … An OPEN vocabulary:
+   *  every connector may add one, so consumers must not switch exhaustively. */
+  readonly type: string;
   readonly snippet: string;
   readonly url: string | null;
+  /** Epoch MILLISECONDS, matching `GET /v1/items/resolve`'s `item.modified_at`. */
+  readonly modified_at: number;
 }
 
 export interface ClipRelatedDeps {

--- a/packages/gateway/src/clips/clip-related.ts
+++ b/packages/gateway/src/clips/clip-related.ts
@@ -59,7 +59,14 @@ export function buildRelatedQuery(
   const item = itemId === undefined || itemId === "" ? null : lookupItem(itemId);
   // The item's TITLE, never its body: ftsMatchQuery AND-joins every token, so a
   // 16 KiB body becomes thousands of required terms and matches nothing.
-  const query = (asStr(o.selection) ?? item?.title ?? asStr(o.title) ?? "").trim();
+  //
+  // `item?.title || undefined`, not a bare `item?.title`: a resolved item whose
+  // title is the empty string is non-nullish, so plain `??` chaining would lock
+  // the query to `""` and short-circuit to zero results instead of falling
+  // through to `o.title` like a genuinely missing/unresolved item does. The `||`
+  // here (not `??`) is what turns that empty string back into a nullish value so
+  // the `??` chain below can fall through it.
+  const query = (asStr(o.selection) ?? (item?.title || undefined) ?? asStr(o.title) ?? "").trim();
   const excludeHost = hostOf(asStr(o.canonicalUrl));
   return {
     query,

--- a/packages/gateway/src/glossary/glossary-project.ts
+++ b/packages/gateway/src/glossary/glossary-project.ts
@@ -18,7 +18,7 @@ export function glossaryItemExternalId(termKey: string): string {
 /**
  * Builds the indexed body.
  *
- * `item_fts` indexes only `title` and `body_preview` — metadata JSON is
+ * `item_fts` indexes only `title` and `body` — metadata JSON is
  * invisible to both FTS and the embedding pipeline. Synonyms therefore have to
  * live in the body text, or `ask "what does Change Data Record mean?"` finds
  * nothing while the acronym query succeeds — exactly backwards, since the

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -566,7 +566,7 @@ async function handleClipRelated(
             // COALESCE is load-bearing: snippet() over a NULL body returns NULL,
             // and the browser client's isRelatedHit requires a string — a null
             // would drop the hit from the panel entirely rather than blank a line.
-            `SELECT i.id, i.title, i.service, i.url,
+            `SELECT i.id, i.title, i.service, i.type, i.url, i.modified_at,
                     COALESCE(snippet(item_fts, 1, '', '', '…', 24), '') AS snippet
              FROM item i
              INNER JOIN item_fts ON i.rowid = item_fts.rowid
@@ -578,15 +578,19 @@ async function handleClipRelated(
           id: string;
           title: string;
           service: string;
+          type: string;
           url: string | null;
+          modified_at: number;
           snippet: string;
         }>;
         return rows.map((r) => ({
           id: r.id,
           title: r.title,
           service: r.service,
+          type: r.type,
           snippet: r.snippet,
           url: r.url,
+          modified_at: r.modified_at,
         }));
       },
     },

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -593,6 +593,14 @@ async function handleClipRelated(
           modified_at: r.modified_at,
         }));
       },
+      lookupItem: (id: string): { title: string } | null => {
+        // Inline single-row read, the house pattern — see decisions.ts:33 and
+        // decision-corroborate.ts:49. Metadata only; never a body.
+        const row = db.query("SELECT title FROM item WHERE id = ?").get(id) as {
+          title: string;
+        } | null;
+        return row === null ? null : { title: row.title };
+      },
     },
     body,
   );

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -560,8 +560,14 @@ async function handleClipRelated(
         if (fts === "") return [];
         const rows = db
           .query(
+            // Column 1 is `body`. V48 re-pointed item_fts from (title, body_preview)
+            // to (title, body); index 0 is the TITLE, which this asked for until
+            // 2026-08 and which made every snippet an echo of the line above it.
+            // COALESCE is load-bearing: snippet() over a NULL body returns NULL,
+            // and the browser client's isRelatedHit requires a string — a null
+            // would drop the hit from the panel entirely rather than blank a line.
             `SELECT i.id, i.title, i.service, i.url,
-                    snippet(item_fts, 0, '', '', '…', 10) AS snippet
+                    COALESCE(snippet(item_fts, 1, '', '', '…', 24), '') AS snippet
              FROM item i
              INNER JOIN item_fts ON i.rowid = item_fts.rowid
              WHERE item_fts MATCH ?


### PR DESCRIPTION
Three changes to `POST /v1/clips/related`, driven by the browser clipper's Related panel. Two of them are defects that shipped, not gaps.

## The snippet has always been an extract of the title

`snippet()`'s second argument is an FTS5 **column index**, and V48 re-pointed `item_fts` from `(title, body_preview)` to `(title, body)` — so index `0` is the title. The browser panel renders that snippet directly beneath the same title, which is why the lane reads thin: its second line was its first line again.

Now index `1`, with a 24-token budget. `COALESCE(..., '')` is load-bearing: `snippet()` over a NULL body returns SQL `NULL`, and the client's guard requires a string — a null would drop the whole hit from the panel rather than blank a line.

A negative index was considered and rejected: it auto-selects the best-matching column, which for the title-driven query below re-selects the title. Verified empirically against SQLite on Bun 1.3.14.

## `type` and `modified_at` are projected

Both are indexed columns on the table the query already reads. Purely additive; named as `GET /v1/items/resolve` names them (`type` plain, `modified_at` snake_case, epoch ms) so one client-side boundary parser serves both routes.

## `itemId` makes relatedness about the item, not the page title

The client resolves the page to an indexed item and could only send `document.title` — which on a pull request is mostly chrome, and on Jenkins is `build #42 [Jenkins]`. `RelatedInput.itemId` now takes that item's **title** as the query and drops the item from its own results.

Its title, never its body: `ftsMatchQuery` AND-joins every token, so a 16 KiB body becomes thousands of required terms and matches nothing.

Two rules are deliberately **independent**: query-text precedence is `selection` → `itemId` → `title`, while self-exclusion fires whenever `itemId` is *present and resolves* — not when it wins. Otherwise selecting a phrase on PR #482 would return PR #482 as its own top hit. An unknown id falls through to the title path rather than erroring, since the row may have been deleted between resolve and related.

## Notes

- The host-exclusion rule is untouched. The client stops sending `canonicalUrl` once it can name the item, so the filter simply stops firing on work surfaces — no contract semantics changed.
- `glossary-project.ts` had a comment claiming `item_fts` indexes `body_preview`; V48 made that untrue. Comment-only fix.

Tests: 316 pass across clips + glossary. Typecheck and Biome clean.

Browser-client half: `nimbus-web-clipper` `feat/richer-related-lane`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Related clip results now include each item’s type and last-modified timestamp.
  * Related searches can resolve items by ID, use their title, and exclude the selected item from results.
  * Search snippets are generated from full body content with improved context.

* **Bug Fixes**
  * Added fallback behavior for unknown item IDs and empty snippets when content is unavailable.
  * Improved filtering to prevent duplicate results from the selected item or its canonical host.

* **Documentation**
  * Updated indexing documentation to reflect that titles and body content are searchable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->