### PR TITLE
feat(briefs): research briefs draw on the whole index, not only clips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,8 @@ packages/docs/src/assets/architecture-*.svg
 
 # lychee link-check cache (scripts/check-links.sh); successes only, 1h TTL
 .lycheecache
+
+# Subagent-driven-development scratch: ledger, task briefs, implementer reports
+# and review packages for a plan in flight. Working notes — the commits they
+# name are the durable record.
+.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 All notable changes to the `nimbus` core (headless Gateway + CLI binary + first-party MCP connectors) are documented in this file. release-please appends new entries between this header and the most recent version below when a release PR merges.
 
-## [Unreleased]
-
-### Changed
-
-- **A research brief can draw on everything Nimbus has indexed, not only your saved
-  clips.** `useIndex` searched `web_clip` and nothing else, so the pull requests,
-  builds and issues the connectors index — the reason to run a local gateway at all —
-  were invisible to a brief. The search now covers every indexed type, and each
-  citation carries what kind of item it is, so a brief that leans on a pull request
-  says so rather than calling it a clip.
-
 ## [2.6.0](https://github.com/nimbus-agent/Nimbus/compare/v2.5.0...v2.6.0) (2026-08-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `nimbus` core (headless Gateway + CLI binary + first-party MCP connectors) are documented in this file. release-please appends new entries between this header and the most recent version below when a release PR merges.
 
+## [Unreleased]
+
+### Changed
+
+- **A research brief can draw on everything Nimbus has indexed, not only your saved
+  clips.** `useIndex` searched `web_clip` and nothing else, so the pull requests,
+  builds and issues the connectors index — the reason to run a local gateway at all —
+  were invisible to a brief. The search now covers every indexed type, and each
+  citation carries what kind of item it is, so a brief that leans on a pull request
+  says so rather than calling it a clip.
+
 ## [2.6.0](https://github.com/nimbus-agent/Nimbus/compare/v2.5.0...v2.6.0) (2026-08-18)
 
 

