### PR TITLE
perf(test): a migrated-once schema template and a deadline-bounded poll, for the Windows hot path

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -315,9 +315,17 @@ jobs:
         run: |
           set +e
           for attempt in 1 2; do
-            bun test packages/gateway packages/cli packages/mcp-connectors scripts --timeout 60000 --preload "${GITHUB_WORKSPACE}/scripts/coverage/istanbul-register.ts" --preload "${GITHUB_WORKSPACE}/scripts/coverage/report-coverage.ts" --reporter=junit --reporter-outfile=junit-reports/junit-unit.xml
+            # Redirect-then-cat, NOT a pipe: a pipeline would make `$?` the exit code of the
+            # last command and silently mask every failure. Same shape as `ci.yml`'s
+            # cross-platform retry, and for the same reason — a silent retry costs a full
+            # suite run and leaves nothing in the summary to investigate.
+            bun test packages/gateway packages/cli packages/mcp-connectors scripts --timeout 60000 --preload "${GITHUB_WORKSPACE}/scripts/coverage/istanbul-register.ts" --preload "${GITHUB_WORKSPACE}/scripts/coverage/report-coverage.ts" --reporter=junit --reporter-outfile=junit-reports/junit-unit.xml > "${RUNNER_TEMP}/attempt-${attempt}.log" 2>&1
             code=$?
+            cat "${RUNNER_TEMP}/attempt-${attempt}.log"
             if [ "$code" -eq 0 ]; then
+              if [ "$attempt" -eq 2 ]; then
+                echo "::warning title=Retry masked a failure::The unit suite FAILED on attempt 1 and passed on attempt 2 (${{ inputs.runner }}). Green, but two full suite runs were paid for — see the annotations naming the failing test(s)."
+              fi
               exit 0
             fi
             if [ "$attempt" -eq 2 ]; then
@@ -325,6 +333,14 @@ jobs:
               exit "$code"
             fi
             echo "Attempt $attempt failed (exit $code), retrying in 5 s..."
+            failed=$(grep -E '^\(fail\)' "${RUNNER_TEMP}/attempt-${attempt}.log" | head -20 || true)
+            if [ -n "$failed" ]; then
+              while IFS= read -r line; do
+                echo "::warning title=Flaky test::${line}"
+              done <<< "$failed"
+            else
+              echo "::warning title=Attempt 1 failed with no (fail) line::exit ${code} — a timeout, crash or hang rather than an assertion. See the attempt-1 output above."
+            fi
             sleep 5
           done
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,12 +353,27 @@ jobs:
         # to absorb that variance while still bounding a true hang well under the
         # job ceiling. Re-check this number if a healthy run ever exceeds ~700 s;
         # the durable fix is making the suite faster, not raising the cap again.
+        # A SILENT retry is the expensive kind. Attempt 1 costs a full suite run — on
+        # windows-2025 that was 882 s in run 32452626344, where ONE test
+        # (`briefs/brief-e2e.test.ts`'s leak check) timed out and the retry passed, so the job
+        # went green having burned ~11 extra minutes with nothing in the summary to investigate.
+        # Attempt 1's output is therefore captured to a file, echoed to the log unchanged, and
+        # its `(fail)` lines surfaced as annotations plus a job-summary block.
+        #
+        # Redirect-then-cat, NOT a pipe into `tee`: a pipeline makes `$?` the exit code of the
+        # LAST command, which would silently turn every failure into a success here. The
+        # redirect leaves `$?` as the test run's own code, which is what both branches below
+        # depend on.
         run: |
           set +e
           for attempt in 1 2; do
-            bun scripts/run-with-timeout.ts 900 bun test "packages/${{ matrix.pkg }}/src" --timeout 60000
+            bun scripts/run-with-timeout.ts 900 bun test "packages/${{ matrix.pkg }}/src" --timeout 60000 > "${RUNNER_TEMP}/attempt-${attempt}.log" 2>&1
             code=$?
+            cat "${RUNNER_TEMP}/attempt-${attempt}.log"
             if [ "$code" -eq 0 ]; then
+              if [ "$attempt" -eq 2 ]; then
+                echo "::warning title=Retry masked a failure::${{ matrix.pkg }} on ${{ matrix.os }} FAILED on attempt 1 and passed on attempt 2. The job is green but paid for two full suite runs — see the annotations naming the failing test(s)."
+              fi
               exit 0
             fi
             if [ "$attempt" -eq 2 ]; then
@@ -366,6 +381,29 @@ jobs:
               exit "$code"
             fi
             echo "Attempt $attempt failed (exit $code), retrying in 5 s..."
