### PR TITLE
docs(specs): clip source metadata on POST /v1/clips

### DIFF
--- a/docs/superpowers/specs/2026-08-20-clip-source-metadata-design-review.md
+++ b/docs/superpowers/specs/2026-08-20-clip-source-metadata-design-review.md
@@ -2,7 +2,19 @@
 
 Below are comments, questions, and suggested improvements for the `2026-08-20-clip-source-metadata-design.md` specification.
 
-## Open Questions & Clarifications
+> **Status: closed.** Every item below was answered and the specification now
+> carries the outcome — so read this file as a record of how the contract was
+> argued, not as open questions. In summary:
+>
+> | Item | Outcome |
+> | --- | --- |
+> | `leadImage` 200-char cap corrupts CDN URLs | **Adopted, and generalised.** The bound is 2048 and over-bound values are **dropped, not truncated** — half a URL is a broken link rather than a shorter one. This produced the spec's prose-truncates / structured-values-drop rule. |
+> | `publishedAt` should be an integer | **Adopted.** `Number.isFinite` alone admits `1.5`; the validator now requires an integer within `Date`'s range. |
+> | Reject negative (pre-1970) dates | **Declined.** They are legitimate — an index holding papers and archived essays meets 1965 publication dates, and dropping them would fail exactly the library case the field serves. |
+> | Reject far-future dates | **Declined.** Embargoed and scheduled posts carry future dates honestly, and nothing sorts on `publishedAt` — `modified_at` still comes from `capturedAt`, so the sort-order concern does not arise. |
+> | Drop over-long `lang` rather than truncate | **Adopted**, and the justification corrected: BCP 47 sets no maximum tag length, so 20 is a stated product limit rather than a standards fact. |
+
+## Open Questions & Clarifications (as originally raised)
 
 1. **`leadImage` URL Length Restriction**
    * **Scenario:** Modern CDN images (such as Unsplash, Cloudinary, AWS S3, or Cloudfront) often carry query parameters for resizing, formatting, and access tokens, which easily exceed 200 characters.

--- a/docs/superpowers/specs/2026-08-20-clip-source-metadata-design-review.md
+++ b/docs/superpowers/specs/2026-08-20-clip-source-metadata-design-review.md
@@ -1,0 +1,18 @@
+# Design Review: Clip source metadata (2026-08-20)
+
+Below are comments, questions, and suggested improvements for the `2026-08-20-clip-source-metadata-design.md` specification.
+
+## Open Questions & Clarifications
+
+1. **`leadImage` URL Length Restriction**
+   * **Scenario:** Modern CDN images (such as Unsplash, Cloudinary, AWS S3, or Cloudfront) often carry query parameters for resizing, formatting, and access tokens, which easily exceed 200 characters.
+   * **Question:** The current design truncates `leadImage` at 200 characters. Truncating a URL will corrupt it, rendering the image broken. To avoid broken image links while protecting the database, could we increase the limit for `leadImage` to 1024 or 2048 characters?
+
+2. **`publishedAt` Numeric Type and Value Range**
+   * **Question:** The validator uses `Number.isFinite` to check `publishedAt`. Should we specifically enforce that it is an integer (e.g., `Number.isInteger`) to avoid fractional milliseconds?
+   * **Validation Range:** Should we reject or drop dates that are negative (pre-1970) or in the far future (e.g. more than 1 year from the current time) to prevent garbage data from corrupting the index sort order/display?
+
+## Suggested Improvements
+
+1. **Schema Validation for `lang`**
+   * **Suggestion:** While length-capping `lang` to 20 characters is a safe defense, language tags are almost never longer than 10 characters (typically BCP-47 tags like `en-US` or `zh-Hans-CN`). If a page sends something longer than 20 characters, it is almost certainly garbage text rather than a valid language identifier. Dropping the field entirely when it exceeds 20 characters (instead of truncating it) might be cleaner and prevent storing corrupted/truncated language tags.