--- a/docs/superpowers/plans/2026-08-19-brief-index-widening-review.md
+++ b/docs/superpowers/plans/2026-08-19-brief-index-widening-review.md
@@ -6,6 +6,7 @@ Below are comments, questions, and suggested improvements for the `2026-08-19-br
 
 1. **Helper for Test Fixtures (Task 1, Step 5)**
    * **Suggestion:** Instead of manually adding `itemType: "web_clip"` to every single existing hit literal in `brief-registry.test.ts` (which can be tedious and prone to future compiler breaks if we add more required fields), consider introducing a small helper in the test file, e.g.:
+
      ```ts
      function mockHit(overrides: Partial<IndexHit>): IndexHit {
        return {
@@ -18,10 +19,11 @@ Below are comments, questions, and suggested improvements for the `2026-08-19-br
        };
      }
      ```
+
      This keeps existing test setup cleaner and more robust against future changes.
 
 2. **Null/Undefined Guard on `h.itemType` (Task 2, Step 1)**
-   * **Question:** Is it guaranteed that `RankedIndexItem.itemType` will always be defined and non-null on all items in the database? If there is any legacy item or schema gap where `itemType` is missing, doing `itemType: h.itemType` might violate the required string constraint in `IndexHit`. 
+   * **Question:** Is it guaranteed that `RankedIndexItem.itemType` will always be defined and non-null on all items in the database? If there is any legacy item or schema gap where `itemType` is missing, doing `itemType: h.itemType` might violate the required string constraint in `IndexHit`.
    * **Suggestion:** Use a safe fallback, such as `h.itemType ?? "unknown"`.
 
 3. **Task 4 Step 3 E2E Helper Import**

--- a/docs/superpowers/plans/2026-08-19-brief-index-widening-review.md
+++ b/docs/superpowers/plans/2026-08-19-brief-index-widening-review.md
@@ -1,0 +1,28 @@
+# Implementation Plan Review: Brief Index Widening (2026-08-19)
+
+Below are comments, questions, and suggested improvements for the `2026-08-19-brief-index-widening.md` implementation plan.
+
+## Suggested Improvements & Questions
+
+1. **Helper for Test Fixtures (Task 1, Step 5)**
+   * **Suggestion:** Instead of manually adding `itemType: "web_clip"` to every single existing hit literal in `brief-registry.test.ts` (which can be tedious and prone to future compiler breaks if we add more required fields), consider introducing a small helper in the test file, e.g.:
+     ```ts
+     function mockHit(overrides: Partial<IndexHit>): IndexHit {
+       return {
+         itemId: "nimbus:clip:aa",
+         itemType: "web_clip",
+         title: "Saved",
+         url: "https://z.test",
+         snippet: "snip",
+         ...overrides,
+       };
+     }
+     ```
+     This keeps existing test setup cleaner and more robust against future changes.
+
+2. **Null/Undefined Guard on `h.itemType` (Task 2, Step 1)**
+   * **Question:** Is it guaranteed that `RankedIndexItem.itemType` will always be defined and non-null on all items in the database? If there is any legacy item or schema gap where `itemType` is missing, doing `itemType: h.itemType` might violate the required string constraint in `IndexHit`. 
+   * **Suggestion:** Use a safe fallback, such as `h.itemType ?? "unknown"`.
+
+3. **Task 4 Step 3 E2E Helper Import**
+   * **Suggestion:** Ensure that `Report` is properly imported in `brief-test-server.ts` when exposing `runBriefWithIndexHits(hits: IndexHit[]): Promise<Report>` to avoid any compiler/lint issues in the test harness file.

--- a/docs/superpowers/plans/2026-08-19-brief-index-widening.md
+++ b/docs/superpowers/plans/2026-08-19-brief-index-widening.md
@@ -168,9 +168,28 @@ In `packages/gateway/src/briefs/brief-registry.ts`, replace the body of the `for
   }
 ```
 
-- [ ] **Step 5: Fix the pre-existing fixtures**
+- [ ] **Step 5: Fix the pre-existing fixtures through one helper**
 
-`itemType` is required, so every existing `IndexHit` literal in the test file no longer compiles. Add `itemType: "web_clip"` to each — in `"adds index hits as C1..Cm with clip citations"`, `"caps index hits at MAX_INDEX_HITS"`, and any other hit literal the compiler flags. Search the file for `itemId:` to find them all.
+`itemType` is required, so every existing `IndexHit` literal in the test file no longer compiles. Do **not** hand-edit each one — add a single factory at the top of the file and route the literals through it, so the next required field is a one-line change instead of a sweep:
+
+```ts
+function mockHit(overrides: Partial<IndexHit> = {}): IndexHit {
+  return {
+    itemId: "nimbus:clip:aa",
+    itemType: "web_clip",
+    title: "Saved",
+    url: "https://z.test",
+    snippet: "snip",
+    ...overrides,
+  };
+}
+```
+
+Import the type for it: `import type { IndexHit } from "./brief-registry.ts";`
+
+Then rewrite the existing hit literals as `mockHit(...)` calls — in `"adds index hits as C1..Cm with clip citations"`, `"caps index hits at MAX_INDEX_HITS"` (its `Array.from` becomes `mockHit({ itemId: \`nimbus:clip:${i}\`, title: \`C${i}\`, url: null, snippet: "s" })`), and any other the compiler flags. Search for `itemId:` to find them all.
+
+Leave the three tests you wrote in Step 1 as explicit literals: they are *about* the field combinations, so spelling each one out is the point.
 
 - [ ] **Step 6: Run the tests to verify they pass**
 
@@ -200,6 +219,20 @@ git commit -m "feat(briefs): a citation can say what kind of item it cites"
 **Interfaces:**
 - Consumes: `IndexHit.itemType` from Task 1.
 - Produces: a `briefSearch` that returns hits of every type.
+
+> **Do NOT write `h.itemType ?? "unknown"`.** `RankedIndexItem` extends `NimbusItem`, whose
+> `itemType: ItemType` is **required and non-nullable** (`@nimbus-dev/sdk/dist/types.d.ts:14`),
+> and `rowToRankedItem` builds it unconditionally from `String(row.type)`
+> (`local-index.ts:161,179`) — `String()` cannot yield null or undefined. A fallback here
+> would be dead code that fabricates a type value, and the SDK is explicit about why that is
+> worse than nothing: *"The one thing consumers must never do is rewrite an unrecognised type
+> to a recognised one — that is data corruption"* (`item-types.ts:18-21`). A fabricated
+> `"unknown"` would also reach the clipper's UI and render as a real type label.
+>
+> Note also that `RankedIndexItem` carries **two** identical type fields — `itemType` from
+> `NimbusItem` and its own `indexedType`, both `String(row.type)`. Use `itemType`: it is the
+> SDK-canonical name and the one `IndexHit` mirrors. They are the same value; do not "fix"
+> one to the other later.
 
 - [ ] **Step 1: Drop the filter and map the type through**
 
@@ -394,6 +427,15 @@ Add to `packages/gateway/src/briefs/brief-e2e.test.ts`, following the file's exi
 - [ ] **Step 3: Teach the harness to serve typed hits**
 
 In `brief-test-server.ts`, add `itemType` to every hit literal it already builds, and expose the helper the test above calls — a function that starts the server with a given hit list injected as its `IndexSearch`, runs one brief through create → sources → run → poll, and returns the finished `Report`. Name it `runBriefWithIndexHits(hits: IndexHit[]): Promise<Report>` and export it from the test server module so the e2e file imports it rather than redefining the flow.
+
+Both names in that signature are types this file may not yet import. Add whichever are missing before writing the function, or the harness fails to compile:
+
+```ts
+import type { IndexHit } from "./brief-registry.ts";
+import type { Report } from "./brief-types.ts";
+```
+
+Import the e2e side too: `brief-e2e.test.ts` needs `runBriefWithIndexHits` imported from the test server module.
 
 - [ ] **Step 4: Run the e2e suite**
 

--- a/docs/superpowers/plans/2026-08-19-brief-index-widening.md
+++ b/docs/superpowers/plans/2026-08-19-brief-index-widening.md
@@ -1,0 +1,529 @@
+# Brief Index Widening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a research brief draw on every indexed item type — pull requests, builds, issues, docs — instead of only `web_clip`, and make each citation say what kind of thing it is.
+
+**Architecture:** The search widening is a deletion: `IndexSearchQuery.itemType` is optional, so dropping it from the brief search in `assemble.ts` searches everything through the same hybrid path. The real work is the citation shape — `SourceRef` gains two *additive* optional fields (`itemType`, `itemId`) while `kind` and `clipId` keep their current meanings, so already-saved briefs stay true and the two repos can land in either order.
+
+**Tech Stack:** TypeScript (strict), Bun runtime, `bun:test`, Biome. SQLite-backed local index with BM25 + vector hybrid search.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-brief-index-widening-design.md`
+
+## Global Constraints
+
+- **`kind` keeps exactly two members** — `"source" | "clip"`. Never add a third. It is persisted in saved `research_brief` items; a new member fails validation in readers that predate it.
+- **`clipId` is populated only for `nimbus:web_clip` hits.** Its docblock says it is a clip id; a PR id in that field is a lie `brief-save.ts` would persist.
+- **`itemType` is an arbitrary string, never an enum.** Connectors are added independently; an enum breaks on somebody else's release.
+- **`MAX_INDEX_HITS` stays 8.** Out of scope for this plan.
+- **Gap copy keeps its three-way split** — search-failed / no-hits / keyword-only must stay separately distinguishable. Only the noun changes.
+- **No `any`.** TypeScript strict; use `unknown` plus a guard at boundaries.
+- Gates: `bun run typecheck`, `bun run lint`, `bun test packages/gateway`.
+
+---
+
+### Task 1: The citation shape carries a type and a generic id
+
+**Files:**
+- Modify: `packages/gateway/src/briefs/brief-types.ts:2-10` (`SourceRef`)
+- Modify: `packages/gateway/src/briefs/brief-registry.ts:4-9` (`IndexHit`), `:79-92` (the `C{n}` loop)
+- Test: `packages/gateway/src/briefs/brief-registry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing — first task.
+- Produces: `IndexHit.itemType: string` (**required**, not optional — the producer always knows it); `SourceRef.itemType?: string`; `SourceRef.itemId?: string`. Task 2 supplies `itemType` from `assemble.ts`; Task 5 may read it in the prompt.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/gateway/src/briefs/brief-registry.test.ts` inside `describe("buildRegistry", …)`:
+
+```ts
+  test("a non-clip index hit gets itemId and itemType, and NO clipId", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:pull_request:acme/web/482",
+          itemType: "pull_request",
+          title: "Drop the legacy worker pool",
+          url: "https://github.test/acme/web/pull/482",
+          snippet: "the pool is replaced by",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    const ref = registry.get("C1")?.ref;
+    expect(ref?.kind).toBe("clip");
+    expect(ref?.itemType).toBe("pull_request");
+    expect(ref?.itemId).toBe("nimbus:pull_request:acme/web/482");
+    // The whole point: `clipId` says "clip", so a PR must not claim one.
+    expect(ref?.clipId).toBeUndefined();
+  });
+
+  test("a web_clip index hit still gets clipId, plus the new fields", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:clip:aa",
+          itemType: "web_clip",
+          title: "Saved",
+          url: "https://z.test",
+          snippet: "snip",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    const ref = registry.get("C1")?.ref;
+    expect(ref?.clipId).toBe("nimbus:clip:aa");
+    expect(ref?.itemId).toBe("nimbus:clip:aa");
+    expect(ref?.itemType).toBe("web_clip");
+  });
+
+  test("an itemType this build has never heard of is carried through verbatim", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:slack_message:C123/1699",
+          itemType: "slack_message",
+          title: "standup",
+          url: null,
+          snippet: "we are blocked on",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    // Connectors land upstream on their own schedule. Never an enum.
+    expect(registry.get("C1")?.ref.itemType).toBe("slack_message");
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/briefs/brief-registry.test.ts`
+Expected: FAIL. The new fixtures pass `itemType` to a type that has no such property, so this fails at typecheck/compile before any assertion runs.
+
+- [ ] **Step 3: Widen the two types**
+
+In `packages/gateway/src/briefs/brief-types.ts`, replace the `SourceRef` declaration:
+
+```ts
+/** A validated citation. `quote`, when present, is a span taken from the cited body. */
+export type SourceRef = {
+  /**
+   * `"source"` = a page the client fed. `"clip"` = an item from the user's INDEX —
+   * historically only clips, hence the name, which is kept because it is persisted
+   * in every saved `research_brief`. Read `itemType` for what the item actually is.
+   */
+  kind: "source" | "clip";
+  title: string;
+  url?: string;
+  /**
+   * The `nimbus:clip:<sha256>` item id. Present only for a `nimbus:web_clip` hit —
+   * NOT for every kind: "clip" ref. A non-clip index hit sets `itemId` and leaves
+   * this absent, so a reader that trusts the name is never lied to.
+   */
+  clipId?: string;
+  /** The index item id for ANY indexed hit, whatever its type. */
+  itemId?: string;
+  /** The indexed item's type, verbatim. Arbitrary string — never validated as an enum. */
+  itemType?: string;
+  /** <= MAX_QUOTE_CHARS, verbatim from the cited body (see quote-verify.ts). */
+  quote?: string;
+};
+```
+
+In `packages/gateway/src/briefs/brief-registry.ts`, replace the `IndexHit` declaration:
+
+```ts
+export type IndexHit = {
+  readonly itemId: string;
+  /** The item's type, e.g. `web_clip`, `pull_request`. Required: the producer always knows it. */
+  readonly itemType: string;
+  readonly title: string;
+  readonly url: string | null;
+  readonly snippet: string;
+};
+```
+
+- [ ] **Step 4: Populate the new fields**
+
+In `packages/gateway/src/briefs/brief-registry.ts`, replace the body of the `for (const hit of hits)` loop:
+
+```ts
+  for (const hit of hits) {
+    m += 1;
+    const token = `C${m}`;
+    registry.set(token, {
+      token,
+      ref: {
+        kind: "clip",
+        title: clipTitle(hit.title),
+        itemId: hit.itemId,
+        itemType: hit.itemType,
+        // `clipId` is the NARROW, legacy field: only a real clip may claim it.
+        ...(hit.itemType === "web_clip" ? { clipId: hit.itemId } : {}),
+        ...(hit.url === null ? {} : { url: clipUrl(hit.url) }),
+      },
+      body: hit.snippet,
+    });
+  }
+```
+
+- [ ] **Step 5: Fix the pre-existing fixtures**
+
+`itemType` is required, so every existing `IndexHit` literal in the test file no longer compiles. Add `itemType: "web_clip"` to each — in `"adds index hits as C1..Cm with clip citations"`, `"caps index hits at MAX_INDEX_HITS"`, and any other hit literal the compiler flags. Search the file for `itemId:` to find them all.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/briefs/brief-registry.test.ts`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 7: Typecheck the whole gateway**
+
+Run: `bun run typecheck`
+Expected: PASS. If `assemble.ts` errors because its `IndexSearch` no longer satisfies the type, leave it — Task 2 fixes it. Note the error and continue.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/gateway/src/briefs/brief-types.ts packages/gateway/src/briefs/brief-registry.ts packages/gateway/src/briefs/brief-registry.test.ts
+git commit -m "feat(briefs): a citation can say what kind of item it cites"
+```
+
+---
+
+### Task 2: The brief search stops filtering to web_clip
+
+**Files:**
+- Modify: `packages/gateway/src/platform/assemble.ts:1997-2016`
+- Test: `packages/gateway/src/briefs/brief-registry.test.ts` (already covers the mapping); typecheck is the real gate here
+
+**Interfaces:**
+- Consumes: `IndexHit.itemType` from Task 1.
+- Produces: a `briefSearch` that returns hits of every type.
+
+- [ ] **Step 1: Drop the filter and map the type through**
+
+In `packages/gateway/src/platform/assemble.ts`, replace the `briefSearch` definition:
+
+```ts
+  const briefSearch: IndexSearch = async (query, limit) => {
+    // NO itemType filter: a brief draws on the whole index. `IndexSearchQuery.itemType`
+    // is optional and the SQL applies it only when set, so omitting it is the widening.
+    const hits = await localIndex.searchRankedAsync(
+      { name: query, limit },
+      { semantic: true, contextChunks: 2 },
+    );
+    return {
+      // NOTE: RankedIndexItem extends the SDK's NimbusItem, whose title field is `name`
+      // — there is no `title` and no `body_preview` on it (see index/ranked-item.ts and
+      // @nimbus-dev/sdk types.d.ts). The only body text available here is the matched
+      // chunk in `semanticSnippet`, which is absent on the BM25 fallback path.
+      hits: hits.map((h) => ({
+        itemId: h.indexPrimaryKey,
+        itemType: h.itemType,
+        title: h.name,
+        url: h.url ?? h.canonicalUrl ?? null,
+        snippet: h.semanticSnippet ?? h.name,
+      })),
+      // A hit with no vectorRank anywhere means the hybrid path did not run.
+      semanticAvailable: hits.some((h) => h.vectorRank !== undefined && h.vectorRank !== null),
+    };
+  };
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS with no errors. This is the gate: it proves `RankedIndexItem.itemType` exists and satisfies `IndexHit.itemType`.
+
+- [ ] **Step 3: Run the brief suite**
+
+Run: `bun test packages/gateway/src/briefs`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/gateway/src/platform/assemble.ts
+git commit -m "feat(briefs): search the whole index, not only web clips"
+```
+
+---
+
+### Task 3: The gap copy stops saying "clips" about a search that is not only clips
+
+**Files:**
+- Modify: `packages/gateway/src/briefs/brief-gaps.ts:33-50`
+- Test: `packages/gateway/src/briefs/brief-gaps.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks — pure string change.
+- Produces: three reworded gap strings. The clipper matches gaps by equality only against `synthesis.disclosure`, so nothing downstream pins these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/gateway/src/briefs/brief-gaps.test.ts` inside `describe("buildServerGaps", …)`:
+
+```ts
+  test("the index gaps describe the whole index, not only clips", () => {
+    const failed = buildServerGaps({ ...base, useIndex: true, searchFailed: true });
+    const empty = buildServerGaps({ ...base, useIndex: true, indexHits: 0 });
+    const keyword = buildServerGaps({
+      ...base,
+      useIndex: true,
+      indexHits: 3,
+      semanticAvailable: false,
+    });
+    for (const g of [...failed, ...empty, ...keyword]) {
+      expect(g.toLowerCase()).not.toContain("saved clips");
+    }
+  });
+
+  test("a broken search and an empty result stay DIFFERENT statements", () => {
+    const failed = buildServerGaps({ ...base, useIndex: true, searchFailed: true }).join(" ");
+    const empty = buildServerGaps({ ...base, useIndex: true, indexHits: 0 }).join(" ");
+    expect(failed).not.toEqual(empty);
+    // Only one of these is the user's problem, and it is not the empty one.
+    expect(failed).toContain("error");
+    expect(empty.toLowerCase()).toContain("matched");
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/briefs/brief-gaps.test.ts`
+Expected: FAIL on the first test — the current strings contain "saved clips".
+
+- [ ] **Step 3: Reword the three strings**
+
+In `packages/gateway/src/briefs/brief-gaps.ts`, replace the `if (input.useIndex)` block:
+
+```ts
+  if (input.useIndex) {
+    if (input.searchFailed) {
+      // NEVER launder a broken index into "your corpus had nothing relevant". They are
+      // completely different statements and only one of them is the user's problem.
+      gaps.push(
+        "Your index could not be searched (the local index returned an error), so this report draws only on the sources you selected.",
+      );
+    } else if (input.indexHits === 0) {
+      gaps.push(
+        "Nothing in your index matched this question, so the report draws only on the sources you selected.",
+      );
+    } else if (!input.semanticAvailable) {
+      gaps.push(
+        "Index recall was keyword-only (semantic search unavailable); relevant indexed items may be under-represented.",
+      );
+    }
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/briefs/brief-gaps.test.ts`
+Expected: PASS, including the pre-existing cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/briefs/brief-gaps.ts packages/gateway/src/briefs/brief-gaps.test.ts
+git commit -m "fix(briefs): the index gaps no longer say clips about the whole index"
+```
+
+---
+
+### Task 4: A mixed-type brief survives end to end
+
+**Files:**
+- Modify: `packages/gateway/src/briefs/brief-test-server.ts`
+- Test: `packages/gateway/src/briefs/brief-e2e.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+- Produces: the compatibility guarantee the clipper's spec depends on.
+
+- [ ] **Step 1: Read the harness before changing it**
+
+Run: `grep -n "web_clip\|IndexSearch\|search" packages/gateway/src/briefs/brief-test-server.ts`
+
+The test server injects the `IndexSearch` the e2e run uses. Note how it builds hits; you are adding `itemType` to those literals and making at least two of them differ.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `packages/gateway/src/briefs/brief-e2e.test.ts`, following the file's existing run-a-brief pattern (reuse its helper for create → sources → run → poll rather than hand-rolling a second one):
+
+```ts
+  test("a brief whose index hits span several types cites each with its own itemType", async () => {
+    // Two DIFFERENT types, one of them unknown to this build, plus a real clip.
+    const hits = [
+      {
+        itemId: "nimbus:pull_request:acme/web/482",
+        itemType: "pull_request",
+        title: "Drop the legacy worker pool",
+        url: "https://github.test/acme/web/pull/482",
+        snippet: "the pool is replaced by a bounded queue",
+      },
+      {
+        itemId: "nimbus:slack_message:C123/1699",
+        itemType: "slack_message",
+        title: "standup",
+        url: null,
+        snippet: "we are blocked on the worker pool",
+      },
+      {
+        itemId: "nimbus:clip:aa",
+        itemType: "web_clip",
+        title: "Bounded queues",
+        url: "https://z.test",
+        snippet: "a bounded queue drops work",
+      },
+    ];
+    const report = await runBriefWithIndexHits(hits); // harness helper from Step 3
+    const cited = report.findings.flatMap((f) => f.citations).filter((c) => c.kind === "clip");
+    const types = new Set(cited.map((c) => c.itemType));
+    expect(types.size).toBeGreaterThan(1);
+    // The unknown type is carried, not dropped and not rejected.
+    expect(cited.some((c) => c.itemType === "slack_message")).toBe(true);
+    // Only the real clip claims clipId.
+    for (const c of cited) {
+      if (c.itemType !== "web_clip") expect(c.clipId).toBeUndefined();
+    }
+  });
+```
+
+- [ ] **Step 3: Teach the harness to serve typed hits**
+
+In `brief-test-server.ts`, add `itemType` to every hit literal it already builds, and expose the helper the test above calls — a function that starts the server with a given hit list injected as its `IndexSearch`, runs one brief through create → sources → run → poll, and returns the finished `Report`. Name it `runBriefWithIndexHits(hits: IndexHit[]): Promise<Report>` and export it from the test server module so the e2e file imports it rather than redefining the flow.
+
+- [ ] **Step 4: Run the e2e suite**
+
+Run: `bun test packages/gateway/src/briefs/brief-e2e.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run every gate**
+
+Run: `bun run typecheck && bun run lint && bun test packages/gateway`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/briefs/brief-test-server.ts packages/gateway/src/briefs/brief-e2e.test.ts
+git commit -m "test(briefs): a mixed-type index brief keeps every type it cited"
+```
+
+---
+
+### Task 5 (GATED — may end in "no change"): does the model use the type?
+
+Decision 4 of the spec refuses to assume. This task **measures first** and is allowed to end with nothing shipped; that is a successful outcome, not a failed task.
+
+**Files:**
+- Modify (only if the measurement says so): `packages/gateway/src/briefs/brief-synthesis.ts:46-53`
+- Test: `packages/gateway/src/briefs/brief-synthesis.test.ts`
+
+**Interfaces:**
+- Consumes: `SourceRef.itemType` from Task 1.
+- Produces: either a `type` key on the prompt's per-source object, or a recorded decision not to add one.
+
+- [ ] **Step 1: Write the prompt-shape test**
+
+```ts
+  test("the prompt names each index hit's type when the type is known", () => {
+    // Shape is fixed by the spec: ONE key, raw itemType, absent for S{n} entries.
+    const prompt = buildPrompt(run, registryWithTypedHit("pull_request"));
+    expect(prompt).toContain('"type":"pull_request"');
+    // A fed source is the user's own page and needs no type to be understood.
+    expect(prompt).not.toMatch(/"token":"S1"[^}]*"type"/);
+  });
+```
+
+Build `run` and `registryWithTypedHit` with the same `BriefRunController` pattern `brief-registry.test.ts` uses; do not invent a new fixture style.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `bun test packages/gateway/src/briefs/brief-synthesis.test.ts`
+Expected: FAIL — no `type` key is emitted today.
+
+- [ ] **Step 3: Add the key**
+
+In `buildPrompt`, replace the `sources` map:
+
+```ts
+  const sources = [...registry.values()].map((e) => ({
+    token: e.token,
+    ...(e.ref.itemType === undefined ? {} : { type: e.ref.itemType }),
+    title: e.ref.title,
+    url: e.ref.url ?? null,
+    text: e.body,
+  }));
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `bun test packages/gateway/src/briefs/brief-synthesis.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Judge whether it earns its tokens — then decide**
+
+Run the full brief suite and read what changed: `bun test packages/gateway/src/briefs`
+
+**Keep it** if attribution behaviour improves or is unchanged and the added prompt cost is a single short key per index hit (it is). **Revert it** — `git checkout packages/gateway/src/briefs/brief-synthesis.ts` and delete the test — if any synthesis test regresses. Write the outcome, either way, into the spec's decision 4 as a status line so the next reader knows it was measured rather than assumed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/gateway/src/briefs/ docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+git commit -m "feat(briefs): tell the model what kind of item each index hit is"
+# or, if reverted:
+git commit -m "docs(spec): record that the prompt does not need the item type"
+```
+
+---
+
+### Task 6: Land it
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Record the user-facing change**
+
+Add under `## [Unreleased]`, in the `### Changed` section (create it if absent), matching the repo's narrative changelog voice:
+
+```markdown
+- **A research brief can draw on everything Nimbus has indexed, not only your saved
+  clips.** `useIndex` searched `web_clip` and nothing else, so the pull requests,
+  builds and issues the connectors index — the reason to run a local gateway at all —
+  were invisible to a brief. The search now covers every indexed type, and each
+  citation carries what kind of item it is, so a brief that leans on a pull request
+  says so rather than calling it a clip.
+```
+
+- [ ] **Step 2: Run every gate one final time**
+
+Run: `bun run typecheck && bun run lint && bun test packages/gateway`
+Expected: all PASS. Paste the real output into the PR body; do not summarise it from memory.
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): briefs draw on the whole index"
+git push -u origin dev/asafgolombek/brief-index-widening
+```
+
+- [ ] **Step 4: Open the PR**
+
+Title: `feat(briefs): research briefs draw on the whole index, not only clips`
+
+Body must state: what widened, that `kind`/`clipId` are unchanged and why, the ~5 KB-per-hit bound from the chunker, that no per-type quota was added and why, and the named downstream consumer (`nimbus-web-clipper`, branch `dev/asafgolombek/briefs-over-your-index`).
+
+---
+
+## Self-Review
+
+**Spec coverage:** Decision 1 → Task 2. Decision 2 → Task 1. Decision 3 → Task 3. Decision 4 → Task 5 (gated). Decisions 5, 6 and 8 are recorded rationale with no code to write — Task 5's judgement step and the PR body carry them. Decision 7 (query embedding) is explicitly out of scope. The "unknown itemType must not break validation" test from the Testing section → Task 1 Step 1 and Task 4 Step 2.
+
+**Type consistency:** `IndexHit.itemType` is `string` (required) everywhere — declared in Task 1, produced in Task 2, consumed in Tasks 4 and 5. `SourceRef.itemType`/`itemId` are `string | undefined` everywhere. `runBriefWithIndexHits(hits: IndexHit[]): Promise<Report>` is named identically in Task 4 Steps 2 and 3.
+
+**Known follow-ups, deliberately not tasks:** the query-embedding egress (spec decision 7) and a gap line naming type skew (decision 6) — neither has evidence it is needed yet.

--- a/docs/superpowers/plans/2026-08-19-brief-index-widening.md
+++ b/docs/superpowers/plans/2026-08-19-brief-index-widening.md
@@ -25,11 +25,13 @@
 ### Task 1: The citation shape carries a type and a generic id
 
 **Files:**
+
 - Modify: `packages/gateway/src/briefs/brief-types.ts:2-10` (`SourceRef`)
 - Modify: `packages/gateway/src/briefs/brief-registry.ts:4-9` (`IndexHit`), `:79-92` (the `C{n}` loop)
 - Test: `packages/gateway/src/briefs/brief-registry.test.ts`
 
 **Interfaces:**
+
 - Consumes: nothing — first task.
 - Produces: `IndexHit.itemType: string` (**required**, not optional — the producer always knows it); `SourceRef.itemType?: string`; `SourceRef.itemId?: string`. Task 2 supplies `itemType` from `assemble.ts`; Task 5 may read it in the prompt.
 
@@ -187,7 +189,7 @@ function mockHit(overrides: Partial<IndexHit> = {}): IndexHit {
 
 Import the type for it: `import type { IndexHit } from "./brief-registry.ts";`
 
-Then rewrite the existing hit literals as `mockHit(...)` calls — in `"adds index hits as C1..Cm with clip citations"`, `"caps index hits at MAX_INDEX_HITS"` (its `Array.from` becomes `mockHit({ itemId: \`nimbus:clip:${i}\`, title: \`C${i}\`, url: null, snippet: "s" })`), and any other the compiler flags. Search for `itemId:` to find them all.
+Then rewrite the existing hit literals as `mockHit(...)` calls — in `"adds index hits as C1..Cm with clip citations"`, `"caps index hits at MAX_INDEX_HITS"` (its `Array.from` becomes `mockHit({ itemId: \`nimbus:clip:${i}\`, title: \`C${i}\`, url: null, snippet: "s" })`), and any other the compiler flags. Search for`itemId:` to find them all.
 
 Leave the three tests you wrote in Step 1 as explicit literals: they are *about* the field combinations, so spelling each one out is the point.
 
@@ -213,10 +215,12 @@ git commit -m "feat(briefs): a citation can say what kind of item it cites"
 ### Task 2: The brief search stops filtering to web_clip
 
 **Files:**
+
 - Modify: `packages/gateway/src/platform/assemble.ts:1997-2016`
 - Test: `packages/gateway/src/briefs/brief-registry.test.ts` (already covers the mapping); typecheck is the real gate here
 
 **Interfaces:**
+
 - Consumes: `IndexHit.itemType` from Task 1.
 - Produces: a `briefSearch` that returns hits of every type.
 
@@ -286,10 +290,12 @@ git commit -m "feat(briefs): search the whole index, not only web clips"
 ### Task 3: The gap copy stops saying "clips" about a search that is not only clips
 
 **Files:**
+
 - Modify: `packages/gateway/src/briefs/brief-gaps.ts:33-50`
 - Test: `packages/gateway/src/briefs/brief-gaps.test.ts`
 
 **Interfaces:**
+
 - Consumes: nothing from earlier tasks — pure string change.
 - Produces: three reworded gap strings. The clipper matches gaps by equality only against `synthesis.disclosure`, so nothing downstream pins these.
 
@@ -368,10 +374,12 @@ git commit -m "fix(briefs): the index gaps no longer say clips about the whole i
 ### Task 4: A mixed-type brief survives end to end
 
 **Files:**
+
 - Modify: `packages/gateway/src/briefs/brief-test-server.ts`
 - Test: `packages/gateway/src/briefs/brief-e2e.test.ts`
 
 **Interfaces:**
+
 - Consumes: everything from Tasks 1-3.
 - Produces: the compatibility guarantee the clipper's spec depends on.
 
@@ -461,10 +469,12 @@ git commit -m "test(briefs): a mixed-type index brief keeps every type it cited"
 Decision 4 of the spec refuses to assume. This task **measures first** and is allowed to end with nothing shipped; that is a successful outcome, not a failed task.
 
 **Files:**
+
 - Modify (only if the measurement says so): `packages/gateway/src/briefs/brief-synthesis.ts:46-53`
 - Test: `packages/gateway/src/briefs/brief-synthesis.test.ts`
 
 **Interfaces:**
+
 - Consumes: `SourceRef.itemType` from Task 1.
 - Produces: either a `type` key on the prompt's per-source object, or a recorded decision not to add one.
 
@@ -526,6 +536,7 @@ git commit -m "docs(spec): record that the prompt does not need the item type"
 ### Task 6: Land it
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 
 - [ ] **Step 1: Record the user-facing change**

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design-review.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design-review.md
@@ -6,7 +6,7 @@ Below are comments, questions, and suggested improvements for the `2026-08-19-br
 
 1. **Token Budget & Chunk Size Limits**
    * **Question:** Widening the search to pull requests, builds, and code files means the content chunk sizes (`contextChunks: 2` per hit, up to 8 hits) might be significantly larger than web clips. Do we have constraints/truncation logic to ensure a single massive PR/build log hit does not exhaust the model's prompt token limit?
-   
+
 2. **Result Ranking & Prioritization**
    * **Question:** When searching across all indexed types without filtering, how does the hybrid ranker rank them? If a query matches 20 items (some clips, some issues, some builds), does the ranking algorithm naturally bias towards certain types, or is it purely semantic/keyword score-based? Should there be a fallback ratio (e.g., at least 2 clips, at least 2 issues) to avoid one type dominating the 8 slots?
 

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design-review.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design-review.md
@@ -1,0 +1,19 @@
+# Design Review: Brief index widening (2026-08-19)
+
+Below are comments, questions, and suggested improvements for the `2026-08-19-brief-index-widening-design.md` specification.
+
+## Open Questions & Clarifications
+
+1. **Token Budget & Chunk Size Limits**
+   * **Question:** Widening the search to pull requests, builds, and code files means the content chunk sizes (`contextChunks: 2` per hit, up to 8 hits) might be significantly larger than web clips. Do we have constraints/truncation logic to ensure a single massive PR/build log hit does not exhaust the model's prompt token limit?
+   
+2. **Result Ranking & Prioritization**
+   * **Question:** When searching across all indexed types without filtering, how does the hybrid ranker rank them? If a query matches 20 items (some clips, some issues, some builds), does the ranking algorithm naturally bias towards certain types, or is it purely semantic/keyword score-based? Should there be a fallback ratio (e.g., at least 2 clips, at least 2 issues) to avoid one type dominating the 8 slots?
+
+3. **Prompt Enrichment (`itemType`)**
+   * **Question:** Regarding Decision 4: If the synthesis test demonstrates that passing `itemType` improves attribution, what schema structure will it take? Feeding type information is likely highly beneficial (e.g., distinguishing a Jira issue from a git commit allows the LLM to write cleaner syntheses like "According to PR #12...").
+
+## Suggested Improvements
+
+1. **Robust Parser/Validator Resiliency**
+   * **Suggestion:** Ensure the client validation (e.g., Zod schema or JSON parsing) explicitly maps `itemType` as an optional string that accepts *any* arbitrary value. Since other connectors can be added to the gateway independently, the client shouldn't crash if it encounters a novel type like `itemType: "slack_message"`.

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
@@ -1,0 +1,167 @@
+# Brief index widening
+
+**Status:** design, approved 2026-08-19.
+
+**Branching:** `dev/asafgolombek/brief-index-widening`, off `origin/main` (`10b31750`,
+*feat(engine): [persona] gives Nimbus a configurable voice (#1248)*). Nothing is stacked.
+
+**Consumer:** `nimbus-web-clipper`, branch `dev/asafgolombek/briefs-over-your-index`, spec
+`docs/superpowers/specs/2026-08-19-briefs-over-your-index-design.md` there. That client
+ships the first `useIndex: true` caller this surface has ever had.
+
+## What this builds
+
+`POST /v1/briefs` has taken `useIndex` since the research-briefs surface landed, and
+`buildRegistry` has always searched the index and minted `C1..Cn` citation tokens for the
+hits. What it searches is **one item type**:
+
+```ts
+// platform/assemble.ts
+const hits = await localIndex.searchRankedAsync(
+  { name: query, itemType: "web_clip", limit },
+  { semantic: true, contextChunks: 2 },
+);
+```
+
+So a brief can draw on pages the user clipped, and on nothing else. Not the pull requests,
+builds, issues or docs the connectors index — the corpus that is the reason to run a local
+gateway at all.
+
+This slice widens that search to every indexed type, and makes a citation say **what kind
+of thing it is**, which the shape currently cannot express.
+
+## The decisions
+
+### 1. Widening is a deletion
+
+`IndexSearchQuery.itemType` is optional (`index/local-index.ts:83`) and the SQL applies it
+only when set and non-empty (`:552`, `:677`). Omitting it searches every type through the
+same hybrid path, with the same `limit` and the same `semanticAvailable` signal.
+
+So the widening itself introduces no new machinery, no new query shape and no new failure
+mode. `MAX_INDEX_HITS` stays 8: the bound exists because a registry entry is prompt budget,
+and that reasoning is indifferent to which types the hits came from.
+
+### 2. `SourceRef` grows `itemType` and `itemId`; `kind` and `clipId` do not move
+
+Today:
+
+```ts
+export type SourceRef = {
+  kind: "source" | "clip";
+  title: string;
+  url?: string;
+  /** The `nimbus:clip:<sha256>` item id. Present only for kind: "clip". */
+  clipId?: string;
+  quote?: string;
+};
+```
+
+Widen the search without touching this and a Jira issue arrives as `kind: "clip"` carrying
+a non-clip id in a field whose docblock says it is a clip id. The shape would be lying, and
+`brief-save.ts` would persist that lie into every saved `research_brief` item.
+
+Two additive optional fields, and nothing else:
+
+- **`itemType?: string`** — the indexed item's type, straight from `RankedIndexItem.itemType`
+  (`local-index.ts:161`). Present on every index-sourced ref.
+- **`itemId?: string`** — the item id for **any** indexed hit.
+
+`clipId` stays exactly as documented and is populated **only** for genuine
+`nimbus:web_clip` hits, so every existing reader keeps its current meaning and every
+already-saved brief stays true. `kind` keeps its two members: it is persisted upstream in
+saved items, and a third member would fail validation in readers that predate it — for a
+distinction `itemType` now expresses precisely. Its documentation changes from *a clip* to
+*an item from your index*; the value does not.
+
+This is deliberately additive so the two repos can land in either order. An un-upgraded
+client sees a ref it can already parse.
+
+### 3. The gap copy is wrong the moment the search is wider
+
+`brief-gaps.ts:35-48` writes, in three places, about *saved clips*:
+
+- "Saved clips could not be searched (the local index returned an error) …"
+- "No saved clips matched this question …"
+- "Index recall was keyword-only (semantic search unavailable); relevant saved clips may be
+  under-represented."
+
+After this slice each statement is about the whole index. The three-way split is the
+valuable part and is kept exactly — the comment above it is the rule this repo cares about:
+
+> NEVER launder a broken index into "your corpus had nothing relevant". They are completely
+> different statements and only one of them is the user's problem.
+
+Only the noun changes. The clipper filters gaps by equality against `synthesis.disclosure`
+alone, so rewording these three is safe across the boundary.
+
+### 4. Whether the prompt should name the type — decide with a test, not by assumption
+
+`buildPrompt` (`brief-synthesis.ts:47`) hands the model `{token, title, url, text}` per
+registry entry. Once entries span types, telling the model that `C3` is a pull request and
+`C4` is a page the user clipped is plausibly better grounding — and plausibly just more
+tokens.
+
+Not assumed either way here. The implementation adds the field to the prompt entry only if
+a synthesis test shows it changes attribution behaviour; otherwise it stays out. The
+citation carries `itemType` regardless, because the **user** benefits from it whether or
+not the model does.
+
+### 5. Out of scope: the query embedding leaves even when the corpus does not
+
+`searchRankedAsync` embeds the query via `ss.embedQueryDual(nameQ)`. That call is routed by
+ordinary embedding configuration and is **not** covered by `LOCAL_ONLY_PROSE_TYPES`, which
+governs indexing prose (`embedding/routing.ts:72`, the Nimbus#1006 fix). So a brief search
+can send the user's question to a remote embedder while every clip it searches stays on
+disk.
+
+This slice does not change that, and widening does not worsen it — the query is one string
+either way, independent of how many types it is matched against.
+
+It is nonetheless a real hole in what the client can honestly promise, and the client is
+disclosing it rather than papering over it. **Follow-up worth its own slice:** force a
+local-only query embedding when a search is index-scoped for briefs, or expose a pre-run
+signal so a client can state the destination truthfully instead of hedging.
+
+### 6. What widening *does* change: more of your corpus can reach a remote model
+
+Today a `useIndex` run can send the user's clips to whatever `createBriefLlm` resolves,
+which falls back to remote when no local provider is available. After this slice the same
+run can send snippets of indexed pull requests, builds and issues.
+
+The existing disclosure covers it literally — *"The brief and all source text were sent to
+that provider — they left this machine"* is true of a PR snippet as much as a clip. But it
+is a wider blast radius under the same sentence, and it is recorded here so the next reader
+does not discover it by surprise.
+
+## Shape
+
+| File | Change |
+| --- | --- |
+| `platform/assemble.ts` | Drop `itemType: "web_clip"` from the brief search; map `itemType` into each `IndexHit` |
+| `briefs/brief-registry.ts` | `IndexHit.itemType`; set `itemType`/`itemId` on each `C{n}` ref; `clipId` only for `nimbus:web_clip` |
+| `briefs/brief-types.ts` | `SourceRef.itemType?` / `.itemId?`; re-document `kind: "clip"` and `clipId` |
+| `briefs/brief-gaps.ts` | Reword the three "saved clips" lines; keep the three-way split |
+| `briefs/brief-validate.ts` | Unchanged — `useIndex` already validated |
+| `briefs/brief-synthesis.ts` | Only if decision 4's test says so |
+| `briefs/brief-test-server.ts` | Serve hits of more than one type |
+
+## Testing
+
+`brief-registry.test.ts` carries the core: a non-clip hit gets `itemId` and `itemType` and
+**no** `clipId`; a `web_clip` hit still gets `clipId`; declaration order and token minting
+are unchanged. `brief-gaps.test.ts` pins the reworded strings, keeping the three cases
+distinguishable. `brief-e2e.test.ts` runs a brief whose index hits span two types and
+asserts the citations come back typed.
+
+A regression test worth having explicitly: **a search that returns hits of a type the
+client has never seen must not break report validation.** That is the compatibility claim
+decision 2 rests on.
+
+## Not in this slice
+
+- **A client-supplied scope.** `useIndex` stays a boolean. Which types to search is a
+  contract change for a choice nobody has asked for.
+- **Renaming `kind`.** Decision 2.
+- **The query-embedding fix.** Decision 5.
+- **Changing `MAX_INDEX_HITS`.** Decision 1.

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
@@ -204,19 +204,91 @@ that provider — they left this machine"* is true of a PR snippet as much as a 
 is a wider blast radius under the same sentence, and it is recorded here so the next reader
 does not discover it by surprise.
 
+### 9. A `briefs`-scoped token now reads the whole index
+
+`clips/api-scopes.ts:16-24` says that granting every scope to tokens already in the wild
+would hand them "the ability to run any read-only agent over the whole index … which is
+precisely the escalation scopes exist to prevent", and `LEGACY_SCOPES` is
+`["clip", "briefs"]`. After this slice, a `briefs` token minted so a browser extension
+could save web pages can surface material from the user's indexed email, transcripts,
+invoices and pull requests. The token did not change; what `briefs` reaches did.
+
+The bound is real and worth stating precisely. A citation carries `title`, `url`, `itemId`
+and `itemType` plus a verified quote of at most `MAX_QUOTE_CHARS` (200) characters, and
+`resolveItem` (`briefs/brief-report.ts:112-133`) is the only path a body reaches the report
+through — the raw item body is never returned. So the exposure is metadata plus short
+verified spans, not the corpus.
+
+It is nonetheless materially wider than "pages this extension clipped", which is how the
+scope reads to anyone who granted it, and this spec did not frame it that way before.
+Recorded, not fixed: a code-level restriction — scoping the brief search by the token's
+scope, or splitting `briefs` into a clip-only and an index-wide grant — is an available
+follow-up. **This slice does not take it**, and shipping without it is a decision, not an
+oversight.
+
+### 10. A brief can now cite an earlier brief
+
+`briefs/brief-save.ts:64-84` writes every saved report into the index as a `research_brief`
+item, with `body: effective.summary`, and schedules an embedding for it. While the search
+was pinned to `web_clip` that item was unreachable by any later brief. It is not any more.
+
+So model-written prose can come back as a `C{n}` citation and sit in the registry beside a
+pull request, indistinguishable as evidence except by `itemType`. A second brief on the same
+topic can cite the first one's summary and read as corroboration when it is really the same
+inference repeated — and quote verification does not help here, because the quote genuinely
+does appear verbatim in the cited body.
+
+The alternative is one line: exclude `research_brief` from the brief search the way
+`web_clip` was excluded from everything else. **This slice does not take it.** The user's own
+saved research is legitimately part of their corpus, and suppressing it by type would be the
+same kind of unasked-for scoping decision this design rejects elsewhere. Recorded as a known
+consequence so the first person to see a brief cite a brief knows it was foreseen.
+
+### 11. Two new ref fields fan out to 400 citations, so the save ladder sheds ids first
+
+`brief-constants.ts:57-70` already reasons about ref fan-out: a ref is copied into every
+citation that names it, and the count caps allow `MAX_FINDINGS` 25 x `MAX_CITATIONS_PER_ITEM`
+8, plus the same again for conflicts — 400 citations. This slice adds `itemId` (on a
+`web_clip` citation, byte-identical to `clipId`) and `itemType` to every one of them:
+roughly +110 bytes per article-clip citation and +175 for a selection clip, so +44-70 KB
+worst case against `brief-save.ts`'s 60 KB `META_BUDGET_BYTES`. A brief that used to save at
+~55 KB could now throw `ReportTooLargeError`, and the user cannot save the brief in front of
+them.
+
+The budget constants do not move — they are sized against `RAW_META_MAX_BYTES` and are not
+this slice's to spend. Instead the degradation ladder gains a first rung ABOVE quote
+stripping: drop `itemId` wherever it equals `clipId`. That rung is free — `clipId` still
+resolves the item and `itemType` still says what it is, so nothing recoverable is lost and it
+carries no gap line. Quotes are the user's evidence and go only when the duplicate ids were
+not enough. The ordering is the contract and is pinned by test, not just the fact that
+degradation happens.
+
 ## Shape
 
 | File | Change |
 | --- | --- |
-| `platform/assemble.ts` | Drop `itemType: "web_clip"` from the brief search; map `itemType` into each `IndexHit` |
+| `platform/assemble.ts` | Drop `itemType: "web_clip"` from the brief search; map `itemType` into each `IndexHit` — now via the factory below |
+| `briefs/brief-index-search.ts` | **New.** `createBriefIndexSearch(localIndex)`: the real query, extracted out of the boot closure so a seeded-index test can reach it |
 | `briefs/brief-registry.ts` | `IndexHit.itemType`; set `itemType`/`itemId` on each `C{n}` ref; `clipId` only for `nimbus:web_clip` |
 | `briefs/brief-types.ts` | `SourceRef.itemType?` / `.itemId?`; re-document `kind: "clip"` and `clipId` |
 | `briefs/brief-gaps.ts` | Reword the three "saved clips" lines; keep the three-way split |
 | `briefs/brief-validate.ts` | Unchanged — `useIndex` already validated |
 | `briefs/brief-synthesis.ts` | Only if decision 4's test says so |
 | `briefs/brief-test-server.ts` | Serve hits of more than one type |
+| `briefs/brief-save.ts` | Degradation ladder sheds `itemId` where it equals `clipId` BEFORE stripping quotes (decision 11) |
 
 ## Testing
+
+`brief-index-search.test.ts` carries the widening itself, and it is the ONLY test that can:
+every other brief test injects a stub `IndexSearch`, so none of them can see the query the
+gateway actually issues — which is why the query was extracted out of `assemble.ts` into
+`createBriefIndexSearch`. It seeds a real in-memory `LocalIndex` with a `web_clip`, a
+`pull_request` and an `email`, and asserts all three come back with the `itemType` they were
+seeded with. Restoring `itemType: "web_clip"` to the query fails it.
+
+`brief-save.test.ts` pins the degradation ORDER of decision 11, not merely that degradation
+happens: a report that fits once the duplicated ids are gone keeps its quotes, and one that
+does not fall through to stripping them.
 
 `brief-registry.test.ts` carries the core: a non-clip hit gets `itemId` and `itemType` and
 **no** `clipId`; a `web_clip` hit still gets `clipId`; declaration order and token minting
@@ -244,3 +316,5 @@ spec's test list carries the matching case.
 - **Renaming `kind`.** Decision 2.
 - **The query-embedding fix.** Decision 7.
 - **Changing `MAX_INDEX_HITS`.** Decision 1.
+- **Restricting the brief search by token scope.** Decision 9.
+- **Excluding `research_brief` from the brief search.** Decision 10.

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
@@ -103,9 +103,9 @@ registry entry. Once entries span types, telling the model that `C3` is a pull r
 tokens.
 
 Not assumed either way here. The implementation adds the field to the prompt entry only if
-a synthesis test shows it changes attribution behaviour; otherwise it stays out. The
-citation carries `itemType` regardless, because the **user** benefits from it whether or
-not the model does.
+doing so does not regress the synthesis suite and costs no more than the single
+pre-authorised key below; otherwise it stays out. The citation carries `itemType`
+regardless, because the **user** benefits from it whether or not the model does.
 
 **If the test says yes, the shape is fixed in advance** so the decision is about whether,
 never about what: one additional key on the existing per-source object, carrying the raw
@@ -126,6 +126,13 @@ test regressed, and the discriminating test (`brief-synthesis.test.ts`, `buildPr
 block) confirms the key is present on a typed `C{n}` entry and absent on `S1`. Cost is exactly
 the single short key the spec allowed. Nothing else in `INSTRUCTIONS` or the source shape
 changed.
+
+What this did **not** measure: every LLM call in this suite is a canned/stubbed response
+that ignores prompt content, so no test here can show a change in attribution behaviour in
+either direction — the stricter "does the model use it" question this section opens with is
+still open, and stays open until a slice with a real (live-model) eval harness can ask it.
+"Kept" rests on absence of regression at pre-authorised cost, not on a demonstrated
+improvement in grounding.
 
 ### 5. A hit's prompt cost is set by the chunker, not by the item
 

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
@@ -120,6 +120,13 @@ to be understood. No prose label, no per-type instruction text in `INSTRUCTIONS`
 is given the fact and left to use it. Anything more elaborate is a prompt-engineering slice
 with its own evidence bar, not a rider on this one.
 
+**Measured (Task 5, 2026-08-19): kept.** Added the `type` key per the fixed shape above and
+ran the full `packages/gateway/src/briefs` suite (164 tests) before and after: no synthesis
+test regressed, and the discriminating test (`brief-synthesis.test.ts`, `buildPrompt` describe
+block) confirms the key is present on a typed `C{n}` entry and absent on `S1`. Cost is exactly
+the single short key the spec allowed. Nothing else in `INSTRUCTIONS` or the source shape
+changed.
+
 ### 5. A hit's prompt cost is set by the chunker, not by the item
 
 The intuition that a build log or a large pull request would drag far more text into the

--- a/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
+++ b/docs/superpowers/specs/2026-08-19-brief-index-widening-design.md
@@ -107,7 +107,63 @@ a synthesis test shows it changes attribution behaviour; otherwise it stays out.
 citation carries `itemType` regardless, because the **user** benefits from it whether or
 not the model does.
 
-### 5. Out of scope: the query embedding leaves even when the corpus does not
+**If the test says yes, the shape is fixed in advance** so the decision is about whether,
+never about what: one additional key on the existing per-source object, carrying the raw
+`itemType` and nothing derived —
+
+```ts
+{ token: "C3", type: "pull_request", title: …, url: …, text: … }
+```
+
+Absent for `S{n}` entries, which are the pages the user themselves supplied and need no type
+to be understood. No prose label, no per-type instruction text in `INSTRUCTIONS`: the model
+is given the fact and left to use it. Anything more elaborate is a prompt-engineering slice
+with its own evidence bar, not a rider on this one.
+
+### 5. A hit's prompt cost is set by the chunker, not by the item
+
+The intuition that a build log or a large pull request would drag far more text into the
+prompt than a web clip is worth stating and rejecting, because it is wrong in a way that
+matters for whether this slice needs a new cap.
+
+A snippet is not the item. `semanticSnippetForHit` returns the **winning chunk plus
+`contextChunks` neighbours on each side** (`search/hybrid-internal.ts:34-39`), and a chunk is
+bounded by the chunker at 256 tokens — `maxChars = maxChunkTokens * 4`, so ~1 KB
+(`embedding/chunker.ts:9,142`). With `contextChunks: 2` that is at most 5 chunks, ~5 KB per
+hit, ~40 KB across all 8.
+
+A 40 MB build log therefore produces *more* chunks, not bigger ones, and still contributes
+one winning chunk plus its neighbours. **The bound is identical for every item type**, which
+is precisely why widening does not move it.
+
+Worth recording honestly: index-hit bodies are subject to **no brief-side byte cap**.
+`MAX_SOURCE_BYTES` and `MAX_RUN_BYTES` govern sources the client *feeds*; a `C{n}` body
+enters through `buildRegistry` and is capped only by the chunker. That is a pre-existing
+property, not one this slice introduces, and ~40 KB against a 4 MB run budget does not
+justify a second cap. Noted so the next reader does not assume the feed-stage accounting
+covers this path.
+
+### 6. Ranking stays purely score-based — no per-type quota
+
+`tryBuildHybridHit` scores by reciprocal rank fusion over the BM25 rank and the vector rank
+(`search/hybrid-internal.ts:258-266`). Nothing in it reads the item type, so widening
+introduces no type bias: the 8 slots go to the 8 best-scoring items.
+
+One consequence is real and accepted: **a single type can take all 8 slots.** Ask a question
+about a migration during a week of migration PRs and you may get eight pull requests and
+none of your clips.
+
+A quota — "at least 2 clips, at least 2 issues" — is the wrong fix. It buys type balance by
+demoting better-matching items in favour of worse-matching ones, on the assumption that
+variety of *source type* proxies for variety of *evidence*. It does not: eight PRs may be
+exactly the right answer, and a forced clip is noise the model then has to be told to ignore.
+Relevance ordering is the feature.
+
+If dominance turns out to hurt real briefs, the honest remedy is a gap line naming the skew
+("all 8 index hits were pull requests"), not a reshuffle that hides it. Not built now —
+there is no evidence it happens.
+
+### 7. Out of scope: the query embedding leaves even when the corpus does not
 
 `searchRankedAsync` embeds the query via `ss.embedQueryDual(nameQ)`. That call is routed by
 ordinary embedding configuration and is **not** covered by `LOCAL_ONLY_PROSE_TYPES`, which
@@ -123,7 +179,7 @@ disclosing it rather than papering over it. **Follow-up worth its own slice:** f
 local-only query embedding when a search is index-scoped for briefs, or expose a pre-run
 signal so a client can state the destination truthfully instead of hedging.
 
-### 6. What widening *does* change: more of your corpus can reach a remote model
+### 8. What widening *does* change: more of your corpus can reach a remote model
 
 Today a `useIndex` run can send the user's clips to whatever `createBriefLlm` resolves,
 which falls back to remote when no local provider is available. After this slice the same
@@ -158,10 +214,19 @@ A regression test worth having explicitly: **a search that returns hits of a typ
 client has never seen must not break report validation.** That is the compatibility claim
 decision 2 rests on.
 
+That claim has a second half, and it belongs on the **client** side of the boundary: a
+report carrying `itemType: "slack_message"` — a type from a connector that did not exist
+when the client shipped — must parse and render. Connectors are added to the gateway
+independently of any client release, so treating `itemType` as an enum would guarantee a
+break on the next connector. It is validated as *an optional string of any value*, which is
+what the clipper's hand-written guards do naturally (this repo and that one both use type
+guards, not a schema library, so there is no enum to accidentally reach for). The clipper
+spec's test list carries the matching case.
+
 ## Not in this slice
 
 - **A client-supplied scope.** `useIndex` stays a boolean. Which types to search is a
   contract change for a choice nobody has asked for.
 - **Renaming `kind`.** Decision 2.
-- **The query-embedding fix.** Decision 5.
+- **The query-embedding fix.** Decision 7.
 - **Changing `MAX_INDEX_HITS`.** Decision 1.

--- a/packages/gateway/src/briefs/brief-constants.ts
+++ b/packages/gateway/src/briefs/brief-constants.ts
@@ -50,7 +50,11 @@ export const MAX_SUMMARY_CHARS = 2000;
 /** Characters of one finding's or conflict's prose. */
 export const MAX_ITEM_TEXT_CHARS = 600;
 
-/** Indexed clips pulled in when useIndex is true. */
+/**
+ * Items pulled from the user's index when useIndex is true — of ANY indexed type, not
+ * only clips. The bound exists because a registry entry is prompt budget, and that
+ * reasoning is indifferent to which types the hits came from.
+ */
 export const MAX_INDEX_HITS = 8;
 
 /**

--- a/packages/gateway/src/briefs/brief-e2e.test.ts
+++ b/packages/gateway/src/briefs/brief-e2e.test.ts
@@ -9,7 +9,7 @@
 import { expect, test } from "bun:test";
 import { MAX_RUN_BYTES, MAX_SOURCE_BYTES, MAX_SOURCES_PER_RUN } from "./brief-constants.ts";
 import type { BriefSynthesizerLlm } from "./brief-synthesis.ts";
-import { startBriefTestServer } from "./brief-test-server.ts";
+import { runBriefWithIndexHits, startBriefTestServer } from "./brief-test-server.ts";
 import type { Report } from "./brief-types.ts";
 
 type CreateOk = { id: string; status: string; expected: number };
@@ -174,6 +174,43 @@ test("happy path: create -> feed both -> run -> poll done -> citations resolve -
     expect(row.c).toBe(1);
   } finally {
     s.stop();
+  }
+});
+
+test("a brief whose index hits span several types cites each with its own itemType", async () => {
+  // Two DIFFERENT types, one of them unknown to this build, plus a real clip.
+  const hits = [
+    {
+      itemId: "nimbus:pull_request:acme/web/482",
+      itemType: "pull_request",
+      title: "Drop the legacy worker pool",
+      url: "https://github.test/acme/web/pull/482",
+      snippet: "the pool is replaced by a bounded queue",
+    },
+    {
+      itemId: "nimbus:slack_message:C123/1699",
+      itemType: "slack_message",
+      title: "standup",
+      url: null,
+      snippet: "we are blocked on the worker pool",
+    },
+    {
+      itemId: "nimbus:clip:aa",
+      itemType: "web_clip",
+      title: "Bounded queues",
+      url: "https://z.test",
+      snippet: "a bounded queue drops work",
+    },
+  ];
+  const report = await runBriefWithIndexHits(hits); // harness helper from Step 3
+  const cited = report.findings.flatMap((f) => f.citations).filter((c) => c.kind === "clip");
+  const types = new Set(cited.map((c) => c.itemType));
+  expect(types.size).toBeGreaterThan(1);
+  // The unknown type is carried, not dropped and not rejected.
+  expect(cited.some((c) => c.itemType === "slack_message")).toBe(true);
+  // Only the real clip claims clipId.
+  for (const c of cited) {
+    if (c.itemType !== "web_clip") expect(c.clipId).toBeUndefined();
   }
 });
 

--- a/packages/gateway/src/briefs/brief-gaps.test.ts
+++ b/packages/gateway/src/briefs/brief-gaps.test.ts
@@ -31,13 +31,13 @@ describe("buildServerGaps", () => {
 
   test("flags an empty index result when useIndex was requested", () => {
     const g = buildServerGaps({ ...base, useIndex: true, indexHits: 0 });
-    expect(g.join(" ").toLowerCase()).toContain("no saved clips");
+    expect(g.join(" ").toLowerCase()).toContain("nothing");
   });
 
   test("distinguishes a failed index search from an empty one", () => {
     const g = buildServerGaps({ ...base, useIndex: true, indexHits: 0, searchFailed: true });
     expect(g.join(" ").toLowerCase()).toContain("returned an error");
-    expect(g.join(" ").toLowerCase()).not.toContain("no saved clips");
+    expect(g.join(" ").toLowerCase()).not.toContain("matched");
   });
 
   test("flags keyword-only recall when semantic search was unavailable", () => {
@@ -63,5 +63,28 @@ describe("buildServerGaps", () => {
   test("adds no index gap when the index search succeeded with semantic recall available", () => {
     const g = buildServerGaps({ ...base, useIndex: true, indexHits: 3, semanticAvailable: true });
     expect(g).toEqual([]);
+  });
+
+  test("the index gaps describe the whole index, not only clips", () => {
+    const failed = buildServerGaps({ ...base, useIndex: true, searchFailed: true });
+    const empty = buildServerGaps({ ...base, useIndex: true, indexHits: 0 });
+    const keyword = buildServerGaps({
+      ...base,
+      useIndex: true,
+      indexHits: 3,
+      semanticAvailable: false,
+    });
+    for (const g of [...failed, ...empty, ...keyword]) {
+      expect(g.toLowerCase()).not.toContain("saved clips");
+    }
+  });
+
+  test("a broken search and an empty result stay DIFFERENT statements", () => {
+    const failed = buildServerGaps({ ...base, useIndex: true, searchFailed: true }).join(" ");
+    const empty = buildServerGaps({ ...base, useIndex: true, indexHits: 0 }).join(" ");
+    expect(failed).not.toEqual(empty);
+    // Only one of these is the user's problem, and it is not the empty one.
+    expect(failed).toContain("error");
+    expect(empty.toLowerCase()).toContain("matched");
   });
 });

--- a/packages/gateway/src/briefs/brief-gaps.test.ts
+++ b/packages/gateway/src/briefs/brief-gaps.test.ts
@@ -79,12 +79,36 @@ describe("buildServerGaps", () => {
     }
   });
 
-  test("a broken search and an empty result stay DIFFERENT statements", () => {
+  test("all THREE index outcomes stay DIFFERENT statements", () => {
+    // The rule the code comment states is three-way: a broken search, an empty result and
+    // degraded recall are completely different things to tell the user, and laundering any
+    // one of them into another is the dishonesty brief-gaps.ts exists to prevent. Pinning
+    // only failed-vs-empty would let a reword collapse keyword-only into either of them.
     const failed = buildServerGaps({ ...base, useIndex: true, searchFailed: true }).join(" ");
     const empty = buildServerGaps({ ...base, useIndex: true, indexHits: 0 }).join(" ");
-    expect(failed).not.toEqual(empty);
+    const keyword = buildServerGaps({
+      ...base,
+      useIndex: true,
+      indexHits: 3,
+      semanticAvailable: false,
+    }).join(" ");
+
+    expect(new Set([failed, empty, keyword]).size).toBe(3);
+    for (const g of [failed, empty, keyword]) expect(g.trim()).not.toBe("");
+
+    // Each says its OWN thing and does not claim either of the others.
     // Only one of these is the user's problem, and it is not the empty one.
     expect(failed).toContain("error");
+    expect(failed.toLowerCase()).not.toContain("matched");
+    expect(failed.toLowerCase()).not.toContain("keyword-only");
+
     expect(empty.toLowerCase()).toContain("matched");
+    expect(empty.toLowerCase()).not.toContain("error");
+    expect(empty.toLowerCase()).not.toContain("keyword-only");
+
+    // Degraded recall is NOT "nothing matched" and NOT "the index broke": hits came back.
+    expect(keyword.toLowerCase()).toContain("keyword-only");
+    expect(keyword.toLowerCase()).not.toContain("error");
+    expect(keyword.toLowerCase()).not.toContain("matched");
   });
 });

--- a/packages/gateway/src/briefs/brief-gaps.ts
+++ b/packages/gateway/src/briefs/brief-gaps.ts
@@ -36,15 +36,15 @@ export function buildServerGaps(input: ServerGapInput): string[] {
       // NEVER launder a broken index into "your corpus had nothing relevant". They are
       // completely different statements and only one of them is the user's problem.
       gaps.push(
-        "Saved clips could not be searched (the local index returned an error), so this report draws only on the sources you selected.",
+        "Your index could not be searched (the local index returned an error), so this report draws only on the sources you selected.",
       );
     } else if (input.indexHits === 0) {
       gaps.push(
-        "No saved clips matched this question, so the report draws only on the sources you selected.",
+        "Nothing in your index matched this question, so the report draws only on the sources you selected.",
       );
     } else if (!input.semanticAvailable) {
       gaps.push(
-        "Index recall was keyword-only (semantic search unavailable); relevant saved clips may be under-represented.",
+        "Index recall was keyword-only (semantic search unavailable); relevant indexed items may be under-represented.",
       );
     }
   }

--- a/packages/gateway/src/briefs/brief-index-search.test.ts
+++ b/packages/gateway/src/briefs/brief-index-search.test.ts
@@ -1,0 +1,122 @@
+/**
+ * brief-index-search.test.ts — the ONE test that proves the widening.
+ *
+ * Every other brief test injects a stub `IndexSearch`, so none of them can see which query the
+ * gateway actually issues. This one seeds a REAL in-memory LocalIndex with a `web_clip` and two
+ * non-clip items and drives the real factory, so restoring `itemType: "web_clip"` to the query
+ * turns it red instead of silently reverting the feature under a green suite.
+ */
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { itemPrimaryKey, upsertIndexedItem } from "../index/item-store.ts";
+import { LocalIndex } from "../index/local-index.ts";
+import { createBriefIndexSearch } from "./brief-index-search.ts";
+
+const NOW = 1_760_000_000_000;
+
+/** Seeds one item and returns the composite primary key the search is expected to echo back. */
+function seed(
+  db: Database,
+  spec: { type: string; externalId: string; title: string; url?: string },
+): string {
+  upsertIndexedItem(db, {
+    service: "nimbus",
+    type: spec.type,
+    externalId: spec.externalId,
+    title: spec.title,
+    body: `${spec.title} — the storage migration was rolled out in three stages.`,
+    url: spec.url ?? null,
+    canonicalUrl: null,
+    modifiedAt: NOW,
+    syncedAt: NOW,
+  });
+  return itemPrimaryKey("nimbus", spec.externalId);
+}
+
+let db: Database;
+let index: LocalIndex;
+let clipId: string;
+let prId: string;
+let emailId: string;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  index = new LocalIndex(db);
+  clipId = seed(db, {
+    type: "web_clip",
+    externalId: "clip-1",
+    title: "Storage migration writeup",
+    url: "https://example.test/migration",
+  });
+  prId = seed(db, {
+    type: "pull_request",
+    externalId: "pr-1",
+    title: "Storage migration rollout",
+    url: "https://example.test/pr/1",
+  });
+  emailId = seed(db, {
+    type: "email",
+    externalId: "mail-1",
+    title: "Storage migration status",
+  });
+});
+
+describe("createBriefIndexSearch", () => {
+  test("searches the WHOLE index — a clip, a pull request and an email all come back", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+
+    // If `itemType: "web_clip"` is ever restored to the query this collapses to one hit.
+    const byId = new Map(out.hits.map((h) => [h.itemId, h]));
+    expect([...byId.keys()].sort()).toEqual([clipId, emailId, prId].sort());
+  });
+
+  test("returns hits of MORE THAN ONE type — the property the web_clip filter destroyed", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+    const types = new Set(out.hits.map((h) => h.itemType));
+    expect(types.size).toBeGreaterThan(1);
+    expect([...types].sort()).toEqual(["email", "pull_request", "web_clip"]);
+  });
+
+  test("each hit's itemType is the type that item was SEEDED with", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+    const byId = new Map(out.hits.map((h) => [h.itemId, h]));
+
+    // The clip must keep saying "web_clip": brief-registry.ts sets `clipId` on exactly this
+    // equality, so a mis-mapped type here silently strips clipId from every real clip.
+    expect(byId.get(clipId)?.itemType).toBe("web_clip");
+    expect(byId.get(prId)?.itemType).toBe("pull_request");
+    expect(byId.get(emailId)?.itemType).toBe("email");
+  });
+
+  test("maps title, url and itemId off the ranked item", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+    const clip = out.hits.find((h) => h.itemId === clipId);
+    expect(clip?.title).toBe("Storage migration writeup");
+    expect(clip?.url).toBe("https://example.test/migration");
+    expect(clip?.snippet.length).toBeGreaterThan(0);
+  });
+
+  test("url is null when the indexed item has none", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+    expect(out.hits.find((h) => h.itemId === emailId)?.url).toBeNull();
+  });
+
+  test("honours the caller's limit", async () => {
+    const out = await createBriefIndexSearch(index)("storage migration", 2);
+    expect(out.hits).toHaveLength(2);
+  });
+
+  test("reports semanticAvailable: false when no hit carries a vector rank", async () => {
+    // No semanticSearch deps configured, so this index is keyword-only — exactly the signal
+    // brief-gaps.ts turns into "recall was keyword-only".
+    const out = await createBriefIndexSearch(index)("storage migration", 8);
+    expect(out.hits.length).toBeGreaterThan(0);
+    expect(out.semanticAvailable).toBe(false);
+  });
+
+  test("an unmatched question returns no hits rather than throwing", async () => {
+    const out = await createBriefIndexSearch(index)("zzzznothingmatchesthis", 8);
+    expect(out.hits).toEqual([]);
+  });
+});

