### PR TITLE
fix(preflight): an unknown service must not pass the deploy gate

### DIFF
--- a/.claude/commands/nimbus-cicd-data-layer.md
+++ b/.claude/commands/nimbus-cicd-data-layer.md
@@ -118,6 +118,15 @@ The function itself is trivial; the heavy lifting is in the SQL the RPC handler 
 
 Verdict is `ok` if all three counts are zero, `warn` otherwise. The CLI's `--mode block` flag flips a `warn` verdict into exit code 1; the calculator itself does not know about modes.
 
+That rule is for a service the gateway could actually evaluate. An **unknown service** — an id in
+neither `[metrics.dora.<id>]` nor `[ci.service.<id>]` — never reaches `computeDeployPreflight` at
+all: `ipc/preflight-rpc.ts`'s `unconfiguredEnvelope` answers it with `verdict: "warn"`, zero counts
+and `gap: "unknown_service"` on all three checks, so `--mode block` blocks. It returned `ok` until
+F24a. **Do not "simplify" that back to `ok` on the grounds that the counts are zero** — zero counts
+there mean nothing was checked. And do not close it by adding a third `verdict` value: the
+first-party Action's `safeVerdict` coerces any value it does not recognise, so a new verdict would
+arrive at an already-published Action as `ok`.
+
 ## Deployment Annotation
 
 `annotateDeployment` validates the input, derives the `external_id` (`<provider>:<sha>:<env>`), and writes three rows in one transaction via `dbRun` (invariant I14):

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -957,6 +957,13 @@ nimbus deploy preflight --service payment-service --target-ref release/v2.14 --m
 
 **Exit codes:** `0` = ok (or `warn` mode with findings); `1` = `block` mode triggered or usage error; `2` = infrastructure failure (gateway not running, IPC error, malformed envelope).
 
+**An unknown service does not pass the gate.** If `--service <id>` matches neither
+`[metrics.dora.<id>]` nor `[ci.service.<id>]` in `nimbus.toml`, none of the three checks can run,
+so the verdict is **`warn`** with `unknown_service` on every check — `--mode block` exits 1. It is
+deliberately not `ok`: a typo'd or renamed service id is the most likely misconfiguration of a
+deploy gate, and the counts being zero means "nothing was checked", not "nothing was found". The
+same envelope is served over `GET /v1/preflight/deploy`, so the GitHub Action blocks too.
+
 A first-party GitHub Action wraps `GET /v1/preflight/deploy` for use directly in workflows — see [`packages/github-actions/preflight-query/`](../packages/github-actions/preflight-query/).
 
 Read-only; no HITL.

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -183,6 +183,41 @@ describe("runDeployCli — dispatcher", () => {
     expect(out).toContain('"service": "svc"');
   });
 
