### PR TITLE
docs: point the connector path at create-nimbus-connector

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -175,20 +175,55 @@ If a file is genuinely untestable glue rather than logic, it can be excluded —
 
 Connectors live in `packages/mcp-connectors/`. They depend only on `@nimbus-dev/sdk`.
 
-Two generators exist. Use the one that matches how you are working:
+Use [`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector). It is
+published on npm and emits the whole connector package from a JSON spec — `src/server.ts`, the
+`nimbus.extension.json` manifest, a per-package TypeScript config, a `package.json` matching the
+connector convention, a `README.md`, and `test/sandbox.test.ts`, plus `src/search-filter.ts` when
+the spec declares a search tool.
 
-- **Inside this repo** (you have Nimbus checked out and built): `nimbus scaffold extension packages/mcp-connectors/your-service` — the id is a positional argument, not `--name`/`--output` flags, and it doubles as both the output directory (relative to your current working directory) and the `id` field written into the generated manifest, so pass the full repo-relative path you want.
-- **Standalone** (you want a connector outside the monorepo): [`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector)
+```bash
+bunx create-nimbus-connector --spec ./your-service.spec.json
+```
 
-`nimbus scaffold extension` emits a generic extension shell, not a connector-shaped one: `nimbus.extension.json`, `package.json`, `dist/index.js`, and `smoke.test.ts` — no `src/server.ts`, no per-package TypeScript config, no README, and no `@nimbus-dev/sdk` dependency. Because every connector-specific gate (`audit:connector-registry-drift`, `audit:connector-entrypoints`, `audit:connector-deps`) keys off the presence of `src/server.ts`, a freshly scaffolded directory is invisible to all three of them — they report clean, which is not the same as done, and `bun run typecheck` silently skips it too (see step 5). None of this is automatic; do this by hand after scaffolding:
+**Run it from the repository root.** In monorepo mode it writes to `packages/mcp-connectors/<name>`
+relative to your current directory, so running it from inside `packages/mcp-connectors/` nests the
+output at `packages/mcp-connectors/packages/mcp-connectors/<name>`.
 
