### PR TITLE
fix(ci): make the sandbox spawn suite report why it failed, and gate it on the platforms it is about

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,21 @@ jobs:
         env:
           CI: "true"
 
+      # macOS denials never reach the child's stderr — the kernel logs them, and the process just
+      # dies (SIGABRT -> exit 134 through the wrapper's signal translation) with both streams
+      # empty. That is why two rounds of in-test diagnostics could not name the macOS cause while
+      # the Windows one was legible immediately: on Windows the launcher's own message is on
+      # stderr, on macOS it is nowhere the test can see. This reads it from the one place it
+      # exists. `|| true` so a log-query failure cannot mask the real test failure above.
+      - name: macOS — sandbox denials from the kernel log (on failure only)
+        if: failure() && runner.os == 'macOS' && matrix.pkg == 'gateway'
+        shell: bash
+        run: |
+          echo "Sandbox denials logged in the last 5 minutes:"
+          log show --last 5m --style compact \
+            --predicate 'senderImagePath CONTAINS "Sandbox" OR eventMessage CONTAINS "deny"' \
+            2>/dev/null | grep -iE "deny|sandbox" | head -60 || true
+
   # Code duplication scan — runs in parallel with the above two jobs.
   # Scans only packages/ for code duplication; docs-only PRs can't introduce
   # new code-duplication regressions, so we skip when code-changed is false.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,36 @@ jobs:
         env:
           CI: "true"
 
+      # ── Platform-sensitive integration tests ────────────────────────────────
+      # The step above is scoped to `packages/<pkg>/src`, so it does NOT collect
+      # `packages/gateway/test/integration/`. On the PR gate that integration suite runs on
+      # UBUNTU ONLY, which is how a Windows- and macOS-broken sandbox spawn suite merged green
+      # (#1294): the suite added specifically to prove the wrapper spawns on all three platforms
+      # had never once run on two of them before it reached `main`, and the push matrix found it
+      # minutes after merge.
+      #
+      # This does NOT widen the PR gate to the whole integration suite — that would add minutes
+      # to every PR on two slow runners for tests that are not platform-sensitive. It runs the
+      # named suites whose whole purpose is per-platform behaviour, and nothing else. Add a suite
+      # here only when it genuinely branches on the OS; the Ubuntu integration job stays the
+      # place for everything else.
+      - name: Build sandbox helper (Windows, for the spawn suite below)
+        if: needs.filter.outputs.code-changed == 'true' && matrix.pkg == 'gateway' && runner.os == 'Windows'
+        shell: pwsh
+        run: bun run build:sandbox-helper:win32
+
+      - name: Platform-sensitive integration tests
+        if: needs.filter.outputs.code-changed == 'true' && matrix.pkg == 'gateway'
+        shell: bash
+        # No retry wrapper: these are seconds-long, and a sandbox spawn that fails intermittently
+        # is a finding, not a flake to paper over.
+        run: |
+          bun test \
+            packages/gateway/test/integration/platform/sandbox/ \
+            --timeout 60000
+        env:
+          CI: "true"
+
   # Code duplication scan — runs in parallel with the above two jobs.
   # Scans only packages/ for code duplication; docs-only PRs can't introduce
   # new code-duplication regressions, so we skip when code-changed is false.

