### PR TITLE
docs(spec): the whitelist test needs 70 KB, not 60 — 60 never crossed the ceiling

### DIFF
--- a/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-20-clip-source-metadata-design.md
@@ -108,10 +108,11 @@ existing field checks:
   half of the bounds below. Every per-field cap is worthless if an unrecognised
   sibling key rides along beside them: `ingestClip` stores whatever `source`
   holds, `upsertIndexedItem` serialises the whole metadata object, and it
-  **throws** above 64 KB. A page that put 60 KB under `source.junk` would make
-  its own clip un-ingestable, which is precisely the denial the caps exist to
-  prevent. A whitelist, not a blocklist: the shape TypeScript describes and the
-  shape that reaches storage must be the same object, built here.
+  **throws** above 64 KB (`RAW_META_MAX_BYTES`, 65,536 bytes). A page that put
+  enough under `source.junk` to cross that ceiling would make its own clip
+  un-ingestable, which is precisely the denial the caps exist to prevent. A
+  whitelist, not a blocklist: the shape TypeScript describes and the shape that
+  reaches storage must be the same object, built here.
 
 Every field is bounded, because `upsertIndexedItem` throws outright when an
 item's serialised metadata exceeds 64 KB
@@ -237,11 +238,18 @@ Against `clip-ingest.test.ts`'s existing style:
   gone, `siteName` is there (the drop-don't-throw rule, which is the one a
   reviewer will most want to see proven)
 - a 5,000-character `author` → truncated to 200, and the item still ingests
-- **a 60 KB unknown member** (`source: { author: "A", junk: "<60KB>" }`) → the
+- **a 70 KB unknown member** (`source: { author: "A", junk: "<70KB>" }`) → the
   clip ingests, `metadata.source` carries `author` and **no `junk` key**. This
   is the test that proves the whitelist: without it the item would exceed the
   store's 64 KB metadata ceiling and `upsertIndexedItem` would throw, so a page
-  could deny ingestion of its own clip
+  could deny ingestion of its own clip.
+  **The size has to be over the ceiling, not merely large.** This bullet said
+  60 KB when the spec was approved, and the implementation copied it before
+  review caught the arithmetic: that metadata serialises to 60,112 bytes against
+  `RAW_META_MAX_BYTES` of 65,536, so it never crossed, and the test passed on its
+  `toEqual` assertion while advertising itself as a denial-of-ingestion fence.
+  70 KB serialises to 70,112 bytes and genuinely crosses. Shipped that way in
+  #1285
 - a valid 22-character BCP 47 tag (`en-x-abcdefgh-abcdefgh`) → dropped, and the
   clip still ingests — pinning that the 20-character bound is a product limit
   applied deliberately, not a claim that longer tags are malformed


### PR DESCRIPTION
## Summary

Corrects an arithmetic error in the clip-source-metadata design spec (merged 2026-08-20), and records why it changed.

The spec's Testing section specified **a 60 KB unknown member** as the case that proves the `source` whitelist, on the reasoning that without the whitelist the item "would exceed the store's 64 KB metadata ceiling and `upsertIndexedItem` would throw, so a page could deny ingestion of its own clip."

It would not. `RAW_META_MAX_BYTES` is 65,536, and that metadata serialises to **60,112 bytes** — comfortably under. The implementation in #1285 copied the number faithfully, which produced a test that passed on its `toEqual` assertion while advertising itself as a denial-of-ingestion fence. Review caught it before merge and shipped **70 KB** (70,112 bytes), which genuinely crosses.

Two edits:

- The Testing bullet now says 70 KB, and states plainly that the size has to be *over* the ceiling rather than merely large — with the original 60 KB error recorded rather than quietly overwritten, since the arithmetic is the entire point of that bullet.
- The "Unknown members are discarded" rule no longer names a specific size at all. It now cites `RAW_META_MAX_BYTES` (65,536 bytes) and says "enough to cross that ceiling", which cannot go stale.

## Related Issue

Follow-up to #1285 (2.5 S2). No issue number.

## Type of Change

- [x] Documentation only

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors (no code changed)
- [x] `bun run lint` passes (no code changed)
- [x] All existing tests pass (no code changed — the shipped test already uses 70 KB)
- [x] New behaviour is covered by tests (n/a — documentation only)
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction (n/a)
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] Does not touch `docs/README.md`

## Testing

`bun run lint:markdown` — 138 files, 0 issues. `bun scripts/structure-audit/check-doc-references.ts --check` — 1,208 refs across 41 docs, all resolve. No code paths touched.

## Notes for Reviewers

Worth doing now rather than later because **S3 of roadmap 2.5 is gated on S2 being released**, and S3's author will read this spec. Leaving the wrong number in it invites re-deriving a test that looks like a DoS fence and isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the clip source metadata specification with a clearer oversized-field validation example.
  - Increased the example payload from 60 KB to 70 KB to explicitly exceed the 64 KB metadata limit.
  - Added an explanation of the size calculation and clarified that oversized unknown fields are excluded before storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->