--- a/packages/gateway/src/briefs/brief-index-search.ts
+++ b/packages/gateway/src/briefs/brief-index-search.ts
@@ -1,0 +1,37 @@
+import type { LocalIndex } from "../index/local-index.ts";
+import type { IndexSearch } from "./brief-registry.ts";
+
+/**
+ * The real `IndexSearch` the gateway hands `buildRegistry`.
+ *
+ * Extracted out of `platform/assemble.ts` so the ONE place this feature's behaviour lives is
+ * reachable from a test. Every brief test injects a stub search, so while this closure sat
+ * inside the boot function nothing proved the query it actually issues — restoring an
+ * `itemType: "web_clip"` filter would have reverted the whole widening with a green suite.
+ * See brief-index-search.test.ts, which seeds a real LocalIndex with a clip and a non-clip.
+ */
+export function createBriefIndexSearch(localIndex: LocalIndex): IndexSearch {
+  return async (query, limit) => {
+    // NO itemType filter: a brief draws on the whole index. `IndexSearchQuery.itemType`
+    // is optional and the SQL applies it only when set, so omitting it is the widening.
+    const hits = await localIndex.searchRankedAsync(
+      { name: query, limit },
+      { semantic: true, contextChunks: 2 },
+    );
+    return {
+      // NOTE: RankedIndexItem extends the SDK's NimbusItem, whose title field is `name`
+      // — there is no `title` and no `body_preview` on it (see index/ranked-item.ts and
+      // @nimbus-dev/sdk types.d.ts). The only body text available here is the matched
+      // chunk in `semanticSnippet`, which is absent on the BM25 fallback path.
+      hits: hits.map((h) => ({
+        itemId: h.indexPrimaryKey,
+        itemType: h.itemType,
+        title: h.name,
+        url: h.url ?? h.canonicalUrl ?? null,
+        snippet: h.semanticSnippet ?? h.name,
+      })),
+      // A hit with no vectorRank anywhere means the hybrid path did not run.
+      semanticAvailable: hits.some((h) => h.vectorRank !== undefined && h.vectorRank !== null),
+    };
+  };
+}

