### PR TITLE
fix(test): stop the Windows deploy.preflight hook timeout and clear the Sonar backlog

### DIFF
--- a/packages/cli/src/commands/people.ts
+++ b/packages/cli/src/commands/people.ts
@@ -135,62 +135,71 @@ type PeopleListDoc = {
 // render.
 type PeopleListResult = PersonJson[] | PeopleListDoc | MissingSubstrateRefusal;
 
-async function runPeopleList(args: string[]): Promise<void> {
-  const { unlinkedOnly, limit, notReviewed, sinceRaw, explain, wantJson } = parseListFlags(args);
+interface PeopleListParams {
+  unlinkedOnly: boolean;
+  limit: number;
+  notReviewed?: boolean;
+  sinceMs?: number;
+  explain?: boolean;
+}
 
-  let sinceMs: number | undefined;
-  if (sinceRaw !== undefined) {
-    sinceMs = Date.now() - parseSinceDurationToMs(sinceRaw);
-  }
-
-  const params: {
-    unlinkedOnly: boolean;
-    limit: number;
-    notReviewed?: boolean;
-    sinceMs?: number;
-    explain?: boolean;
-  } = { unlinkedOnly, limit };
-  if (notReviewed) {
+/** Omit the optionals rather than sending them undefined, so they don't appear in the request. */
+function buildListParams(f: {
+  unlinkedOnly: boolean;
+  limit: number;
+  notReviewed: boolean;
+  sinceMs: number | undefined;
+  explain: boolean;
+}): PeopleListParams {
+  const params: PeopleListParams = { unlinkedOnly: f.unlinkedOnly, limit: f.limit };
+  if (f.notReviewed) {
     params.notReviewed = true;
   }
-  if (sinceMs !== undefined) {
-    params.sinceMs = sinceMs;
+  if (f.sinceMs !== undefined) {
+    params.sinceMs = f.sinceMs;
   }
-  if (explain) {
+  if (f.explain) {
     params.explain = true;
   }
+  return params;
+}
 
-  const r = await withGatewayIpc((c) => c.call<PeopleListResult>("people.list", params));
+/**
+ * `--not-reviewed` is WINDOWED (spec § 4.4): with no `--since` the window is ALL TIME
+ * ("has not reviewed EVER"), never a silently-narrowed recent window. That must be visible
+ * in what is printed, not just true of what was asked for — otherwise a caller reading the
+ * output has no way to tell an all-time answer from a recent one.
+ *
+ * Extracted from a nested ternary (S3358); the three outcomes now read top to bottom.
+ */
+function windowLineFor(notReviewed: boolean, sinceRaw: string | undefined): string | undefined {
+  if (!notReviewed) {
+    return undefined;
+  }
+  if (sinceRaw !== undefined) {
+    return `Window: reviews since --since ${sinceRaw}`;
+  }
+  return 'Window: ALL TIME — no --since given, so this reports "never reviewed, ever", not a recent window';
+}
 
-  if (isMissingSubstrateRefusal(r)) {
-    printRefusal(r, wantJson);
-    process.exitCode = 1;
+function printListJson(
+  r: PersonJson[] | PeopleListDoc,
+  notReviewed: boolean,
+  sinceRaw: string | undefined,
+  sinceMs: number | undefined,
+): void {
+  if (Array.isArray(r)) {
+    console.log(JSON.stringify(r, null, 2));
     return;
   }
-
-  // `--not-reviewed` is WINDOWED (spec § 4.4): with no `--since` the window is ALL TIME
-  // ("has not reviewed EVER"), never a silently-narrowed recent window. That must be visible
-  // in what is printed, not just true of what was asked for — otherwise a caller reading the
-  // output has no way to tell an all-time answer from a recent one.
-  const windowLine = notReviewed
-    ? sinceRaw !== undefined
-      ? `Window: reviews since --since ${sinceRaw}`
-      : 'Window: ALL TIME — no --since given, so this reports "never reviewed, ever", not a recent window'
-    : undefined;
-
-  if (wantJson) {
-    if (Array.isArray(r)) {
-      console.log(JSON.stringify(r, null, 2));
-      return;
-    }
-    const doc: Record<string, unknown> = { ...r };
-    if (notReviewed) {
-      doc["window"] = { sinceMs: sinceMs ?? 0, allTime: sinceRaw === undefined };
-    }
-    console.log(JSON.stringify(doc, null, 2));
-    return;
+  const doc: Record<string, unknown> = { ...r };
+  if (notReviewed) {
+    doc["window"] = { sinceMs: sinceMs ?? 0, allTime: sinceRaw === undefined };
   }
+  console.log(JSON.stringify(doc, null, 2));
+}
 
+function printListText(r: PersonJson[] | PeopleListDoc, windowLine: string | undefined): void {
   const people = Array.isArray(r) ? r : r.people;
   const gaps = Array.isArray(r) ? undefined : r.gaps;
   const meta = Array.isArray(r) ? undefined : r.meta;
@@ -211,6 +220,28 @@ async function runPeopleList(args: string[]): Promise<void> {
   if (explainBlock !== undefined) {
     printExplainBlock(explainBlock);
   }
+}
+
+async function runPeopleList(args: string[]): Promise<void> {
+  const { unlinkedOnly, limit, notReviewed, sinceRaw, explain, wantJson } = parseListFlags(args);
+
+  const sinceMs =
+    sinceRaw === undefined ? undefined : Date.now() - parseSinceDurationToMs(sinceRaw);
+
+  const params = buildListParams({ unlinkedOnly, limit, notReviewed, sinceMs, explain });
+  const r = await withGatewayIpc((c) => c.call<PeopleListResult>("people.list", params));
+
+  if (isMissingSubstrateRefusal(r)) {
+    printRefusal(r, wantJson);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (wantJson) {
+    printListJson(r, notReviewed, sinceRaw, sinceMs);
+    return;
+  }
+  printListText(r, windowLineFor(notReviewed, sinceRaw));
 }
 
 async function runPeopleSearch(args: string[]): Promise<void> {

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -43,9 +43,7 @@ function formatDurationMs(ms: number): string {
   return `${String(ms)}ms`;
 }
 
-export async function runQuery(args: string[]): Promise<void> {
-  if (args.length === 0 || args[0] === "help" || args[0] === "--help" || args[0] === "-h") {
-    console.log(`nimbus query — structured index reads (Gateway IPC)
+const QUERY_HELP = `nimbus query — structured index reads (Gateway IPC)
 
 Usage:
   nimbus query --service <id> [--type <t>] [--since 7d] [--limit N] [--json | --pretty]
@@ -76,7 +74,96 @@ Output:
   piped (default)→ compact JSON, one row per array (jq-friendly)
   --json         → pretty JSON (2-space indent), good for inspection
   --pretty       → force cards even when piped
-`);
+`;
+
+/**
+ * Guards on `--not-touching` / `--no-downstream-incident`, all of which must run BEFORE any IPC
+ * call. Split out of `runQuery` for cognitive complexity (S3776); the reasoning for each is
+ * unchanged and lives with the check it justifies.
+ */
+function validateNegationFlags(f: {
+  type: string | undefined;
+  notTouchingRequested: boolean;
+  notTouchingRaw: string | undefined;
+  noDownstreamIncident: boolean;
+}): void {
+  // Scoping validated BEFORE any IPC call (non-negotiable): unscoped, `--not-touching`
+  // would return every issue, message and commit — all of which trivially "do not touch"
+  // any path, because they cannot touch anything. Checked on the REQUEST (whether the flag
+  // was supplied), not on its parsed value, so a present-but-blank `--not-touching ''` still
+  // trips the guard rather than silently skipping it.
+  if (f.notTouchingRequested && f.type !== "pr") {
+    throw new Error("--not-touching requires --type pr");
+  }
+  // A SUPPLIED flag must never become an OMITTED filter. `takeFlag` returns `args[i + 1]`
+  // verbatim, so `--not-touching` at the end of argv yields `undefined` and a blank one yields
+  // `""` — both would drop `notTouching` from the params below and answer "every PR" to a caller
+  // who asked "PRs not touching X". The gateway cannot catch that: an absent param is
+  // indistinguishable there from a caller who never asked. The option-token case is the same
+  // failure wearing a value — `--not-touching --json` sends `"--json"` as the glob, a pattern
+  // that matches no path, so EVERY covered PR comes back as "not touching" with no gap or
+  // refusal to signal it.
+  if (f.notTouchingRequested) {
+    if (f.notTouchingRaw === undefined || f.notTouchingRaw.trim() === "") {
+      throw new Error("--not-touching requires a glob pattern (e.g. --not-touching 'tests/**')");
+    }
+    if (f.notTouchingRaw.startsWith("--")) {
+      throw new Error(
+        `--not-touching requires a glob pattern, got the option "${f.notTouchingRaw}" ` +
+          "(quote the pattern if it really starts with --)",
+      );
+    }
+  }
+  if (f.noDownstreamIncident && f.type !== "deployment") {
+    throw new Error("--no-downstream-incident requires --type deployment");
+  }
+}
+
+interface QueryItemsParams {
+  services: string[];
+  types?: string[];
+  sinceMs?: number;
+  limit: number;
+  notTouching?: string;
+  noDownstreamIncident?: boolean;
+  explain?: boolean;
+}
+
+/** Omit the optionals rather than sending them undefined, so they don't appear in the request. */
+function buildQueryParams(f: {
+  service: string;
+  type: string | undefined;
+  sinceMs: number | undefined;
+  limit: number;
+  notTouchingRaw: string | undefined;
+  noDownstreamIncident: boolean;
+  explainRequested: boolean;
+}): QueryItemsParams {
+  const params: QueryItemsParams = {
+    services: [f.service],
+    limit: Number.isFinite(f.limit) && f.limit > 0 ? Math.min(1000, f.limit) : 50,
+  };
+  if (f.sinceMs !== undefined) {
+    params.sinceMs = f.sinceMs;
+  }
+  if (f.type !== undefined && f.type !== "") {
+    params.types = [f.type];
+  }
+  if (f.notTouchingRaw !== undefined && f.notTouchingRaw !== "") {
+    params.notTouching = f.notTouchingRaw;
+  }
+  if (f.noDownstreamIncident) {
+    params.noDownstreamIncident = true;
+  }
+  if (f.explainRequested) {
+    params.explain = true;
+  }
+  return params;
+}
+
+export async function runQuery(args: string[]): Promise<void> {
+  if (args.length === 0 || args[0] === "help" || args[0] === "--help" || args[0] === "-h") {
+    console.log(QUERY_HELP);
     return;
   }
 
@@ -107,69 +194,20 @@ Output:
   const explainRequested = args.includes("--explain");
   const limit = limitRaw === undefined ? Number.NaN : Number.parseInt(limitRaw, 10);
 
-  // Scoping validated BEFORE any IPC call (non-negotiable): unscoped, `--not-touching`
-  // would return every issue, message and commit — all of which trivially "do not touch"
-  // any path, because they cannot touch anything. Checked on the REQUEST (whether the flag
-  // was supplied), not on its parsed value, so a present-but-blank `--not-touching ''` still
-  // trips the guard rather than silently skipping it.
-  if (notTouchingRequested && type !== "pr") {
-    throw new Error("--not-touching requires --type pr");
-  }
-  // A SUPPLIED flag must never become an OMITTED filter. `takeFlag` returns `args[i + 1]`
-  // verbatim, so `--not-touching` at the end of argv yields `undefined` and a blank one yields
-  // `""` — both would drop `notTouching` from the params below and answer "every PR" to a caller
-  // who asked "PRs not touching X". The gateway cannot catch that: an absent param is
-  // indistinguishable there from a caller who never asked. The option-token case is the same
-  // failure wearing a value — `--not-touching --json` sends `"--json"` as the glob, a pattern
-  // that matches no path, so EVERY covered PR comes back as "not touching" with no gap or
-  // refusal to signal it.
-  if (notTouchingRequested) {
-    if (notTouchingRaw === undefined || notTouchingRaw.trim() === "") {
-      throw new Error("--not-touching requires a glob pattern (e.g. --not-touching 'tests/**')");
-    }
-    if (notTouchingRaw.startsWith("--")) {
-      throw new Error(
-        `--not-touching requires a glob pattern, got the option "${notTouchingRaw}" ` +
-          "(quote the pattern if it really starts with --)",
-      );
-    }
-  }
-  if (noDownstreamIncident && type !== "deployment") {
-    throw new Error("--no-downstream-incident requires --type deployment");
-  }
+  validateNegationFlags({ type, notTouchingRequested, notTouchingRaw, noDownstreamIncident });
 
-  let sinceMs: number | undefined;
-  if (sinceRaw !== undefined) {
-    sinceMs = Date.now() - parseSinceDurationToMs(sinceRaw);
-  }
+  const sinceMs =
+    sinceRaw === undefined ? undefined : Date.now() - parseSinceDurationToMs(sinceRaw);
 
-  const params: {
-    services: string[];
-    types?: string[];
-    sinceMs?: number;
-    limit: number;
-    notTouching?: string;
-    noDownstreamIncident?: boolean;
-    explain?: boolean;
-  } = {
-    services: [service],
-    limit: Number.isFinite(limit) && limit > 0 ? Math.min(1000, limit) : 50,
-  };
-  if (sinceMs !== undefined) {
-    params.sinceMs = sinceMs;
-  }
-  if (type !== undefined && type !== "") {
-    params.types = [type];
-  }
-  if (notTouchingRaw !== undefined && notTouchingRaw !== "") {
-    params.notTouching = notTouchingRaw;
-  }
-  if (noDownstreamIncident) {
-    params.noDownstreamIncident = true;
-  }
-  if (explainRequested) {
-    params.explain = true;
-  }
+  const params = buildQueryParams({
+    service,
+    type,
+    sinceMs,
+    limit,
+    notTouchingRaw,
+    noDownstreamIncident,
+    explainRequested,
+  });
 
   const r = await withGatewayIpc((c) => c.call<QueryItemsResult>("index.queryItems", params));
 
@@ -179,29 +217,39 @@ Output:
     return;
   }
 
+  printQueryResult(r, { wantJson, pretty, noDownstreamIncident });
+}
+
+function printQueryResult(
+  r: Exclude<QueryItemsResult, MissingSubstrateRefusal>,
+  o: { wantJson: boolean; pretty: boolean; noDownstreamIncident: boolean },
+): void {
   const isNegationResult = r.gaps !== undefined || r.explain !== undefined;
-  if (wantJson && isNegationResult) {
+  if (o.wantJson && isNegationResult) {
     const doc: Record<string, unknown> = { ...r };
-    if (noDownstreamIncident) {
+    if (o.noDownstreamIncident) {
       doc["correlationWindowMs"] = CORRELATION_WINDOW_MS_CLI_MIRROR;
     }
     console.log(JSON.stringify(doc, null, 2));
     return;
   }
 
-  printRows(r.items, wantJson, pretty);
-  if (!wantJson && r.gaps !== undefined) {
+  printRows(r.items, o.wantJson, o.pretty);
+  if (o.wantJson) {
+    return;
+  }
+  if (r.gaps !== undefined) {
     console.log(formatGapLine(r.gaps));
     console.log(formatBatchCaveat(r.meta));
   }
-  if (!wantJson && noDownstreamIncident) {
+  if (o.noDownstreamIncident) {
     console.log(
       `Correlation window: ${formatDurationMs(CORRELATION_WINDOW_MS_CLI_MIRROR)} (fixed at ` +
         "write time by the deployment→incident correlator; not adjustable per-query — see " +
         "the design doc § 4.2/D5)",
     );
   }
-  if (!wantJson && r.explain !== undefined) {
+  if (r.explain !== undefined) {
     printExplainBlock(r.explain);
   }
 }

--- a/packages/gateway/src-native/sandbox-helper-win32/main.c
+++ b/packages/gateway/src-native/sandbox-helper-win32/main.c
@@ -25,6 +25,12 @@
 #define MAPPINGS_KEY   L"Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\" \
                        L"CurrentVersion\\AppContainer\\Mappings"
 
+/* NOSONAR c:S923 — the variadic is deliberate and is the SAFER option here. This is the single
+ * audited wrapper over vfwprintf for all 26 diagnostic sites, each with its own format string and
+ * argument types (`%s` paths, `%lu` Win32 codes, `%08lx` HRESULTs). Removing the ellipsis means
+ * every one of those sites pre-formats into its own stack buffer, replacing one reviewed call
+ * with 26 hand-managed buffers in security-sensitive C — more attack surface, not less, for a
+ * rule aimed at unchecked variadic APIs rather than a fixed-format logger. */
 static void err(const wchar_t *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
@@ -129,7 +135,8 @@ static int mode_delete_profile(const wchar_t *name) {
  * on the wrong path makes that test fail. Do not widen a grant to make it pass.
  */
 static int grant_path(const wchar_t *path, PSID sid, DWORD rights, DWORD inherit) {
-    PACL old_acl = NULL, new_acl = NULL;
+    PACL old_acl = NULL;
+    PACL new_acl = NULL;
     PSECURITY_DESCRIPTOR sd = NULL;
     DWORD rc = GetNamedSecurityInfoW((LPWSTR)path, SE_FILE_OBJECT,
                                      DACL_SECURITY_INFORMATION, NULL, NULL, &old_acl, NULL, &sd);
@@ -195,51 +202,91 @@ static int append_quoted(wchar_t *dst, size_t cap, size_t *len, const wchar_t *a
 #undef PUT
 }
 
-static int mode_spawn(int argc, wchar_t **argv) {
-    const wchar_t *profile = NULL;
-    const wchar_t *cwd = NULL;
-    BOOL want_net = FALSE;
-    const wchar_t *reads[64];  int nread = 0;
-    const wchar_t *writes[64]; int nwrite = 0;
-    int i = 1;
+#define MAX_GRANTS 64
 
+/* Parsed `--profile ... -- <child argv>` invocation. `child_argv_start` is the index of the first
+ * token AFTER the `--` separator. */
+typedef struct {
+    const wchar_t *profile;
+    const wchar_t *cwd;
+    BOOL want_net;
+    const wchar_t *reads[MAX_GRANTS];
+    int nread;
+    const wchar_t *writes[MAX_GRANTS];
+    int nwrite;
+    int child_argv_start;
+} spawn_opts;
+
+/* Parse argv into `o`. Returns 0, or the process exit code the caller must return verbatim —
+ * every failure path has already emitted its own diagnostic. Split out of mode_spawn for
+ * cognitive complexity (S3776); the accepted grammar is unchanged. */
+static int parse_spawn_args(int argc, wchar_t **argv, spawn_opts *o) {
+    o->profile = NULL;
+    o->cwd = NULL;
+    o->want_net = FALSE;
+    o->nread = 0;
+    o->nwrite = 0;
+
+    int i = 1;
     for (; i < argc; i++) {
         if (wcscmp(argv[i], L"--") == 0) { i++; break; }
-        if (wcscmp(argv[i], L"--profile") == 0 && i + 1 < argc)          { profile = argv[++i]; }
-        else if (wcscmp(argv[i], L"--cwd") == 0 && i + 1 < argc)         { cwd = argv[++i]; }
-        else if (wcscmp(argv[i], L"--capability") == 0 && i + 1 < argc)  { i++; if (wcscmp(argv[i], L"internetClient") == 0) want_net = TRUE; }
-        else if (wcscmp(argv[i], L"--grant-read") == 0 && i + 1 < argc)  { if (nread  >= 64) { err(L"too many --grant-read");  return 64; } reads[nread++]   = argv[++i]; }
-        else if (wcscmp(argv[i], L"--grant-write") == 0 && i + 1 < argc) { if (nwrite >= 64) { err(L"too many --grant-write"); return 64; } writes[nwrite++] = argv[++i]; }
+        if (wcscmp(argv[i], L"--profile") == 0 && i + 1 < argc)          { o->profile = argv[++i]; }
+        else if (wcscmp(argv[i], L"--cwd") == 0 && i + 1 < argc)         { o->cwd = argv[++i]; }
+        else if (wcscmp(argv[i], L"--capability") == 0 && i + 1 < argc)  { i++; if (wcscmp(argv[i], L"internetClient") == 0) o->want_net = TRUE; }
+        else if (wcscmp(argv[i], L"--grant-read") == 0 && i + 1 < argc)  { if (o->nread  >= MAX_GRANTS) { err(L"too many --grant-read");  return 64; } o->reads[o->nread++]   = argv[++i]; }
+        else if (wcscmp(argv[i], L"--grant-write") == 0 && i + 1 < argc) { if (o->nwrite >= MAX_GRANTS) { err(L"too many --grant-write"); return 64; } o->writes[o->nwrite++] = argv[++i]; }
         else { err(L"unexpected arg: %s", argv[i]); return 64; }
     }
-    if (profile == NULL) { err(L"--profile is required"); return 64; }
-    if (cwd == NULL)     { err(L"--cwd is required"); return 64; }
-    if (i >= argc)       { err(L"expected -- followed by child argv"); return 64; }
+    o->child_argv_start = i;
 
-    PSID sid = NULL;
-    HRESULT hr = profile_sid(profile, &sid);
-    if (FAILED(hr)) { err(L"profile %s: hr=0x%08lx", profile, (unsigned long)hr); return 65; }
+    if (o->profile == NULL) { err(L"--profile is required"); return 64; }
+    if (o->cwd == NULL)     { err(L"--cwd is required"); return 64; }
+    if (i >= argc)          { err(L"expected -- followed by child argv"); return 64; }
+    return 0;
+}
 
+/* Apply the cwd grant and the policy-path grants. Returns 0 or the exit code. Does NOT free
+ * `sid` — the caller owns it on every path, which is why this returns a code rather than
+ * cleaning up itself. */
+static int apply_grants(PSID sid, const spawn_opts *o) {
     /* The working directory: Modify, inheritable — the child works inside it. */
-    int rc = grant_path(cwd, sid, FILE_GENERIC_READ | FILE_GENERIC_EXECUTE | FILE_GENERIC_WRITE,
+    int rc = grant_path(o->cwd, sid, FILE_GENERIC_READ | FILE_GENERIC_EXECUTE | FILE_GENERIC_WRITE,
                         SUB_CONTAINERS_AND_OBJECTS_INHERIT);
-    if (rc != 0) { FreeSid(sid); return rc; }
+    if (rc != 0) return rc;
 
     /* Policy paths are subtree grants, so they inherit. Their ancestors get NOTHING: Windows
      * bypasses traverse checking by default, so a known full path opens without listing rights on
      * the way down — the spike's failure was on ENUMERATION, not traversal. If a connector turns
      * out to need more than this, widen it deliberately and record why; do not widen on a hunch. */
-    for (int k = 0; k < nread; k++) {
-        rc = grant_path(reads[k], sid, FILE_GENERIC_READ | FILE_GENERIC_EXECUTE,
+    for (int k = 0; k < o->nread; k++) {
+        rc = grant_path(o->reads[k], sid, FILE_GENERIC_READ | FILE_GENERIC_EXECUTE,
                         SUB_CONTAINERS_AND_OBJECTS_INHERIT);
-        if (rc != 0) { FreeSid(sid); return rc; }
+        if (rc != 0) return rc;
     }
-    for (int k = 0; k < nwrite; k++) {
-        rc = grant_path(writes[k], sid,
+    for (int k = 0; k < o->nwrite; k++) {
+        rc = grant_path(o->writes[k], sid,
                         FILE_GENERIC_READ | FILE_GENERIC_EXECUTE | FILE_GENERIC_WRITE,
                         SUB_CONTAINERS_AND_OBJECTS_INHERIT);
-        if (rc != 0) { FreeSid(sid); return rc; }
+        if (rc != 0) return rc;
     }
+    return 0;
+}
+
+static int mode_spawn(int argc, wchar_t **argv) {
+    spawn_opts o;
+    int prc = parse_spawn_args(argc, argv, &o);
+    if (prc != 0) return prc;
+
+    const wchar_t *cwd = o.cwd;
+    const BOOL want_net = o.want_net;
+    const int i = o.child_argv_start;
+
+    PSID sid = NULL;
+    HRESULT hr = profile_sid(o.profile, &sid);
+    if (FAILED(hr)) { err(L"profile %s: hr=0x%08lx", o.profile, (unsigned long)hr); return 65; }
+
+    int rc = apply_grants(sid, &o);
+    if (rc != 0) { FreeSid(sid); return rc; }
 
     /* Job Object: the analogue of bwrap's --die-with-parent. When our handle closes — including
      * on a crash — the OS terminates the child rather than orphaning it. */

--- a/packages/gateway/src/agents/_lib/markdown-sections.ts
+++ b/packages/gateway/src/agents/_lib/markdown-sections.ts
@@ -304,6 +304,37 @@ const BARE_GAPS_LABEL = /^\s*(?:[-*+]\s*)?\*{0,2}gaps\*{0,2}:?\s*$/i;
  * Fence-aware through the shared `headingLines` scan's sibling logic: a fenced YAML example
  * containing `category:` is documentation, not fabrication.
  */
+/**
+ * Walk back from the `category:` line over contiguous field lines, then over a single label line
+ * if one is present. Split out for cognitive complexity (S3776); the scan is unchanged.
+ */
+function envelopeStart(lines: readonly string[], fenced: readonly boolean[], i: number): number {
+  let start = i;
+  while (start > 0 && !fenced[start - 1] && ENVELOPE_FIELD_LINE.test(lines[start - 1] ?? "")) {
+    start--;
+  }
+  if (start > 0 && !fenced[start - 1] && BARE_GAPS_LABEL.test(lines[start - 1] ?? "")) {
+    start--;
+  }
+  return start;
+}
+
+/** Walk forward over field lines and the blank lines between them. */
+function envelopeEnd(lines: readonly string[], fenced: readonly boolean[], i: number): number {
+  let end = i;
+  for (let j = i + 1; j < lines.length; j++) {
+    if (fenced[j]) break;
+    const line = lines[j] ?? "";
+    if (ENVELOPE_FIELD_LINE.test(line)) {
+      end = j;
+      continue;
+    }
+    if (line.trim() === "") continue;
+    break;
+  }
+  return end;
+}
+
 export function stripSerializedGapEnvelope(markdown: string): string {
   const lines = markdown.split("\n");
   const fenced = fencedLineFlags(lines);
@@ -313,28 +344,8 @@ export function stripSerializedGapEnvelope(markdown: string): string {
     if (fenced[i] || drop.has(i)) continue;
     if (!CATEGORY_LINE.test(lines[i] ?? "")) continue;
 
-    // Walk back over contiguous field lines, then over a single label line if present.
-    let start = i;
-    while (start > 0 && !fenced[start - 1] && ENVELOPE_FIELD_LINE.test(lines[start - 1] ?? "")) {
-      start--;
-    }
-    if (start > 0 && !fenced[start - 1] && BARE_GAPS_LABEL.test(lines[start - 1] ?? "")) {
-      start--;
-    }
-
-    // Walk forward over field lines and the blank lines between them.
-    let end = i;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (fenced[j]) break;
-      const line = lines[j] ?? "";
-      if (ENVELOPE_FIELD_LINE.test(line)) {
-        end = j;
-        continue;
-      }
-      if (line.trim() === "") continue;
-      break;
-    }
-
+    const start = envelopeStart(lines, fenced, i);
+    const end = envelopeEnd(lines, fenced, i);
     for (let j = start; j <= end; j++) drop.add(j);
   }
 

--- a/packages/gateway/src/agents/_lib/meta-preamble.test.ts
+++ b/packages/gateway/src/agents/_lib/meta-preamble.test.ts
@@ -21,17 +21,20 @@ describe("stripMetaPreamble (F4)", () => {
     expect(out).toContain("**main**");
   });
 
-  test("leaves a brief with no preamble untouched", () => {
-    const md = "# Glossary\n\n- **main** — 21 mention(s)";
-    expect(stripMetaPreamble(md)).toBe(md);
-  });
-
-  test("never strips a renderer-authored disclosure", () => {
+  // These cases assert one property — the input comes back byte-identical — and differ only in
+  // WHICH input. Parameterized (S5976) so the next case is a row rather than a fourth copy of the
+  // same body, and so a change to the property is made in one place.
+  test.each([
+    ["a brief with no preamble", "# Glossary\n\n- **main** — 21 mention(s)"],
     // `negotiate`'s window clause lives in exactly this position and is the thing I31 exists to
     // protect. Stripping it to remove model chatter would be a far worse trade than leaving the
     // chatter in.
-    const md =
-      "_window: last 90d — the index records last-modified, not created._\n\n# Negotiation brief";
+    [
+      "a renderer-authored disclosure",
+      "_window: last 90d — the index records last-modified, not created._\n\n# Negotiation brief",
+    ],
+    ["ordinary prose above a heading", "A short summary of the week.\n\n# Catchup"],
+  ])("leaves %s untouched", (_case, md) => {
     expect(stripMetaPreamble(md)).toBe(md);
   });
 
@@ -41,10 +44,5 @@ describe("stripMetaPreamble (F4)", () => {
     const md =
       "# Decisions\n\nWe chose Postgres based on the provided benchmark numbers.\n\n## Gaps\n\n- none";
     expect(stripMetaPreamble(md)).toContain("based on the provided benchmark");
-  });
-
-  test("ordinary prose above a heading survives", () => {
-    const md = "A short summary of the week.\n\n# Catchup";
-    expect(stripMetaPreamble(md)).toBe(md);
   });
 });

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -155,6 +155,17 @@ function collectLaneOutput(results: readonly SubTaskResult[]): {
       });
       continue;
     }
+    // Unguarded `JSON.parse` on purpose, and it stays safe only while this holds: `r.text` on a
+    // `done` result is ALWAYS `JSON.stringify` of a locally-typed `SubAgentResult`, produced by
+    // `makeSubAgent` above from one of the six lane functions in this file. No LLM output, no
+    // network payload and no user input reaches it, so the text cannot be malformed and
+    // `findings` cannot be a non-array. A throw inside `execute()` never arrives here either —
+    // the coordinator converts it to `status: "error"`, which the branch above turns into a gap.
+    //
+    // A try/catch here today would be a branch no test could reach, which the branch-coverage
+    // floor would then charge us for. If a lane is ever backed by a model or a remote call,
+    // that stops being true: parse into `unknown`, validate, and route a bad payload down the
+    // failed-lane gap path above.
     const decoded: SubAgentResult = JSON.parse(r.text);
     if (decoded.findings !== undefined) findings.push(...decoded.findings);
     if (decoded.gap !== undefined) gaps.push(decoded.gap);

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -1,7 +1,7 @@
 import type { Database } from "bun:sqlite";
 
 import type { NimbusFilesystemRootToml } from "../config/filesystem-toml.ts";
-import { AgentCoordinator, type SubTask } from "../engine/coordinator.ts";
+import { AgentCoordinator, type SubTask, type SubTaskResult } from "../engine/coordinator.ts";
 import type { BlameLookup } from "../security/blame-store.ts";
 import { type BlameSpawn, ensureBlameLine } from "./_lib/blame-on-demand.ts";
 import { emitBriefWithSynthesis } from "./_lib/emit-brief.ts";
@@ -76,26 +76,24 @@ function makeSubAgent(
   };
 }
 
-export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief> {
-  const start = performance.now();
-  const preflightGaps: GapNote[] = [];
-  const empty = detectEmptyIndex(ctx.db);
-  if (empty !== null) preflightGaps.push(empty);
+interface WhyLaneResolution {
+  readonly subject: WhySubject | null;
+  readonly blame: BlameLookup | null;
+  readonly pr: PrForSha | null;
+  /** `undefined` on the ref arm (the field is omitted entirely); `null` when a change */
+  /** was asked about and could not be named. The two are NOT interchangeable. */
+  readonly changeSubject: WhyChangeSubject | null | undefined;
+  readonly queryRef: string;
+  readonly queryLine: number | null;
+}
 
-  let subject: WhySubject | null = null;
-  let blame: BlameLookup | null = null;
-  let pr: PrForSha | null = null;
-  let changeSubject: WhyChangeSubject | null | undefined;
-  let queryRef: string;
-  let queryLine: number | null;
-
-  if (isWhyPrInput(input)) {
-    queryRef = input.prUrl;
-    queryLine = null;
-    const resolved = resolvePrSubject(ctx.db, input.prUrl);
-    // null, not absent: the caller asked about a change and we could not name it.
-    changeSubject = resolved.ok ? resolved.subject : null;
-    pr = resolved.ok
+/** The `--pr` arm: resolve the change subject and the PR shape the lanes consume. */
+function resolvePrArm(db: Database, prUrl: string): WhyLaneResolution {
+  const resolved = resolvePrSubject(db, prUrl);
+  return {
+    subject: null,
+    blame: null,
+    pr: resolved.ok
       ? {
           entityId: resolved.subject.entityId,
           number: resolved.subject.number,
@@ -103,24 +101,76 @@ export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief
           url: resolved.subject.url,
           modifiedAt: resolved.subject.modifiedAt,
         }
-      : null;
-  } else {
-    queryRef = input.ref;
-    queryLine = input.line ?? parseRef(input.ref).line;
-    subject = resolveWhySubject(ctx.db, ctx.roots, input);
-    // Resolve-once design: two lanes need the blamed SHA, and running
-    // `ensureBlameLine` inside parallel sub-agents could double-spawn on a
-    // cold line. Resolve it here, once, and hand the result to every lane.
-    if (subject !== null && subject.lineNo !== null) {
-      blame = await ensureBlameLine(
-        ctx.db,
-        { repoRoot: subject.repoRoot, filePath: subject.filePath },
-        subject.lineNo,
-        ctx.spawn,
-      );
-    }
-    pr = blame === null ? null : findPrForSha(ctx.db, blame.commitSha);
+      : null,
+    // null, not absent: the caller asked about a change and we could not name it.
+    changeSubject: resolved.ok ? resolved.subject : null,
+    queryRef: prUrl,
+    queryLine: null,
+  };
+}
+
+/**
+ * The ref arm. Resolve-once design: two lanes need the blamed SHA, and running `ensureBlameLine`
+ * inside parallel sub-agents could double-spawn on a cold line. Resolve it here, once, and hand
+ * the result to every lane.
+ */
+async function resolveRefArm(
+  input: Exclude<WhyInput, { prUrl: string }>,
+  ctx: WhyContext,
+): Promise<WhyLaneResolution> {
+  const subject = resolveWhySubject(ctx.db, ctx.roots, input);
+  let blame: BlameLookup | null = null;
+  if (subject !== null && subject.lineNo !== null) {
+    blame = await ensureBlameLine(
+      ctx.db,
+      { repoRoot: subject.repoRoot, filePath: subject.filePath },
+      subject.lineNo,
+      ctx.spawn,
+    );
   }
+  return {
+    subject,
+    blame,
+    pr: blame === null ? null : findPrForSha(ctx.db, blame.commitSha),
+    changeSubject: undefined,
+    queryRef: input.ref,
+    queryLine: input.line ?? parseRef(input.ref).line,
+  };
+}
+
+/** Decode the sub-agent results into findings + gap notes; a failed lane becomes a gap, not a throw. */
+function collectLaneOutput(results: readonly SubTaskResult[]): {
+  findings: WhyFinding[];
+  gaps: GapNote[];
+} {
+  const findings: WhyFinding[] = [];
+  const gaps: GapNote[] = [];
+  for (const r of results) {
+    if (r.status !== "done" || r.text === undefined) {
+      gaps.push({
+        category: "missing_connector",
+        detail: `why sub-agent #${r.taskIndex} failed${
+          r.errorText === undefined ? "" : `: ${r.errorText}`
+        }`,
+      });
+      continue;
+    }
+    const decoded: SubAgentResult = JSON.parse(r.text);
+    if (decoded.findings !== undefined) findings.push(...decoded.findings);
+    if (decoded.gap !== undefined) gaps.push(decoded.gap);
+  }
+  return { findings, gaps };
+}
+
+export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief> {
+  const start = performance.now();
+  const preflightGaps: GapNote[] = [];
+  const empty = detectEmptyIndex(ctx.db);
+  if (empty !== null) preflightGaps.push(empty);
+
+  const { subject, blame, pr, changeSubject, queryRef, queryLine } = isWhyPrInput(input)
+    ? resolvePrArm(ctx.db, input.prUrl)
+    : await resolveRefArm(input, ctx);
 
   const lane: LaneInput = {
     subject,
@@ -153,23 +203,7 @@ export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief
   ];
 
   const results = await coordinator.run(tasks);
-
-  const allFindings: WhyFinding[] = [];
-  const laneGaps: GapNote[] = [];
-  for (const r of results) {
-    if (r.status !== "done" || r.text === undefined) {
-      laneGaps.push({
-        category: "missing_connector",
-        detail: `why sub-agent #${r.taskIndex} failed${
-          r.errorText === undefined ? "" : `: ${r.errorText}`
-        }`,
-      });
-      continue;
-    }
-    const decoded: SubAgentResult = JSON.parse(r.text);
-    if (decoded.findings !== undefined) allFindings.push(...decoded.findings);
-    if (decoded.gap !== undefined) laneGaps.push(decoded.gap);
-  }
+  const { findings: allFindings, gaps: laneGaps } = collectLaneOutput(results);
 
   const gaps = aggregateMissingEntityTypes([...preflightGaps, ...laneGaps]);
 

--- a/packages/gateway/src/briefs/brief-test-server.ts
+++ b/packages/gateway/src/briefs/brief-test-server.ts
@@ -40,8 +40,12 @@ function makeInMemoryVault(tokensJson?: string): NimbusVault {
 
 /** Turns a fixed hit list into the `IndexSearch` seam, ignoring the query and limit. */
 function makeIndexSearch(hits: IndexHit[]): IndexSearch {
-  return async (_query: string, limit: number) =>
-    Promise.resolve({ hits: hits.slice(0, limit), semanticAvailable: true });
+  // `async` already wraps the return value in a promise; `Promise.resolve` on top of it is
+  // redundant (S7746). The seam's signature is unchanged.
+  return async (_query: string, limit: number) => ({
+    hits: hits.slice(0, limit),
+    semanticAvailable: true,
+  });
 }
 
 /** Kicks off synthesis fire-and-forget — same contract as `BriefsWriteSurface.startRun`. */
@@ -203,7 +207,8 @@ function citeAllTokensLlm(): BriefSynthesizerLlm {
         text: `Finding ${i + 1} supported by ${t}.`,
         refs: [t],
       }));
-      return Promise.resolve({
+      // `generateJson` is already `async`, so the wrapper is redundant (S7746).
+      return {
         text: JSON.stringify({
           summary: "Synthesized summary citing every available token.",
           findings,
@@ -212,7 +217,7 @@ function citeAllTokensLlm(): BriefSynthesizerLlm {
         }),
         model: "stub-cite-all-tokens",
         remote: false,
-      });
+      };
     },
   };
 }

--- a/packages/gateway/src/engine/context-fairness.ts
+++ b/packages/gateway/src/engine/context-fairness.ts
@@ -29,13 +29,24 @@ interface ServiceScoped {
  * Relevance order WITHIN a service is preserved: the input is already ranked, and reshuffling it
  * would discard the ordering the search just computed.
  */
-export function capPerService<T extends ServiceScoped>(items: readonly T[], limit: number): T[] {
+/**
+ * Group by service in input order, so each bucket keeps the relevance ordering search computed.
+ *
+ * Split out of `capPerService` for cognitive complexity (S3776): the grouping and the round-robin
+ * drain are independent steps, and reading either one no longer means holding the other in mind.
+ */
+function bucketByService<T extends ServiceScoped>(items: readonly T[]): Map<string, T[]> {
   const byService = new Map<string, T[]>();
   for (const item of items) {
     const bucket = byService.get(item.service);
     if (bucket === undefined) byService.set(item.service, [item]);
     else bucket.push(item);
   }
+  return byService;
+}
+
+export function capPerService<T extends ServiceScoped>(items: readonly T[], limit: number): T[] {
+  const byService = bucketByService(items);
   if (byService.size <= 1) return items.slice(0, limit);
 
   const out: T[] = [];

--- a/packages/gateway/src/graph/relationship-graph.metadata.test.ts
+++ b/packages/gateway/src/graph/relationship-graph.metadata.test.ts
@@ -179,6 +179,14 @@ describe("upsertGraphEntity — compile-time co-owned-type guard", () => {
       externalId: "pr:1",
       label: "PR #1",
     });
+
+    // The runtime assertion is NOT that guard. It is here so the case cannot quietly become a
+    // no-op: a body that asserts nothing passes just as happily if `upsertGraphEntity` stops
+    // writing anything at all, which is the failure a compile-time-only test cannot see.
+    const row = db
+      .query("SELECT type, label FROM graph_entity WHERE external_id = ?")
+      .get("pr:1") as { type: string; label: string } | null;
+    expect(row).toEqual({ type: "pr", label: "PR #1" });
   });
 
   test("a co-owned literal type is rejected at compile time", () => {
@@ -189,5 +197,16 @@ describe("upsertGraphEntity — compile-time co-owned-type guard", () => {
       externalId: "file:/repo:z.ts",
       label: "z.ts",
     });
+
+    // `@ts-expect-error` is the assertion that matters — it fails `typecheck` the moment this
+    // call stops being an error. What the runtime check adds is WHY that guard has to exist:
+    // nothing here refuses the write. The row lands with `service` NULL — un-namespaced, the
+    // exact state `upsertGraphEntityNamespaced` exists to prevent — so the type system is the
+    // ONLY thing between a co-owned entity and a namespace-less row. Verified, not assumed.
+    const row = db
+      .query("SELECT service FROM graph_entity WHERE external_id = ?")
+      .get("file:/repo:z.ts") as { service: string | null } | null;
+    expect(row).not.toBeNull();
+    expect(row?.service).toBeNull();
   });
 });

--- a/packages/gateway/src/ipc/diagnostics-rpc.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.ts
@@ -24,7 +24,11 @@ import { buildItemListSql } from "../index/item-list-query.ts";
 import type { LocalIndex } from "../index/local-index.ts";
 import { LocalIndex as LocalIndexClass } from "../index/local-index.ts";
 import type { NegationExplain } from "../index/negation-predicates.ts";
-import { runNoDownstreamIncidentQuery, runNotTouchingQuery } from "../index/negation-query.ts";
+import {
+  type NegationOutcome,
+  runNoDownstreamIncidentQuery,
+  runNotTouchingQuery,
+} from "../index/negation-query.ts";
 import type { SandboxRunner } from "../platform/sandbox/sandbox-runner.ts";
 import { buildTelemetryPreview } from "../telemetry/collector.ts";
 import type { ConsentCoordinator } from "./consent.ts";
@@ -335,29 +339,43 @@ function rpcDbSetMeta(params: unknown, ctx: DiagnosticsRpcContext): DiagnosticsR
 // file reads the same as before.
 type QueryExplain = NegationExplain;
 
-function rpcIndexQueryItems(params: unknown, ctx: DiagnosticsRpcContext): DiagnosticsRpcOutcome {
+interface QueryItemsRequest {
+  readonly sinceMs: number | undefined;
+  readonly untilMs: number | undefined;
+  readonly limit: number;
+  readonly services: string[];
+  readonly types: string[];
+  readonly notTouching: string | undefined;
+  readonly noDownstreamIncident: boolean;
+  readonly explain: boolean;
+}
+
+/** A finite number floored to an int, or `undefined` for anything else. */
+function optFiniteInt(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? Math.floor(v) : undefined;
+}
+
+/** The string members of an array param; `[]` for a non-array. */
+function stringArrayParam(v: unknown): string[] {
+  return Array.isArray(v) ? (v as unknown[]).filter((x): x is string => typeof x === "string") : [];
+}
+
+/**
+ * Coerce and VALIDATE `index.queryItems` params. Split out of `rpcIndexQueryItems` for cognitive
+ * complexity (S3776) — every guard below is unchanged, including the fail-closed reasoning that
+ * is the whole point of this surface.
+ */
+function parseQueryItemsParams(params: unknown): QueryItemsRequest {
   const rec = asRecord(params);
-  const rawSinceMs = rec?.["sinceMs"];
-  const sinceMs =
-    typeof rawSinceMs === "number" && Number.isFinite(rawSinceMs)
-      ? Math.floor(rawSinceMs)
-      : undefined;
-  const rawUntilMs = rec?.["untilMs"];
-  const untilMs =
-    typeof rawUntilMs === "number" && Number.isFinite(rawUntilMs)
-      ? Math.floor(rawUntilMs)
-      : undefined;
+  const sinceMs = optFiniteInt(rec?.["sinceMs"]);
+  const untilMs = optFiniteInt(rec?.["untilMs"]);
   const limitRaw = rec?.["limit"];
   const limit =
     typeof limitRaw === "number" && Number.isFinite(limitRaw)
       ? Math.min(1000, Math.max(1, Math.floor(limitRaw)))
       : 50;
-  const services = Array.isArray(rec?.["services"])
-    ? (rec["services"] as unknown[]).filter((x): x is string => typeof x === "string")
-    : [];
-  const types = Array.isArray(rec?.["types"])
-    ? (rec["types"] as unknown[]).filter((x): x is string => typeof x === "string")
-    : [];
+  const services = stringArrayParam(rec?.["services"]);
+  const types = stringArrayParam(rec?.["types"]);
   const rawNotTouching = rec?.["notTouching"];
   // A PRESENT but unusable `notTouching` must NEVER silently fall through to the plain path: that
   // would answer a different question ("every item") than the one asked ("items not touching X"),
@@ -404,6 +422,35 @@ function rpcIndexQueryItems(params: unknown, ctx: DiagnosticsRpcContext): Diagno
   }
   const explain = rec?.["explain"] === true;
 
+  return { sinceMs, untilMs, limit, services, types, notTouching, noDownstreamIncident, explain };
+}
+
+/**
+ * Shape a negation outcome into the RPC result. Both predicate branches produced this block
+ * verbatim; one definition means they cannot drift into answering in different shapes.
+ */
+function negationResult<Row, Gaps>(
+  outcome: NegationOutcome<Row, Gaps>,
+  limit: number,
+): DiagnosticsRpcOutcome {
+  if (outcome.kind === "refused") {
+    return { kind: "hit", value: outcome.refusal };
+  }
+  return {
+    kind: "hit",
+    value: {
+      items: outcome.rows,
+      meta: { limit, total: outcome.rows.length },
+      gaps: outcome.gaps,
+      ...(outcome.explain === undefined ? {} : { explain: outcome.explain }),
+    },
+  };
+}
+
+function rpcIndexQueryItems(params: unknown, ctx: DiagnosticsRpcContext): DiagnosticsRpcOutcome {
+  const { sinceMs, untilMs, limit, services, types, notTouching, noDownstreamIncident, explain } =
+    parseQueryItemsParams(params);
+
   const baseParams = {
     services,
     types,
@@ -430,18 +477,7 @@ function rpcIndexQueryItems(params: unknown, ctx: DiagnosticsRpcContext): Diagno
       limit,
       explain,
     });
-    if (outcome.kind === "refused") {
-      return { kind: "hit", value: outcome.refusal };
-    }
-    return {
-      kind: "hit",
-      value: {
-        items: outcome.rows,
-        meta: { limit, total: outcome.rows.length },
-        gaps: outcome.gaps,
-        ...(outcome.explain === undefined ? {} : { explain: outcome.explain }),
-      },
-    };
+    return negationResult(outcome, limit);
   }
 
   // --no-downstream-incident: same probe-first shape, over the `correlates_with` substrate.
@@ -455,18 +491,7 @@ function rpcIndexQueryItems(params: unknown, ctx: DiagnosticsRpcContext): Diagno
       limit,
       explain,
     });
-    if (outcome.kind === "refused") {
-      return { kind: "hit", value: outcome.refusal };
-    }
-    return {
-      kind: "hit",
-      value: {
-        items: outcome.rows,
-        meta: { limit, total: outcome.rows.length },
-        gaps: outcome.gaps,
-        ...(outcome.explain === undefined ? {} : { explain: outcome.explain }),
-      },
-    };
+    return negationResult(outcome, limit);
   }
 
   // Plain path — no negation predicate requested. `--explain` still works here: the spec (§ 5)

--- a/packages/gateway/src/prfiles/pr-file-fetch.ts
+++ b/packages/gateway/src/prfiles/pr-file-fetch.ts
@@ -159,6 +159,63 @@ function dedupeFileRowsByPath(rows: readonly ChangedFileRow[]): ChangedFileRow[]
  * Pages are mapped and concatenated as they arrive rather than being buffered as raw JSON, so a
  * large PR never holds more than one page of payload in memory.
  */
+interface PrFilePages {
+  readonly rows: ChangedFileRow[];
+  /** True only when a page reported `hasMore === false` — i.e. we hold the FULL path set. */
+  readonly pagesExhausted: boolean;
+  readonly failed: boolean;
+  readonly rateLimited: boolean;
+}
+
+/**
+ * Walk one PR's changed-file pages. Split out of `runPrFilePass` for cognitive complexity
+ * (S3776) — the page walk and the per-candidate bookkeeping are separate concerns, and the
+ * three mutable flags the caller used to thread through the loop are now this function's
+ * return value.
+ */
+async function collectPrFilePages(
+  ctx: SyncContext,
+  args: { readonly service: Provider; readonly fetchPage: FetchPage },
+  c: PrFileCandidate,
+): Promise<PrFilePages> {
+  const rows: ChangedFileRow[] = [];
+  for (let page = 1; page <= MAX_PAGES_PER_PR; page++) {
+    // `tryAcquire`, never `acquire`: at least one existing 429 handler in this codebase
+    // (`_lib/gitlab/pipelines.ts`) calls `rateLimiter.penalise()` WITHOUT throwing, by
+    // design — its own caller keeps going rather than aborting the sync. `acquire` would
+    // then SLEEP OUT that whole penalty window right here, blocking one of only
+    // `maxConcurrentSyncs` scheduler slots for the full `Retry-After`. `tryAcquire` never
+    // sleeps (see its doc comment in `sync/rate-limiter.ts`) — it takes a token if one is
+    // free and returns `false` instantly otherwise — so a penalised or exhausted provider
+    // is detected without blocking, and the pass simply stops for THIS tick.
+    const ok = await ctx.rateLimiter.tryAcquire(args.service);
+    if (!ok) {
+      return { rows, pagesExhausted: false, failed: false, rateLimited: true };
+    }
+    const res = await args.fetchPage(c, page);
+    if (res === null) {
+      // Warn on the SILENT failure path too, not just on the throw path below. `null` is what
+      // every forge closure returns for a non-ok response (a 404 on a deleted or now-private
+      // repo, most of all) and for an unparseable body — precisely the failures that repeat
+      // forever on the same PRs. Unlogged, the head-of-line stall that
+      // `PR_ATTEMPT_BUDGET_MULTIPLIER` bounds would be invisible: coverage would sit still
+      // with nothing in the log to say why.
+      ctx.logger.warn(
+        { service: args.service, itemId: c.itemId, page },
+        "PR changed-file page unavailable (non-fatal, PR left uncovered, will retry next tick)",
+      );
+      return { rows, pagesExhausted: false, failed: true, rateLimited: false };
+    }
+    rows.push(...res.rows);
+    if (!res.hasMore) {
+      return { rows, pagesExhausted: true, failed: false, rateLimited: false };
+    }
+  }
+  // Ran out of page budget with more still on offer — not exhausted, so the caller marks the
+  // record truncated.
+  return { rows, pagesExhausted: false, failed: false, rateLimited: false };
+}
+
 export async function runPrFilePass(
   ctx: SyncContext,
   args: {
@@ -180,46 +237,13 @@ export async function runPrFilePass(
     if (recorded >= MAX_PRS_PER_TICK) {
       break;
     }
-    const collected: ChangedFileRow[] = [];
-    let pagesExhausted = false;
-    let failed = false;
-    let rateLimited = false;
     try {
-      for (let page = 1; page <= MAX_PAGES_PER_PR; page++) {
-        // `tryAcquire`, never `acquire`: at least one existing 429 handler in this codebase
-        // (`_lib/gitlab/pipelines.ts`) calls `rateLimiter.penalise()` WITHOUT throwing, by
-        // design — its own caller keeps going rather than aborting the sync. `acquire` would
-        // then SLEEP OUT that whole penalty window right here, blocking one of only
-        // `maxConcurrentSyncs` scheduler slots for the full `Retry-After`. `tryAcquire` never
-        // sleeps (see its doc comment in `sync/rate-limiter.ts`) — it takes a token if one is
-        // free and returns `false` instantly otherwise — so a penalised or exhausted provider
-        // is detected without blocking, and the pass simply stops for THIS tick.
-        const ok = await ctx.rateLimiter.tryAcquire(args.service);
-        if (!ok) {
-          rateLimited = true;
-          break;
-        }
-        const res = await args.fetchPage(c, page);
-        if (res === null) {
-          // Warn on the SILENT failure path too, not just on the throw path below. `null` is what
-          // every forge closure returns for a non-ok response (a 404 on a deleted or now-private
-          // repo, most of all) and for an unparseable body — precisely the failures that repeat
-          // forever on the same PRs. Unlogged, the head-of-line stall that
-          // `PR_ATTEMPT_BUDGET_MULTIPLIER` bounds would be invisible: coverage would sit still
-          // with nothing in the log to say why.
-          ctx.logger.warn(
-            { service: args.service, itemId: c.itemId, page },
-            "PR changed-file page unavailable (non-fatal, PR left uncovered, will retry next tick)",
-          );
-          failed = true;
-          break;
-        }
-        collected.push(...res.rows);
-        if (!res.hasMore) {
-          pagesExhausted = true;
-          break;
-        }
-      }
+      const {
+        rows: collected,
+        pagesExhausted,
+        failed,
+        rateLimited,
+      } = await collectPrFilePages(ctx, args, c);
       if (rateLimited) {
         // No coverage row for this candidate — same handling as a failed fetch, and the
         // selector re-queues it next tick. Stop the WHOLE pass, not just this candidate: every

--- a/packages/gateway/src/prfiles/pr-file-mapping.ts
+++ b/packages/gateway/src/prfiles/pr-file-mapping.ts
@@ -48,8 +48,9 @@ export function mapGithubPrFiles(payload: unknown): ChangedFileRow[] {
     const status = normaliseGithubStatus(stringField(rec, "status") ?? "modified");
     const previous = stringField(rec, "previous_filename");
     if (status === "renamed" && previous !== undefined && previous !== "") {
-      out.push({ path, status: "renamed", counterpartPath: previous });
-      out.push({ path: previous, status: "renamed", counterpartPath: path });
+      // Was two inline pushes duplicating `pushPair` below; GitHub's `filename` is the NEW path
+      // and `previous_filename` the OLD one, so the argument order preserves the emitted order.
+      pushPair(out, previous, path);
       continue;
     }
     out.push({ path, status, counterpartPath: null });
@@ -59,8 +60,35 @@ export function mapGithubPrFiles(payload: unknown): ChangedFileRow[] {
 
 /** Emit one row per touched path, collapsing a rename's two paths into two rows. */
 function pushPair(out: ChangedFileRow[], oldPath: string, newPath: string): void {
-  out.push({ path: newPath, status: "renamed", counterpartPath: oldPath });
-  out.push({ path: oldPath, status: "renamed", counterpartPath: newPath });
+  out.push(
+    { path: newPath, status: "renamed", counterpartPath: oldPath },
+    { path: oldPath, status: "renamed", counterpartPath: newPath },
+  );
+}
+
+/**
+ * GitLab's three booleans, resolved to a status. Extracted from a nested ternary (S3358) — and
+ * the extraction is what brings `mapGitlabMrFiles` back under the complexity ceiling.
+ */
+function gitlabStatus(rec: Record<string, unknown>): ChangedFileStatus {
+  if (rec["new_file"] === true) {
+    return "added";
+  }
+  if (rec["deleted_file"] === true) {
+    return "removed";
+  }
+  return "modified";
+}
+
+/** Bitbucket's `status` string, narrowed to the three we store. Same reasoning as above. */
+function bitbucketStatus(raw: string): ChangedFileStatus {
+  if (raw === "added") {
+    return "added";
+  }
+  if (raw === "removed") {
+    return "removed";
+  }
+  return "modified";
 }
 
 /**
@@ -88,9 +116,7 @@ export function mapGitlabMrFiles(payload: unknown): ChangedFileRow[] {
     if (path === "") {
       continue;
     }
-    const status: ChangedFileStatus =
-      rec["new_file"] === true ? "added" : rec["deleted_file"] === true ? "removed" : "modified";
-    out.push({ path, status, counterpartPath: null });
+    out.push({ path, status: gitlabStatus(rec), counterpartPath: null });
   }
   return out;
 }
@@ -129,9 +155,7 @@ export function mapBitbucketPrFiles(payload: unknown): ChangedFileRow[] {
     if (path === "") {
       continue;
     }
-    const status: ChangedFileStatus =
-      raw === "added" ? "added" : raw === "removed" ? "removed" : "modified";
-    out.push({ path, status, counterpartPath: null });
+    out.push({ path, status: bitbucketStatus(raw), counterpartPath: null });
   }
   return out;
 }

--- a/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
+++ b/packages/gateway/test/e2e/scenarios/preflight-deploy.e2e.test.ts
@@ -1,8 +1,5 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { CURRENT_SCHEMA_VERSION } from "../../../src/index/local-index.ts";
 import { runIndexedSchemaMigrations } from "../../../src/index/migrations/runner.ts";
 import { dispatchPreflightRpc } from "../../../src/ipc/preflight-rpc.ts";
@@ -12,26 +9,30 @@ import {
 } from "../../fixtures/preflight/payment-service/seed.ts";
 
 describe("E2E (in-process): deploy.preflight", () => {
-  let dir: string;
   let db: Database;
 
+  // `:memory:`, not a temp-dir file — matching every sibling scenario in this directory
+  // (catchup / decisions / expert / glossary / impact all do the same).
+  //
+  // This hook runs the whole migration chain, and it does so once PER TEST. Against a file it
+  // measured 145-161 ms locally versus 12-13 ms in memory, and the CI runner is ~13-18x slower
+  // at exactly this work — temp-dir SQLite. That put the hook at ~3 s on Windows with nothing
+  // between it and Bun's 5 s hook budget, so the suite did not fail on an assertion, it failed
+  // with "a beforeEach/afterEach hook timed out for this test" on `main` (runs 32611067170 and
+  // 32638974730). The sibling test was passing at 2970 ms — over half the budget — which is the
+  // shape of a flake, not a pass.
+  //
+  // Nothing here needs a file: `dispatchPreflightRpc` takes the handle, never a path. Dropping
+  // the temp dir also drops the afterEach that existed solely to survive Windows file locking
+  // (#972, #973) — an unfinalized statement can make `db.close()` a silent no-op that pins the
+  // file open, and that hook was itself competing for the same timeout budget.
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "nimbus-preflight-e2e-"));
-    db = new Database(join(dir, "nimbus.db"));
+    db = new Database(":memory:");
     runIndexedSchemaMigrations(db, CURRENT_SCHEMA_VERSION);
   });
 
   afterEach(() => {
     db.close();
-    try {
-      // maxRetries: 0 / retryDelay: 0 — an unfinalized statement can make db.close() a
-      // silent no-op that pins the file open, and Windows will otherwise burn the hook's
-      // timeout budget retrying the delete. Fail fast and leak the temp dir instead: it's
-      // the accepted trade-off (#972, #973). Do NOT turn this back into a blocking retry.
-      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
-    } catch {
-      /* non-fatal */
-    }
   });
 
   it("returns a warn-verdict envelope on the fixture", async () => {

--- a/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
+++ b/packages/gateway/test/integration/platform/sandbox/sandbox-wrapper-spawn.test.ts
@@ -560,8 +560,12 @@ describe.skipIf(!READY && !IS_CI)("sandbox wrapper: real spawn on every platform
     // of silently skipping. This is the only test bun-test-registers on CI when the precondition
     // is unmet; the five real spawn tests below are deliberately not registered in that case —
     // running them anyway would only produce confusing secondary failures on top of this one.
+    // `expect.unreachable` rather than a bare `throw`: the two fail this test identically, but an
+    // assertion-free body is what S2699 flags — and it is right to, because that shape is
+    // indistinguishable from a test that simply forgot to assert. Reaching this line IS the
+    // failure, which is exactly what `unreachable` says.
     it("fails loudly instead of silently skipping when its CI prerequisite is missing", () => {
-      throw new Error(
+      expect.unreachable(
         `sandbox-wrapper-spawn: CI precondition unmet — ${MISSING}. ` +
           "This suite must never silently skip on CI: that is the exact hole it exists to " +
           "close. Install the missing sandbox dependency for this platform's CI job and re-run.",

--- a/watch-pr.sh
+++ b/watch-pr.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-while true; do
-  m=$(gh pr view 1316 --json state --jq '.state' 2>/dev/null)
-  if [ "$m" = "MERGED" ]; then echo "MERGED: PR #1316 landed on main"; break; fi
-  if [ "$m" = "CLOSED" ]; then echo "CLOSED: PR #1316 closed without merging"; break; fi
-  red=$(gh pr checks 1316 --json name,state --jq '.[] | select(.state=="FAILURE" or .state=="ERROR" or .state=="CANCELLED" or .state=="TIMED_OUT") | "RED: \(.name)"' 2>/dev/null | sort | tr '\n' ' ')
-  if [ -n "$red" ]; then echo "$red"; break; fi
-  sleep 60
-done

--- a/watch-pr.sh
+++ b/watch-pr.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+while true; do
+  m=$(gh pr view 1316 --json state --jq '.state' 2>/dev/null)
+  if [ "$m" = "MERGED" ]; then echo "MERGED: PR #1316 landed on main"; break; fi
+  if [ "$m" = "CLOSED" ]; then echo "CLOSED: PR #1316 closed without merging"; break; fi
+  red=$(gh pr checks 1316 --json name,state --jq '.[] | select(.state=="FAILURE" or .state=="ERROR" or .state=="CANCELLED" or .state=="TIMED_OUT") | "RED: \(.name)"' 2>/dev/null | sort | tr '\n' ' ')
+  if [ -n "$red" ]; then echo "$red"; break; fi
+  sleep 60
+done


### PR DESCRIPTION
## The flake

`E2E (in-process): deploy.preflight > returns a warn-verdict envelope on the fixture` has been failing intermittently on `main`'s Windows leg — runs 32611067170 and 32638974730, the latter being the post-merge run for #1315.

It is **not an assertion failure**. The log says so directly:

```
(fail) ... returns a warn-verdict envelope on the fixture [5393.55ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

`beforeEach` created a temp-dir SQLite file and ran the full migration chain to V56 — **per test**. Measured locally:

| storage | migration chain to V56 |
|---|---|
| temp-dir file | **145–161 ms** |
| `:memory:` | **12–13 ms** |

The CI runner is ~13–18× slower at exactly that work, putting the hook near ~3 s with nothing between it and Bun's 5 s hook budget. The sibling test in the same describe was *passing* at 2970 ms — over half the budget already, which is the shape of a flake rather than a pass.

**Fix:** `:memory:`, matching every sibling scenario in that directory (`catchup`, `decisions`, `expert`, `glossary`, `impact` — this file was the outlier). Nothing here needs a file: `dispatchPreflightRpc` takes the handle, never a path. It also removes the `afterEach` that existed only to survive Windows file locking (#972/#973), which was competing for the same budget. Whole file: **547 ms → 157 ms**.

## The Sonar backlog — all 23

The gate was already green (these sit outside the new-code period), so this is cleanup rather than an unblock.

**Three assertion-free tests (BLOCKER, S2699)** — the "tests that cannot fail" class:

- `relationship-graph.metadata.test.ts` ×2. Both are genuine compile-time guards where `@ts-expect-error` is the real assertion, but neither asserted anything at runtime. Rather than guess, I probed the actual behaviour: a co-owned type passed to the un-namespaced writer **is not refused** — the row lands with `service` NULL. So the added assertion documents *why* the compile-time guard must exist, instead of encoding a guess.
- `sandbox-wrapper-spawn.test.ts` — a deliberate `throw` for a missing CI prerequisite. Now `expect.unreachable()` (already the repo idiom), which fails identically but is a real assertion. Red-proved: the loud named message still fires verbatim.

**Nine cognitive-complexity refactors (S3776)** — all pure extraction, no behaviour change:

| file | was |
|---|---|
| `main.c` `mode_spawn` | 54 → arg parsing + grant application extracted |
| `diagnostics-rpc.ts` | 44 → param parse/validate + one shared negation result shaper |
| `query.ts` | 34 → help constant, flag validation, params, output |
| `pr-file-fetch.ts` | 26 → the page walk, with its three flags now a return value |
| `why.ts` | 25 → the two input arms + the lane decoder |
| `markdown-sections.ts` | 25 → the two envelope scans |
| `people.ts` | 23 → params, window line, JSON/text output |
| `pr-file-mapping.ts` ×2 | 16 → status resolvers extracted |
| `context-fairness.ts` | 16 → the service bucketing |

**The rest:** two `return Promise.resolve(v)` in an already-`async` function, two repeated `Array#push()`, three nested ternaries, one parameterized test, one C multi-declaration.

### One I did not "fix" as written

`c:S923` — *Remove use of ellipsis notation* on `err(const wchar_t *fmt, ...)` in the sandbox helper. Marked `NOSONAR` with a written justification rather than complied with, because complying makes the code **worse**: this is the single audited `vfwprintf` wrapper for 26 diagnostic sites, each with its own format string and argument types. Removing the ellipsis means 26 hand-managed stack buffers in security-sensitive C — more attack surface, for a rule aimed at unchecked variadic APIs rather than a fixed-format logger. `NOSONAR` with a reason is established practice in this repo. Flagging it explicitly so the call is reviewable rather than buried.

## Verification

- **`bun test packages/gateway packages/cli packages/mcp-connectors scripts`** — the exact command CI runs: **20,068 pass, 148 skip, 0 fail**, exit 0
- `bun run preflight:fast` — 32/32, including `audit:invariants` (D23) and `audit:boundaries`
- The C helper **rebuilds clean under `/W4 /WX`**, and the real sandbox spawn suite went from **5 skip → 5 pass** against the rebuilt binary, so confined spawns actually executed through the refactored `mode_spawn` rather than being skipped
- `preflight-deploy.e2e.test.ts` — 2 pass, before/after timings above

The one thing I could not verify locally is that each S3776 refactor lands under Sonar's threshold — that needs a `SONAR_TOKEN` I do not have. Each was reduced by extracting whole blocks rather than shaved toward 15, so there should be margin, but this PR's own Sonar run is the check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CLI handling for people lists and queries, including consistent review-window and result formatting.
  * Simplified diagnostic, sandbox, envelope, lane-resolution, fairness, and pull-request file-processing workflows while preserving existing behavior.
  * Centralized query negation responses and file-status mapping for more consistent results.

* **Tests**
  * Expanded runtime coverage for relationship-graph writes.
  * Consolidated metadata scenarios and improved sandbox test failure reporting.
  * Updated deployment tests to use in-memory databases for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->