+  // F24a, end to end: the exact shape the gateway now returns for a service that is not in
+  // nimbus.toml — verdict `warn`, zero counts, `unknown_service` on all three checks — must
+  // BLOCK. Before the fix this envelope carried `verdict: "ok"` and the gate exited 0, so a
+  // typo'd or renamed service id let a deploy through silently. This is the assertion that
+  // fails if the fail-open is ever reintroduced at either end.
+  it("blocks on an unknown service: --mode block exits non-zero on an unknown_service warn", async () => {
+    const envelope = {
+      service: "totally-made-up",
+      target_ref: "main",
+      verdict: "warn" as const,
+      computed_at: "2026-05-22T00:00:00Z",
+      checks: {
+        active_p1_incidents: { count: 0, findings: [], gap: "unknown_service" },
+        failing_ci_runs: { count: 0, findings: [], gap: "unknown_service" },
+        merge_conflicts: { count: 0, findings: [], gap: "unknown_service" },
+      },
+    };
+    const mock = createMockIpcClient([envelope]);
+    setFixture({ gatewayState: { socketPath: FAKE_SOCKET_PATH }, ipcClient: mock.client });
+    await expect(
+      runDeployCli([
+        "preflight",
+        "--service",
+        "totally-made-up",
+        "--target-ref",
+        "main",
+        "--mode",
+        "block",
+      ]),
+    ).rejects.toThrow(/process\.exit/);
+    const out = stdoutChunks.join("");
+    expect(out).toContain("[warn]");
+    expect(out).toContain("unknown_service");
+  });
+
   it("triggers the block-exit branch when --mode block AND verdict warn", async () => {
     const envelope = {
       service: "svc",

--- a/packages/gateway/openapi/v1.yaml
+++ b/packages/gateway/openapi/v1.yaml
@@ -312,7 +312,19 @@ components:
         gap:
           nullable: true
           type: string
-          enum: [no_pagerduty_mapping, no_repos, no_deployment_data, low_sample, approximate_lead_time]
+          # Mirrors `DoraGap` in src/metrics/dora.ts. `unknown_service` (F24b) means the id is in
+          # neither [metrics.dora.<id>] nor [ci.service.<id>]; `no_repos` means it exists with no
+          # repos bound. `mixed_source` was already missing here — synced in the same pass.
+          enum:
+            [
+              unknown_service,
+              no_pagerduty_mapping,
+              no_repos,
+              no_deployment_data,
+              low_sample,
+              approximate_lead_time,
+              mixed_source,
+            ]
     DeployPreflightResult:
       type: object
       required: [service, target_ref, computed_at, verdict, checks]
@@ -363,7 +375,16 @@ components:
     PreflightGap:
       nullable: true
       type: string
-      enum: [no_pagerduty_mapping, no_repos, unknown_mergeable_state]
+      # Mirrors `PreflightGap` in src/preflight/preflight.ts. `pagerduty_urgency_without_priority`
+      # was already missing here — synced in the same pass as `unknown_service` (F24a).
+      enum:
+        [
+          unknown_service,
+          no_pagerduty_mapping,
+          no_repos,
+          unknown_mergeable_state,
+          pagerduty_urgency_without_priority,
+        ]
     IncidentFinding:
       type: object
       required: [id, title, status, severity, opened_at_ms, pagerduty_service_id, url]

--- a/packages/gateway/src/ipc/http-server.test.ts
+++ b/packages/gateway/src/ipc/http-server.test.ts
@@ -544,14 +544,16 @@ describe("startReadOnlyHttpServer — simple read-only routes", () => {
     expect(typeof body.error).toBe("string");
   });
 
-  it("GET /v1/preflight/deploy returns a 200 unconfigured envelope for an unknown service", async () => {
+  it("GET /v1/preflight/deploy returns a 200 unconfigured envelope that verdicts warn for an unknown service", async () => {
     const res = await fetch(
       `http://127.0.0.1:${handle!.port}/v1/preflight/deploy?service=github&target_ref=main&max_findings=5`,
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { service: string; verdict: string };
     expect(body.service).toBe("github");
-    expect(body.verdict).toBe("ok");
+    // F24a: the HTTP route shares `dispatchPreflightRpc`, so an unknown service verdicts `warn`
+    // here too. This is the route the first-party GitHub Action calls.
+    expect(body.verdict).toBe("warn");
   });
 });
 

--- a/packages/gateway/src/ipc/metrics-rpc.ts
+++ b/packages/gateway/src/ipc/metrics-rpc.ts
@@ -99,9 +99,21 @@ function requireStatsParams(params: unknown): {
   };
 }
 
+/**
+ * `metrics.dora` answers an unconfigured service softly, with a fixed set of four all-null metric
+ * slots, where `metrics.stats` refuses (see the comment in `dispatchMetricsRpc` below). That
+ * asymmetry is about SHAPE and is kept: `dora` has four fixed slots it can place-hold, `stats`
+ * has a series whose bucket count and unit depend on config it does not have.
+ *
+ * What changed (F24b) is the gap LABEL. These slots used to report `no_repos`, which states that
+ * the service exists and has no repositories bound — a different and much more fixable-looking
+ * problem than "this service key was never defined". A reader, or an agent calling the
+ * `getDoraMetrics` MCP tool, would go looking for repos to bind to a service that does not exist.
+ * `DoraGap` now carries `unknown_service`, and the renderer prints whatever gap it is handed.
+ */
 function unconfiguredEnvelope(service: string, sinceMs: number, nowMs: number): DoraMetricsResult {
   const placeholder = (unit: string) =>
-    ({ value: null, unit, sample: 0, gap: "no_repos" as const }) as const;
+    ({ value: null, unit, sample: 0, gap: "unknown_service" as const }) as const;
   return {
     service,
     since_ms: sinceMs,

--- a/packages/gateway/src/ipc/preflight-rpc.ts
+++ b/packages/gateway/src/ipc/preflight-rpc.ts
@@ -80,6 +80,25 @@ function requireParams(params: unknown): {
   return { service, targetRef, maxFindings };
 }
 
+/**
+ * The service id is in neither `[metrics.dora.<id>]` nor `[ci.service.<id>]`, so not one of the
+ * three checks could run.
+ *
+ * Verdict is `warn`, NOT `ok` (F24a). `--mode block` is a deploy gate and its only mechanism is
+ * the exit code: `commands/deploy.ts` exits 1 when `mode === "block" && verdict === "warn"`, and
+ * the first-party Action's `decideExitCode` does the same. Returning `ok` here made a typo'd or
+ * renamed service id pass the gate silently — a healthy service and a nonexistent one produced
+ * byte-identical envelopes apart from their gap labels.
+ *
+ * `warn` rather than a new third verdict, deliberately: the published Action's `safeVerdict`
+ * coerces every value it does not recognise, so a `"unknown_service"` VERDICT would arrive at an
+ * already-deployed Action as `ok` and reintroduce the same fail-open one layer out. `warn` is the
+ * only value that fails closed in every consumer, old and new. The reason travels in the gap
+ * instead, which is a free-form string on the wire and degrades to a printed label.
+ *
+ * Counts stay 0 with no findings: this is "could not evaluate", not "found three problems", and
+ * the gap is what distinguishes them.
+ */
 function unconfiguredEnvelope(
   service: string,
   targetRef: string,
@@ -89,15 +108,11 @@ function unconfiguredEnvelope(
     service,
     target_ref: targetRef,
     computed_at: new Date(nowMs).toISOString(),
-    verdict: "ok",
+    verdict: "warn",
     checks: {
-      active_p1_incidents: {
-        count: 0,
-        findings: [],
-        gap: "no_pagerduty_mapping",
-      },
-      failing_ci_runs: { count: 0, findings: [], gap: "no_repos" },
-      merge_conflicts: { count: 0, findings: [], gap: "no_repos" },
+      active_p1_incidents: { count: 0, findings: [], gap: "unknown_service" },
+      failing_ci_runs: { count: 0, findings: [], gap: "unknown_service" },
+      merge_conflicts: { count: 0, findings: [], gap: "unknown_service" },
     },
   };
 }

--- a/packages/gateway/src/metrics/dora.ts
+++ b/packages/gateway/src/metrics/dora.ts
@@ -4,6 +4,10 @@ import { distinctCiServiceColumns, distinctPrServiceColumns } from "./dora-confi
 
 export type DoraGap =
   | null
+  // The service id is in neither `[metrics.dora.<id>]` nor `[ci.service.<id>]`. Distinct from
+  // `no_repos`, which means the service EXISTS with no repos bound — a different and much more
+  // fixable-looking problem, and the one `unconfiguredEnvelope` used to report for BOTH. See F24b.
+  | "unknown_service"
   | "no_pagerduty_mapping"
   | "no_repos"
   | "no_deployment_data"

--- a/packages/gateway/src/preflight/preflight.ts
+++ b/packages/gateway/src/preflight/preflight.ts
@@ -4,6 +4,10 @@ import { distinctCiServiceColumns, distinctPrServiceColumns } from "../metrics/d
 
 export type PreflightGap =
   | null
+  // The service id is not in `[metrics.dora.<id>]` or `[ci.service.<id>]` at all, so no check
+  // could run. Distinct from `no_repos`, which means the service EXISTS and has no repos bound
+  // — a different, and much more fixable-looking, problem. See F24.
+  | "unknown_service"
   | "no_pagerduty_mapping"
   | "no_repos"
   | "unknown_mergeable_state"

--- a/packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts
+++ b/packages/gateway/test/e2e/scenarios/metrics-dora.e2e.test.ts
@@ -49,7 +49,10 @@ describe("nimbus metrics dora (e2e, in-process)", () => {
     db.close();
   });
 
-  test("returns null-everywhere envelope with gap='no_repos' when the service is not configured", async () => {
+  // F24b: was `gap='no_repos'`. An id in neither [metrics.dora.<id>] nor [ci.service.<id>] is
+  // `unknown_service`; `no_repos` means the service EXISTS with no repos bound, which is what the
+  // other tests in this suite cover. The soft all-null envelope shape is unchanged.
+  test("returns null-everywhere envelope with gap='unknown_service' when the service is not configured", async () => {
     const db = new Database(":memory:");
     runIndexedSchemaMigrations(db, TARGET_SCHEMA_VERSION);
 
@@ -69,25 +72,25 @@ describe("nimbus metrics dora (e2e, in-process)", () => {
       value: null,
       unit: "deploys_per_day",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(metrics.lead_time_for_changes).toEqual({
       value: null,
       unit: "seconds_median",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(metrics.change_failure_rate).toEqual({
       value: null,
       unit: "ratio",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(metrics.mttr).toEqual({
       value: null,
       unit: "seconds_median",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
 
     db.close();

--- a/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
+++ b/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
@@ -52,7 +52,9 @@ describe("E2E (in-process): deploy.preflight", () => {
     expect(out.value.checks.merge_conflicts.count).toBe(1);
   });
 
-  it("returns ok+gaps envelope when the service has no config", async () => {
+  // F24a: was "returns ok+gaps envelope". An unknown service verdicts `warn` so `--mode block`
+  // blocks; see `unconfiguredEnvelope` in `ipc/preflight-rpc.ts`.
+  it("returns a warn+unknown_service envelope when the service has no config", async () => {
     const out = await dispatchPreflightRpc(
       "deploy.preflight",
       { service: "unknown-service", target_ref: "main" },
@@ -63,7 +65,7 @@ describe("E2E (in-process): deploy.preflight", () => {
       },
     );
     if (out.kind !== "hit") throw new Error("expected hit");
-    expect(out.value.verdict).toBe("ok");
-    expect(out.value.checks.active_p1_incidents.gap).toBe("no_pagerduty_mapping");
+    expect(out.value.verdict).toBe("warn");
+    expect(out.value.checks.active_p1_incidents.gap).toBe("unknown_service");
   });
 });

--- a/packages/gateway/test/unit/ipc/metrics-rpc.test.ts
+++ b/packages/gateway/test/unit/ipc/metrics-rpc.test.ts
@@ -42,7 +42,10 @@ describe("metrics-rpc", () => {
     expect(result.service).toBe("payment-service");
   });
 
-  it("returns null-everywhere envelope when service id has no config", async () => {
+  // F24b: these four slots reported `no_repos` — "the service exists and has no repos bound" —
+  // for a service that was never defined at all. `unknown_service` is the fact. The soft-envelope
+  // SHAPE is unchanged and still deliberate; only the label moved.
+  it("gaps unknown_service, not no_repos, when the service id has no config", async () => {
     const out = await dispatchMetricsRpc(
       "metrics.dora",
       { service: "unknown", since: "30d" },
@@ -54,25 +57,25 @@ describe("metrics-rpc", () => {
       value: null,
       unit: "deploys_per_day",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(m.lead_time_for_changes).toEqual({
       value: null,
       unit: "seconds_median",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(m.change_failure_rate).toEqual({
       value: null,
       unit: "ratio",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
     expect(m.mttr).toEqual({
       value: null,
       unit: "seconds_median",
       sample: 0,
-      gap: "no_repos",
+      gap: "unknown_service",
     });
   });
 

--- a/packages/gateway/test/unit/ipc/preflight-rpc.test.ts
+++ b/packages/gateway/test/unit/ipc/preflight-rpc.test.ts
@@ -46,7 +46,16 @@ describe("preflight-rpc: deploy.preflight", () => {
     expect(out.value.verdict).toBe("warn");
   });
 
-  it("returns an unconfigured envelope (all checks gapped) when service has no config", async () => {
+  // F24a: an unknown service must NOT verdict `ok`. `nimbus deploy preflight --mode block`
+  // blocks on `warn` alone (`commands/deploy.ts`), and the first-party Action's `safeVerdict`
+  // coerces every value that is not literally "warn" to "ok" — so a third verdict value would
+  // be silently downgraded by an already-published Action. "warn" is therefore the only value
+  // that fails closed in every consumer, old and new; the `unknown_service` gap on all three
+  // checks carries the reason.
+  //
+  // This assertion is the INVERSE of the one it replaces, which pinned `verdict: "ok"` for an
+  // unconfigured service. That was the fail-open contract, asserted; it is changed on purpose.
+  it("verdicts `warn` with an unknown_service gap when the service has no config", async () => {
     const out = await dispatchPreflightRpc(
       "deploy.preflight",
       { service: "unknown", target_ref: "main" },
@@ -57,10 +66,24 @@ describe("preflight-rpc: deploy.preflight", () => {
       },
     );
     if (out.kind !== "hit") throw new Error("expected hit");
-    expect(out.value.verdict).toBe("ok");
-    expect(out.value.checks.active_p1_incidents.gap).toBe("no_pagerduty_mapping");
-    expect(out.value.checks.failing_ci_runs.gap).toBe("no_repos");
-    expect(out.value.checks.merge_conflicts.gap).toBe("no_repos");
+    expect(out.value.verdict).toBe("warn");
+    expect(out.value.checks.active_p1_incidents.gap).toBe("unknown_service");
+    expect(out.value.checks.failing_ci_runs.gap).toBe("unknown_service");
+    expect(out.value.checks.merge_conflicts.gap).toBe("unknown_service");
+  });
+
+  // The count half: a `warn` from an unknown service must still carry zero findings, so a
+  // reader cannot mistake "could not evaluate" for "found three problems".
+  it("reports zero counts and no findings for an unknown service", async () => {
+    const out = await dispatchPreflightRpc(
+      "deploy.preflight",
+      { service: "unknown", target_ref: "main" },
+      { db, loadConfig: () => new Map(), nowMs: () => PREFLIGHT_FIXTURE_NOW_MS },
+    );
+    if (out.kind !== "hit") throw new Error("expected hit");
+    expect(out.value.checks.active_p1_incidents.count).toBe(0);
+    expect(out.value.checks.failing_ci_runs.findings).toEqual([]);
+    expect(out.value.checks.merge_conflicts.count).toBe(0);
   });
 
   it("rejects array params with -32602", async () => {

--- a/packages/github-actions/preflight-query/src/main.test.ts
+++ b/packages/github-actions/preflight-query/src/main.test.ts
@@ -167,7 +167,10 @@ function check(count: unknown, findings: unknown, gap: unknown) {
 }
 
 describe("sanitizeEnvelope", () => {
-  test("sanitizes strings, coerces counts, normalizes verdict, and maps findings", () => {
+  // The `verdict: "danger"` input below previously normalized to `"ok"`. That assertion pinned
+  // the fail-open (F24a): an unrecognised verdict became a passing gate. It now normalizes to
+  // `"warn"`, and the change is deliberate.
+  test("sanitizes strings, coerces counts, fails an unrecognised verdict CLOSED, and maps findings", () => {
     const raw = {
       service: "che\x00ckout",
       target_ref: "main",
@@ -182,7 +185,7 @@ describe("sanitizeEnvelope", () => {
 
     const out = sanitizeEnvelope(raw);
     expect(out.service).toBe("checkout");
-    expect(out.verdict).toBe("ok");
+    expect(out.verdict).toBe("warn");
     expect(out.checks.active_p1_incidents.count).toBe(3);
     expect(out.checks.active_p1_incidents.findings[0]).toEqual({
       id: "p1",
@@ -209,5 +212,43 @@ describe("sanitizeEnvelope", () => {
       },
     } as unknown as Envelope;
     expect(sanitizeEnvelope(raw).verdict).toBe("warn");
+  });
+
+  // F24a: `safeVerdict` previously read `raw === "warn" ? "warn" : "ok"`, so EVERY value it did
+  // not recognise — a future third verdict, a typo, a truncated body, `undefined` — became `ok`,
+  // and `decideExitCode` then let a `--mode block` run pass. An unrecognised verdict is exactly
+  // the case where the Action does not know whether it is safe to deploy, so it must fail
+  // CLOSED. Written as what cannot pass: only the literal "ok" yields "ok".
+  it.each([["unknown_service"], ["block"], ["OK"], [""], [undefined], [null], [42]])(
+    "coerces an unrecognised verdict %p to warn, never ok",
+    (verdict) => {
+      const raw = {
+        service: "s",
+        target_ref: "r",
+        computed_at: "c",
+        verdict,
+        checks: {
+          active_p1_incidents: check(0, [], null),
+          failing_ci_runs: check(0, [], null),
+          merge_conflicts: check(0, [], null),
+        },
+      } as unknown as Envelope;
+      expect(sanitizeEnvelope(raw).verdict).toBe("warn");
+    },
+  );
+
+  it("still passes a literal ok through as ok", () => {
+    const raw = {
+      service: "s",
+      target_ref: "r",
+      computed_at: "c",
+      verdict: "ok",
+      checks: {
+        active_p1_incidents: check(0, [], null),
+        failing_ci_runs: check(0, [], null),
+        merge_conflicts: check(0, [], null),
+      },
+    } as unknown as Envelope;
+    expect(sanitizeEnvelope(raw).verdict).toBe("ok");
   });
 });

--- a/packages/github-actions/preflight-query/src/main.ts
+++ b/packages/github-actions/preflight-query/src/main.ts
@@ -19,8 +19,20 @@ import {
 // Re-exported so this package's unit tests can import the pure helpers from main.ts.
 export { getBooleanInput, getInput, getIntInput, safeString };
 
+/**
+ * Fails CLOSED: only the literal `"ok"` yields `"ok"`.
+ *
+ * This previously read `raw === "warn" ? "warn" : "ok"`, so every value it did not recognise —
+ * a verdict the gateway adds later, a typo, a truncated body, `undefined` — became `ok`, and
+ * `decideExitCode` then let a `--mode block` run pass. An unrecognised verdict is precisely the
+ * case where this Action cannot tell whether it is safe to deploy, so the safe default is the one
+ * that blocks. See F24a.
+ *
+ * Keep the direction of this test when adding a verdict value: widen the `"ok"` arm only for
+ * values that genuinely mean "nothing wrong", never by re-inverting the default.
+ */
 function safeVerdict(raw: unknown): "ok" | "warn" {
-  return raw === "warn" ? "warn" : "ok";
+  return raw === "ok" ? "ok" : "warn";
 }
 
 type SanitizedFinding = {


### PR DESCRIPTION
`nimbus deploy preflight --service <not-in-config> --target-ref main --mode block` printed `[ok]`
and exited **0**. The gate passed for a service that does not exist.

```text
$ nimbus deploy preflight --service totally-made-up --target-ref main --mode block
Deploy preflight — totally-made-up @ main  [ok]
  Active P1 incidents             0  [no_pagerduty_mapping]
  Failing CI runs                 0  [no_repos]
  Open PR merge conflicts         0  [no_repos]
$ echo $?
0
```

## Why it failed open

`ipc/preflight-rpc.ts`'s `unconfiguredEnvelope` hard-coded `verdict: "ok"`. The verdict vocabulary
is only `ok | warn`, and both consumers block on `warn` alone — `commands/deploy.ts` and the
Action's `decideExitCode`. So a healthy service and a nonexistent one produced byte-identical
envelopes apart from their gap labels, and a typo'd or renamed `--service` was indistinguishable
from a clean bill of health.

The same dispatcher serves `GET /v1/preflight/deploy`, which is what the first-party
`preflight-query` Action calls, and `render.ts` emits **no annotations at all** on an `ok` verdict.
A workflow whose service id drifted out of `nimbus.toml` went green and silent.

Worth noting the contrast that made this a defect rather than a choice: the Action's
`allow-gateway-failure` defaults to `false`, so an **unreachable gateway** already fails the
workflow. The transport was fail-closed; the configuration was fail-open.

## The fix

`unconfiguredEnvelope` now returns `verdict: "warn"` with `gap: "unknown_service"` on all three
checks and counts still zero. `--mode block` exits 1, the Action annotates, and the reason is
legible.

**`warn`, not a new third verdict** — this is the load-bearing decision. The published Action's
`safeVerdict` read:

```ts
function safeVerdict(raw: unknown): "ok" | "warn" {
  return raw === "warn" ? "warn" : "ok";
}
```

Every value it did not recognise became `ok`. A `verdict: "unknown_service"` would therefore have
arrived at an already-deployed Action as `ok` and reintroduced the identical fail-open one layer
out. `warn` is the only value that fails closed in every consumer, old and new; the reason travels
in the gap, which is a free-form string on the wire.

That coercion is fixed in the same PR, in the safe direction: only the literal `"ok"` now yields
`"ok"`. An unrecognised verdict is precisely the case where the Action cannot tell whether it is
safe to deploy.

**F24b**, same envelope one command over: `metrics dora` reported `no_repos` for a service that was
never defined — "exists, no repositories bound", a different and much more fixable-looking problem,
and what an agent calling the `getDoraMetrics` MCP tool would act on. `DoraGap` gains
`unknown_service`. The soft-envelope **shape** asymmetry with `metrics.stats`, which refuses
outright, is deliberate and documented in `metrics-rpc.ts` and is unchanged — only the label moved.

## Tests

Two pre-existing assertions pinned the fail-open and are **inverted on purpose**, each with a
comment saying so:

- `test/unit/ipc/preflight-rpc.test.ts` asserted `verdict: "ok"` for an unconfigured service.
- `preflight-query/src/main.test.ts` asserted `verdict: "danger"` normalizes to `"ok"` — under the
  name *"normalizes verdict"*.

New coverage: a table-driven check that seven unrecognised verdicts all coerce to `warn` and only
literal `"ok"` survives; zero-count/no-findings assertions so `warn` cannot be misread as "found
three problems"; and an end-to-end CLI test that this exact envelope makes `--mode block` exit
non-zero. That last one was red-proved by disabling the block branch, not by watching it pass.

`packages/gateway/openapi/v1.yaml` had already drifted from both source enums — `PreflightGap` was
missing `pagerduty_urgency_without_priority` and `DoraGap` was missing `mixed_source`. Both synced
here alongside the new member. `audit:openapi-drift` compares routes, not enum members, which is
why it did not catch that.

`bun run preflight:fast` passes; 556 tests across the affected scopes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