--- a/packages/gateway/src/platform/sandbox/canonical-path.test.ts
+++ b/packages/gateway/src/platform/sandbox/canonical-path.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { canonicalPath, canonicalPolicyPaths } from "./canonical-path.ts";
+import type { SandboxPolicy } from "./sandbox-policy.ts";
+
+describe("canonicalPath", () => {
+  it("returns a real directory unchanged when it is already canonical", () => {
+    const dir = mkdtempSync(join(canonicalPath(tmpdir()), "nimbus-canon-"));
+    try {
+      expect(canonicalPath(dir)).toBe(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the input for a path that does not exist", () => {
+    // A policy may legitimately name a directory that has not been created yet. Throwing here
+    // would turn that into a refusal to spawn at all, which is worse than granting the
+    // unresolved form.
+    const missing = join(tmpdir(), "nimbus-canon-definitely-not-here-9f3a1c");
+    expect(canonicalPath(missing)).toBe(missing);
+  });
+
+  it.skipIf(process.platform !== "win32")("expands an 8.3 short name on Windows", () => {
+    // The exact CI failure: a runner's TEMP is C:\Users\RUNNER~1\... because `runneradmin` is
+    // longer than eight characters. `C:\PROGRA~1` is the one 8.3 alias present on every Windows
+    // install, so this asserts the mechanism without creating one.
+    const short = "C:\\PROGRA~1";
+    const long = canonicalPath(short);
+    expect(long).not.toContain("~1");
+    expect(long.toLowerCase()).toContain("program files");
+  });
+
+  it.skipIf(process.platform !== "darwin")("resolves /var to /private/var on macOS", () => {
+    // The SBPL grant is compared against the kernel's path, and /var is a symlink.
+    expect(canonicalPath("/var")).toBe("/private/var");
+  });
+});
+
+describe("canonicalPolicyPaths", () => {
+  const policy: SandboxPolicy = {
+    id: "com.acme.x",
+    permissions: {
+      network: ["api.acme.com"],
+      filesystem: { read: ["/nope/read"], write: ["/nope/write"] },
+    },
+  };
+
+  it("carries id and network through untouched — neither is a path", () => {
+    const out = canonicalPolicyPaths(policy);
+    expect(out.id).toBe("com.acme.x");
+    expect(out.permissions.network).toEqual(["api.acme.com"]);
+  });
+
+  it("maps both filesystem lists, preserving order and length", () => {
+    const out = canonicalPolicyPaths(policy);
+    expect(out.permissions.filesystem.read).toHaveLength(1);
+    expect(out.permissions.filesystem.write).toHaveLength(1);
+  });
+
+  it("does not mutate the policy it was given", () => {
+    const before = JSON.stringify(policy);
+    canonicalPolicyPaths(policy);
+    expect(JSON.stringify(policy)).toBe(before);
+  });
+});

--- a/packages/gateway/src/platform/sandbox/canonical-path.ts
+++ b/packages/gateway/src/platform/sandbox/canonical-path.ts
@@ -1,0 +1,59 @@
+import { realpathSync } from "node:fs";
+
+import type { SandboxPolicy } from "./sandbox-policy.ts";
+
+/**
+ * The path as the KERNEL will see it, which is not always the path the caller typed.
+ *
+ * A sandbox is a comparison between two strings: the one written into the policy and the one the
+ * confined process resolves at runtime. When those disagree the sandbox does not fail open, it
+ * fails in the most confusing possible way — the child is denied a path its policy plainly grants.
+ * Both platforms had a live instance of this:
+ *
+ *  * Windows 8.3 short names. A GitHub runner's `TEMP` is
+ *    `C:\Users\RUNNER~1\AppData\Local\Temp` because `runneradmin` exceeds eight characters. The
+ *    ACL grant lands correctly (the short name resolves to the same directory), but the CHILD
+ *    then has to expand `RUNNER~1` back to `runneradmin`, and that requires listing
+ *    `C:\Users` — an ancestor the shipped leaf-only grant policy deliberately does not open.
+ *    PowerShell reported `Access to the path '...' is denied` while `exit 7` succeeded, because
+ *    only the cases that touched the filesystem ever resolved the name. Reproduced exactly by
+ *    pointing `TEMP` at an 8.3 alias on a developer machine.
+ *
+ *  * macOS `/var` → `/private/var`. `/var` is a symlink, so an SBPL `(subpath "/var/folders/…")`
+ *    grant never matches the `/private/var/folders/…` the kernel checks against.
+ *
+ * `realpathSync.native` is the one that fixes both: the plain `realpathSync` resolves symlinks
+ * but leaves an 8.3 name untouched (measured — `realpathSync("C:\\PROGRA~1")` returns it
+ * unchanged, `.native` returns `C:\Program Files`).
+ *
+ * Falls back to the input when the path cannot be resolved. A policy may legitimately name a
+ * directory that does not exist yet, and refusing to spawn over that would be a worse failure
+ * than granting the unresolved form — which is exactly what happened before this existed.
+ */
+export function canonicalPath(p: string): string {
+  try {
+    return realpathSync.native(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * The same policy with every filesystem path canonicalised.
+ *
+ * Applied together with the cwd at each runner's spawn site, so a grant and the child's view of
+ * the granted directory are always the same string. `network` and `id` are carried through
+ * untouched — neither is a path.
+ */
+export function canonicalPolicyPaths(policy: SandboxPolicy): SandboxPolicy {
+  return {
+    ...policy,
+    permissions: {
+      ...policy.permissions,
+      filesystem: {
+        read: policy.permissions.filesystem.read.map(canonicalPath),
+        write: policy.permissions.filesystem.write.map(canonicalPath),
+      },
+    },
+  };
+}

--- a/packages/gateway/src/platform/sandbox/darwin.test.ts
+++ b/packages/gateway/src/platform/sandbox/darwin.test.ts
@@ -68,3 +68,33 @@ describe("generateSbplProfile", () => {
     expect(profile).toContain(`(subpath "/home/u/docs")`);
   });
 });
+
+describe("generateSbplProfile — startup prerequisites", () => {
+  const profile = generateSbplProfile({
+    cwd: "/tmp/cwd",
+    tmpdir: "/tmp/sbx",
+    policy: { id: "x", permissions: { network: [], filesystem: { read: [], write: [] } } },
+  });
+
+  // Regression guard. Without these the child dies with SIGABRT before it can say why —
+  // silent and total, and it took a post-merge push-matrix failure to find. See the comment
+  // block in darwin.ts for why each one is needed.
+  it("allows sysctl-read, which every runtime does at startup", () => {
+    expect(profile).toContain("(allow sysctl-read)");
+  });
+
+  it("allows the RNG seed and the null sink", () => {
+    expect(profile).toContain('(literal "/dev/urandom")');
+    expect(profile).toContain('(literal "/dev/random")');
+    expect(profile).toContain('(literal "/dev/null")');
+  });
+
+  it("grants /dev by LITERAL, never the whole device tree", () => {
+    // `(subpath "/dev")` would hand the sandbox every raw block device to fix three nodes.
+    expect(profile).not.toContain('(subpath "/dev")');
+  });
+
+  it("still denies by default — the additions are grants, not an opening", () => {
+    expect(profile).toContain("(deny default)");
+  });
+});

--- a/packages/gateway/src/platform/sandbox/darwin.test.ts
+++ b/packages/gateway/src/platform/sandbox/darwin.test.ts
@@ -68,33 +68,3 @@ describe("generateSbplProfile", () => {
     expect(profile).toContain(`(subpath "/home/u/docs")`);
   });
 });
-
-describe("generateSbplProfile — startup prerequisites", () => {
-  const profile = generateSbplProfile({
-    cwd: "/tmp/cwd",
-    tmpdir: "/tmp/sbx",
-    policy: { id: "x", permissions: { network: [], filesystem: { read: [], write: [] } } },
-  });
-
-  // Regression guard. Without these the child dies with SIGABRT before it can say why —
-  // silent and total, and it took a post-merge push-matrix failure to find. See the comment
-  // block in darwin.ts for why each one is needed.
-  it("allows sysctl-read, which every runtime does at startup", () => {
-    expect(profile).toContain("(allow sysctl-read)");
-  });
-
-  it("allows the RNG seed and the null sink", () => {
-    expect(profile).toContain('(literal "/dev/urandom")');
-    expect(profile).toContain('(literal "/dev/random")');
-    expect(profile).toContain('(literal "/dev/null")');
-  });
-
-  it("grants /dev by LITERAL, never the whole device tree", () => {
-    // `(subpath "/dev")` would hand the sandbox every raw block device to fix three nodes.
-    expect(profile).not.toContain('(subpath "/dev")');
-  });
-
-  it("still denies by default — the additions are grants, not an opening", () => {
-    expect(profile).toContain("(deny default)");
-  });
-});

--- a/packages/gateway/src/platform/sandbox/darwin.ts
+++ b/packages/gateway/src/platform/sandbox/darwin.ts
@@ -25,6 +25,26 @@ export function generateSbplProfile(opts: SbplOpts): string {
     "(allow signal (target self))",
     "(allow mach-lookup)",
     "(allow iokit-open)",
+    // ── What a process needs merely to START ────────────────────────────────
+    // Under `(deny default)` these are denied, and the failure is silent and total: the child
+    // dies with SIGABRT (exit 134 through the wrapper's signal translation) having written
+    // nothing to stdout OR stderr, because it never got far enough to have a working stderr.
+    // That is what the first real macOS spawn through this profile did — every case in
+    // sandbox-wrapper-spawn.test.ts, including the trivial "print one line" one.
+    //
+    // `sysctl-read`: every runtime queries CPU count / page size / OS version at startup
+    // (`hw.ncpu`, `hw.memsize`, `kern.osversion`). It reads system SHAPE, never user data.
+    //
+    // `/dev/urandom` + `/dev/random`: the RNG seed. A runtime that cannot seed does not
+    // degrade, it aborts.
+    //
+    // `/dev/null`: the standard sink; a child whose stdio setup writes to it fails at startup.
+    //
+    // These are LITERALS, not `(subpath "/dev")` — the wider grant would hand the sandbox the
+    // whole device tree (`/dev/disk*` raw block devices among them) to fix a three-node problem.
+    "(allow sysctl-read)",
+    '(allow file-read* (literal "/dev/urandom") (literal "/dev/random") (literal "/dev/null"))',
+    '(allow file-write-data (literal "/dev/null"))',
     "(allow file-read*",
     `  (subpath "${opts.cwd}")`,
     `  (subpath "${opts.tmpdir}")`,

--- a/packages/gateway/src/platform/sandbox/darwin.ts
+++ b/packages/gateway/src/platform/sandbox/darwin.ts
@@ -26,26 +26,14 @@ export function generateSbplProfile(opts: SbplOpts): string {
     "(allow signal (target self))",
     "(allow mach-lookup)",
     "(allow iokit-open)",
-    // ── What a process needs merely to START ────────────────────────────────
-    // Under `(deny default)` these are denied, and the failure is silent and total: the child
-    // dies with SIGABRT (exit 134 through the wrapper's signal translation) having written
-    // nothing to stdout OR stderr, because it never got far enough to have a working stderr.
-    // That is what the first real macOS spawn through this profile did — every case in
-    // sandbox-wrapper-spawn.test.ts, including the trivial "print one line" one.
-    //
-    // `sysctl-read`: every runtime queries CPU count / page size / OS version at startup
-    // (`hw.ncpu`, `hw.memsize`, `kern.osversion`). It reads system SHAPE, never user data.
-    //
-    // `/dev/urandom` + `/dev/random`: the RNG seed. A runtime that cannot seed does not
-    // degrade, it aborts.
-    //
-    // `/dev/null`: the standard sink; a child whose stdio setup writes to it fails at startup.
-    //
-    // These are LITERALS, not `(subpath "/dev")` — the wider grant would hand the sandbox the
-    // whole device tree (`/dev/disk*` raw block devices among them) to fix a three-node problem.
-    "(allow sysctl-read)",
-    '(allow file-read* (literal "/dev/urandom") (literal "/dev/random") (literal "/dev/null"))',
-    '(allow file-write-data (literal "/dev/null"))',
+    // NOTE for whoever fixes the macOS SIGABRT: `sysctl-read` and literal grants for
+    // /dev/urandom, /dev/random and /dev/null were added here on the theory that a runtime
+    // cannot start without them, and REMOVED again when the next CI run failed identically.
+    // They may still be necessary — they were demonstrably not sufficient — but widening a
+    // security boundary on an unproven theory is not a trade worth making, and an unnecessary
+    // grant that happens to sit next to a fix is the hardest kind to ever remove. The macOS CI
+    // leg now dumps kernel sandbox denials on failure; add exactly what that log names, and
+    // nothing else.
     "(allow file-read*",
     `  (subpath "${opts.cwd}")`,
     `  (subpath "${opts.tmpdir}")`,

--- a/packages/gateway/src/platform/sandbox/darwin.ts
+++ b/packages/gateway/src/platform/sandbox/darwin.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { parseNetworkEntry } from "../../extensions/permissions-validator.ts";
+import { canonicalPath, canonicalPolicyPaths } from "./canonical-path.ts";
 import type { SandboxPolicy } from "./sandbox-policy.ts";
 import type { SandboxRunner, SandboxSpawnOptions } from "./sandbox-runner.ts";
 
@@ -78,19 +79,26 @@ export function createDarwinSandboxRunner(): SandboxRunner {
   return {
     platform: "darwin",
     spawn(cmd: string, args: string[], opts: SandboxSpawnOptions): ChildProcess {
-      const sandboxDir = mkdtempSync(join(tmpdir(), "nimbus-sandbox-"));
+      // `/var` is a symlink to `/private/var`, so `mkdtempSync(tmpdir())` hands back a path the
+      // kernel never sees. An SBPL `(subpath "/var/folders/…")` grant therefore matches nothing,
+      // and the child is denied the scratch directory its own profile grants it. Canonicalise
+      // the cwd and every policy path for the same reason. See canonical-path.ts.
+      const sandboxDir = canonicalPath(mkdtempSync(join(tmpdir(), "nimbus-sandbox-")));
+      const cwd = canonicalPath(opts.cwd);
       const profilePath = join(sandboxDir, "profile.sb");
       const profile = generateSbplProfile({
-        cwd: opts.cwd,
+        cwd,
         tmpdir: sandboxDir,
-        policy: opts.policy,
+        policy: canonicalPolicyPaths(opts.policy),
       });
       writeFileSync(profilePath, profile);
       // Absolute path to the SIP-protected system binary — never resolve via
       // PATH, which could be attacker-influenced (Sonar S4036 hardening).
       const child = spawn("/usr/bin/sandbox-exec", ["-f", profilePath, cmd, ...args], {
         env: opts.env,
-        cwd: opts.cwd,
+        // The CANONICAL cwd, matching what the profile granted. Spawning into `opts.cwd` here
+        // while granting `cwd` above would reintroduce the mismatch this whole change removes.
+        cwd,
         stdio: opts.stdio,
       });
       child.once("exit", () => {

--- a/packages/gateway/src/platform/sandbox/win32.ts
+++ b/packages/gateway/src/platform/sandbox/win32.ts
@@ -1,7 +1,7 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-
+import { canonicalPath, canonicalPolicyPaths } from "./canonical-path.ts";
 import type { SandboxPolicy } from "./sandbox-policy.ts";
 import type { SandboxRunner, SandboxSpawnOptions } from "./sandbox-runner.ts";
 import { buildHelperArgv } from "./win32-argv.ts";
@@ -56,8 +56,13 @@ export function createWin32SandboxRunner(): SandboxRunner {
           `refusing to spawn unsandboxed on Windows: ${helper.reason ?? "helper unavailable"}`,
         );
       }
-      const argv = [...buildHelperArgv(opts.policy, { cwd: opts.cwd }), cmd, ...args];
-      return spawn(path, argv, { env: opts.env, cwd: opts.cwd, stdio: opts.stdio });
+      // Canonicalise before BOTH the grant and the spawn, and to the SAME value — an ACL applied
+      // to one spelling of a directory while the child runs in another is the failure this
+      // prevents. See canonical-path.ts for the 8.3 short-name case that made it real.
+      const cwd = canonicalPath(opts.cwd);
+      const policy = canonicalPolicyPaths(opts.policy);
+      const argv = [...buildHelperArgv(policy, { cwd }), cmd, ...args];
+      return spawn(path, argv, { env: opts.env, cwd, stdio: opts.stdio });
     },
     isFullyActive(): boolean {
       return helper.available;

--- a/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
+++ b/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
@@ -138,14 +138,30 @@ interface WrapperRun {
 }
 
 /**
- * Substrings that mean THE SANDBOX LAUNCHER ITSELF failed, as opposed to the child running and
- * exiting non-zero. `bwrap:` prefixes every bubblewrap error (`No permissions to create new
- * namespace`, `execvp <path>: No such file or directory`); `nimbus-sandbox-wrapper:` prefixes
- * every `fatal()` in sandbox-wrapper.ts, on all three platforms. Neither is ever printed by a
- * successful launch, so this cannot fire merely because a test expects a non-zero child exit —
- * the exit-7 and denied-77 cases below print nothing.
+ * Should this invocation be dumped? Answered from the SHAPE of the run, never from a list of
+ * known error strings.
+ *
+ * The first version of this matched `["bwrap:", "nimbus-sandbox-wrapper:"]` against stderr — the
+ * Linux launcher and the cross-platform wrapper. It was blind on exactly the two platforms that
+ * then failed on the push matrix: macOS launches through `sandbox-exec` and Windows through
+ * `nimbus-sandbox-helper.exe`, and neither prefix was listed. Both runs reported a bare
+ * `Expected: "hello-from-sandbox" / Received: ""` with the reason nowhere in the log. An
+ * allow-list of failure signatures is the wrong shape for a diagnostic: it can only recognise
+ * failures someone already thought of, and it fails silent on the rest.
+ *
+ * So: dump on anything ANOMALOUS, and let the green path define normal.
+ *  - any stderr at all — no launcher on any platform prints on a clean launch;
+ *  - `status === null` — killed by a signal, which no case here expects;
+ *  - exit 0 with empty stdout — the shape of "the child never really ran". The two cases that
+ *    legitimately produce empty stdout exit 7 and 77, so neither trips this.
+ *
+ * Verified quiet: the five passing cases on this machine produce no dump.
  */
-const LAUNCHER_ERROR_MARKERS = ["bwrap:", "nimbus-sandbox-wrapper:"] as const;
+function isAnomalous(run: WrapperRun): boolean {
+  if (run.stderr.trim() !== "") return true;
+  if (run.status === null) return true;
+  return run.status === 0 && run.stdout === "";
+}
 
 /**
  * Dump everything about an invocation whose sandbox launcher errored.
@@ -163,13 +179,14 @@ const LAUNCHER_ERROR_MARKERS = ["bwrap:", "nimbus-sandbox-wrapper:"] as const;
  * Printing from here keeps every frame pointing at the assertion that failed.
  */
 function reportLauncherError(run: WrapperRun): void {
-  if (!LAUNCHER_ERROR_MARKERS.some((m) => run.stderr.includes(m))) return;
+  if (!isAnomalous(run)) return;
   console.error(
     [
       "",
-      "--- sandbox launcher error (diagnostics, not asserted) ---",
+      "--- sandbox launcher anomaly (diagnostics, not asserted) ---",
       `platform : ${process.platform}`,
       `execPath : ${process.execPath}`,
+      `tmpdir   : ${tmpdir()}`,
       `cwd      : ${run.cwd}`,
       `policy   : ${JSON.stringify(run.policy.permissions)}`,
       `argv     : ${JSON.stringify(run.argv)}`,

--- a/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
+++ b/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
@@ -158,6 +158,17 @@ interface WrapperRun {
  * Verified quiet: the five passing cases on this machine produce no dump.
  */
 function isAnomalous(run: WrapperRun): boolean {
+  // ON CI, DUMP EVERY RUN. Not a placeholder — a decision made after this predicate went blind
+  // TWICE on the same suite:
+  //   1. matching stderr against ["bwrap:", "nimbus-sandbox-wrapper:"] missed macOS's
+  //      `sandbox-exec` and Windows's `nimbus-sandbox-helper.exe` entirely;
+  //   2. the shape-based rewrite below still missed the real macOS failure, which is exit 134
+  //      (SIGABRT, translated by the wrapper's signal handler) with EMPTY stdout AND EMPTY
+  //      stderr — non-zero, non-null, and not exit-0, so it satisfied no clause.
+  // Every attempt to predict which runs are worth reporting has failed against a runner nobody
+  // can log into, and each failure cost a full merge-and-revert cycle. Five runs of ~12 lines is
+  // a trivial price for never paying that again. Local runs keep the quiet heuristic.
+  if (IS_CI) return true;
   if (run.stderr.trim() !== "") return true;
   if (run.status === null) return true;
   return run.status === 0 && run.stdout === "";


### PR DESCRIPTION
Two defects, both mine, both surfaced by #1294 going red on `main` minutes after merge.

## 1. The diagnostic was blind on the platforms that failed

The dump added in #1294 matched stderr against `["bwrap:", "nimbus-sandbox-wrapper:"]` — the Linux launcher and the cross-platform wrapper. macOS launches through `sandbox-exec` and Windows through `nimbus-sandbox-helper.exe`; neither prefix was listed. So both failing runs reported a bare `Expected: "hello-from-sandbox" / Received: ""` with the reason nowhere in the log, on runners nobody can log into.

An allow-list of failure signatures is the wrong shape for a diagnostic: it recognises only failures someone already thought of and fails silent on the rest. It now dumps on anything **anomalous**, derived from the shape of the run rather than from known strings:

- any stderr at all — no launcher prints on a clean launch;
- `status === null` — killed by a signal, which no case expects;
- exit 0 with empty stdout — the shape of "the child never really ran".

The two cases that legitimately produce empty stdout exit 7 and 77, so neither trips it.

**Red-proved** by reproducing the exact CI symptom locally (a child that exits 0 printing nothing): the dump fires with platform, tmpdir, cwd, policy, argv, status, stdout and stderr. **Verified quiet** on the green path — 0 dumps across all five passing cases.

## 2. The PR gate never ran this suite off Linux

`pr-quality`'s cross-platform job runs `bun test packages/<pkg>/src` — scoped to `src/`, so it never collects `packages/gateway/test/integration/`. On the PR gate that integration suite runs on **Ubuntu only**.

That is how a Windows- and macOS-broken spawn suite merged green: the suite written specifically to prove the wrapper spawns on all three platforms had never once run on two of them before reaching `main`. The push matrix found it minutes later.

This does **not** widen the PR gate to the whole integration suite — that would add minutes to every PR on two slow runners for tests that are not platform-sensitive. It adds one step running `packages/gateway/test/integration/platform/sandbox/` (seconds), plus the Windows helper build it needs, both gated on `code-changed` and `pkg == gateway`. Without it, this branch's own fix could not be verified before merge either, and the cycle would repeat.

## What this does NOT fix

The underlying failures. This makes CI say what they are.

Known so far, from the push-matrix logs:

| Platform | Symptom |
| --- | --- |
| macOS | exit **134** (SIGABRT) on every case — the Bun child dies at startup |
| Windows | only the two **stdout-reading** cases fail; exit-code propagation (7) and policy refusal (77) both **pass** |

So on Windows the sandbox itself works and the stdio path does not — a much narrower problem than it first looked. Neither failure reproduces on a local Windows machine, including with output redirected and `CI=true`, which is why the diagnostics come first.

**This PR is expected to go red on the new Windows and macOS steps.** That is the point: it is the first run that will print why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS sandbox startup reliability by allowing required system metadata and device access while preserving restricted access to `/dev`.
  - Added regression coverage for sandbox startup permissions and default-deny behavior.
  - Improved launcher anomaly diagnostics across platforms, including clearer handling of unexpected output and exits.

- **Tests**
  - Expanded cross-platform gateway integration testing in CI, with platform-specific setup and per-test time limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->