### PR TITLE
ci(coverage-gates): stop the sandbox apt step from wedging a job for hours

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -920,6 +920,12 @@ jobs:
     if: inputs.run-tests
     needs: unit-coverage
     runs-on: ${{ inputs.runner }}
+    # These two coverage-gate jobs were the only jobs in this file with no
+    # `timeout-minutes`, so they inherited GitHub's 360-minute default. On
+    # 2026-08-19 the Sandbox leg wedged in its apt step on two concurrent runs
+    # and would have burned six hours of runner time each; every sibling job
+    # here caps at 30, and the whole leg runs in 1-4 minutes.
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -976,11 +982,7 @@ jobs:
       - name: Linux — bubblewrap + libcap-dev + strace + cppcheck (sandbox tests)
         if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
         shell: bash
-        run: |
-          # Drop the GHA runner's preinstalled Microsoft apt repos (azure-cli + prod);
-          # they periodically 403 and fail `apt-get update` wholesale. Not needed here.
-          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
-          sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
+        run: sudo bash scripts/linux/install-sandbox-deps.sh
 
       - name: Build sandbox helper (Linux only, sandbox gate)
         if: runner.os == 'Linux' && matrix.gate.name == 'Sandbox'
@@ -1031,6 +1033,10 @@ jobs:
     if: inputs.run-tests && inputs.runner == 'ubuntu-24.04'
     needs: unit-coverage
     runs-on: ${{ inputs.runner }}
+    # 30, same as `coverage-gates-pal` and every sibling job in this file — see
+    # the note there. Batching makes each leg serial, so the headroom over the
+    # ~3-5 minutes three batches take is smaller here, but still 6x.
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/scripts/linux/install-sandbox-deps.sh
+++ b/scripts/linux/install-sandbox-deps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install the Linux sandbox test dependencies: bubblewrap (the sandbox itself),
+# libcap-dev (the helper's setcap build), strace (the syscall-confinement
+# assertions), and cppcheck (the helper's static analysis).
+#
+# Why this is a script and not an inline `apt-get` step:
+# 1. The GitHub Actions ubuntu runner image ships preconfigured Microsoft apt
+#    repos (packages.microsoft.com azure-cli + prod). During Microsoft signing-key
+#    rotations those repos return `403 Forbidden` / "no longer signed", and because
+#    `apt-get update` fails whole-hog when ANY configured repo can't be refreshed,
+#    our unrelated install of four stock-Ubuntu packages goes red with it. We don't
+#    need those repos here, so remove them before updating.
+# 2. The inline version carried none of the non-interactive settings below and
+#    WEDGED: on 2026-08-19 two concurrent runs sat in this step for 2h20m with no
+#    output and no timeout, blocking the release PR (#1247). A prompt on stdin
+#    blocks forever on a runner; `-y` alone does not prevent one, because debconf
+#    and needrestart ask outside apt's own confirmation. The three defenses are
+#    layered on purpose: `DEBIAN_FRONTEND` + `NEEDRESTART_MODE` stop the prompts
+#    that are known to exist, and `< /dev/null` turns any prompt we did not
+#    anticipate into an immediate EOF failure rather than an indefinite hang.
+#
+# Privilege: does NOT call sudo itself — invoke with `sudo bash scripts/linux/install-sandbox-deps.sh`
+# on CI runners, or run directly when already root. See `_test-suite.yml`.
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+# `a`utomatically restart affected services instead of opening needrestart's
+# interactive "which services should be restarted?" list.
+export NEEDRESTART_MODE=a
+
+# Drop the flaky/unneeded Microsoft repos so `apt-get update` only refreshes the
+# Ubuntu archive. `rm -f` is a no-op when the files are absent (non-GHA environments).
+rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+
+apt-get -o Acquire::Retries=3 update -qq < /dev/null
+apt-get -o Acquire::Retries=3 install -y -qq bubblewrap libcap-dev strace cppcheck < /dev/null

