### PR TITLE
docs: link nimbus-mcp, correct the MCP tool count, reframe the Actions listing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ The non-negotiables in [Contributing](#contributing) follow from that question �
 
 - **local** — the SQLite index, the Vault, and the audit log all live on your machine. The cloud is a connector, not the source of truth. Telemetry is opt-in and off by default (`[telemetry] enabled = false`).
 - **consent-gated** — every destructive or outbound action is intercepted by a human-in-the-loop gate *before* it runs. It lives in the executor, not the prompt, so it cannot be jailbroken away.
-- **MCP** — Nimbus speaks the [Model Context Protocol](https://modelcontextprotocol.io/) in both directions. As an **MCP client** it drives every connector as an MCP server, and hosts any third-party server you register with `nimbus connector add --mcp`. As an **MCP server**, `nimbus mcp-server --stdio` exposes your local index to editor AIs through six read-only tools. The engine never calls a cloud API directly.
+- **MCP** — Nimbus speaks the [Model Context Protocol](https://modelcontextprotocol.io/) in both directions. As an **MCP client** it drives every connector as an MCP server, and hosts any third-party server you register with `nimbus connector add --mcp`. As an **MCP server**, it exposes your local index *and* its built-in agents to any MCP client through 18 read-only tools — 7 index tools plus 11 agent tools (`explainWhy`, `findExpert`, `assessImpact`, `getCatchup`, …). Install it with `npx -y @nimbus-dev/mcp`, or run `nimbus mcp-server --stdio` directly from a checkout. The engine never calls a cloud API directly.
 
 ---
 
@@ -841,6 +841,7 @@ Nimbus is a gateway plus a set of surfaces that talk to it. All of these are sep
 |---|---|
 | [nimbus-sdk](https://github.com/nimbus-agent/nimbus-sdk) | The extension-authoring contract (npm, MIT) — what a connector is written against |
 | [nimbus-client](https://github.com/nimbus-agent/nimbus-client) | Typed IPC wrapper (npm, MIT) — how a client talks to the gateway; consumed by `packages/cli` and the VS Code extension |
+| [nimbus-mcp](https://github.com/nimbus-agent/nimbus-mcp) | `@nimbus-dev/mcp` (npm, MIT) — the launcher that exposes your local index and agents to any MCP client; listed in the official MCP Registry as `io.github.nimbus-agent/nimbus` |
 | [create-nimbus-connector](https://github.com/nimbus-agent/create-nimbus-connector) | Scaffolding generator for a new connector |
 | [nimbus-vscode](https://github.com/nimbus-agent/nimbus-vscode) | VS Code / Open VSX extension |
 | [nimbus-web-clipper](https://github.com/nimbus-agent/nimbus-web-clipper) | Chrome + Firefox MV3 web clipper; the gateway-side surface stays in this repo |

--- a/docs/superpowers/specs/2026-08-19-nimbus-distribution-program-design.md
+++ b/docs/superpowers/specs/2026-08-19-nimbus-distribution-program-design.md
@@ -301,12 +301,32 @@ Three additions to that spec:
    published to npm" once corrected. Both now carry the satellite-repo bullet
    with no published/unpublished framing at all, matching how the sdk and client
    entries read.
-2. **List the first-party GitHub Actions.** `packages/github-actions/`
-   (`annotate-action`, `preflight-query`) is built and unlisted on the Actions
-   Marketplace.
-3. **Wake the satellites.** Cross-link `awesome-nimbus`, `nimbus-raycast` and
-   `create-nimbus-connector` from the main README. It costs nothing and makes
-   the project read as an ecosystem rather than a single repository.
+2. **~~List the first-party GitHub Actions.~~ Not a listing task — it is an
+   extraction decision.** `packages/github-actions/` (`annotate-action`,
+   `preflight-query`) is built and unlisted, and this spec described publishing
+   it as a quick win. It is not one, and the constraint is structural: the
+   **Actions Marketplace requires `action.yml` at the repository ROOT.** Both
+   actions live at `packages/github-actions/<name>/action.yml`, and there is no
+   root `action.yml` — verified 2026-08-21. GitHub cannot list an action from a
+   monorepo subdirectory at all.
+
+   So the real choice is the same one the launcher faced: extract each action to
+   its own repo, or accept that they stay unlisted and are consumed by path
+   (`nimbus-agent/Nimbus/packages/github-actions/annotate-action@<sha>`), which
+   works today and needs no listing. The precedent and the cost model are in
+   [`2026-08-19-mcp-launcher-publish-route.md`](./2026-08-19-mcp-launcher-publish-route.md)
+   and the executed
+   [`../plans/2026-08-20-mcp-launcher-satellite-extraction.md`](../plans/2026-08-20-mcp-launcher-satellite-extraction.md)
+   — note that extraction there cost six org enumeration sites, a full scaffold
+   and a severed cross-repo guard, for a package with far stronger distribution
+   upside than a CI action nobody is searching the Marketplace for. **Do not
+   pick this up expecting an afternoon.**
+3. **~~Wake the satellites.~~ Done — this item was already stale when written.**
+   `awesome-nimbus`, `nimbus-raycast` and `create-nimbus-connector` are all
+   cross-linked from `docs/README.md` (#1276, 2026-08-20). `nimbus-mcp` was
+   added on 2026-08-21 once it existed. The satellite table there now lists all
+   eight: sdk, client, mcp, create-nimbus-connector, vscode, web-clipper,
+   raycast, awesome-nimbus.
 
 The directory spec's honesty guardrails carry over unchanged, and the
 connector-verification audit (Task 2 of the launch plan) still gates any


### PR DESCRIPTION
Follow-on from the MCP Registry listing. Two of the three changes correct claims
that were already wrong.

## The README understated the MCP surface by twelve tools

Line 58 — the "README MCP statement" the distribution spec tracks as `done
(#979)` — said `nimbus mcp-server --stdio` exposes **six read-only tools**.

Counted from `packages/cli/src/mcp/`:

- `INDEX_TOOL_SPECS` = **7** — `searchIndex`, `getConnectorStatus`,
  `getRecentIncidents`, `getRecentPullRequests`, `getRecentDeployments`,
  `getDoraMetrics`, `peekWhy`
- `AGENT_TOOL_SPECS` = **11** — `explainWhy`, `getCatchup`, `findExpert`,
  `assessImpact`, `findConflicts`, `findDecisions`, `getGlossary`, `findOwners`,
  `checkResourceUsage`, `getPeerContext`, `getTeamHuddle`

18 total. `peekWhy` was added after the statement was written, and the agent
tools were never in it. This is the most-read file, and it was understating the
product on the day those tools became reachable from every MCP client. Also adds
`npx -y @nimbus-dev/mcp`, now the actual install path.

## "Wake the satellites" was stale when written

`awesome-nimbus`, `nimbus-raycast` and `create-nimbus-connector` were already
cross-linked by #1276. The real gap was `nimbus-mcp`, which did not exist yet.
Added — the satellite table is now eight rows.

## "List the first-party GitHub Actions" cannot be done as described

The Actions Marketplace requires `action.yml` at the repository **root**. Both
actions live at `packages/github-actions/<name>/action.yml` and there is no root
`action.yml`, so GitHub cannot list them from a monorepo subdirectory at all.

It was never a listing task — it is the same extract-or-accept decision the
launcher faced. Reframed as such and pointed at the launcher extraction as the
cost model, with the asymmetry noted: that extraction cost six org enumeration
sites, a full scaffold and a severed cross-repo guard, for a package with far
stronger distribution upside than a CI action nobody searches the Marketplace
for. Consuming them by path works today and needs no listing.

## Not touched

`CLAUDE.md`'s I29 text carries the same stale "six read-only index tools". Left
alone deliberately — a parallel session is editing that file — so it wants
folding into their PR or a later one.

## Verification

`preflight PASSED`; `audit:doc-refs`, `audit:status-drift`, `audit:readme-cli`
all OK; markdownlint clean across 130 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)