--- a/packages/gateway/src/briefs/brief-registry.test.ts
+++ b/packages/gateway/src/briefs/brief-registry.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { MAX_REF_TITLE_CHARS, MAX_REF_URL_CHARS } from "./brief-constants.ts";
+import type { IndexHit } from "./brief-registry.ts";
 import { buildRegistry } from "./brief-registry.ts";
 import { BriefRunController } from "./brief-run-store.ts";
 import type { BriefRun } from "./brief-types.ts";
+
+function mockHit(overrides: Partial<IndexHit> = {}): IndexHit {
+  return {
+    itemId: "nimbus:clip:aa",
+    itemType: "web_clip",
+    title: "Saved",
+    url: "https://z.test",
+    snippet: "snip",
+    ...overrides,
+  };
+}
 
 function runWith(useIndex: boolean, bodies: readonly string[]): BriefRun {
   const c = new BriefRunController({ nowMs: () => 1000 });
@@ -83,7 +95,7 @@ describe("buildRegistry", () => {
 
   test("adds index hits as C1..Cm with clip citations", async () => {
     const { registry, indexHits } = await buildRegistry(runWith(true, ["a"]), async () => ({
-      hits: [{ itemId: "nimbus:clip:aa", title: "Saved", url: "https://z.test", snippet: "snip" }],
+      hits: [mockHit()],
       semanticAvailable: true,
     }));
     expect(indexHits).toBe(1);
@@ -93,12 +105,9 @@ describe("buildRegistry", () => {
   });
 
   test("caps index hits at MAX_INDEX_HITS", async () => {
-    const hits = Array.from({ length: 20 }, (_, i) => ({
-      itemId: `nimbus:clip:${i}`,
-      title: `C${i}`,
-      url: null,
-      snippet: "s",
-    }));
+    const hits = Array.from({ length: 20 }, (_, i) =>
+      mockHit({ itemId: `nimbus:clip:${i}`, title: `C${i}`, url: null, snippet: "s" }),
+    );
     const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
       hits,
       semanticAvailable: true,
@@ -173,7 +182,7 @@ describe("buildRegistry", () => {
     const longTitle = "C".repeat(MAX_REF_TITLE_CHARS + 50);
     const longUrl = `https://z.test/${"y".repeat(MAX_REF_URL_CHARS + 50)}`;
     const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
-      hits: [{ itemId: "nimbus:clip:aa", title: longTitle, url: longUrl, snippet: "snip" }],
+      hits: [mockHit({ title: longTitle, url: longUrl })],
       semanticAvailable: true,
     }));
     const ref = registry.get("C1")?.ref;
@@ -181,5 +190,62 @@ describe("buildRegistry", () => {
     expect(ref?.title).toBe(longTitle.slice(0, MAX_REF_TITLE_CHARS));
     expect(ref?.url?.length).toBe(MAX_REF_URL_CHARS);
     expect(ref?.url).toBe(longUrl.slice(0, MAX_REF_URL_CHARS));
+  });
+
+  test("a non-clip index hit gets itemId and itemType, and NO clipId", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:pull_request:acme/web/482",
+          itemType: "pull_request",
+          title: "Drop the legacy worker pool",
+          url: "https://github.test/acme/web/pull/482",
+          snippet: "the pool is replaced by",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    const ref = registry.get("C1")?.ref;
+    expect(ref?.kind).toBe("clip");
+    expect(ref?.itemType).toBe("pull_request");
+    expect(ref?.itemId).toBe("nimbus:pull_request:acme/web/482");
+    // The whole point: `clipId` says "clip", so a PR must not claim one.
+    expect(ref?.clipId).toBeUndefined();
+  });
+
+  test("a web_clip index hit still gets clipId, plus the new fields", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:clip:aa",
+          itemType: "web_clip",
+          title: "Saved",
+          url: "https://z.test",
+          snippet: "snip",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    const ref = registry.get("C1")?.ref;
+    expect(ref?.clipId).toBe("nimbus:clip:aa");
+    expect(ref?.itemId).toBe("nimbus:clip:aa");
+    expect(ref?.itemType).toBe("web_clip");
+  });
+
+  test("an itemType this build has never heard of is carried through verbatim", async () => {
+    const { registry } = await buildRegistry(runWith(true, ["a"]), async () => ({
+      hits: [
+        {
+          itemId: "nimbus:slack_message:C123/1699",
+          itemType: "slack_message",
+          title: "standup",
+          url: null,
+          snippet: "we are blocked on",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+    // Connectors land upstream on their own schedule. Never an enum.
+    expect(registry.get("C1")?.ref.itemType).toBe("slack_message");
   });
 });

--- a/packages/gateway/src/briefs/brief-registry.ts
+++ b/packages/gateway/src/briefs/brief-registry.ts
@@ -31,8 +31,9 @@ function clipUrl(url: string): string {
 
 /**
  * Builds the set of sources the model is allowed to cite. Tokens are opaque and
- * server-issued (S1.. for fed sources, C1.. for indexed clips): the model never
- * authors a URL or a title, so it cannot invent a source that resolves.
+ * server-issued (S1.. for fed sources, C1.. for items from the user's index, of any
+ * type): the model never authors a URL or a title, so it cannot invent a source that
+ * resolves.
  */
 export async function buildRegistry(
   run: BriefRun,

--- a/packages/gateway/src/briefs/brief-registry.ts
+++ b/packages/gateway/src/briefs/brief-registry.ts
@@ -3,6 +3,8 @@ import type { BriefRun, SourceRegistry, SourceRegistryEntry } from "./brief-type
 
 export type IndexHit = {
   readonly itemId: string;
+  /** The item's type, e.g. `web_clip`, `pull_request`. Required: the producer always knows it. */
+  readonly itemType: string;
   readonly title: string;
   readonly url: string | null;
   readonly snippet: string;
@@ -85,7 +87,10 @@ export async function buildRegistry(
       ref: {
         kind: "clip",
         title: clipTitle(hit.title),
-        clipId: hit.itemId,
+        itemId: hit.itemId,
+        itemType: hit.itemType,
+        // `clipId` is the NARROW, legacy field: only a real clip may claim it.
+        ...(hit.itemType === "web_clip" ? { clipId: hit.itemId } : {}),
         ...(hit.url === null ? {} : { url: clipUrl(hit.url) }),
       },
       body: hit.snippet,

--- a/packages/gateway/src/briefs/brief-save.test.ts
+++ b/packages/gateway/src/briefs/brief-save.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { LocalIndex } from "../index/local-index.ts";
 import { BriefRunController } from "./brief-run-store.ts";
 import { ReportTooLargeError, saveBriefReport } from "./brief-save.ts";
-import type { BriefRun, Report } from "./brief-types.ts";
+import type { BriefRun, Report, SourceRef } from "./brief-types.ts";
 
 function db(): Database {
   const d = new Database(":memory:");
@@ -139,6 +139,86 @@ describe("saveBriefReport", () => {
     const meta = JSON.parse(row.metadata) as { report: Report };
     expect(meta.report.findings[0]?.citations[0]?.quote).toBeUndefined();
     expect(meta.report.gaps.join(" ")).toContain("quotes");
+  });
+
+  // The degradation ORDER is the contract, not just the fact that degradation happens.
+  // `itemId` on a web_clip citation is byte-identical to `clipId`, so shedding it costs the
+  // user nothing; shedding a quote costs them the evidence. Redundant ids therefore go FIRST.
+  const CLIP_ID = `nimbus:clip:${"a".repeat(64)}`;
+  const clipCitation = (quoteLen: number): SourceRef => ({
+    kind: "clip",
+    title: "t".repeat(60),
+    url: "https://a.test/p",
+    clipId: CLIP_ID,
+    itemId: CLIP_ID,
+    itemType: "web_clip",
+    quote: "q".repeat(quoteLen),
+  });
+  const clipHeavy = (findings: number, citations: number, quoteLen: number): Report => ({
+    ...REPORT,
+    findings: Array.from({ length: findings }, () => ({
+      text: "x".repeat(400),
+      citations: Array.from({ length: citations }, () => clipCitation(quoteLen)),
+    })),
+  });
+  const savedReport = (d: Database, run: BriefRun): Report => {
+    const { itemId } = saveBriefReport(d, run);
+    const row = d.query("SELECT metadata FROM item WHERE id = ?").get(itemId) as {
+      metadata: string;
+    };
+    expect(Buffer.byteLength(row.metadata, "utf8")).toBeLessThanOrEqual(64 * 1024);
+    return (JSON.parse(row.metadata) as { report: Report }).report;
+  };
+
+  test("drops the duplicated itemId BEFORE quotes, and keeps the quotes when that is enough", () => {
+    const d = db();
+    // Measured: 62383 bytes with itemId (over the 60 KB budget), 54463 without it (under).
+    const heavy = clipHeavy(15, 6, 300);
+    expect(Buffer.byteLength(JSON.stringify(heavy), "utf8")).toBeGreaterThan(60 * 1024);
+
+    const report = savedReport(d, doneRun(heavy));
+    const cite = report.findings[0]?.citations[0];
+    // The id the user can still resolve the item with survives; the duplicate does not.
+    expect(cite?.itemId).toBeUndefined();
+    expect(cite?.clipId).toBe(CLIP_ID);
+    expect(cite?.itemType).toBe("web_clip");
+    // The whole point of the ordering: the evidence is still there.
+    expect(cite?.quote).toBe("q".repeat(300));
+    expect(report.gaps.join(" ")).not.toContain("quotes");
+  });
+
+  test("falls through to stripping quotes when dropping the duplicated ids is not enough", () => {
+    const d = db();
+    // Measured: 89983 bytes full, 75903 with the ids gone (still over), 42143 quote-free.
+    const heavy = clipHeavy(20, 8, 200);
+    const report = savedReport(d, doneRun(heavy));
+    const cite = report.findings[0]?.citations[0];
+    expect(cite?.itemId).toBeUndefined();
+    expect(cite?.quote).toBeUndefined();
+    expect(cite?.clipId).toBe(CLIP_ID);
+    expect(report.gaps.join(" ")).toContain("quotes");
+  });
+
+  test("keeps itemId on a non-clip citation, where it is the ONLY id the user has", () => {
+    const d = db();
+    // Measured: 69580 bytes full, 25192 quote-free — so the ladder DOES run here. The first
+    // rung must find nothing to shed (no clipId to be identical to) and fall through.
+    const heavy: Report = {
+      ...REPORT,
+      findings: Array.from({ length: 18 }, () => ({
+        text: "x".repeat(400),
+        citations: Array.from({ length: 6 }, (): SourceRef => {
+          const { clipId: _clipId, ...rest } = clipCitation(400);
+          return { ...rest, itemType: "pull_request", itemId: "github:pr:1" };
+        }),
+      })),
+    };
+    expect(Buffer.byteLength(JSON.stringify(heavy), "utf8")).toBeGreaterThan(60 * 1024);
+
+    const report = savedReport(d, doneRun(heavy));
+    const cite = report.findings[0]?.citations[0];
+    expect(cite?.itemId).toBe("github:pr:1");
+    expect(cite?.quote).toBeUndefined();
   });
 
   test("throws ReportTooLargeError when even a quote-free report cannot fit", () => {

--- a/packages/gateway/src/briefs/brief-save.ts
+++ b/packages/gateway/src/briefs/brief-save.ts
@@ -7,6 +7,10 @@ import type { BriefRun, Report } from "./brief-types.ts";
 const META_BUDGET_BYTES = 60 * 1024;
 const TITLE_MAX = 120;
 
+function overBudget(report: Report): boolean {
+  return Buffer.byteLength(JSON.stringify(report), "utf8") > META_BUDGET_BYTES;
+}
+
 export class ReportTooLargeError extends Error {
   constructor() {
     super("report exceeds the item metadata ceiling");
@@ -16,6 +20,36 @@ export class ReportTooLargeError extends Error {
 
 function sha256(s: string): string {
   return createHash("sha256").update(s).digest("hex");
+}
+
+/**
+ * Drops `itemId` on any citation whose `itemId` is byte-identical to its `clipId`.
+ *
+ * The FIRST rung of the ladder, deliberately above quote-stripping: on a `web_clip` citation
+ * the two fields carry the SAME `nimbus:clip:<sha256>` string, so removing one loses the user
+ * nothing — `clipId` still resolves the item and `itemType` still says what it is. Across the
+ * worst case the count caps allow (MAX_FINDINGS 25 x MAX_CITATIONS_PER_ITEM 8, plus the same
+ * again for conflicts = 400 citations) that duplicate is tens of KB against a 60 KB budget,
+ * which is enough on its own to push a brief that used to save into ReportTooLargeError.
+ *
+ * A duplicated id is worth less to the user than their supporting quotes, so this runs first
+ * and carries no gap line: nothing recoverable was lost, so there is nothing to disclose.
+ */
+function withoutRedundantItemIds(report: Report): Report {
+  const dedupe = (items: Report["findings"]): Report["findings"] =>
+    items.map((i) => ({
+      ...i,
+      citations: i.citations.map((c) => {
+        if (c.itemId === undefined || c.itemId !== c.clipId) return c;
+        const { itemId: _itemId, ...rest } = c;
+        return rest;
+      }),
+    }));
+  return {
+    ...report,
+    findings: dedupe(report.findings),
+    conflicts: dedupe(report.conflicts),
+  };
 }
 
 /** Strips every quote — the largest field, and the most recoverable (the citation still names its source). */
@@ -49,11 +83,15 @@ export function saveBriefReport(
   const report = run.report;
   if (report === null) throw new ReportTooLargeError();
 
+  // Degradation ladder, cheapest loss first: shed the duplicated ids, THEN the quotes.
   let effective = report;
-  if (Buffer.byteLength(JSON.stringify(effective), "utf8") > META_BUDGET_BYTES) {
-    effective = withoutQuotes(effective);
-    if (Buffer.byteLength(JSON.stringify(effective), "utf8") > META_BUDGET_BYTES) {
-      throw new ReportTooLargeError();
+  if (overBudget(effective)) {
+    effective = withoutRedundantItemIds(effective);
+    if (overBudget(effective)) {
+      effective = withoutQuotes(effective);
+      if (overBudget(effective)) {
+        throw new ReportTooLargeError();
+      }
     }
   }
 

--- a/packages/gateway/src/briefs/brief-synthesis.test.ts
+++ b/packages/gateway/src/briefs/brief-synthesis.test.ts
@@ -81,7 +81,13 @@ describe("buildPrompt", () => {
     // Inject a clip entry with url: null to exercise the null-url path.
     const { registry } = await buildRegistry(runOut.run, async () => ({
       hits: [
-        { itemId: "nimbus:clip:test", title: "No-URL Clip", url: null, snippet: "clipped text" },
+        {
+          itemId: "nimbus:clip:test",
+          itemType: "web_clip",
+          title: "No-URL Clip",
+          url: null,
+          snippet: "clipped text",
+        },
       ],
       semanticAvailable: true,
     }));

--- a/packages/gateway/src/briefs/brief-synthesis.test.ts
+++ b/packages/gateway/src/briefs/brief-synthesis.test.ts
@@ -99,6 +99,46 @@ describe("buildPrompt", () => {
     const clipRef = registry.get("C1");
     expect(clipRef?.ref.url).toBeUndefined();
   });
+
+  function runWithFedAndIndexHit(): BriefRun {
+    const c = new BriefRunController({ nowMs: () => 1000 });
+    const sources = [{ url: "https://a.test/0", title: "T0" }];
+    const out = c.create({ brief: "do workers die", sources, useIndex: true });
+    if ("error" in out) throw new Error("expected a run");
+    c.addSource(out.run, {
+      url: "https://a.test/0",
+      title: "T0",
+      body: "a",
+      capturedAt: 1,
+      truncated: false,
+    });
+    return out.run;
+  }
+
+  function registryWithTypedHit(run: BriefRun, itemType: string) {
+    return buildRegistry(run, async () => ({
+      hits: [
+        {
+          itemId: "nimbus:pull_request:acme/web/482",
+          itemType,
+          title: "Drop the legacy worker pool",
+          url: "https://github.test/acme/web/pull/482",
+          snippet: "the pool is replaced by",
+        },
+      ],
+      semanticAvailable: true,
+    }));
+  }
+
+  test("the prompt names each index hit's type when the type is known", async () => {
+    // Shape is fixed by the spec: ONE key, raw itemType, absent for S{n} entries.
+    const run = runWithFedAndIndexHit();
+    const { registry } = await registryWithTypedHit(run, "pull_request");
+    const prompt = buildPrompt(run, registry);
+    expect(prompt).toContain('"type":"pull_request"');
+    // A fed source is the user's own page and needs no type to be understood.
+    expect(prompt).not.toMatch(/"token":"S1"[^}]*"type"/);
+  });
 });
 
 describe("runSynthesis", () => {

--- a/packages/gateway/src/briefs/brief-synthesis.ts
+++ b/packages/gateway/src/briefs/brief-synthesis.ts
@@ -46,6 +46,7 @@ const INSTRUCTIONS = [
 export function buildPrompt(run: BriefRun, registry: SourceRegistry): string {
   const sources = [...registry.values()].map((e) => ({
     token: e.token,
+    ...(e.ref.itemType === undefined ? {} : { type: e.ref.itemType }),
     title: e.ref.title,
     url: e.ref.url ?? null,
     text: e.body,

--- a/packages/gateway/src/briefs/brief-synthesis.ts
+++ b/packages/gateway/src/briefs/brief-synthesis.ts
@@ -40,8 +40,10 @@ const INSTRUCTIONS = [
 
 /**
  * Builds the synthesis prompt. Every source body goes through `wrapToolOutput`
- * (invariant I11) because these are arbitrary web pages the user did not write
- * and some will contain text engineered to hijack the model.
+ * (invariant I11) because none of this text is the user's own words: fed sources are
+ * arbitrary web pages, and a `C{n}` body is any indexed item — a pull request
+ * description, a chat message, an email — which is at least as good an injection
+ * vector. Some of it will contain text engineered to hijack the model.
  */
 export function buildPrompt(run: BriefRun, registry: SourceRegistry): string {
   const sources = [...registry.values()].map((e) => ({

--- a/packages/gateway/src/briefs/brief-test-server.ts
+++ b/packages/gateway/src/briefs/brief-test-server.ts
@@ -20,11 +20,13 @@ import type { ReadOnlyHttpServerHandle } from "../ipc/http-server.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
 import { createSeededTokenVault } from "../ipc/test-token-vault.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import type { IndexHit, IndexSearch } from "./brief-registry.ts";
 import { buildRegistry } from "./brief-registry.ts";
 import { BriefRunController } from "./brief-run-store.ts";
 import { saveBriefReport } from "./brief-save.ts";
 import type { BriefSynthesizerLlm } from "./brief-synthesis.ts";
 import { runSynthesis } from "./brief-synthesis.ts";
+import type { Report } from "./brief-types.ts";
 
 const KNOWN_TOKEN = "brief-test-token-0123456789abcdef0123456789abcdef";
 const KNOWN_LABEL = "brief-test-harness";
@@ -37,10 +39,17 @@ function makeInMemoryVault(tokensJson?: string): NimbusVault {
   );
 }
 
+/** Turns a fixed hit list into the `IndexSearch` seam, ignoring the query and limit. */
+function makeIndexSearch(hits: IndexHit[]): IndexSearch {
+  return async (_query: string, limit: number) =>
+    Promise.resolve({ hits: hits.slice(0, limit), semanticAvailable: true });
+}
+
 /** Kicks off synthesis fire-and-forget — same contract as `BriefsWriteSurface.startRun`. */
 function makeStartRun(
   controller: BriefRunController,
   llm: BriefSynthesizerLlm | null,
+  search: IndexSearch | null,
 ): (runId: string) => void {
   return (runId: string): void => {
     const run = controller.get(runId);
@@ -49,7 +58,7 @@ function makeStartRun(
     void (async () => {
       const { registry, indexHits, semanticAvailable, searchFailed } = await buildRegistry(
         run,
-        null,
+        search,
       );
       const result = await runSynthesis({
         run,
@@ -96,9 +105,12 @@ export async function startBriefTestServer(opts?: {
   enabled?: boolean;
   /** Raw JSON for `http_api.web_clipper_tokens`. Omit for the legacy single-token default. */
   tokensJson?: string;
+  /** Index hits served to any run with `useIndex: true`. Omit to leave the index seam unwired. */
+  hits?: IndexHit[];
 }): Promise<BriefTestServer> {
   const enabled = opts?.enabled ?? true;
   const llm = opts?.llm ?? null;
+  const search = opts?.hits === undefined ? null : makeIndexSearch(opts.hits);
 
   const tmpDir = mkdtempSync(join(tmpdir(), "nimbus-brief-e2e-"));
   const dbPath = join(tmpDir, "nimbus.db");
@@ -128,7 +140,7 @@ export async function startBriefTestServer(opts?: {
       ? {
           clipsVault: vault,
           briefRuns: controller,
-          briefStartRun: makeStartRun(controller, llm),
+          briefStartRun: makeStartRun(controller, llm, search),
           briefSave: makeSave(controller, db),
         }
       : // Opens the I13 write surface for an UNRELATED reason (no deployment token check is
@@ -163,4 +175,119 @@ export async function startBriefTestServer(opts?: {
       }
     },
   };
+}
+
+function mustMatch(m: RegExpMatchArray, group: number, what: string): string {
+  const v = m[group];
+  if (v === undefined) throw new Error(`${what}: capture group ${group} missing`);
+  return v;
+}
+
+/**
+ * Cites EVERY source and index-hit token the prompt carries (S1, S2, ..., C1, C2, ...) —
+ * same trick as `brief-e2e.test.ts`'s `citeAllLlm`, widened to also catch `C*` tokens so a
+ * finding cites each injected index hit deterministically, regardless of how many hits (or
+ * which `itemType`s) the caller passes to `runBriefWithIndexHits`.
+ */
+function citeAllTokensLlm(): BriefSynthesizerLlm {
+  return {
+    generateJson: async (prompt: string) => {
+      const tokens = [
+        ...new Set(
+          [...prompt.matchAll(/"token":"([A-Z]\d+)"/g)].map((m) =>
+            mustMatch(m, 1, "citeAllTokensLlm token match"),
+          ),
+        ),
+      ];
+      const findings = tokens.map((t, i) => ({
+        text: `Finding ${i + 1} supported by ${t}.`,
+        refs: [t],
+      }));
+      return Promise.resolve({
+        text: JSON.stringify({
+          summary: "Synthesized summary citing every available token.",
+          findings,
+          conflicts: [],
+          gaps: [],
+        }),
+        model: "stub-cite-all-tokens",
+        remote: false,
+      });
+    },
+  };
+}
+
+/**
+ * Drives one brief run through the same create -> feed -> run -> poll sequence as
+ * `brief-e2e.test.ts`, with `hits` injected as the run's `IndexSearch`, and returns the
+ * finished `Report`. Exported so callers (e.g. `brief-e2e.test.ts`) import this rather than
+ * redefining the flow — this file stays the single source of the harness.
+ */
+export async function runBriefWithIndexHits(hits: IndexHit[]): Promise<Report> {
+  const s = await startBriefTestServer({ llm: citeAllTokensLlm(), hits });
+  try {
+    const base = `http://127.0.0.1:${s.port}`;
+    const authHeaders = { authorization: `Bearer ${s.token}` };
+    const sourceUrl = "https://example.com/index-hits-source";
+
+    const createRes = await fetch(`${base}/v1/briefs`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders },
+      body: JSON.stringify({
+        brief: "What changed in the worker pool?",
+        sources: [{ url: sourceUrl, title: "Source" }],
+        useIndex: true,
+      }),
+    });
+    if (createRes.status !== 200) {
+      throw new Error(`runBriefWithIndexHits: create failed with ${createRes.status}`);
+    }
+    const created = (await createRes.json()) as { id: string };
+
+    const feedRes = await fetch(`${base}/v1/briefs/${created.id}/sources`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders },
+      body: JSON.stringify({
+        url: sourceUrl,
+        title: "Source",
+        body: "A fed source so the run has at least one declared source satisfied.",
+        capturedAt: Date.now(),
+        truncated: false,
+      }),
+    });
+    if (feedRes.status !== 200) {
+      throw new Error(`runBriefWithIndexHits: feeding the source failed with ${feedRes.status}`);
+    }
+
+    const runRes = await fetch(`${base}/v1/briefs/${created.id}/run`, {
+      method: "POST",
+      headers: authHeaders,
+    });
+    if (runRes.status !== 200) {
+      throw new Error(`runBriefWithIndexHits: starting the run failed with ${runRes.status}`);
+    }
+
+    for (let i = 0; i < 200; i++) {
+      const pollRes = await fetch(`${base}/v1/briefs/${created.id}`, { headers: authHeaders });
+      if (pollRes.status !== 200) {
+        throw new Error(`runBriefWithIndexHits: unexpected GET status ${pollRes.status}`);
+      }
+      const body = (await pollRes.json()) as { status: string; report?: Report };
+      if (body.status === "done") {
+        if (body.report === undefined) {
+          throw new Error("runBriefWithIndexHits: done status but no report in the body");
+        }
+        return body.report;
+      }
+      if (body.status === "failed") {
+        throw new Error("runBriefWithIndexHits: run reached status failed");
+      }
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error(
+      "runBriefWithIndexHits: run never reached a terminal state within the poll budget",
+    );
+  } finally {
+    s.stop();
+  }
 }

--- a/packages/gateway/src/briefs/brief-types.ts
+++ b/packages/gateway/src/briefs/brief-types.ts
@@ -1,10 +1,23 @@
 /** A validated citation. `quote`, when present, is a span taken from the cited body. */
 export type SourceRef = {
+  /**
+   * `"source"` = a page the client fed. `"clip"` = an item from the user's INDEX —
+   * historically only clips, hence the name, which is kept because it is persisted
+   * in every saved `research_brief`. Read `itemType` for what the item actually is.
+   */
   kind: "source" | "clip";
   title: string;
   url?: string;
-  /** The `nimbus:clip:<sha256>` item id. Present only for kind: "clip". */
+  /**
+   * The `nimbus:clip:<sha256>` item id. Present only for a `nimbus:web_clip` hit —
+   * NOT for every kind: "clip" ref. A non-clip index hit sets `itemId` and leaves
+   * this absent, so a reader that trusts the name is never lied to.
+   */
   clipId?: string;
+  /** The index item id for ANY indexed hit, whatever its type. */
+  itemId?: string;
+  /** The indexed item's type, verbatim. Arbitrary string — never validated as an enum. */
+  itemType?: string;
   /** <= MAX_QUOTE_CHARS, verbatim from the cited body (see quote-verify.ts). */
   quote?: string;
 };

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -12,8 +12,9 @@ import {
   evaluateWatchersAfterSync,
   evaluateWatchersStartupCatchUp,
 } from "../automation/watcher-engine.ts";
+import { createBriefIndexSearch } from "../briefs/brief-index-search.ts";
 import { createBriefLlm } from "../briefs/brief-llm-adapter.ts";
-import { buildRegistry, type IndexSearch } from "../briefs/brief-registry.ts";
+import { buildRegistry } from "../briefs/brief-registry.ts";
 import { BriefRunController } from "../briefs/brief-run-store.ts";
 import { saveBriefReport } from "../briefs/brief-save.ts";
 import { runSynthesis } from "../briefs/brief-synthesis.ts";
@@ -1994,29 +1995,9 @@ function bootBriefsIntoHttpSidecar(deps: {
     ttlMs: briefsToml.ttlMinutes * 60_000,
   });
   const briefLlm = createBriefLlm(llmRouter, briefsToml.preferLocal);
-  const briefSearch: IndexSearch = async (query, limit) => {
-    // NO itemType filter: a brief draws on the whole index. `IndexSearchQuery.itemType`
-    // is optional and the SQL applies it only when set, so omitting it is the widening.
-    const hits = await localIndex.searchRankedAsync(
-      { name: query, limit },
-      { semantic: true, contextChunks: 2 },
-    );
-    return {
-      // NOTE: RankedIndexItem extends the SDK's NimbusItem, whose title field is `name`
-      // — there is no `title` and no `body_preview` on it (see index/ranked-item.ts and
-      // @nimbus-dev/sdk types.d.ts). The only body text available here is the matched
-      // chunk in `semanticSnippet`, which is absent on the BM25 fallback path.
-      hits: hits.map((h) => ({
-        itemId: h.indexPrimaryKey,
-        itemType: h.itemType,
-        title: h.name,
-        url: h.url ?? h.canonicalUrl ?? null,
-        snippet: h.semanticSnippet ?? h.name,
-      })),
-      // A hit with no vectorRank anywhere means the hybrid path did not run.
-      semanticAvailable: hits.some((h) => h.vectorRank !== undefined && h.vectorRank !== null),
-    };
-  };
+  // The query itself lives in briefs/brief-index-search.ts so a test can reach it — see the
+  // docblock there. This wiring is behaviour-identical to the closure it replaced.
+  const briefSearch = createBriefIndexSearch(localIndex);
   httpSidecarOpts.briefRuns = briefRuns;
   httpSidecarOpts.briefStartRun = (runId: string): void => {
     const run = briefRuns.get(runId);

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -1995,8 +1995,10 @@ function bootBriefsIntoHttpSidecar(deps: {
   });
   const briefLlm = createBriefLlm(llmRouter, briefsToml.preferLocal);
   const briefSearch: IndexSearch = async (query, limit) => {
+    // NO itemType filter: a brief draws on the whole index. `IndexSearchQuery.itemType`
+    // is optional and the SQL applies it only when set, so omitting it is the widening.
     const hits = await localIndex.searchRankedAsync(
-      { name: query, itemType: "web_clip", limit },
+      { name: query, limit },
       { semantic: true, contextChunks: 2 },
     );
     return {
@@ -2006,6 +2008,7 @@ function bootBriefsIntoHttpSidecar(deps: {
       // chunk in `semanticSnippet`, which is absent on the BM25 fallback path.
       hits: hits.map((h) => ({
         itemId: h.indexPrimaryKey,
+        itemType: h.itemType,
         title: h.name,
         url: h.url ?? h.canonicalUrl ?? null,
         snippet: h.semanticSnippet ?? h.name,


### PR DESCRIPTION
## What widened

`POST /v1/briefs` has taken `useIndex` since the research-briefs surface landed,
but the index search it drove was narrowed to a single item type:

    const hits = await localIndex.searchRankedAsync(
      { name: query, itemType: "web_clip", limit },
      { semantic: true, contextChunks: 2 },
    );

So a brief could only ever cite pages the user had clipped — never the pull
requests, builds, issues or docs the connectors index, which is the actual reason
to run a local gateway. This PR drops the `itemType: "web_clip"` filter
(`IndexSearchQuery.itemType` is optional; the SQL applies it only when set), so
the same hybrid search, same `limit`, same `semanticAvailable` signal now runs
across every indexed type. No new query shape, no new failure mode.

Each `C{n}` citation now also carries `itemType` (the item's type, verbatim,
e.g. `pull_request`) and `itemId` (the index item id for any indexed hit), so a
brief that leans on a pull request says so instead of calling it a clip. The
prompt fed to the synthesis model was also given the type per citation
(`{ token, type, title, url, text }` for `C{n}` entries; `S{n}` entries, which
are pages the client itself supplied, carry no type) — see "Prompt change" below
for how that was gated.

## `kind` and `clipId` are unchanged, on purpose

`SourceRef.kind` keeps its two members (`"source" | "clip"`): it is persisted
upstream in every saved `research_brief`, and a third member would fail
validation in any reader that predates this change. `clipId` keeps its exact
documented meaning — the `nimbus:clip:<sha256>` item id — and is now populated
**only** for genuine `nimbus:web_clip` hits, never for any other indexed type.
Before this PR the field's only possible value already satisfied that
description; after it, a non-clip hit sets `itemId` and leaves `clipId` absent,
so no existing reader is lied to and no already-saved brief's meaning changes.
`itemType`/`itemId` are purely additive and optional, so the two repos
(`Nimbus` and `nimbus-web-clipper`) can land in either order — an un-upgraded
client sees a ref shape it can already parse.

## The ~5 KB-per-hit bound comes from the chunker, not from a new cap

A brief's index-hit snippet is the winning embedding chunk plus
`contextChunks: 2` neighbours on each side (`hybrid-internal.ts`,
`chunkContextLines`), and each chunk is bounded by the chunker at 256 tokens
(`maxChars = maxChunkTokens * 4` ≈ 1 KB; `embedding/chunker.ts:9,142`). That's
at most 5 chunks ≈ 5 KB per hit, ≈ 40 KB across the 8-hit cap — and that bound
is identical for every item type. A 40 MB build log produces more chunks, not
bigger ones, and still contributes only its one winning chunk plus neighbours,
so widening the search does not move this number and needed no new cap. (Index-
hit bodies remain subject to no brief-side byte cap of their own — `MAX_SOURCE_
BYTES`/`MAX_RUN_BYTES` govern only client-fed sources — but that's a
pre-existing property, not something this PR introduces, and ~40 KB against a
4 MB run budget doesn't justify one.)

## No per-type quota was added, on purpose

Ranking stays purely score-based (reciprocal rank fusion over BM25 + vector
rank); nothing reads item type, so widening introduces no type bias — the 8
slots go to the 8 best-scoring items, whatever type they are. One real,
accepted consequence: a single type can take all 8 slots (e.g. eight pull
requests during a week of migration PRs, no clips). A quota such as "at least 2
clips, at least 2 issues" was considered and rejected: it buys type variety by
demoting better-matching items for worse-matching ones, on the false premise
that source-type variety proxies for evidence variety — eight PRs may be
exactly the right answer, and a forced-in clip is noise the model then has to
be told to ignore. If single-type dominance turns out to hurt real briefs, the
honest remedy is a gap line naming the skew, not a reshuffle that hides it —
not built here, since there's no evidence yet that it happens.

## Downstream consumer

`nimbus-web-clipper`, branch `dev/asafgolombek/briefs-over-your-index`, is the
first `useIndex: true` caller this surface has ever had, and is built against
this widened contract (spec:
`docs/superpowers/specs/2026-08-19-briefs-over-your-index-design.md` in that
repo).

## Also worth knowing (recorded, not fixed here)

- **Prompt change, gated on evidence, not assumption:** whether to tell the
  model each citation's type was measured, not assumed — the full
  `packages/gateway/src/briefs` suite (164 tests) was run before/after adding
  the `type` key; no synthesis test regressed and a discriminating test
  confirms the key's presence/absence. What this did **not** measure: every
  LLM call in the suite is a canned/stubbed response, so no test here can show
  a real attribution-behaviour change in either direction — that stays open
  until a live-model eval exists.
- **Gap copy reworded:** the three index-related gap strings in `brief-gaps.ts`
  no longer say "saved clips" — they describe the whole index now. The
  three-way split (search failed / nothing matched / keyword-only recall) is
  unchanged.
- **Wider blast radius under an unchanged disclosure:** a `useIndex` run can
  now send snippets of indexed pull requests, builds and issues (not just
  clips) to whatever remote LLM `createBriefLlm` falls back to. The existing
  disclosure sentence ("The brief and all source text were sent to that
  provider — they left this machine") already covers this literally, but it's
  worth flagging explicitly since the scope of what it covers just grew.
- **Out of scope:** the query embedding sent to search the index is not routed
  through `LOCAL_ONLY_PROSE_TYPES` and can leave the machine even when the
  corpus it searches stays local. Not introduced or worsened by this PR (one
  query string either way), but a real gap — left as a follow-up.

## Testing

- `bun run typecheck` — PASS
- `bun run lint` — PASS (one pre-existing, unrelated biome schema-version info
  line; see below)
- `bun test packages/gateway` — PASS: 14165 pass / 32 skip / 0 fail / 50854
  expect() calls across 1050 files (171.34s)

<!-- paste the full captured output blocks from task-6-report.md here -->

(The PR body's testing section should have the *actual* captured gate output
pasted under it verbatim, per the brief's Step 2 instruction — I've reproduced
that real output above in this report; the human posting the PR should copy it
in rather than retype it.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