--- a/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
@@ -67,6 +67,10 @@ metadata: {
 }
 ```
 
+`input.source` here is the object **`validateClipInput` built**, never the one
+the caller sent — see the whitelist rule below. `ingestClip` stores what it is
+given without further filtering, so the filtering has to have already happened.
+
 ### Why `publishedAt` is a number, not a string
 
 `article:published_time` and JSON-LD `datePublished` carry whatever format the
@@ -98,6 +102,16 @@ existing field checks:
   carries `author: ""`.
 - **Every member absent or dropped** → `source` is omitted entirely rather than
   stored as `{}`.
+- **Unknown members are discarded.** `validateClipInput` **constructs a new
+  `ClipSource`** from the five fields named above; it never returns the caller's
+  object, spread or otherwise. This is not tidiness — it is the load-bearing
+  half of the bounds below. Every per-field cap is worthless if an unrecognised
+  sibling key rides along beside them: `ingestClip` stores whatever `source`
+  holds, `upsertIndexedItem` serialises the whole metadata object, and it
+  **throws** above 64 KB. A page that put 60 KB under `source.junk` would make
+  its own clip un-ingestable, which is precisely the denial the caps exist to
+  prevent. A whitelist, not a blocklist: the shape TypeScript describes and the
+  shape that reaches storage must be the same object, built here.
 
 Every field is bounded, because `upsertIndexedItem` throws outright when an
 item's serialised metadata exceeds 64 KB
@@ -118,8 +132,18 @@ still a byline and still tells you who wrote the thing. Half a URL is not a
 slightly-worse URL — it is a broken link, and storing it is worse than storing
 nothing, because a consumer cannot tell it was truncated. The same is true of a
 language tag: BCP-47 tags top out around 10 characters (`zh-Hans-CN`), so
-anything past 20 is not a long tag, it is garbage prose in the wrong field, and
-truncating it to `en-US`-shaped nonsense would be actively misleading.
+anything past 20 is, in practice, garbage prose in the wrong field rather than a
+tag, and truncating it to `en-US`-shaped nonsense would be actively misleading.
+
+To be precise about that bound, since the reasoning above reads like a fact
+about the standard and is not: **BCP 47 sets no maximum total tag length.**
+Private-use and extension subtags can repeat, so `en-x-abcdefgh-abcdefgh` is a
+perfectly valid 22-character tag. **20 is a product limit**, chosen because
+every tag this field will realistically carry — `en`, `en-US`, `zh-Hans-CN` —
+fits inside it with room to spare, and a longer value is far likelier to be a
+page's prose leaking into the wrong `<meta>` than a genuine private-use tag we
+would do anything with. Tags over the bound are dropped **deliberately**, not
+by accident of the standard.
 
 `leadImage`'s bound is 2048 rather than 200 for the same reason review raised
 it: CDN image URLs routinely carry resize, format and signature parameters, and
@@ -213,6 +237,14 @@ Against `clip-ingest.test.ts`'s existing style:
   gone, `siteName` is there (the drop-don't-throw rule, which is the one a
   reviewer will most want to see proven)
 - a 5,000-character `author` → truncated to 200, and the item still ingests
+- **a 60 KB unknown member** (`source: { author: "A", junk: "<60KB>" }`) → the
+  clip ingests, `metadata.source` carries `author` and **no `junk` key**. This
+  is the test that proves the whitelist: without it the item would exceed the
+  store's 64 KB metadata ceiling and `upsertIndexedItem` would throw, so a page
+  could deny ingestion of its own clip
+- a valid 22-character BCP 47 tag (`en-x-abcdefgh-abcdefgh`) → dropped, and the
+  clip still ingests — pinning that the 20-character bound is a product limit
+  applied deliberately, not a claim that longer tags are malformed
 - a 30-character `lang` → **dropped, not truncated** — with the stored metadata
   asserted to have no `lang` key at all, since "truncated to something
   plausible" is the failure this rule exists to prevent

--- a/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
@@ -1,0 +1,238 @@
+# Clip source metadata — author, publish date and site name on `POST /v1/clips`
+
+> **Status:** design, approved 2026-08-20. This is the **gateway slice** of a
+> cross-repo feature; the browser slice is
+> `nimbus-web-clipper` → `docs/superpowers/specs/2026-08-20-faithful-metadata-and-canonical-url-design.md`
+> (roadmap item **2.5**). The contract below is proposed here and consumed
+> there. The clipper's other two slices do **not** depend on this one and are
+> not blocked by its review.
+
+## What the clipper is asking for
+
+The web clipper extracts a page with Mozilla Readability, which already returns
+`byline`, `siteName`, `publishedTime` and `lang` — parsed from JSON-LD and
+OpenGraph. It throws all four away, because there is nowhere on the wire to put
+them.
+
+`validateClipInput` (`packages/gateway/src/clips/clip-ingest.ts:46`) reads
+exactly seven fields:
+
+```ts
+const url = asString(o, "url");
+const title = asString(o, "title");
+const body = asString(o, "body");
+// mode, capturedAt, tags, canonicalUrl
+return { url, title, body, mode, capturedAt, tags, ...(canonicalUrl ? { canonicalUrl } : {}) };
+```
+
+Everything else in the request body is dropped on the floor. `ingestClip` then
+composes the item's `metadata` itself (`clip-ingest.ts:144`) from `tags`,
+`mode`, `wordCount` and `clippedAt`. So a clip today is a title, a body and a
+URL — a page you saved, with no record of who wrote it or when.
+
+That is the gap. A clip that cannot say who wrote it is not a citeable record,
+and it is the one item type in the index that arrives without provenance —
+every connector-sourced item has an author and a modified time from its source.
+
+## The contract
+
+One optional object on the request body, namespaced so it can never collide
+with the metadata keys `ingestClip` composes for itself:
+
+```ts
+export interface ClipSource {
+  readonly author?: string;
+  readonly publishedAt?: number;   // epoch ms
+  readonly siteName?: string;
+  readonly lang?: string;
+  readonly leadImage?: string;     // absolute http(s) URL
+}
+
+export interface ClipInput {
+  // …the seven existing fields, unchanged…
+  readonly source?: ClipSource;
+}
+```
+
+It lands as `metadata.source`:
+
+```ts
+metadata: {
+  tags: input.tags,
+  mode: input.mode,
+  wordCount: extent.storedWords,
+  …,
+  clippedAt: input.capturedAt,
+  ...(input.source === undefined ? {} : { source: input.source }),
+}
+```
+
+### Why `publishedAt` is a number, not a string
+
+`article:published_time` and JSON-LD `datePublished` carry whatever format the
+publisher chose. Parsing that is real work with real ambiguity (two-digit years,
+missing zones, locale orderings), and it does not belong on a locked ingest path
+where a parse failure would cost the caller their clip.
+
+So the **client normalises to epoch ms** — matching `capturedAt`, which is
+already epoch ms on this same body — and this validator checks only that the
+number is an integer inside `Date`'s range. A date the client cannot parse is a
+field the client omits. This keeps the gateway's date handling at zero and puts
+the messy parsing next to the messy input.
+
+### Validation rules
+
+`validateClipInput` gains one block, and its shape is deliberately unlike the
+existing field checks:
+
+- **`source` absent** → `undefined`, as today. The overwhelmingly common shape.
+- **`source` present but not an object** (or `null`, or an array) →
+  `ClipValidationError("source must be a JSON object", "source")`. A caller
+  sending the wrong *kind* of thing is a bug worth reporting.
+- **A member of the wrong type** → **dropped, not thrown.** This is the
+  departure. `asString` throws because a clip without a title is not a clip; a
+  clip with a malformed byline is still a perfectly good clip, and failing it
+  would mean one bad `<meta>` tag on a page costs the user the capture. Wrong
+  types here are page-supplied noise, not caller error.
+- **An empty string after trimming** → dropped, so `metadata.source` never
+  carries `author: ""`.
+- **Every member absent or dropped** → `source` is omitted entirely rather than
+  stored as `{}`.
+
+Every field is bounded, because `upsertIndexedItem` throws outright when an
+item's serialised metadata exceeds 64 KB
+(`packages/gateway/src/index/item-store.ts:85`) and all of these values are
+controlled by whatever page the user is looking at. Without bounds, a hostile
+page could make a clip un-ingestable. But **how** a field is bounded depends on
+what kind of value it is:
+
+| Field | Bound | Over the bound |
+| --- | --- | --- |
+| `author` | 200 chars | truncated |
+| `siteName` | 200 chars | truncated |
+| `lang` | 20 chars | **dropped** |
+| `leadImage` | 2048 chars | **dropped** |
+
+**Prose degrades; structured values corrupt.** A byline cut to 200 characters is
+still a byline and still tells you who wrote the thing. Half a URL is not a
+slightly-worse URL — it is a broken link, and storing it is worse than storing
+nothing, because a consumer cannot tell it was truncated. The same is true of a
+language tag: BCP-47 tags top out around 10 characters (`zh-Hans-CN`), so
+anything past 20 is not a long tag, it is garbage prose in the wrong field, and
+truncating it to `en-US`-shaped nonsense would be actively misleading.
+
+`leadImage`'s bound is 2048 rather than 200 for the same reason review raised
+it: CDN image URLs routinely carry resize, format and signature parameters, and
+200 characters would put most real lead images over the line. 2048 is the
+practical URL ceiling most stacks assume, and even a full set of these fields at
+their bounds is under 3 KB against a 64 KB ceiling — the cap is there to stop
+abuse, not to economise.
+
+`publishedAt` is bounded too, and by type rather than length:
+
+- **must be an integer** — `Number.isFinite` alone admits `1.5`, and a
+  fractional millisecond is meaningless. The only caller normalises through
+  `Date.parse`, which yields integers, so a non-integer is garbage rather than
+  legitimate data being narrowed; it is dropped, consistent with the rule above.
+- **must be within the range `Date` can represent** (|v| ≤ 8.64e15). This is a
+  principled bound rather than an arbitrary one: it is exactly "a number
+  `new Date()` can turn into a date".
+
+Two range rules review proposed are **deliberately not adopted**:
+
+- **Rejecting negative (pre-1970) values.** They are legitimate. An index that
+  holds papers, archived essays and scanned documents will meet 1965 publication
+  dates, and a clipper that silently dropped them would be wrong in exactly the
+  library case this field exists to serve.
+- **Rejecting dates more than a year in the future.** Embargoed and scheduled
+  posts carry future dates honestly. The concern review raised — garbage
+  "corrupting the index sort order/display" — does not arise here, because
+  `publishedAt` lands in `metadata` and **nothing sorts on it**; `modified_at`
+  still comes from `capturedAt` (see below). If a later change makes
+  `publishedAt` drive ordering, that change owns the bound, and it will have a
+  concrete reason to pick one.
+
+`leadImage` is stored as a reference and **never fetched**. Nothing in this
+change makes an outbound request, so it adds no egress surface and no `I29`
+coverage class.
+
+## What this does not change
+
+Three properties the tests must pin, because each is the kind of thing a future
+reader will assume was broken:
+
+1. **Clip identity is untouched.** `externalIdFor` (`clip-ingest.ts:76`) hashes
+   the canonicalised URL, plus the body for `mode: "selection"`. Metadata is not
+   in the hash and must not enter it. Re-clipping a page after its byline
+   changed stays an `updated` on the same `id` — not a second item.
+2. **`modified_at` still comes from `capturedAt`.** Letting `publishedAt` drive
+   `modified_at` was considered and deliberately rejected for this slice: it
+   would change clip sort order and the panel's freshness line on data already
+   in every user's index, which is a behaviour change on shipped state rather
+   than an addition. Worth doing, worth doing on its own.
+3. **`author_id` stays null.** Resolving a byline string to a `person` row is
+   fuzzy, cross-connector, and a design of its own. `metadata.source.author` is
+   a string the clip carries, not an identity claim.
+
+One inherited behaviour must be **documented rather than fixed**: a re-clip that
+sends no `source` clears a previously-stored one, because `upsertIndexedItem`
+replaces metadata wholesale (`item-store.ts:130`, `metadata = excluded.metadata`).
+`tags` already behave exactly this way. Left silent, the first person to notice
+will file it as a bug.
+
+## Surfaces touched
+
+| File | Change |
+| --- | --- |
+| `packages/gateway/src/clips/clip-ingest.ts` | `ClipSource`, validation block, `metadata.source` |
+| `packages/gateway/src/clips/clip-ingest.test.ts` | the cases below |
+| `docs/CHANGELOG.md` | the new optional field |
+
+Two gates that look like they apply and do not:
+
+- **`packages/gateway/openapi/v1.yaml` needs no edit.** The clip routes are not
+  described there — the file covers the read-only data API, and `/v1/clips`
+  appears nowhere in its 482 lines. Checked rather than assumed.
+- **`WRITE_ROUTE_ALLOWLIST` needs no edit.** This adds a field to an existing
+  route, not a route. No `I13` allowlist change, no `I30` minting change, no
+  clip-token scope change.
+
+`docs/architecture.md`'s allowlist row (line 1689) describes routes, not body
+shapes, so it is likewise unchanged.
+
+## Testing
+
+Against `clip-ingest.test.ts`'s existing style:
+
+- `source` absent → item metadata is byte-identical to today's (the
+  no-regression fence)
+- a full `source` → all five land under `metadata.source`
+- `source: "nope"` / `source: null` / `source: []` → `ClipValidationError` with
+  `field: "source"`
+- `author: 42` alongside a valid `siteName` → the clip ingests, `author` is
+  gone, `siteName` is there (the drop-don't-throw rule, which is the one a
+  reviewer will most want to see proven)
+- a 5,000-character `author` → truncated to 200, and the item still ingests
+- a 30-character `lang` → **dropped, not truncated** — with the stored metadata
+  asserted to have no `lang` key at all, since "truncated to something
+  plausible" is the failure this rule exists to prevent
+- a 3,000-character `leadImage` → **dropped, not truncated**, same assertion
+- a 900-character CDN `leadImage` with resize and signature parameters →
+  **kept intact**, which is the case that motivated the 2048 bound
+- `publishedAt: "2026-01-01"` → dropped, clip ingests
+- `publishedAt: Number.NaN` / `Infinity` / `1.5` → dropped, clip ingests
+- `publishedAt: -157766400000` (a 1965 publication date) → **kept**, pinning
+  that pre-1970 dates are legitimate
+- `publishedAt: 1e300` → dropped (outside `Date`'s range)
+- `author: "   "` → dropped, and `metadata.source` is absent rather than `{}`
+- **identity**: ingest, then re-ingest the same URL with a different `source` →
+  same `id`, `status: "updated"`, one row
+- **metadata replacement**: ingest with `source`, re-ingest without → `source`
+  is gone, documenting the inherited wholesale-replace behaviour
+
+## Gates
+
+`bun run lint:markdown` covers `docs/` and will fail this document if it drifts
+from the house rules — it is the gate that most often turns a locally-green
+branch red here. Otherwise the usual: `bun run typecheck`, `bun run lint`, the
+gateway test suite.


### PR DESCRIPTION
## Summary

Design only — no gateway code in this PR. It proposes one optional `source` object on `POST /v1/clips` so a web clip can carry provenance.

Today `validateClipInput` (`packages/gateway/src/clips/clip-ingest.ts:46`) reads exactly seven fields and drops everything else, and `ingestClip` composes the item's `metadata` itself. So a clip is the **one item type in the index that arrives with no provenance at all** — no author, no publish date, no site name — while every connector-sourced item has them from its source. The browser clipper already extracts `byline`, `siteName`, `publishedTime` and `lang` (Readability parses JSON-LD and OpenGraph for free) and throws all four away, because there is nowhere on the wire to put them.

The proposed shape lands as `metadata.source`:

```ts
source?: { author?: string; publishedAt?: number; siteName?: string; lang?: string; leadImage?: string }
```

Two decisions the spec argues rather than assumes:

- **`publishedAt` is epoch ms, normalised client-side.** `article:published_time` and JSON-LD `datePublished` carry whatever format the publisher chose; parsing that on a locked ingest path where a parse failure costs the caller their clip is the wrong place for it. The validator checks only "integer inside `Date`'s range".
- **A malformed member is dropped, not thrown.** `asString` throws because a clip without a title is not a clip; a clip with a malformed byline is still a perfectly good clip, and failing it would mean one bad `<meta>` tag costs the user their capture. Bounds are typed by what the value *is*: prose truncates, structured values are dropped — half a URL is a broken link rather than a shorter one.

It also pins three things this must **not** change: clip identity (`externalIdFor` hashes the canonical URL and, for selections, the body — never metadata), `modified_at` (still `capturedAt`; letting `publishedAt` drive it would reorder data already in every user's index), and `author_id` (byline → person resolution is its own design).

Two gates that look like they apply and do not, both checked rather than assumed: `packages/gateway/openapi/v1.yaml` describes the read-only data API and does not mention `/v1/clips`, and this adds a field to an existing route rather than a route, so `WRITE_ROUTE_ALLOWLIST` and the `I30` minting rule are untouched.

## Related Issue

Relates to the web clipper's roadmap item 2.5. This is the **S2** slice of a cross-repo design; the browser slices live in [`nimbus-web-clipper`](https://github.com/nimbus-agent/nimbus-web-clipper). S1 (canonical-URL fidelity, client-only) shipped there in nimbus-agent/nimbus-web-clipper#67. S3 (extraction and threading) is deliberately gated on this landing — shipping it earlier would put Author and Published in the extension's pre-send preview while this validator discarded them, making that preview lie about what leaves.

Closes #

## Type of Change

- [x] Documentation only

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`)
- [x] New behaviour is covered by tests — n/a, design document only; the spec enumerates the test cases the implementation must carry, including the drop-don't-throw rule and a 1965 publication date staying valid
- [x] No `any` types introduced — `unknown` is used for external data
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction — n/a
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] If this PR touches `docs/README.md` — n/a

Also verified: `bun run lint:markdown` clean, and `bun scripts/structure-audit/check-doc-references.ts --check` resolves 1208 refs across 41 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an approved design for optional source metadata on clip submissions, including author, publication date, site name, language, and lead-image URL.
  * Documented validation, size limits, timestamp handling, metadata replacement behavior, and privacy-preserving URL handling.
  * Added a design review covering open questions around URL lengths, publication dates, and language values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->