+            # `|| true` so a no-match grep (a timeout/crash with no `(fail)` line) does not end
+            # the step under a future `set -e`, and does not skip the retry.
+            failed=$(grep -E '^\(fail\)' "${RUNNER_TEMP}/attempt-${attempt}.log" | head -20 || true)
+            if [ -n "$failed" ]; then
+              while IFS= read -r line; do
+                echo "::warning title=Flaky test::${line}"
+              done <<< "$failed"
+            else
+              echo "::warning title=Attempt 1 failed with no (fail) line::exit ${code} — a timeout, crash or hang rather than an assertion. See the attempt-1 output above."
+            fi
+            {
+              echo "### ⚠ ${{ matrix.pkg }} on ${{ matrix.os }} needed a retry"
+              echo ""
+              echo "Attempt 1 exited \`${code}\`; attempt 2 follows. A retry costs a full suite run."
+              echo ""
+              if [ -n "$failed" ]; then
+                echo '```text'
+                echo "$failed"
+                echo '```'
+              else
+                echo "No \`(fail)\` line — attempt 1 timed out, crashed or hung."
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
             sleep 5
           done
         env:

--- a/packages/gateway/src/agent-runs/agent-test-server.ts
+++ b/packages/gateway/src/agent-runs/agent-test-server.ts
@@ -12,8 +12,7 @@ import { Database } from "bun:sqlite";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
-import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
+import { materializeMigratedDb } from "../index/migrated-db-template.ts";
 import type { ReadOnlyHttpServerHandle } from "../ipc/http-server.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
 import { createSeededTokenVault } from "../ipc/test-token-vault.ts";
@@ -58,11 +57,11 @@ export async function startAgentTestServer(opts?: {
   const tmpDir = mkdtempSync(join(tmpdir(), "nimbus-agent-e2e-"));
   const dbPath = join(tmpDir, "nimbus.db");
 
-  // Migrate + close (same pattern as brief-test-server.ts): the server opens its own readonly +
-  // writable handles on `dbPath`, so the setup connection must not linger.
-  const setupDb = new Database(dbPath);
-  runIndexedSchemaMigrations(setupDb, CURRENT_SCHEMA_VERSION);
-  setupDb.close();
+  // Materialize + hold no handle (same pattern as brief-test-server.ts): the server opens its own
+  // readonly + writable handles on `dbPath`, so a lingering setup connection would be a second
+  // writer. The copy comes from a template migrated once per process; `materializeMigratedDb`
+  // closes its builder connection first, so the file it leaves is complete and unowned.
+  materializeMigratedDb(dbPath);
 
   // A separate writable handle held only by this harness, for asserting on ledger rows — distinct
   // from the server's own handles.

--- a/packages/gateway/src/briefs/brief-e2e.test.ts
+++ b/packages/gateway/src/briefs/brief-e2e.test.ts
@@ -11,6 +11,7 @@ import { MAX_RUN_BYTES, MAX_SOURCE_BYTES, MAX_SOURCES_PER_RUN } from "./brief-co
 import type { BriefSynthesizerLlm } from "./brief-synthesis.ts";
 import { runBriefWithIndexHits, startBriefTestServer } from "./brief-test-server.ts";
 import type { Report } from "./brief-types.ts";
+import { pollBriefUntilTerminal } from "./poll-until-terminal.ts";
 
 type CreateOk = { id: string; status: string; expected: number };
 type SourceOk = { accepted: boolean; received: number; expected: number };
@@ -37,16 +38,7 @@ async function postNoBody(url: string, token: string): Promise<Response> {
 }
 
 async function pollUntilTerminal(base: string, token: string, id: string): Promise<GetOk> {
-  for (let i = 0; i < 200; i++) {
-    const res = await fetch(`${base}/v1/briefs/${id}`, {
-      headers: { authorization: `Bearer ${token}` },
-    });
-    if (res.status !== 200) throw new Error(`unexpected GET status ${res.status}`);
-    const body = (await res.json()) as GetOk;
-    if (body.status === "done" || body.status === "failed") return body;
-    await new Promise((r) => setTimeout(r, 5));
-  }
-  throw new Error("brief run never reached a terminal state within the poll budget");
+  return (await pollBriefUntilTerminal(base, token, id)) as GetOk;
 }
 
 /**
@@ -612,8 +604,14 @@ test("leak check: the bearer token, the fed source body, and its URL never appea
 
     await captureJson<RunOk>(await postNoBody(`${base}/v1/briefs/${created.id}/run`, s.token), 200);
 
+    // This loop cannot use `pollBriefUntilTerminal`: the assertion below inspects EVERY response
+    // body this test saw, so each poll's raw text has to go through `captureJson` into `bodies`.
+    // The budget is wall-clock for the same reason the shared helper's is — see
+    // `poll-until-terminal.ts`. This test is the one that hit the 60 s harness timeout inside
+    // its old 200-iteration budget on a slow Windows runner.
     let done: GetOk | undefined;
-    for (let i = 0; i < 200; i++) {
+    const pollDeadline = Date.now() + 20_000;
+    while (done === undefined && Date.now() < pollDeadline) {
       const body = await captureJson<GetOk>(
         await fetch(`${base}/v1/briefs/${created.id}`, {
           headers: { authorization: `Bearer ${s.token}` },
@@ -624,9 +622,9 @@ test("leak check: the bearer token, the fed source body, and its URL never appea
         done = body;
         break;
       }
-      await new Promise((r) => setTimeout(r, 5));
+      await new Promise((r) => setTimeout(r, 25));
     }
-    const finished = must(done, "a terminal GET body within the poll budget");
+    const finished = must(done, "a terminal GET body within the 20 s poll budget");
     expect(finished.status).toBe("done");
     // The stub deliberately cites nothing, so the report legitimately carries zero citations —
     // there is no legitimate path for the fed URL to appear in the report either.

--- a/packages/gateway/src/briefs/brief-http.test.ts
+++ b/packages/gateway/src/briefs/brief-http.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BriefSynthesizerLlm } from "./brief-synthesis.ts";
 import { startBriefTestServer } from "./brief-test-server.ts";
+import { pollBriefUntilTerminal } from "./poll-until-terminal.ts";
 
 const OK_LLM: BriefSynthesizerLlm = {
   generateJson: async () =>
@@ -50,23 +51,6 @@ async function createAndFeedRun(base: string, token: string): Promise<{ id: stri
   return { id: created.id };
 }
 
-async function pollUntilTerminal(
-  base: string,
-  token: string,
-  id: string,
-): Promise<{ status: string; report?: unknown; failureReason?: string }> {
-  for (let i = 0; i < 50; i++) {
-    const res = await fetch(`${base}/v1/briefs/${id}`, {
-      headers: { authorization: `Bearer ${token}` },
-    });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string; report?: unknown; failureReason?: string };
-    if (body.status === "done" || body.status === "failed") return body;
-    await new Promise((r) => setTimeout(r, 5));
-  }
-  throw new Error("brief run never reached a terminal state");
-}
-
 describe("GET /v1/briefs/{id} auth", () => {
   test("a tokenless GET is 401, proving briefs are not in the unauthenticated read table", async () => {
     const s = await startBriefTestServer();
@@ -104,7 +88,7 @@ describe("GET /v1/briefs/{id} lifecycle", () => {
       });
       expect(runRes.status).toBe(200);
 
-      const body = await pollUntilTerminal(base, s.token, id);
+      const body = await pollBriefUntilTerminal(base, s.token, id);
       expect(body.status).toBe("done");
       expect(body.report).toBeDefined();
       expect("failureReason" in body).toBe(false);
@@ -142,7 +126,7 @@ describe("GET /v1/briefs/{id} lifecycle", () => {
       });
       expect(runRes.status).toBe(200);
 
-      const body = await pollUntilTerminal(base, s.token, id);
+      const body = await pollBriefUntilTerminal(base, s.token, id);
       expect(body.status).toBe("failed");
       expect(typeof body.failureReason).toBe("string");
       expect((body as Record<string, unknown>)["error"]).toBeUndefined();

--- a/packages/gateway/src/briefs/brief-test-server.ts
+++ b/packages/gateway/src/briefs/brief-test-server.ts
@@ -14,8 +14,7 @@ import { Database } from "bun:sqlite";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
-import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
+import { materializeMigratedDb } from "../index/migrated-db-template.ts";
 import type { ReadOnlyHttpServerHandle } from "../ipc/http-server.ts";
 import { startReadOnlyHttpServer } from "../ipc/http-server.ts";
 import { createSeededTokenVault } from "../ipc/test-token-vault.ts";
@@ -115,11 +114,12 @@ export async function startBriefTestServer(opts?: {
   const tmpDir = mkdtempSync(join(tmpdir(), "nimbus-brief-e2e-"));
   const dbPath = join(tmpDir, "nimbus.db");
 
-  // Migrate + close (same pattern as clip-e2e.test.ts / http-server.test.ts): the server opens
-  // its own readonly + writable handles on `dbPath`, so the setup connection must not linger.
-  const setupDb = new Database(dbPath);
-  runIndexedSchemaMigrations(setupDb, CURRENT_SCHEMA_VERSION);
-  setupDb.close();
+  // Materialize a migrated database at `dbPath` and hold no handle on it: the server opens its
+  // own readonly + writable handles, so a lingering setup connection would be a second writer.
+  // This copies a template migrated once per process rather than replaying every migration per
+  // harness — `materializeMigratedDb` closes its builder connection before copying, so the file
+  // it leaves is complete and unowned, which is exactly what the old migrate-then-close did.
+  materializeMigratedDb(dbPath);
 
   // A separate writable handle, held only by this harness, for `save` (saveBriefReport) and for
   // the `db` field callers use to assert on saved items — distinct from the server's own handles.

--- a/packages/gateway/src/briefs/poll-until-terminal.ts
+++ b/packages/gateway/src/briefs/poll-until-terminal.ts
@@ -1,0 +1,70 @@
+/**
+ * Test-only: wait for a run to reach a terminal state, bounded by WALL-CLOCK time.
+ *
+ * WHY NOT AN ITERATION COUNT. Every caller of this used to loop a fixed number of times with a
+ * 5 ms sleep between polls, which makes the real budget `n * (sleep + one loopback round trip)`
+ * — a quantity that depends entirely on how fast the machine answers HTTP. On the `windows-2025`
+ * CI runner a round trip can cost hundreds of milliseconds, and `briefs/brief-e2e.test.ts`'s
+ * 200-iteration loop was measured hitting the harness's own 60 s timeout BEFORE exhausting its
+ * iterations (run 32452626344: 60006.53 ms, a 6.53 ms overshoot, so the timer fired on schedule
+ * and the loop was still going). The failure therefore surfaced as a bare
+ * "this test timed out after 60000ms" rather than as this helper's own message, and the CI
+ * retry wrapper re-ran the whole 831-file suite — about eleven extra minutes.
+ *
+ * A deadline fixes both halves. A slow runner spends its budget on fewer, more expensive polls
+ * instead of falling off the end of a counter, and when the budget IS exhausted the throw says
+ * what actually happened, well inside the harness timeout.
+ *
+ * The default sleep is deliberately larger than the old 5 ms: at 5 ms a slow runner spends its
+ * whole budget issuing requests, and the polling itself becomes the load.
+ */
+
+const DEFAULT_BUDGET_MS = 20_000;
+const DEFAULT_SLEEP_MS = 25;
+
+export type TerminalBody = { status: string; report?: unknown; failureReason?: string };
+
+export type PollOptions = {
+  /** Wall-clock budget. Keep it well under the test timeout so this throws first. */
+  budgetMs?: number;
+  sleepMs?: number;
+};
+
+/**
+ * Poll `GET {base}/v1/briefs/{id}` until `status` is `done` or `failed`.
+ *
+ * Throws — naming the elapsed time, the poll count and the last status seen — rather than
+ * returning a non-terminal body, so a caller can never mistake "still running" for a result.
+ */
+export async function pollBriefUntilTerminal(
+  base: string,
+  token: string,
+  id: string,
+  opts?: PollOptions,
+): Promise<TerminalBody> {
+  const budgetMs = opts?.budgetMs ?? DEFAULT_BUDGET_MS;
+  const sleepMs = opts?.sleepMs ?? DEFAULT_SLEEP_MS;
+  const deadline = Date.now() + budgetMs;
+
+  let polls = 0;
+  let lastStatus = "<never polled>";
+  const startedAt = Date.now();
+
+  while (Date.now() < deadline) {
+    const res = await fetch(`${base}/v1/briefs/${id}`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    polls++;
+    if (res.status !== 200) throw new Error(`unexpected GET status ${String(res.status)}`);
+    const body = (await res.json()) as TerminalBody;
+    lastStatus = body.status;
+    if (body.status === "done" || body.status === "failed") return body;
+    await new Promise((r) => setTimeout(r, sleepMs));
+  }
+
+  throw new Error(
+    `brief run ${id} never reached a terminal state: ${String(polls)} polls over ` +
+      `${String(Date.now() - startedAt)} ms (budget ${String(budgetMs)} ms), last status ` +
+      `"${lastStatus}"`,
+  );
+}

--- a/packages/gateway/src/index/migrated-db-template.test.ts
+++ b/packages/gateway/src/index/migrated-db-template.test.ts
@@ -1,0 +1,164 @@
+import { Database } from "bun:sqlite";
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalIndex } from "./local-index.ts";
+import {
+  cleanupMigratedDbTemplate,
+  materializeMigratedDb,
+  openMigratedDb,
+  openMigratedMemoryDb,
+} from "./migrated-db-template.ts";
+
+const roots: string[] = [];
+
+function freshDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "migrated-tpl-test-"));
+  roots.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+  cleanupMigratedDbTemplate();
+});
+
+/** Every object SQLite reports, name + type + normalized DDL, as a comparable snapshot. */
+function schemaSnapshot(db: Database): string {
+  const rows = db
+    .query("SELECT type, name, COALESCE(sql, '') AS sql FROM sqlite_master ORDER BY type, name")
+    .all() as { type: string; name: string; sql: string }[];
+  return rows.map((r) => `${r.type}\t${r.name}\t${r.sql.replace(/\s+/g, " ").trim()}`).join("\n");
+}
+
+/**
+ * The load-bearing assertion for this module. If a copied template ever stops matching what
+ * `LocalIndex.ensureSchema` builds, every harness that switched to the copy is silently testing
+ * against a different schema than production migrates to — so this compares the FULL
+ * `sqlite_master` contents, not just the user_version, which would pass on a missing table.
+ */
+test("a copied template is schema-identical to a freshly migrated database", () => {
+  const fresh = new Database(join(freshDir(), "fresh.db"));
+  LocalIndex.ensureSchema(fresh);
+
+  const copied = openMigratedDb(join(freshDir(), "copied.db"));
+
+  expect(schemaSnapshot(copied)).toBe(schemaSnapshot(fresh));
+  expect((copied.query("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(
+    (fresh.query("PRAGMA user_version").get() as { user_version: number }).user_version,
+  );
+  expect((copied.query("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(
+    LocalIndex.SCHEMA_VERSION,
+  );
+
+  fresh.close();
+  copied.close();
+});
+
+/**
+ * The in-memory path is a second reader of the same template, so it gets the same proof. A
+ * `deserialize` that silently produced an empty or older database would otherwise look fine —
+ * the tests using it construct their own rows anyway.
+ */
+test("an in-memory database from the template is schema-identical to a migrated one", () => {
+  const fresh = new Database(":memory:");
+  LocalIndex.ensureSchema(fresh);
+
+  const mem = openMigratedMemoryDb();
+
+  expect(schemaSnapshot(mem)).toBe(schemaSnapshot(fresh));
+  expect((mem.query("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(
+    LocalIndex.SCHEMA_VERSION,
+  );
+  expect((mem.query("PRAGMA foreign_keys").get() as { foreign_keys: number }).foreign_keys).toBe(1);
+
+  fresh.close();
+  mem.close();
+});
+
+test("two in-memory databases from the template are independent", () => {
+  const a = openMigratedMemoryDb();
+  const b = openMigratedMemoryDb();
+
+  a.run(
+    `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at)
+     VALUES ('only-in-a', 'github', 'pr', 'x', 'x', 0, 0)`,
+  );
+
+  expect((a.query("SELECT COUNT(*) AS n FROM item").get() as { n: number }).n).toBe(1);
+  expect((b.query("SELECT COUNT(*) AS n FROM item").get() as { n: number }).n).toBe(0);
+
+  a.close();
+  b.close();
+});
+
+/**
+ * Cleanup must be re-entrant AND non-destructive to the run that continues after it. The second
+ * call has nothing to remove and must not throw; the call after that must still hand back a
+ * usable database, because the template is rebuilt lazily rather than assumed to exist. Without
+ * that property, `cleanupMigratedDbTemplate` firing early (it is registered on `exit`, and a
+ * test file may call it in an `afterAll`) would break every later caller in the same process.
+ */
+test("cleanup is re-entrant, and the template rebuilds itself afterwards", () => {
+  openMigratedDb(join(freshDir(), "before-cleanup.db")).close();
+
+  cleanupMigratedDbTemplate();
+  expect(() => cleanupMigratedDbTemplate()).not.toThrow();
+
+  const after = openMigratedDb(join(freshDir(), "after-cleanup.db"));
+  expect((after.query("PRAGMA user_version").get() as { user_version: number }).user_version).toBe(
+    LocalIndex.SCHEMA_VERSION,
+  );
+  after.close();
+});
+
+test("openMigratedDb enables foreign keys, as ensureSchema does", () => {
+  const db = openMigratedDb(join(freshDir(), "fk.db"));
+  expect((db.query("PRAGMA foreign_keys").get() as { foreign_keys: number }).foreign_keys).toBe(1);
+  db.close();
+});
+
+/**
+ * The isolation property the per-test `ensureSchema` pattern was buying. Sharing the template
+ * must not become sharing the database — a row written through one handle must be invisible to
+ * another caller's, or the speedup would have traded away the thing the tests rely on.
+ */
+test("two databases from the same template are independent files", () => {
+  const a = openMigratedDb(join(freshDir(), "a.db"));
+  const b = openMigratedDb(join(freshDir(), "b.db"));
+
+  a.run(
+    `INSERT INTO item (id, service, type, external_id, title, modified_at, synced_at)
+     VALUES ('only-in-a', 'github', 'pr', 'x', 'x', 0, 0)`,
+  );
+
+  expect((a.query("SELECT COUNT(*) AS n FROM item").get() as { n: number }).n).toBe(1);
+  expect((b.query("SELECT COUNT(*) AS n FROM item").get() as { n: number }).n).toBe(0);
+
+  a.close();
+  b.close();
+});
+
+/**
+ * `materializeMigratedDb` exists for harnesses that migrate a path and then let something else
+ * open it. If the copy left a handle open, or left WAL content stranded in a sidecar the copy
+ * did not carry, a second connection would see an unmigrated or partially-migrated file.
+ */
+test("materializeMigratedDb leaves a complete file no handle is holding", () => {
+  const path = join(freshDir(), "handed-off.db");
+  materializeMigratedDb(path);
+
+  const reopened = new Database(path, { create: false, readwrite: true });
+  expect(
+    (reopened.query("PRAGMA user_version").get() as { user_version: number }).user_version,
+  ).toBe(LocalIndex.SCHEMA_VERSION);
+  expect(
+    (
+      reopened.query("SELECT COUNT(*) AS n FROM sqlite_master WHERE name = 'item'").get() as {
+        n: number;
+      }
+    ).n,
+  ).toBe(1);
+  reopened.close();
+});

--- a/packages/gateway/src/index/migrated-db-template.ts
+++ b/packages/gateway/src/index/migrated-db-template.ts
@@ -1,0 +1,128 @@
+import { Database } from "bun:sqlite";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dbRun } from "../db/write.ts";
+import { LocalIndex } from "./local-index.ts";
+import { readIndexedUserVersion } from "./migrations/runner.ts";
+import { ensureSqliteVecForConnection } from "./sqlite-vec-load.ts";
+
+/**
+ * A migrated-once SQLite template that test harnesses copy instead of re-migrating.
+ *
+ * WHY THIS EXISTS. Hundreds of tests build a throwaway index by calling
+ * `LocalIndex.ensureSchema` on a fresh file, which replays every migration from zero. That is
+ * the right shape — each test gets a private database no sibling can see — but the migration
+ * replay is pure repetition, and on the `windows-2025` CI runner it dominates the gateway
+ * suite. Measured on a dev machine with `LocalIndex.SCHEMA_VERSION` at 55:
+ *
+ *   migrations only      146.5 ms
+ *   vec load only          0.5 ms
+ *   copy template + vec    2.7 ms   <- this module
+ *   full ensureSchema    142.8 ms
+ *
+ * The isolation property is unchanged: every caller still gets its own file on disk. Only the
+ * *construction* is shared, and it is shared through a byte copy, not a shared handle.
+ *
+ * WHY THE TEMPLATE IS BUILT BY `ensureSchema` AND NOT BY A HAND-LISTED MIGRATION SET. Calling
+ * the production entry point is what makes the copy definitionally identical to what a caller
+ * would have built itself. A hand-rolled equivalent could drift from `ensureSchema` silently,
+ * which is exactly the class of bug a test harness must not introduce.
+ *
+ * WHY THE HANDLE IS CLOSED BEFORE THE FILE IS COPIED. An open SQLite connection may hold
+ * committed pages in a `-wal` sidecar that a single-file copy would leave behind. Closing
+ * checkpoints them into the main database first, so the copy is complete. `templatePath()`
+ * therefore never hands back a path whose builder connection is still open.
+ */
+
+let templateDir: string | undefined;
+let templateFile: string | undefined;
+
+function templatePath(): string {
+  if (templateFile !== undefined) return templateFile;
+
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-schema-tpl-"));
+  const file = join(dir, "template.db");
+
+  const db = new Database(file);
+  try {
+    LocalIndex.ensureSchema(db);
+  } finally {
+    // Checkpoints any WAL content into the main file — see the note above.
+    db.close();
+  }
+
+  templateDir = dir;
+  templateFile = file;
+  return file;
+}
+
+/**
+ * Copy the migrated template to `dbPath`, leaving the file closed.
+ *
+ * For callers that migrate a path and then hand it to something which opens its own handles —
+ * `brief-test-server.ts` and `agent-test-server.ts` both do exactly that, and their setup
+ * connection must not linger.
+ */
+export function materializeMigratedDb(dbPath: string): void {
+  copyFileSync(templatePath(), dbPath);
+}
+
+/**
+ * Drop-in replacement for `new Database(dbPath)` followed by `LocalIndex.ensureSchema(db)`.
+ *
+ * The per-connection work `ensureSchema` does after migrating — loading sqlite-vec and turning
+ * foreign keys on — is NOT part of the file and so is redone here for the new handle. That is
+ * the 2.7 ms, and skipping it would hand back a connection that behaves differently from one
+ * `ensureSchema` produced.
+ */
+export function openMigratedDb(dbPath: string): Database {
+  materializeMigratedDb(dbPath);
+  const db = new Database(dbPath);
+  ensureSqliteVecForConnection(db, readIndexedUserVersion(db));
+  dbRun(db, "PRAGMA foreign_keys = ON");
+  return db;
+}
+
+let templateBytes: Uint8Array | undefined;
+
+/**
+ * The `:memory:` counterpart of {@link openMigratedDb}, for harnesses that never wanted a file.
+ *
+ * `Database.deserialize` rehydrates a serialized image into a NEW in-memory database, so each
+ * caller still gets a private one — the same isolation the file copy preserves. The image is
+ * taken from the same on-disk template, which is what keeps the two paths from drifting: there
+ * is one migrated artifact, read two ways.
+ */
+export function openMigratedMemoryDb(): Database {
+  if (templateBytes === undefined) {
+    const src = new Database(templatePath(), { readonly: true });
+    try {
+      templateBytes = src.serialize();
+    } finally {
+      src.close();
+    }
+  }
+  const db = Database.deserialize(templateBytes);
+  ensureSqliteVecForConnection(db, readIndexedUserVersion(db));
+  dbRun(db, "PRAGMA foreign_keys = ON");
+  return db;
+}
+
+/**
+ * Remove the template directory. Registered on `exit` so a test run does not leave a temp
+ * directory behind; safe to call more than once, and safe to call when no template was built.
+ */
+export function cleanupMigratedDbTemplate(): void {
+  if (templateDir === undefined) return;
+  try {
+    rmSync(templateDir, { recursive: true, force: true });
+  } catch {
+    /* a locked file on Windows is not worth failing a test run over */
+  }
+  templateDir = undefined;
+  templateFile = undefined;
+  templateBytes = undefined;
+}
+
+process.on("exit", cleanupMigratedDbTemplate);

--- a/packages/gateway/src/ipc/diagnostics-rpc.test.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.test.ts
@@ -1,10 +1,11 @@
-import { Database } from "bun:sqlite";
+import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
 import { upsertGraphEntity, upsertGraphRelation } from "../graph/relationship-graph.ts";
 import { LocalIndex } from "../index/local-index.ts";
+import { openMigratedDb } from "../index/migrated-db-template.ts";
 import type { SandboxRunner } from "../platform/sandbox/sandbox-runner.ts";
 import { recordPrChangedFiles } from "../prfiles/pr-changed-file-store.ts";
 import type { DiagnosticsRpcContext } from "./diagnostics-rpc.ts";
@@ -45,8 +46,9 @@ function makeCtxWithIndex(dataDir: string): {
   db: Database;
   localIndex: LocalIndex;
 } {
-  const db = new Database(join(dataDir, "nimbus.db"));
-  LocalIndex.ensureSchema(db);
+  // Copies a migrated template rather than replaying 55 migrations per test — this helper is
+  // called by 68 tests in this file, which made it the single slowest file in the Windows suite.
+  const db = openMigratedDb(join(dataDir, "nimbus.db"));
   const localIndex = new LocalIndex(db);
   const ctx: DiagnosticsRpcContext = {
     dataDir,

--- a/packages/gateway/src/platform/assemble.test.ts
+++ b/packages/gateway/src/platform/assemble.test.ts
@@ -1,4 +1,4 @@
-import { Database } from "bun:sqlite";
+import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   existsSync,
@@ -18,8 +18,7 @@ import { writeConnectorSecret } from "../connectors/connector-vault.ts";
 import { THIS_BINARY_COVERAGE } from "../egress/egress-coverage.ts";
 import { appendEgressEntry } from "../egress/egress-ledger.ts";
 import { coverageForWindow } from "../egress/egress-verify.ts";
-import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
-import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
+import { openMigratedMemoryDb } from "../index/migrated-db-template.ts";
 import type { Syncable } from "../sync/types.ts";
 import {
   appendBootMarkerOrWarn,
@@ -47,8 +46,10 @@ describe("assemblePlatformServices (smoke)", () => {
 describe("appendBootMarkerOrWarn", () => {
   let db: Database;
   beforeEach(() => {
-    db = new Database(":memory:");
-    runIndexedSchemaMigrations(db, CURRENT_SCHEMA_VERSION);
+    // Rehydrates a template migrated once per process instead of replaying every migration for
+    // each of this block's tests — see `migrated-db-template.ts`. Still a private in-memory
+    // database per test; `deserialize` builds a new one from the image, it does not share it.
+    db = openMigratedMemoryDb();
   });
   afterEach(() => db.close());
 

--- a/scripts/coverage-floor/exclusions.ts
+++ b/scripts/coverage-floor/exclusions.ts
@@ -65,6 +65,15 @@ export const EXCLUSIONS: readonly ExclusionPattern[] = Object.freeze([
   { kind: "exact", path: "packages/gateway/src/agent-runs/agent-test-server.ts" },
   // `http-api-test-server.ts` is the third harness of this shape — same reason.
   { kind: "exact", path: "packages/gateway/src/ipc/http-api-test-server.ts" },
+  // `poll-until-terminal.ts` is the fourth: test-only, not `.test.ts`-suffixed, imported by the
+  // brief suites rather than redefined in each. Its uncovered branches are exactly the ones a
+  // harness exists to have — the non-200 bail-out and the budget-exhausted throw fire only when
+  // the surface under test is already broken, so exercising them would mean asserting on a
+  // deliberately broken server. Its SIBLING `migrated-db-template.ts` is deliberately NOT
+  // exempted: that one carries a load-bearing claim (a copied template is schema-identical to a
+  // freshly migrated database) and is tested directly, so it earns its coverage rather than an
+  // exemption.
+  { kind: "exact", path: "packages/gateway/src/briefs/poll-until-terminal.ts" },
   // `test-token-vault.ts` is the in-memory seeded Vault those harnesses share. It was extracted
   // from `brief-test-server.ts` + `agent-test-server.ts` (both already excluded here) when their
   // byte-identical copies were deduplicated, so it inherits their exemption rather than earning a


### PR DESCRIPTION
P1 and P2 from the CI critical-path spec that lands in #1289. Run
32452626344 took 31m11s, and the critical path was the Windows
cross-platform job at 30m35s, not the 12-minute Unit + Coverage job.
This attacks that job from two directions.

## P2 — stop replaying 55 migrations per test

Hundreds of tests build a throwaway index by calling
`LocalIndex.ensureSchema` on a fresh file, which replays every migration
from zero. The shape is right: each test gets a private database no
sibling can see. The replay is pure repetition, and on the
`windows-2025` runner it dominates.

Measured on a dev machine at `LocalIndex.SCHEMA_VERSION` 55:

```
migrations only      146.5 ms
vec load only          0.5 ms
copy template + vec    2.7 ms
full ensureSchema    142.8 ms
```

New `packages/gateway/src/index/migrated-db-template.ts` builds the
schema once per process and hands out byte copies. The isolation
property is unchanged — every caller still gets its own file, or its own
deserialized in-memory database. Only the construction is shared.

The template is built by calling `LocalIndex.ensureSchema` itself, not by
a hand-listed migration set, so a copy is definitionally identical to
what a caller would have built. Its builder connection is closed before
the file is copied, so any WAL content is checkpointed in first and the
copy is complete.

Three exports, each with a reason to exist separately: `openMigratedDb`
replaces `new Database(p)` plus `ensureSchema`; `materializeMigratedDb`
leaves a complete file with no handle on it, which is what the two HTTP
test servers need because the server opens its own handles;
`openMigratedMemoryDb` serves the `:memory:` callers via
serialize/deserialize.

## P1 — the flake, and the retry that hid it

The Windows job ran the gateway suite twice. Attempt 1 took 882.41s and
exited 1; attempt 2 took 646.58s and passed. One test failed:

```
packages\gateway\src\briefs\brief-e2e.test.ts
(fail) leak check: the bearer token, the fed source body, and its URL
       never appear in any response or audit row [60006.53ms]
```

The overshoot is 6.53 ms, so the harness timer fired on schedule and the
event loop was responsive. That rules out starvation. The test polls up
to 200 times with a 5 ms sleep, which makes its real budget 200 times
sleep-plus-one-loopback-round-trip. At roughly 300 ms per round trip on
a loaded runner that reaches 60 s before the iteration counter runs out,
so the test died on the harness timeout rather than on its own error
message.

New `poll-until-terminal.ts` replaces the iteration count with a
wall-clock deadline and raises the sleep to 25 ms. A slow runner now
spends its budget on fewer, more expensive polls, and an exhausted
budget throws naming the elapsed time, the poll count and the last
status seen. The leak-check test keeps its own inline loop, because its
assertion inspects every response body it saw, but gets the same
deadline treatment.

Both retry wrappers now surface what they retried. Attempt 1's output
goes to a file, is echoed to the log unchanged, and its failing test
names become annotations plus a job-summary block; a second attempt that
passes says so explicitly. Redirect-then-cat rather than a pipe into
tee, because a pipeline makes the shell variable the exit code of the
last command and would silently turn every failure into a success. The
logs go to RUNNER_TEMP so nothing lands in the workspace that a later
Sonar or artifact step could pick up.

## Measured effect, locally

| File | Before | After |
|---|---|---|
| `ipc/diagnostics-rpc.test.ts` | 13.17 s | 4.34 s |
| `briefs/brief-e2e.test.ts` | 2.25 s | 0.45 s |
| `agent-runs/agent-http-e2e.test.ts` | 2.89 s | 0.44 s |
| `briefs/brief-http.test.ts` | 1.66 s | 0.34 s |
| `platform/assemble.test.ts` | 11.79 s | 11.19 s |
| `embedding/lazy-scheduler.test.ts` | 2.30 s | 2.04 s |
| Total | 34.06 s | 18.80 s |

Two honest notes on that table. `assemble.test.ts` barely moved: only
two of its 24 tests use the migrating `beforeEach`, so its cost is
somewhere else and this change does not address it.
`lazy-scheduler.test.ts` is untouched on purpose — its harness migrates
to version 0 or 30, never to current, so the template does not apply and
forcing it would have been wrong.

On Windows CI these same six files were 447, 232, 159, 139, 95 and 57
seconds across both attempts, which is 74% of the whole suite.

## Verification

`bun run preflight:fast` passes all 30 gates. `bun run verify:docker`
passes every fast-tier gate in the CI Linux image. Every directory that
touches the changed harnesses — ipc, index, platform, briefs, agent-runs
— runs green: 2781 tests across 187 files.

The template's schema-identity test was red-proved by building the
template three versions behind: three of its tests fail, and the
identity test names the first missing table rather than just reporting a
version mismatch. The retry wrapper's control flow was probed against a
stub across four scenarios; the load-bearing one is two genuine failures
propagating attempt 2's exit code rather than reporting green.

`poll-until-terminal.ts` is added to the coverage-floor exclusion
registry as the fourth test-only harness of that shape. Its sibling
`migrated-db-template.ts` is deliberately not excluded: it carries a
load-bearing claim and is tested directly, so it earns its coverage.

One residual risk, stated rather than glossed: the per-file coverage
floor is Linux-authoritative and `verify:docker --full` is the only
local way to run it, which OOMs on this machine. By inspection
`migrated-db-template.ts` has one uncovered line and one uncovered
branch arm, both in a defensive catch, which clears both floors — but
that is reasoning, not a measurement, and CI is the check.