-1. Write `src/server.ts` implementing the MCP server against the service's API — copy the shape of an existing connector (e.g. `packages/mcp-connectors/github/src/server.ts`) rather than the scaffold's `dist/index.js` placeholder.
-2. Rewrite `package.json` to the real connector convention: `name: "nimbus-mcp-<service>"`, a `bin` entry, `dependencies` limited to the connector allow-list (`@modelcontextprotocol/sdk`, `@nimbus-dev/sdk`, `zod`, and a short list of others — see `ALLOWED_CONNECTOR_DEPS` in `scripts/structure-audit/check-connector-deps.ts`), and `build`/`typecheck`/`lint` scripts — the scaffold's `package.json` has only `test`.
-3. Add a per-package tsconfig.json next to your connector's `package.json` — every real connector has one; the scaffold does not generate one.
-4. Rewrite `nimbus.extension.json` to the real shape used by connectors: `id: "com.nimbus.<service>"`, `displayName` set to a human-readable name (not the scaffold path), `entrypoint: "dist/server.js"`, `permissions: { network: [...] }`, and `hitlRequired: ["write", "delete"]` — an array of the permission names your write/delete tools need gated, not a boolean; the Gateway enforces HITL automatically from that declaration. (The scaffold writes `id`/`entrypoint`/`permissions` in a generic-extension shape connectors don't use, and it writes the positional argument you passed verbatim into both `id` and `displayName`, so `displayName` needs fixing too — it will otherwise read as your scaffold path.)
-5. Add the new package path to the root `package.json`'s `workspaces` array. It is an explicit list, not a glob — `bun install` and `bun run typecheck` (which runs `--filter '*'` over workspace members) silently skip a connector directory that isn't listed there. Run `bun install` after adding it.
-6. Run the SDK contract tests against your manifest with `runContractTests(manifest)` from `@nimbus-dev/sdk` (validates mandatory tool surface, HITL declaration, item-ID format, `SyncResult` shape). If your connector declares `permissions.{network,filesystem}` for the T2 PR 1 sandbox, also run `runSandboxContractTests()`. Use `MockGateway` from `@nimbus-dev/sdk/testing` for in-process IPC stubbing in unit tests.
-7. Run `bun run gen:connector-registry` to register the connector in the generated `packages/gateway/src/connectors/bundled-connector-registry.ts`, and commit the result — `bun run audit:connector-registry-drift` fails until you do, and the shipped binary cannot start an unregistered connector.
+Model your spec on one of the generator's own fixtures — `fixtures/netlify.spec.json` is a good
+read-only example. Add `--standalone` if you want the connector outside this repo; that variant
+resolves its helpers from the published `@nimbus-dev/sdk` instead of relative `../../shared/*`
+paths.
+
+**`nimbus scaffold extension` is not the tool for this.** It emits a four-file generic extension
+shell with no `src/server.ts`, and every connector gate — `audit:connector-registry-drift`,
+`audit:connector-entrypoints`, `audit:connector-deps` — keys off that file, so its output is
+invisible to all three. They report clean, which is not the same as done.
+
+### After generating
+
+Two steps are still yours, and the gates enforce both:
+
+1. **Add the package path to the root `package.json` `workspaces` array.** It is an explicit list,
+   not a glob — `bun install` and `bun run typecheck` (which runs `--filter '*'` over workspace
+   members) silently skip a connector directory that is not listed. Run `bun install` afterwards.
+2. **Run `bun run gen:connector-registry`** and commit the result. The bundled registry is a
+   generated, committed file; `bun run audit:connector-registry-drift` fails until you regenerate
+   it, and the shipped binary cannot start an unregistered connector.
+
+Then verify:
+
+```bash
+bun run audit:connector-entrypoints
+bun run audit:connector-deps
+bun run audit:connector-registry-drift
+bun run typecheck
+```
+
+Run the SDK contract tests against your manifest with `runContractTests(manifest)` from
+`@nimbus-dev/sdk` — it validates the mandatory tool surface, the HITL declaration, the item-ID
+format and the `SyncResult` shape. If your connector declares `permissions.{network,filesystem}`
+for the sandbox, also run `runSandboxContractTests()`. `MockGateway` from `@nimbus-dev/sdk/testing`
+stubs IPC in unit tests.
 
 See the [architecture](./architecture.md) for connector mesh details.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -723,17 +723,30 @@ Found a vulnerability? See [`SECURITY.md`](./SECURITY.md) and the [security mode
 
 ## Extensions
 
-Writing a new connector takes an afternoon, not a sprint. The `@nimbus-dev/sdk` handles scaffolding; the Gateway handles OAuth, credential storage, sync scheduling, and HITL enforcement. You write the service API integration.
+Two different things live under the same command family, and picking the wrong one costs an afternoon.
+
+**Writing a connector** — something that indexes a service into your local index. Use
+[`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector). Describe the
+service in a JSON spec and it emits the whole package: `src/server.ts`, the manifest, the
+tsconfig, the package.json and a test.
 
 ```bash
-nimbus scaffold extension my-connector   # always created at ./my-connector/ in the cwd
-cd my-connector && bun test              # scaffolded package.json defines only `test`; dist/index.js is written for you
-
-nimbus extension install .          # Test locally
-nimbus ask "search my-connector for quarterly review"
-
-npm publish --access public         # Publish to the community
+bunx create-nimbus-connector --spec ./my-service.spec.json --standalone
+cd my-service && bun run typecheck && bun test
 ```
+
+**Writing a generic extension** — anything that is not a connector. `nimbus scaffold extension`
+emits a four-file shell for that case; it does not produce a connector, and a package it
+generates is invisible to the connector gates because it has no `src/server.ts`.
+
+```bash
+nimbus scaffold extension my-extension   # always created at ./my-extension/ in the cwd
+nimbus extension install .               # Test locally
+npm publish --access public              # Publish to the community
+```
+
+The Gateway handles OAuth, credential storage, sync scheduling, and HITL enforcement either way.
+You write the service API integration.
 
 Extensions declare permissions in `nimbus.extension.json`. Write and delete tools must declare `hitlRequired` — the Gateway enforces HITL automatically for those tool calls regardless of how the extension implements them.
 
@@ -846,7 +859,7 @@ Architecture is stabilizing; not all interfaces are frozen.
 3. Check issues tagged `good first issue`.
 4. Open a discussion before large PRs.
 
-**Adding a connector is the easiest way in.** `nimbus scaffold extension packages/mcp-connectors/your-service` generates a starting shell you then shape into a connector, or use [`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector) standalone. See [Contributing](./CONTRIBUTING.md#adding-a-new-mcp-connector).
+**Adding a connector is the easiest way in.** Run [`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector) from the repository root — `bunx create-nimbus-connector --spec ./your-service.spec.json` — and it emits the whole connector package: the server, the manifest, the tsconfig, the package.json and a test. See [Contributing](./CONTRIBUTING.md#adding-a-new-mcp-connector).
 
 For workflow, verification commands, and PR expectations, see [`CONTRIBUTING.md`](./CONTRIBUTING.md). Community standards are in [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -728,7 +728,8 @@ Two different things live under the same command family, and picking the wrong o
 **Writing a connector** — something that indexes a service into your local index. Use
 [`create-nimbus-connector`](https://github.com/nimbus-agent/create-nimbus-connector). Describe the
 service in a JSON spec and it emits the whole package: `src/server.ts`, the manifest, the
-tsconfig, the package.json and a test.
+tsconfig, the package.json, a README and `test/sandbox.test.ts` — plus `src/search-filter.ts` when
+the spec declares a search tool.
 
 ```bash
 bunx create-nimbus-connector --spec ./my-service.spec.json --standalone
@@ -741,6 +742,7 @@ generates is invisible to the connector gates because it has no `src/server.ts`.
 
 ```bash
 nimbus scaffold extension my-extension   # always created at ./my-extension/ in the cwd
+cd my-extension                          # the scaffold does NOT change your working directory
 nimbus extension install .               # Test locally
 npm publish --access public              # Publish to the community
 ```


### PR DESCRIPTION
## Summary

Follow-up to #1259. That PR documented the connector on-ramp honestly but pointed contributors at the wrong tool. This measures both generators and repoints the guidance at the one that works.

## What was measured

I generated a throwaway connector from a JSON spec with `create-nimbus-connector` — published on npm at 0.13.1 — into a real checkout, ran the repository's own gates against it, then deleted it.

It emits the complete connector package: `src/server.ts`, the manifest, a per-package TypeScript config, a `package.json` byte-identical in shape to the real Netlify connector's, a README, and a sandbox test. The emitted code typechecks clean. The manifest is the real connector shape, including `hitlRequired` as an array.

The gates can see it, which is the part that matters:

| Gate | `nimbus scaffold extension` | `create-nimbus-connector` |
|---|---|---|
| `audit:connector-entrypoints` | invisible — reports clean | ok |
| `audit:connector-deps` | invisible — reports clean | ok |
| `audit:connector-registry-drift` | invisible — reports clean | correctly fails, names the connector, gives the fix |

`nimbus scaffold extension` emits a four-file generic extension shell with no `src/server.ts`, and all three gates key off that file — so its output is invisible to every one of them. They report clean, which is not the same as done. That is the trap this PR removes.

## What changed

**`docs/CONTRIBUTING.md`** — the connector section now leads with `create-nimbus-connector`, states that `nimbus scaffold extension` is not the tool for this and why, and reduces the manual follow-up from seven steps to the two that remain: adding the path to the root `workspaces` array, and regenerating the bundled registry. Both are gate-enforced, and the verification commands are listed.

**Two documentation defects fixed:**

- The old step 2 said the connector convention includes a `bin` entry. Only 18 of 95 connectors have one, and the generator omits it — matching the other 77.
- Added a warning that in monorepo mode the generator writes relative to your current directory. Running it from inside `packages/mcp-connectors/` nests the output at `packages/mcp-connectors/packages/mcp-connectors/<name>`. I hit this on the first attempt.

**`docs/README.md`** — the Extensions section conflated the two paths: it said "writing a new connector" and then showed the extension scaffold. Connectors and generic extensions are now separated, each with the right tool. The contributing pointer was updated to match.

## Testing

- `bun run preflight:fast` — 30 gates, all pass
- The measurement above, run against a real checkout and then reverted; the tree is clean and `audit:connector-registry-drift` is back to ok

Documentation only. No product code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance for creating connectors with the recommended generator and JSON specifications.
  * Documented generated files, standalone mode, fixtures, repository requirements, and post-generation validation steps.
  * Clarified the distinction between connector development and generic extension development.
  * Added connector-specific testing and registration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->