--- a/scripts/linux/install-vault-deps.sh
+++ b/scripts/linux/install-vault-deps.sh
@@ -14,10 +14,17 @@
 # on CI runners, or run directly when already root (e.g. inside a Docker container).
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
+# `a`utomatically restart affected services instead of opening needrestart's
+# interactive "which services should be restarted?" list. `DEBIAN_FRONTEND`
+# alone does not cover needrestart, which is a post-install hook, not a debconf
+# question — and a prompt on stdin blocks a runner forever. See the sibling
+# `install-sandbox-deps.sh`, written after the inline step it replaced wedged
+# for 2h20m with no output and no timeout.
+export NEEDRESTART_MODE=a
 
 # Drop the flaky/unneeded Microsoft repos so `apt-get update` only refreshes the
 # Ubuntu archive. `rm -f` is a no-op when the files are absent (non-GHA environments).
 rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
 
-apt-get update -qq
-apt-get install -y -qq libsecret-tools gnome-keyring dbus
+apt-get -o Acquire::Retries=3 update -qq < /dev/null
+apt-get -o Acquire::Retries=3 install -y -qq libsecret-tools gnome-keyring dbus < /dev/null


### PR DESCRIPTION
## What broke

At 04:32 UTC today two concurrent runs wedged in the SAME step of the Linux
`Coverage — Sandbox` gate and sat there with no output:

| Run | Job | Stuck since |
| --- | --- | --- |
| 32215321881 | PR quality, release PR #1247 | 04:32:14 |
| 32215286724 | push CI on `main` | 04:34:17 |

Step 7 of 12 — the inline `apt-get` install of bubblewrap, libcap-dev, strace
and cppcheck. The coverage gate itself never started. Every sibling shard in the
same matrix finished in 45s to 2.5min, the same gate passed in 58s on run
32214313933 eighteen minutes earlier, and GitHub Status reported Actions
operational throughout. So: not the tests, not the branch, not an outage.

Two independent defects, both in this file.

## 1. The step could hang forever

The inline step carried no non-interactive settings:

```bash
sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap libcap-dev strace cppcheck
```

`-y` answers apt's OWN confirmation. It does not answer debconf, and it does not
answer needrestart, whose "which services should be restarted?" list is a
post-install hook. A prompt on a runner blocks on stdin forever, which is what
the two wedged jobs look like from the outside: a step with no output and no
end.

Its direct sibling, `scripts/linux/install-vault-deps.sh`, already sets
`DEBIAN_FRONTEND=noninteractive` — and the Vault gate's own apt install
succeeded at 04:32 on the same wedged run, on the same archive. That asymmetry
is the evidence.

This PR moves the step into `scripts/linux/install-sandbox-deps.sh`, mirroring
the vault script, with three layered defenses:

- `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` stop the prompts we
  know about;
- `< /dev/null` on both apt invocations turns any prompt we did NOT anticipate
  into an immediate EOF failure instead of an indefinite hang;
- `-o Acquire::Retries=3` covers a flaky mirror, the other way this step has
  historically gone red.

The same three are applied to `install-vault-deps.sh`, which shares the blind
spot — it had only the first of them, so it can still be wedged by needrestart.

## 2. Nothing capped the job

`coverage-gates-pal` and `coverage-gates-linux` were the ONLY two jobs in
`_test-suite.yml` without `timeout-minutes`; the other six all carry 30 or 60.
They inherited GitHub's 360-minute default, so a wedge costs six hours of runner
time per job before anything kills it. Both now carry `timeout-minutes: 30`,
against an observed 1-4 minute runtime.

## Verification

- `scripts/linux/install-sandbox-deps.sh` and the hardened
  `install-vault-deps.sh` both run green end-to-end in an `ubuntu:24.04`
  container — the runner's distro — installing all four and all three packages
  respectively. Not a syntax check: real apt, real installs, exit 0.
- `bun run preflight:fast` — 29 of 29 gates pass, including `audit:workflow-lint`
  and `audit:coverage-gate-pal`, which parses both job blocks I edited.
- `bun test scripts/structure-audit/check-coverage-gate-pal.test.ts` — 39 pass.

## Known gap, deliberately left

A survey of all 74 jobs across the 25 workflows finds 12 without
`timeout-minutes`. Five are reusable-workflow callers, where the key is not
supported and the called workflow's own jobs carry the cap — those are exempt.
The other seven are real and still uncapped: `filter` and `scope` and `label`
and `action` and `analysis` and `stale` and `detect-trigger`. They are all small
jobs and none is implicated here, so capping them, plus an audit that keeps a
new job from forgetting, belongs in its own PR rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
