### PR TITLE
feat(egress): record how a targeted fetch ended (U3a)

### DIFF
--- a/docs/SECURITY-INVARIANTS.md
+++ b/docs/SECURITY-INVARIANTS.md
@@ -664,6 +664,29 @@ influences, and only through a token the gateway itself verified: `destination` 
 service id derived internally from the URL's host, never anything the caller supplied. Nothing
 about I29's completeness changes — the same rows are appended, at the same point, fail-closed.
 
+**A completed targeted fetch now appends a SECOND row recording how it ended (U3).** The
+authorising row is appended BEFORE the connector call — fail-closed, no row no fetch — so its
+`result_status` records the authorisation decision and a fetch that 404s or times out still reads
+`authorized`. A `source_type='outcome'` row now follows it, carrying the status (`indexed` /
+`not_found` / `rate_limited`) and, on success, the item id. It names its authorising row by that
+row's `row_hash`, carried in `source_id` — the column prune tombstones already use for an attested
+hash, and the value the chain commits to.
+
+**It is a MARKER, and that is what keeps I29's counts honest.** An outcome row is bookkeeping about
+an outbound call this ledger has already counted; a fetch and its outcome are ONE outbound event,
+not two. `outcome` therefore joins `MARKER_SOURCE_TYPES` rather than becoming an egress class,
+`COVERAGE_CLASSES` is untouched, and the existing "COVERAGE_CLASSES is exactly the non-marker
+source types" test proves the two lists stayed in step without needing a new assertion of its own.
+
+**The two appends have deliberately opposite failure postures.** The authorising append is
+fail-closed. The outcome append swallows and warns, because by the time it runs the request has
+already left the machine: propagating would turn a fetch that genuinely succeeded into a failure
+and make the caller retry, causing MORE egress than the failure it reports. This is
+`appendBootMarkerOrWarn`'s precedent, and its rule holds here too — swallowing must never be
+silent, so the warning names what was lost. A reader seeing an authorising row with no outcome
+beside it may conclude only that the outcome was NOT RECORDED; a row written by a gateway predating
+this change is indistinguishable from one whose outcome append was lost.
+
 **`GET /v1/egress/prove` exposes `signWindowDigest` to a labelled clip token, and the bound is narrow by construction.** The caller supplies only `since`/`until` integers, so the signed message is always the BLAKE3 digest of a payload the gateway builds — never caller-chosen bytes. The `nimbus-egress-window-v2` tag lives inside that hashed payload, so a digest produced under a different rule cannot collide with one produced under this one. Share files sign `canonicalizeBody(body)` — canonical JSON — so a signature harvested here is not replayable as a share file. What the two artifacts do share is identity: both verify under the share keypair's public key, which `share.pubkey` already publishes. The route carries its own rate-limit budget (10/min, its own limiter instance) because it is the only one of the four doing asymmetric crypto per call.
 
 **How to comply:** `EgressSink` is the only DI seam for the ledger write — inject `makeEgressSink(db)` at boot (or the explicit `NULL_EGRESS_SINK` for an executor that structurally never dispatches). Every new action type that reaches `connectors.dispatch` from `executor.ts` will automatically be ledgered. If you add a new chokepoint around `connectors.dispatch`, you must run it through the existing executor gate (not bypass it) — the D22 static check will catch a new site that spells the literal string, but will not catch a decorator, façade, or raw-execute path, so those require a code-review judgment call, not just a green `audit:invariants`. For a new surface that serves gateway-synthesised content to an outside client, add its append at the surface's single dispatch entry point, before any work, with no `try/catch` — and land the `EGRESS_SOURCE_TYPES` member, the `COVERAGE_CLASSES` entry, the `THIS_BINARY_COVERAGE` granularity, the D22 caller pin, and the enforcement test in the same commit as the appender, exactly as `mcp` did.

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows-review.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows-review.md
@@ -1,0 +1,56 @@
+# Plan Review: Outcome Rows on the Egress Ledger (U3a)
+
+**Date:** 2026-08-24
+**Status:** Plan Review / Feedback
+**Target Plan:** [2026-08-24-egress-outcome-rows.md](./2026-08-24-egress-outcome-rows.md)
+
+---
+
+## 1. Summary of Feedback
+
+The implementation plan is extremely detailed, covers every step of the lifecycle cleanly (TDD, implementation, type checking, invariants validation, documentation, and commits), and respects all global constraints.
+
+Here are a few suggestions and validation items to keep in mind when executing this plan:
+
+---
+
+## 2. Detailed Feedback & Open Questions
+
+### Q1. TypeScript Casting for Logger Mock in Task 4 Test
+
+In Task 4, you add a test checking that a throwing outcome append does not abort the fetch and instead warns:
+
+```ts
+    logger: {
+      warn: (...args: unknown[]) => void warnings.push(args),
+    },
+```
+
+**Superseded — see the plan.** The plan now injects a `warn` seam on `TargetedFetchDeps` rather
+than reaching into `ctx.logger`, so no cast is needed at all. The observation below is correct and
+is what prompted the change.
+
+* **Suggestion:**
+  * Since `SyncContext["logger"]` is a Pino logger, TypeScript has strict type checks for it and will complain that the mock object is missing fields like `info`, `error`, `child`, etc.
+  * Ensure the mock is cast with `as unknown as SyncContext["logger"]` when overriding `fakeCtx` in `depsWith` (similar to the rateLimiter mock structure) to avoid strict typecheck errors.
+
+### Q2. TSC Strictness on Function Return Type Constraints
+
+The plan defines `appendEgress` and `appendOutcome` with explicit `undefined` return values to prevent `async void` assignments.
+
+* **Suggestion:**
+  * Some TS configs can be lenient with returning `void` when `undefined` is expected, or vice-versa.
+  * When configuring mock implementations in the tests, verify that `() => undefined` (explicitly returning `undefined` or a block returning nothing) is used in place of implicitly typed arrow functions to ensure absolute compliance with compiler expectations.
+
+### Q3. Static D22 Verification
+
+* **Check:**
+  * Task 4 imports `FetchOutcomeStatus` from `../egress/outcome-egress.ts` into `targeted-fetch.ts`.
+  * Double check that this import only carries type definitions and does not pull in any runtime implementation from `egress/` (which would trigger the static D22 rule if it restricts imports). Since `FetchOutcomeStatus` is a TypeScript `type`, this should be perfectly safe, but using `import type { FetchOutcomeStatus }` explicitly is recommended.
+
+---
+
+## 3. Recommended Actions
+
+* Adopt the `superpowers:subagent-driven-development` sub-skill as suggested to execute this plan incrementally.
+* Ensure that `bun run typecheck` is run after Task 4 and Task 5 to catch any residual type mismatches.

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -154,7 +154,7 @@ git commit -m "refactor(egress): return the row hash the append already computed
 - Consumes: nothing.
 - Produces: `"outcome"` as an `EgressSourceType` and a member of `MARKER_SOURCE_TYPES`, consumed by Task 3.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 The existing test asserts the exact ten-member list, so it must be EDITED, not appended to. In `egress-source-type.test.ts`:
 
@@ -189,12 +189,12 @@ The existing test asserts the exact ten-member list, so it must be EDITED, not a
 
 Keep the existing `isMarkerSourceType` test's egress-bearing and unknown cases exactly as they are.
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `bun test packages/gateway/src/egress/egress-source-type.test.ts`
 Expected: FAIL — the union has ten members and `MARKER_SOURCE_TYPES` has three.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `egress-source-type.ts`, append the member and add its decision paragraph — the file's header requires one, and both `mcp` and `http` set the precedent:
 
@@ -232,7 +232,7 @@ export const MARKER_SOURCE_TYPES: ReadonlySet<EgressSourceType> = new Set<Egress
 ]);
 ```
 
-- [ ] **Step 4: Run the tests, including the invariant that validates the choice**
+- [x] **Step 4: Run the tests, including the invariant that validates the choice**
 
 Run: `bun test packages/gateway/src/egress/egress-source-type.test.ts`
 Expected: PASS.
@@ -240,7 +240,7 @@ Expected: PASS.
 Run: `bun test packages/gateway/src/security-invariants.test.ts`
 Expected: PASS, **with no edit to that file**. It asserts `COVERAGE_CLASSES` is exactly the non-marker source types; adding a marker keeps that identity. If it fails, `outcome` was added to `COVERAGE_CLASSES` or omitted from `MARKER_SOURCE_TYPES` — fix the code, never the assertion.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/gateway/src/egress/egress-source-type.ts packages/gateway/src/egress/egress-source-type.test.ts

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -737,12 +737,12 @@ git commit -m "feat(sync): record how a targeted fetch ended"
 - Consumes: everything above.
 - Produces: nothing.
 
-- [ ] **Step 1: Confirm the invariant suite still passes untouched**
+- [x] **Step 1: Confirm the invariant suite still passes untouched**
 
 Run: `bun test packages/gateway/src/security-invariants.test.ts`
 Expected: PASS with no edit to that file. If it fails, stop — the failure is the specification of what went wrong, and it means `outcome` landed in the wrong list.
 
-- [ ] **Step 2: Write the note**
+- [x] **Step 2: Write the note**
 
 In the I29 section of `docs/SECURITY-INVARIANTS.md`, after the U2a paragraph, record three things:
 
@@ -752,12 +752,12 @@ In the I29 section of `docs/SECURITY-INVARIANTS.md`, after the U2a paragraph, re
 
 Respect the launch-messaging guardrail: the ledger records dispatched actions at the executor chokepoint, not raw network traffic.
 
-- [ ] **Step 3: Lint the docs**
+- [x] **Step 3: Lint the docs**
 
 Run: `bun run lint:markdown`
 Expected: 0 issues.
 
-- [ ] **Step 4: Full verification**
+- [x] **Step 4: Full verification**
 
 Run:
 
@@ -769,7 +769,7 @@ bun run typecheck
 
 Expected: all pass. Remember `bun run lint` false-fails inside a worktree — use the `bunx biome check` form.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add docs/SECURITY-INVARIANTS.md

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -19,7 +19,8 @@
 - **Never commit on `main`.** This work lands on `dev/asafgolombek/egress-outcome` in `.claude/worktrees/egress-outcome`. Verify with `git rev-parse --abbrev-ref HEAD` before the first commit.
 - **Biome false-fails in worktrees.** `bun run lint` reports "0 files processed" and exits 1 inside `.claude/worktrees/`. Validate with `bunx biome check packages scripts` instead.
 - **`docs/**` is markdownlint-gated.** Validate with `bun run lint:markdown` before committing.
-- **`appendEgressEntry` is confined to `egress/*` by the static D22 rule.** Never import it from `sync/`, `ipc/` or anywhere else — the write site receives an injected closure, as `targetedFetch` already does.
+- **`appendEgressEntry` is confined to `egress/*` by the static D22 rule.** Never import it from `sync/`, `ipc/` or anywhere else — the write site receives an injected closure, as `targetedFetch` already does. The rule is a SYMBOL regex (`/appendEgressEntry/`, `scripts/structure-audit/check-nimbus-invariants.ts`), not a path-import rule, so Task 4's `import type { FetchOutcomeStatus } from "../egress/outcome-egress.ts"` is fine — it names no confined symbol, and a type-only import emits nothing at runtime regardless.
+- **`() => undefined`, never a bare `() => {}`, for every append seam stub.** The seams return `undefined` rather than `void` on purpose; `targeted-fetch.test.ts` already defaults them as `overrides.appendEgress ?? (() => undefined)`, and new stubs follow that.
 - **The outcome row must never count as outbound.** It joins `MARKER_SOURCE_TYPES`. `COVERAGE_CLASSES` is NOT touched, and the existing `I29: COVERAGE_CLASSES is exactly the non-marker source types` test must pass unchanged. If it fails, the member went in the wrong list.
 - **The authorising append stays fail-closed; the outcome append swallows and warns.** By the time the outcome runs the request has left the machine — propagating would turn a successful fetch into a 500 and make the caller retry, causing MORE egress than the failure it reports. Swallowing must never be silent.
 - **The append seams stay synchronous.** They are typed to return `undefined` (not `void`) so an `async` implementation is a compile error: an async rejection would surface after `targetedFetch` had moved past the call, breaking fail-closed. Widening a return type must preserve that — return a plain object, never a promise.
@@ -577,9 +578,7 @@ test("a throwing outcome append does not fail the fetch, and warns", async () =>
     appendOutcome: () => {
       throw new Error("disk full");
     },
-    logger: {
-      warn: (...args: unknown[]) => void warnings.push(args),
-    },
+    warn: (...args: unknown[]) => void warnings.push(args),
     syncableFor: (service) => ({
       serviceId: service,
       defaultIntervalMs: 60_000,
@@ -601,7 +600,16 @@ test("a throwing outcome append does not fail the fetch, and warns", async () =>
 });
 ```
 
-The last test needs the fake `SyncContext`'s logger to be overridable. `depsWith` builds `fakeCtx` with `logger: pino({ level: "silent" })` — add an optional `logger` override to `DepsOverrides` and use it in place of the pino instance when present.
+The last test needs `warn` on `DepsOverrides`, defaulted to a no-op alongside `appendEgress`.
+
+**Inject `warn`; do not reach into `ctx.logger`.** `SyncContext["logger"]` is a pino `Logger`, so a
+`{ warn }` mock does not structurally satisfy it and the test would need an
+`as unknown as SyncContext["logger"]` cast. Every other collaborator in `TargetedFetchDeps` is
+already injected (`sleep`, `appendEgress`, `urlIsSupported`, `contextFor`) and `targetedFetch` does
+not log at all today, so a logger reached through the context would be the odd one out. Narrowing
+the dependency to what is actually used is also the precedent `appendBootMarkerOrWarn` sets, taking
+`Pick<Logger, "warn">` rather than a whole logger. The production wiring in `assemble.ts` passes
+`syncLogger.warn.bind(syncLogger)`.
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
@@ -639,6 +647,12 @@ In `targeted-fetch.ts`, widen `appendEgress` and add `appendOutcome` to `Targete
     readonly itemId?: string | undefined;
     readonly reason?: string | undefined;
   }) => undefined;
+  /**
+   * Where a swallowed outcome-append failure is reported. Injected rather than reached through
+   * `ctx.logger`: everything else this module collaborates with is injected, and a narrow seam is
+   * what `appendBootMarkerOrWarn` takes too (`Pick<Logger, "warn">`).
+   */
+  readonly warn: (err: unknown, message: string) => void;
 ```
 
 Import the type: `import type { FetchOutcomeStatus } from "../egress/outcome-egress.ts";`
@@ -671,7 +685,7 @@ Then the write site. Replace the tail of `targetedFetch`:
         ...("reason" in result ? { reason: result.reason } : {}),
       });
     } catch (err) {
-      ctx.logger.warn(
+      deps.warn(
         { err },
         "I29: failed to append the targeted-fetch outcome marker — the ledger will report this " +
           "fetch as authorised with no recorded outcome",
@@ -688,6 +702,7 @@ In `assemble.ts`, wire the new closure beside the existing `appendEgress` one:
 
 ```ts
         appendOutcome: (row) => recordFetchOutcomeEgress(db, { ...row, now: Date.now() }),
+        warn: (err, message) => syncLogger.warn(err, message),
 ```
 
 - [ ] **Step 4: Run the tests to verify they pass**
@@ -766,5 +781,12 @@ git commit -m "docs(security): record the outcome marker against I29"
 **Placeholder scan.** No TBD/TODO. Task 5's doc note is prose specified by its three required points rather than verbatim text, because it must read continuously with the paragraphs around it; every claim it must make is enumerated.
 
 **Type consistency.** `{ rowHash: string }` is introduced in Task 1 and consumed under that exact name in Tasks 3 and 4. `FetchOutcomeStatus` is defined in Task 3 and imported in Task 4. `recordFetchOutcomeEgress`'s argument names (`destination`, `authorizingRowHash`, `status`, `itemId`, `reason`, `now`) match Task 4's `appendOutcome` row exactly, less `now`, which the assemble closure supplies — the same split `recordSyncEgress` already uses.
+
+**No D22 caller-pin is added for `recordFetchOutcomeEgress`, deliberately.** Rule (c) pins
+`recordAgentBriefEgress` to exactly one caller, which makes its chokepoint total. The closer
+analogue here is `recordSyncEgress` — also an `egress/` appender reached through an injected
+closure — and it carries no pin either. Adding one for a new appender while its sibling has none
+would be inconsistent, and the property this row class needs (never counted as outbound) is already
+structural through `MARKER_SOURCE_TYPES` rather than dependent on who calls it.
 
 **The risk worth flagging to the executor.** Task 4 widens a seam's return type. That seam is typed to return `undefined` rather than `void` specifically so an `async` implementation is a compile error, and U2a already produced one silent failure in this exact area — a closure with fewer parameters stayed assignable and dropped its argument. Typecheck cannot catch either shape. The behavioural tests in Task 4 are what prove the value arrives; do not weaken them into type assertions.

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -473,7 +473,7 @@ git commit -m "feat(egress): an outcome marker that names the row it describes"
 - Consumes: Task 1's `recordSyncEgress` return; Task 3's `recordFetchOutcomeEgress` and `FetchOutcomeStatus`.
 - Produces: `TargetedFetchDeps.appendEgress` returning `{ rowHash: string } | undefined`, and a new `TargetedFetchDeps.appendOutcome`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `packages/gateway/src/sync/targeted-fetch.test.ts`. The file's `depsWith` factory needs an `appendOutcome` override — add it to `DepsOverrides` and default it to `() => undefined` alongside `appendEgress`:
 
@@ -611,12 +611,12 @@ the dependency to what is actually used is also the precedent `appendBootMarkerO
 `Pick<Logger, "warn">` rather than a whole logger. The production wiring in `assemble.ts` passes
 `syncLogger.warn.bind(syncLogger)`.
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `bun test packages/gateway/src/sync/targeted-fetch.test.ts`
 Expected: FAIL — `appendOutcome` is not a known dep, and no outcome rows are recorded.
 
-- [ ] **Step 3: Implement the seam and the write site**
+- [x] **Step 3: Implement the seam and the write site**
 
 In `targeted-fetch.ts`, widen `appendEgress` and add `appendOutcome` to `TargetedFetchDeps`:
 
@@ -698,14 +698,18 @@ Then the write site. Replace the tail of `targetedFetch`:
 
 `result.status` is `"indexed" | "not_found" | "rate_limited"` here: `fetchOneWithRetry` returns a `FetchOneResult`, whose fourth arm `unsupported_url` is unreachable because the pre-append `willAttempt` check already refused it. If TypeScript does not narrow that automatically, narrow it explicitly with an `if (result.status !== "unsupported_url")` guard rather than casting.
 
-In `assemble.ts`, wire the new closure beside the existing `appendEgress` one:
+In `assemble.ts`, wire the new closures beside the existing `appendEgress` one. **`syncLogger` is
+not in scope inside `bootTargetedFetchIntoHttpSidecar`** — it is declared in the enclosing
+`assemble` function, so thread it through that function's deps as
+`logger: Pick<Logger, "warn">` (the same narrowing `appendBootMarkerOrWarn` uses) and pass
+`logger: syncLogger` at the call site:
 
 ```ts
         appendOutcome: (row) => recordFetchOutcomeEgress(db, { ...row, now: Date.now() }),
         warn: (err, message) => syncLogger.warn(err, message),
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `bun test packages/gateway/src/sync packages/gateway/src/egress`
 Expected: PASS.
@@ -713,7 +717,7 @@ Expected: PASS.
 Run: `bun run typecheck`
 Expected: 0 errors. **Do not skip this** — `bun test` does not typecheck strictly, and a test file's local row type may need the new optional fields.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/gateway/src/sync/targeted-fetch.ts packages/gateway/src/sync/targeted-fetch.test.ts packages/gateway/src/platform/assemble.ts

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -54,7 +54,7 @@
 - Consumes: nothing.
 - Produces: `appendEgressEntry(db, entry): { rowHash: string }` and `recordSyncEgress(db, args): { rowHash: string } | undefined`, both consumed by Tasks 3 and 4.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `packages/gateway/src/egress/egress-ledger.test.ts`:
 
@@ -86,12 +86,12 @@ test("returns undefined for a local-only destination, because no row was written
 
 If `egress-ledger.test.ts` has no `e()` entry factory or `listEgress` import, copy both from `egress-verify.test.ts`, which has them.
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `bun test packages/gateway/src/egress/egress-ledger.test.ts packages/gateway/src/egress/sync-egress.test.ts`
 Expected: FAIL — `out.rowHash` is undefined because both functions return `void`/`undefined`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `egress-ledger.ts`, change the signature and add the return. The body is otherwise untouched — `rowHash` is already computed on line 56:
 
@@ -127,12 +127,12 @@ export function recordSyncEgress(
 
 The return type stays a union with `undefined` rather than becoming `void`, for the reason its doc comment already gives: `void`-return leniency would silently accept an `async` implementation at either seam this function is assigned to.
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `bun test packages/gateway/src/egress`
-Expected: PASS. Every existing test in the directory must still pass — this change is additive at both call sites.
+Expected: PASS. **Two existing assertions need updating, and this step's original claim that the change is "additive at both call sites" was wrong:** `sync-egress.test.ts`'s first test asserted `expect(out).toBeUndefined()`, which pinned the old return — change it to assert the hash, never delete it. And `assemble.ts`'s `appendEgress` closure is declared `=> undefined`, so it no longer typechecks: make it `(row) => void recordSyncEgress(...)` until Task 4 widens the seam to consume the value. `bun test` will NOT catch the second one — only `bun run typecheck` will.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git rev-parse --abbrev-ref HEAD   # must print dev/asafgolombek/egress-outcome

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -1,0 +1,770 @@
+# Outcome Rows on the Egress Ledger (U3a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record how a targeted fetch ended, so the ledger stops reporting every fetch as `authorized` regardless of what came back.
+
+**Architecture:** A second ledger row per completed targeted fetch, written after the connector call. It is a MARKER (`source_type: "outcome"`), so it never counts as outbound egress — it is bookkeeping about a call already counted. It names the row it describes by that row's `row_hash`, carried in `source_id`, which means `appendEgressEntry` must start returning the hash it already computes.
+
+**Tech Stack:** Bun 1.2+, TypeScript strict, `bun:test`, Biome, markdownlint-cli2.
+
+**Spec:** [`2026-08-24-egress-outcome-rows-design.md`](../specs/2026-08-24-egress-outcome-rows-design.md)
+**Review + answers:** [`2026-08-24-egress-outcome-rows-design-review.md`](../specs/2026-08-24-egress-outcome-rows-design-review.md)
+
+**Consumer:** U3b in `nimbus-web-clipper` renders the outcome column. Not in this plan.
+
+## Global Constraints
+
+- **No `any`.** `unknown` for external data, narrowed by a guard. TypeScript strict is non-negotiable.
+- **Never commit on `main`.** This work lands on `dev/asafgolombek/egress-outcome` in `.claude/worktrees/egress-outcome`. Verify with `git rev-parse --abbrev-ref HEAD` before the first commit.
+- **Biome false-fails in worktrees.** `bun run lint` reports "0 files processed" and exits 1 inside `.claude/worktrees/`. Validate with `bunx biome check packages scripts` instead.
+- **`docs/**` is markdownlint-gated.** Validate with `bun run lint:markdown` before committing.
+- **`appendEgressEntry` is confined to `egress/*` by the static D22 rule.** Never import it from `sync/`, `ipc/` or anywhere else — the write site receives an injected closure, as `targetedFetch` already does.
+- **The outcome row must never count as outbound.** It joins `MARKER_SOURCE_TYPES`. `COVERAGE_CLASSES` is NOT touched, and the existing `I29: COVERAGE_CLASSES is exactly the non-marker source types` test must pass unchanged. If it fails, the member went in the wrong list.
+- **The authorising append stays fail-closed; the outcome append swallows and warns.** By the time the outcome runs the request has left the machine — propagating would turn a successful fetch into a 500 and make the caller retry, causing MORE egress than the failure it reports. Swallowing must never be silent.
+- **The append seams stay synchronous.** They are typed to return `undefined` (not `void`) so an `async` implementation is a compile error: an async rejection would surface after `targetedFetch` had moved past the call, breaking fail-closed. Widening a return type must preserve that — return a plain object, never a promise.
+- **Honesty guardrail (`docs/launch-messaging.md`).** The egress ledger records the agent's dispatched actions at the I29 executor chokepoint, never raw network traffic.
+- **Commit messages are discarded on merge.** The PR title and description become the squash commit.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/gateway/src/egress/egress-ledger.ts` (modify) | `appendEgressEntry` returns the `row_hash` it already computes. |
+| `packages/gateway/src/egress/egress-source-type.ts` (modify) | `outcome` joins the frozen union AND `MARKER_SOURCE_TYPES`. |
+| `packages/gateway/src/egress/outcome-egress.ts` (create) | The outcome appender. Pure of the fetch — takes a status, writes a row. |
+| `packages/gateway/src/egress/sync-egress.ts` (modify) | `recordSyncEgress` passes the hash through. |
+| `packages/gateway/src/sync/targeted-fetch.ts` (modify) | The seam types and the write site. |
+| `packages/gateway/src/platform/assemble.ts` (modify) | Wires the new `appendOutcome` closure. |
+| `docs/SECURITY-INVARIANTS.md` (modify) | The I29 note. |
+
+---
+
+## Task 1: `appendEgressEntry` returns the hash it already computes
+
+**Files:**
+
+- Modify: `packages/gateway/src/egress/egress-ledger.ts:54`
+- Modify: `packages/gateway/src/egress/sync-egress.ts`
+- Test: `packages/gateway/src/egress/egress-ledger.test.ts`, `packages/gateway/src/egress/sync-egress.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `appendEgressEntry(db, entry): { rowHash: string }` and `recordSyncEgress(db, args): { rowHash: string } | undefined`, both consumed by Tasks 3 and 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/gateway/src/egress/egress-ledger.test.ts`:
+
+```ts
+test("returns the row hash it stored, so a later row can name this one", () => {
+  const out = appendEgressEntry(db, e({ method: "a.x", timestamp: 1 }));
+  const stored = listEgress(db, {})[0];
+  expect(out.rowHash).toBe(stored?.rowHash);
+  expect(out.rowHash).toMatch(/^[0-9a-f]{64}$/);
+});
+```
+
+Add to `packages/gateway/src/egress/sync-egress.test.ts`:
+
+```ts
+test("returns the appended row's hash", () => {
+  const out = recordSyncEgress(db, { destination: "github", method: "items.fetch", now: 1_000 });
+  expect(out?.rowHash).toBe(listEgress(db, {})[0]?.rowHash);
+});
+
+test("returns undefined for a local-only destination, because no row was written", () => {
+  // The caller uses this to decide whether an outcome row may be written at all:
+  // with no authorising row there is nothing for one to name.
+  expect(
+    recordSyncEgress(db, { destination: "filesystem", method: "items.fetch", now: 1_000 }),
+  ).toBeUndefined();
+});
+```
+
+If `egress-ledger.test.ts` has no `e()` entry factory or `listEgress` import, copy both from `egress-verify.test.ts`, which has them.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/egress/egress-ledger.test.ts packages/gateway/src/egress/sync-egress.test.ts`
+Expected: FAIL — `out.rowHash` is undefined because both functions return `void`/`undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `egress-ledger.ts`, change the signature and add the return. The body is otherwise untouched — `rowHash` is already computed on line 56:
+
+```ts
+/**
+ * Append one chained row, and return the hash it was stored under.
+ *
+ * The hash is returned because a later MARKER row may need to name this one —
+ * see `outcome-egress.ts`. It is the value the chain already commits to, so a
+ * correlation key built on it cannot drift from the row it points at.
+ */
+export function appendEgressEntry(db: Database, entry: EgressEntry): { rowHash: string } {
+  // ... unchanged body ...
+  return { rowHash };
+}
+```
+
+In `sync-egress.ts`, thread it through. Keep the `undefined` arm and its reasoning:
+
+```ts
+export function recordSyncEgress(
+  db: Database,
+  args: { /* ... unchanged ... */ },
+): { rowHash: string } | undefined {
+  if (LOCAL_ONLY_SYNC_SERVICES.has(args.destination)) {
+    return undefined;
+  }
+  return appendEgressEntry(db, {
+    // ... unchanged entry ...
+  });
+}
+```
+
+The return type stays a union with `undefined` rather than becoming `void`, for the reason its doc comment already gives: `void`-return leniency would silently accept an `async` implementation at either seam this function is assigned to.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/egress`
+Expected: PASS. Every existing test in the directory must still pass — this change is additive at both call sites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # must print dev/asafgolombek/egress-outcome
+git add packages/gateway/src/egress/egress-ledger.ts packages/gateway/src/egress/sync-egress.ts packages/gateway/src/egress/egress-ledger.test.ts packages/gateway/src/egress/sync-egress.test.ts
+git commit -m "refactor(egress): return the row hash the append already computed"
+```
+
+---
+
+## Task 2: `outcome` joins the frozen union, as a marker
+
+**Files:**
+
+- Modify: `packages/gateway/src/egress/egress-source-type.ts`
+- Modify: `packages/gateway/src/egress/egress-source-type.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `"outcome"` as an `EgressSourceType` and a member of `MARKER_SOURCE_TYPES`, consumed by Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+The existing test asserts the exact ten-member list, so it must be EDITED, not appended to. In `egress-source-type.test.ts`:
+
+```ts
+  test("is exactly these eleven members, in this order", () => {
+    expect([...EGRESS_SOURCE_TYPES]).toEqual([
+      "task",
+      "prune",
+      "session",
+      "sync",
+      "model",
+      "peer",
+      "mcp",
+      "boot",
+      "degraded",
+      "http",
+      "outcome",
+    ]);
+  });
+
+  test("marker types are the four bookkeeping classes", () => {
+    expect([...MARKER_SOURCE_TYPES].sort()).toEqual(["boot", "degraded", "outcome", "prune"]);
+  });
+
+  test("outcome is a MARKER, so it can never be counted as outbound egress", () => {
+    // The whole argument for admitting an eleventh member: an outcome row is
+    // bookkeeping about an outbound call the ledger has ALREADY counted.
+    // Counting it again would double every targeted fetch.
+    expect(isMarkerSourceType("outcome")).toBe(true);
+  });
+```
+
+Keep the existing `isMarkerSourceType` test's egress-bearing and unknown cases exactly as they are.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/egress/egress-source-type.test.ts`
+Expected: FAIL — the union has ten members and `MARKER_SOURCE_TYPES` has three.
+
+- [ ] **Step 3: Implement**
+
+In `egress-source-type.ts`, append the member and add its decision paragraph — the file's header requires one, and both `mcp` and `http` set the precedent:
+
+```ts
+ * `outcome` is the eleventh member, and the first added as a MARKER rather than an egress class.
+ * It records how a targeted fetch ENDED: `targetedFetch` appends its egress row before calling the
+ * connector (fail-closed — no row, no fetch), so `result_status` records the authorisation
+ * decision and nothing in the ledger ever said what came back.
+ *
+ * Marker, not egress class, is the whole argument. The row is bookkeeping about an outbound call
+ * this ledger has already counted; counting it again would double every targeted fetch and inflate
+ * the exact number I29 exists to state honestly. Because it joins `MARKER_SOURCE_TYPES` it claims
+ * no coverage granularity, `COVERAGE_CLASSES` is untouched, and the existing
+ * "COVERAGE_CLASSES is exactly the non-marker source types" invariant proves the two lists stayed
+ * in step.
+ *
+ * Reusing `sync` with a reserved `method` was rejected: `sync` is not a marker, so every outcome
+ * row would count as outbound unless the counting predicate grew a method-level special case —
+ * reintroducing by hand the miscount `MARKER_SOURCE_TYPES` exists to make structural.
+ */
+export const EGRESS_SOURCE_TYPES = [
+  // ... the existing ten, unchanged and in order ...
+  "outcome", // how a targeted fetch ended — a marker, never counted as egress
+] as const;
+```
+
+and:
+
+```ts
+export const MARKER_SOURCE_TYPES: ReadonlySet<EgressSourceType> = new Set<EgressSourceType>([
+  "prune",
+  "boot",
+  "degraded",
+  "outcome",
+]);
+```
+
+- [ ] **Step 4: Run the tests, including the invariant that validates the choice**
+
+Run: `bun test packages/gateway/src/egress/egress-source-type.test.ts`
+Expected: PASS.
+
+Run: `bun test packages/gateway/src/security-invariants.test.ts`
+Expected: PASS, **with no edit to that file**. It asserts `COVERAGE_CLASSES` is exactly the non-marker source types; adding a marker keeps that identity. If it fails, `outcome` was added to `COVERAGE_CLASSES` or omitted from `MARKER_SOURCE_TYPES` — fix the code, never the assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/egress/egress-source-type.ts packages/gateway/src/egress/egress-source-type.test.ts
+git commit -m "feat(egress): admit outcome to the frozen union, as a marker"
+```
+
+---
+
+## Task 3: The outcome appender
+
+**Files:**
+
+- Create: `packages/gateway/src/egress/outcome-egress.ts`
+- Test: `packages/gateway/src/egress/outcome-egress.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1's `appendEgressEntry`; Task 2's `"outcome"` source type.
+- Produces: `recordFetchOutcomeEgress(db, args): undefined` where `args` is `{ destination: string; authorizingRowHash: string; status: FetchOutcomeStatus; itemId?: string; reason?: string; now: number }`, and `export type FetchOutcomeStatus = "indexed" | "not_found" | "rate_limited"`. Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/gateway/src/egress/outcome-egress.test.ts`, modelled on `sync-egress.test.ts` (copy its `beforeEach` DB setup and `listEgress` import):
+
+```ts
+describe("recordFetchOutcomeEgress", () => {
+  test("writes one outcome marker naming the authorising row by hash", () => {
+    const authorizing = appendEgressEntry(db, {
+      timestamp: 1_000,
+      sourceType: "sync",
+      sourceId: "asafs-browser",
+      destination: "github",
+      method: "items.fetch",
+      payloadSummary: "{}",
+      hitlStatus: "not_required",
+      resultStatus: "authorized",
+    });
+
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: authorizing.rowHash,
+      status: "indexed",
+      itemId: "github:acme/web#482",
+      now: 2_000,
+    });
+
+    const rows = listEgress(db, {});
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({
+      sourceType: "outcome",
+      // The correlation key. `source_id` carries an attested hash on prune
+      // tombstones already, so a marker using it this way is established.
+      sourceId: authorizing.rowHash,
+      destination: "github",
+      method: "items.fetch.outcome",
+      hitlStatus: "not_required",
+      // "was this allowed", not "did it work" — the fetch's success lives in
+      // the summary, which is the field with three values.
+      resultStatus: "authorized",
+    });
+    expect(rows[1]?.payloadSummary).toContain("indexed");
+    expect(rows[1]?.payloadSummary).toContain("github:acme/web#482");
+  });
+
+  test("carries the miss reason on not_found, and no itemId", () => {
+    recordFetchOutcomeEgress(db, {
+      destination: "jira",
+      authorizingRowHash: "a".repeat(64),
+      status: "not_found",
+      reason: "deleted",
+      now: 2_000,
+    });
+    const summary = listEgress(db, {})[0]?.payloadSummary ?? "";
+    expect(summary).toContain("not_found");
+    expect(summary).toContain("deleted");
+    expect(summary).not.toContain("itemId");
+  });
+
+  test("an outcome row does NOT count as outbound egress", () => {
+    // The double-count guard. A fetch and its outcome are ONE outbound event.
+    appendEgressEntry(db, {
+      timestamp: 1_000,
+      sourceType: "sync",
+      sourceId: null,
+      destination: "github",
+      method: "items.fetch",
+      payloadSummary: "{}",
+      hitlStatus: "not_required",
+      resultStatus: "authorized",
+    });
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: "b".repeat(64),
+      status: "rate_limited",
+      now: 2_000,
+    });
+    expect(countOutboundEgress(db, {})).toBe(1);
+  });
+
+  test("the chain still verifies across the pair", () => {
+    const first = appendEgressEntry(db, {
+      timestamp: 1_000,
+      sourceType: "sync",
+      sourceId: null,
+      destination: "github",
+      method: "items.fetch",
+      payloadSummary: "{}",
+      hitlStatus: "not_required",
+      resultStatus: "authorized",
+    });
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: first.rowHash,
+      status: "indexed",
+      itemId: "github:acme/web#1",
+      now: 2_000,
+    });
+    const verdict = verifyEgressChain(db);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.verifiedRows).toBe(2);
+  });
+
+  test("a throwing append propagates — the caller owns the swallow", () => {
+    // Swallowing lives at the call site (targeted-fetch.ts), following
+    // `appendBootMarkerOrWarn`. This function must not hide a failure from a
+    // caller that may want to warn about it.
+    db.close();
+    expect(() =>
+      recordFetchOutcomeEgress(db, {
+        destination: "github",
+        authorizingRowHash: "c".repeat(64),
+        status: "indexed",
+        now: 2_000,
+      }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test packages/gateway/src/egress/outcome-egress.test.ts`
+Expected: FAIL — cannot resolve `./outcome-egress.ts`.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/gateway/src/egress/outcome-egress.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import { appendEgressEntry } from "./egress-ledger.ts";
+import { redactEgressSummary } from "./egress-record.ts";
+
+/**
+ * How a targeted fetch ended, for the three arms reachable AFTER the egress append.
+ *
+ * The other three `TargetedFetchOutcome` arms — `unsupported_url`, `no_targeted_fetch`,
+ * `not_configured` — are refused before any row is written, so no outcome row can describe them:
+ * there is nothing for one to name.
+ */
+export type FetchOutcomeStatus = "indexed" | "not_found" | "rate_limited";
+
+/**
+ * Append ONE `outcome` marker describing a completed targeted fetch.
+ *
+ * A MARKER, never an egress class: this is bookkeeping about an outbound call the ledger has
+ * already counted, and counting it again would double every targeted fetch.
+ *
+ * `authorizingRowHash` goes in `source_id` — the column prune tombstones already use to carry an
+ * attested hash. It is the value the chain commits to, and every consumer of `GET /v1/egress`
+ * receives it as `rowHash`, so the join needs no new field on the wire.
+ *
+ * Throws on append failure rather than swallowing. The swallow belongs at the call site, which has
+ * the logger and the context to say what was lost — see `appendBootMarkerOrWarn` for the shape.
+ */
+export function recordFetchOutcomeEgress(
+  db: Database,
+  args: {
+    readonly destination: string;
+    readonly authorizingRowHash: string;
+    readonly status: FetchOutcomeStatus;
+    readonly itemId?: string | undefined;
+    readonly reason?: string | undefined;
+    readonly now: number;
+  },
+): undefined {
+  appendEgressEntry(db, {
+    timestamp: args.now,
+    sourceType: "outcome",
+    sourceId: args.authorizingRowHash,
+    destination: args.destination,
+    method: "items.fetch.outcome",
+    payloadSummary: redactEgressSummary({
+      status: args.status,
+      ...(args.itemId === undefined ? {} : { itemId: args.itemId }),
+      ...(args.reason === undefined ? {} : { reason: args.reason }),
+    }),
+    hitlStatus: "not_required",
+    // "was this action allowed", not "did it succeed". The fetch's result lives in the summary.
+    resultStatus: "authorized",
+  });
+  return undefined;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/egress`
+Expected: PASS, including the double-count guard and the chain verification.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/egress/outcome-egress.ts packages/gateway/src/egress/outcome-egress.test.ts
+git commit -m "feat(egress): an outcome marker that names the row it describes"
+```
+
+---
+
+## Task 4: The write site
+
+**Files:**
+
+- Modify: `packages/gateway/src/sync/targeted-fetch.ts`
+- Modify: `packages/gateway/src/platform/assemble.ts`
+- Test: `packages/gateway/src/sync/targeted-fetch.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1's `recordSyncEgress` return; Task 3's `recordFetchOutcomeEgress` and `FetchOutcomeStatus`.
+- Produces: `TargetedFetchDeps.appendEgress` returning `{ rowHash: string } | undefined`, and a new `TargetedFetchDeps.appendOutcome`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/gateway/src/sync/targeted-fetch.test.ts`. The file's `depsWith` factory needs an `appendOutcome` override — add it to `DepsOverrides` and default it to `() => undefined` alongside `appendEgress`:
+
+```ts
+type OutcomeRow = {
+  readonly destination: string;
+  readonly authorizingRowHash: string;
+  readonly status: string;
+  readonly itemId?: string | undefined;
+  readonly reason?: string | undefined;
+};
+
+test("an indexed fetch writes one outcome row naming the authorising row, with the item id", async () => {
+  const outcomes: OutcomeRow[] = [];
+  const deps = depsWith({
+    hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+    appendEgress: () => ({ rowHash: "d".repeat(64) }),
+    appendOutcome: (r) => {
+      outcomes.push(r);
+      return undefined;
+    },
+    syncableFor: (service) => ({
+      serviceId: service,
+      defaultIntervalMs: 60_000,
+      initialSyncDepthDays: 30,
+      async sync() {
+        throw new Error("not exercised");
+      },
+      fetchOne: async (): Promise<FetchOneResult> => ({
+        status: "indexed",
+        itemId: "github:acme/web#482",
+      }),
+    }),
+  });
+
+  await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+  expect(outcomes).toHaveLength(1);
+  expect(outcomes[0]).toMatchObject({
+    destination: "github",
+    authorizingRowHash: "d".repeat(64),
+    status: "indexed",
+    itemId: "github:acme/web#482",
+  });
+});
+
+test("a miss writes an outcome carrying the reason and no item id", async () => {
+  const outcomes: OutcomeRow[] = [];
+  const deps = depsWith({
+    hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+    appendEgress: () => ({ rowHash: "d".repeat(64) }),
+    appendOutcome: (r) => {
+      outcomes.push(r);
+      return undefined;
+    },
+    syncableFor: (service) => ({
+      serviceId: service,
+      defaultIntervalMs: 60_000,
+      initialSyncDepthDays: 30,
+      async sync() {
+        throw new Error("not exercised");
+      },
+      fetchOne: async (): Promise<FetchOneResult> => ({
+        status: "not_found",
+        reason: "deleted",
+      }),
+    }),
+  });
+
+  await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+  expect(outcomes[0]).toMatchObject({ status: "not_found", reason: "deleted" });
+  expect(outcomes[0]?.itemId).toBeUndefined();
+});
+
+test("the arms that return BEFORE the authorising append write no outcome row", async () => {
+  // There is nothing for an outcome to name: no egress row was written, because
+  // nothing left the machine.
+  const outcomes: OutcomeRow[] = [];
+  const deps = depsWith({
+    hostMap: new Map(),
+    appendOutcome: (r) => {
+      outcomes.push(r);
+      return undefined;
+    },
+  });
+
+  const out = await targetedFetch(deps, "https://unclaimed.example/o/r/pull/1");
+
+  expect(out).toEqual({ status: "not_configured" });
+  expect(outcomes).toHaveLength(0);
+});
+
+test("a throwing outcome append does not fail the fetch, and warns", async () => {
+  // The request has already left the machine. Propagating would turn a fetch
+  // that genuinely succeeded into a 500, and the caller would retry — causing
+  // MORE egress than the failure it reports.
+  const warnings: unknown[] = [];
+  const deps = depsWith({
+    hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+    appendEgress: () => ({ rowHash: "d".repeat(64) }),
+    appendOutcome: () => {
+      throw new Error("disk full");
+    },
+    logger: {
+      warn: (...args: unknown[]) => void warnings.push(args),
+    },
+    syncableFor: (service) => ({
+      serviceId: service,
+      defaultIntervalMs: 60_000,
+      initialSyncDepthDays: 30,
+      async sync() {
+        throw new Error("not exercised");
+      },
+      fetchOne: async (): Promise<FetchOneResult> => ({
+        status: "indexed",
+        itemId: "github:acme/web#482",
+      }),
+    }),
+  });
+
+  const out = await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+  expect(out).toEqual({ status: "indexed", itemId: "github:acme/web#482" });
+  expect(warnings).toHaveLength(1);
+});
+```
+
+The last test needs the fake `SyncContext`'s logger to be overridable. `depsWith` builds `fakeCtx` with `logger: pino({ level: "silent" })` — add an optional `logger` override to `DepsOverrides` and use it in place of the pino instance when present.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test packages/gateway/src/sync/targeted-fetch.test.ts`
+Expected: FAIL — `appendOutcome` is not a known dep, and no outcome rows are recorded.
+
+- [ ] **Step 3: Implement the seam and the write site**
+
+In `targeted-fetch.ts`, widen `appendEgress` and add `appendOutcome` to `TargetedFetchDeps`:
+
+```ts
+  /**
+   * ... existing doc comment, unchanged ...
+   *
+   * Returns the hash of the row it wrote, so the outcome row below can name it. `undefined` means
+   * NO row was written (a local-only destination) — and therefore no outcome row may be written
+   * either, because there would be nothing for it to name.
+   */
+  readonly appendEgress: (row: {
+    readonly destination: FetchableService;
+    readonly sourceType: "sync";
+    readonly method: string;
+    readonly sourceId?: string | undefined;
+  }) => { rowHash: string } | undefined;
+  /**
+   * Appends ONE `outcome` marker after the connector call. Injected for the same D22 reason
+   * `appendEgress` is: `appendEgressEntry` is confined to `egress/*`.
+   *
+   * Synchronous, like `appendEgress`, and for the same reason — see that comment.
+   */
+  readonly appendOutcome: (row: {
+    readonly destination: FetchableService;
+    readonly authorizingRowHash: string;
+    readonly status: FetchOutcomeStatus;
+    readonly itemId?: string | undefined;
+    readonly reason?: string | undefined;
+  }) => undefined;
+```
+
+Import the type: `import type { FetchOutcomeStatus } from "../egress/outcome-egress.ts";`
+
+Then the write site. Replace the tail of `targetedFetch`:
+
+```ts
+  // BEFORE the outbound call. A throw here propagates and no fetch happens — fail-closed, no row
+  // means no fetch.
+  const authorizing = deps.appendEgress({
+    destination: service,
+    sourceType: "sync",
+    method: "items.fetch",
+    ...(callerLabel === undefined ? {} : { sourceId: callerLabel }),
+  });
+
+  const result = await fetchOneWithRetry(fetchOne, ctx, canonical);
+
+  // AFTER the call, and deliberately the opposite posture: the request has already left the
+  // machine, so there is nothing left to abort. Propagating would turn a fetch that succeeded into
+  // a failure and make the caller retry — more egress than the failure it reports. Swallow and
+  // warn, never silently (see `appendBootMarkerOrWarn`).
+  if (authorizing !== undefined) {
+    try {
+      deps.appendOutcome({
+        destination: service,
+        authorizingRowHash: authorizing.rowHash,
+        status: result.status,
+        ...("itemId" in result ? { itemId: result.itemId } : {}),
+        ...("reason" in result ? { reason: result.reason } : {}),
+      });
+    } catch (err) {
+      ctx.logger.warn(
+        { err },
+        "I29: failed to append the targeted-fetch outcome marker — the ledger will report this " +
+          "fetch as authorised with no recorded outcome",
+      );
+    }
+  }
+
+  return result;
+```
+
+`result.status` is `"indexed" | "not_found" | "rate_limited"` here: `fetchOneWithRetry` returns a `FetchOneResult`, whose fourth arm `unsupported_url` is unreachable because the pre-append `willAttempt` check already refused it. If TypeScript does not narrow that automatically, narrow it explicitly with an `if (result.status !== "unsupported_url")` guard rather than casting.
+
+In `assemble.ts`, wire the new closure beside the existing `appendEgress` one:
+
+```ts
+        appendOutcome: (row) => recordFetchOutcomeEgress(db, { ...row, now: Date.now() }),
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test packages/gateway/src/sync packages/gateway/src/egress`
+Expected: PASS.
+
+Run: `bun run typecheck`
+Expected: 0 errors. **Do not skip this** — `bun test` does not typecheck strictly, and a test file's local row type may need the new optional fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/sync/targeted-fetch.ts packages/gateway/src/sync/targeted-fetch.test.ts packages/gateway/src/platform/assemble.ts
+git commit -m "feat(sync): record how a targeted fetch ended"
+```
+
+---
+
+## Task 5: Record it against I29
+
+**Files:**
+
+- Modify: `docs/SECURITY-INVARIANTS.md` (the I29 section)
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Confirm the invariant suite still passes untouched**
+
+Run: `bun test packages/gateway/src/security-invariants.test.ts`
+Expected: PASS with no edit to that file. If it fails, stop — the failure is the specification of what went wrong, and it means `outcome` landed in the wrong list.
+
+- [ ] **Step 2: Write the note**
+
+In the I29 section of `docs/SECURITY-INVARIANTS.md`, after the U2a paragraph, record three things:
+
+1. A completed targeted fetch now appends a SECOND row, `source_type='outcome'`, carrying the status (`indexed` / `not_found` / `rate_limited`) and, on success, the item id. It names its authorising row by that row's `row_hash`, in `source_id` — the column prune tombstones already use for an attested hash.
+2. It is a MARKER, so it is excluded from the outbound count: a fetch and its outcome are ONE outbound event, not two. `COVERAGE_CLASSES` is untouched and the existing identity test proves it.
+3. The two appends have deliberately opposite failure postures. The authorising append is fail-closed. The outcome append swallows and warns, because by then the request has left the machine and propagating would cause more egress than the failure it reports — the `appendBootMarkerOrWarn` precedent. Swallowing is never silent.
+
+Respect the launch-messaging guardrail: the ledger records dispatched actions at the executor chokepoint, not raw network traffic.
+
+- [ ] **Step 3: Lint the docs**
+
+Run: `bun run lint:markdown`
+Expected: 0 issues.
+
+- [ ] **Step 4: Full verification**
+
+Run:
+
+```bash
+bun test packages/gateway packages/cli packages/mcp-connectors scripts
+bunx biome check packages scripts
+bun run typecheck
+```
+
+Expected: all pass. Remember `bun run lint` false-fails inside a worktree — use the `bunx biome check` form.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/SECURITY-INVARIANTS.md
+git commit -m "docs(security): record the outcome marker against I29"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** The row shape → Task 3. The union decision → Task 2. The `appendEgressEntry` seam change → Task 1. The write site and its asymmetric failure posture → Task 4. The `EgressSink` non-change → nothing to do, and the plan never mentions it beyond this line. The I29 note → Task 5. The page-boundary rule and the client join are U3b, out of scope by the spec's own slicing, and the plan says so in its header.
+
+**Placeholder scan.** No TBD/TODO. Task 5's doc note is prose specified by its three required points rather than verbatim text, because it must read continuously with the paragraphs around it; every claim it must make is enumerated.
+
+**Type consistency.** `{ rowHash: string }` is introduced in Task 1 and consumed under that exact name in Tasks 3 and 4. `FetchOutcomeStatus` is defined in Task 3 and imported in Task 4. `recordFetchOutcomeEgress`'s argument names (`destination`, `authorizingRowHash`, `status`, `itemId`, `reason`, `now`) match Task 4's `appendOutcome` row exactly, less `now`, which the assemble closure supplies — the same split `recordSyncEgress` already uses.
+
+**The risk worth flagging to the executor.** Task 4 widens a seam's return type. That seam is typed to return `undefined` rather than `void` specifically so an `async` implementation is a compile error, and U2a already produced one silent failure in this exact area — a closure with fewer parameters stayed assignable and dropped its argument. Typecheck cannot catch either shape. The behavioural tests in Task 4 are what prove the value arrives; do not weaken them into type assertions.

--- a/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
+++ b/docs/superpowers/plans/2026-08-24-egress-outcome-rows.md
@@ -261,7 +261,7 @@ git commit -m "feat(egress): admit outcome to the frozen union, as a marker"
 - Consumes: Task 1's `appendEgressEntry`; Task 2's `"outcome"` source type.
 - Produces: `recordFetchOutcomeEgress(db, args): undefined` where `args` is `{ destination: string; authorizingRowHash: string; status: FetchOutcomeStatus; itemId?: string; reason?: string; now: number }`, and `export type FetchOutcomeStatus = "indexed" | "not_found" | "rate_limited"`. Consumed by Task 4.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `packages/gateway/src/egress/outcome-egress.test.ts`, modelled on `sync-egress.test.ts` (copy its `beforeEach` DB setup and `listEgress` import):
 
@@ -380,12 +380,12 @@ describe("recordFetchOutcomeEgress", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `bun test packages/gateway/src/egress/outcome-egress.test.ts`
 Expected: FAIL — cannot resolve `./outcome-egress.ts`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Create `packages/gateway/src/egress/outcome-egress.ts`:
 
@@ -446,12 +446,12 @@ export function recordFetchOutcomeEgress(
 }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `bun test packages/gateway/src/egress`
 Expected: PASS, including the double-count guard and the chain verification.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/gateway/src/egress/outcome-egress.ts packages/gateway/src/egress/outcome-egress.test.ts

--- a/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design-review.md
+++ b/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design-review.md
@@ -1,0 +1,61 @@
+# Design Review: Outcome Rows on the Egress Ledger (U3)
+
+**Date:** 2026-08-24
+**Status:** Design Review / Feedback
+**Target Spec:** [2026-08-24-egress-outcome-rows-design.md](./2026-08-24-egress-outcome-rows-design.md)
+
+---
+
+## 1. Summary of Feedback
+
+The proposed design for recording targeted fetch outcomes on the egress ledger is well-reasoned and solves the gap of unrecorded outcomes (C4.1) cleanly. Reusing the existing `TargetedFetchOutcome` vocabulary, defining `outcome` as a member of `MARKER_SOURCE_TYPES` to avoid double-counting, and correlating outcomes using the authorising row's `row_hash` in `source_id` are excellent architectural choices.
+
+This review presents specific suggestions and points to verify during implementation.
+
+---
+
+## 2. Detailed Feedback & Open Questions
+
+### Q1. API/Client Join Efficiency
+
+Under the proposed design, the Activity page on the client side (`nimbus-web-clipper`) needs to join authorising rows with their corresponding `outcome` rows.
+
+* **Concerns:**
+  * If a client fetches a page of egress logs (via `GET /v1/egress`), it will receive both the authorizing rows and the outcome rows as separate items in the array. The client will need to perform a client-side O(N) association by building a map of `rowHash` to `outcome`.
+* **Suggestions:**
+  * Consider adding an optional query parameter to the egress listing endpoint (or modifying the default JSON-RPC representation) that returns the outcome inline/nested inside the authorizing row if it exists (e.g. `{ ..., outcome: { status, itemId, reason } }`).
+  * If this is out of scope for U3a, document the client-side O(N) Map-matching requirement in the companion spec in the `nimbus-web-clipper` repository.
+
+### Q2. Redaction Safety of `itemId` in `payloadSummary`
+
+The design suggests writing `payloadSummary: redactEgressSummary({ status, itemId?, reason? })`.
+
+* **Concerns:**
+  * `itemId` contains external identifiers (e.g., `github:owner/repo/pull/123` or `jira:issue-key`). While these are not secret credentials, we must ensure they are permitted under the egress ledger's redaction policy.
+* **Suggestions:**
+  * Verify that the existing `redactEgressSummary` helper (or equivalent) in `egress/` is equipped to handle the `{ status, itemId, reason }` object structure and does not strip necessary fields or leak sensitive URL parameters.
+
+### Q3. Seam Change and `EgressSink` Alignment
+
+To propagate the authorizing `rowHash` to `targetedFetch`, the spec states:
+> `TargetedFetchDeps.appendEgress` becomes `(row) => { rowHash: string } | undefined`
+
+* **Suggestions:**
+  * Update the parent `appendEgressEntry` function in `packages/gateway/src/egress/egress-ledger.ts` to return `{ rowHash: string }` instead of `void`.
+  * Ensure the change is also propagated through `EgressSink` interfaces and mock sinks in unit tests to keep Typescript signatures green.
+
+---
+
+## 3. Checklist for Implementation
+
+* [ ] Update `appendEgressEntry` in `egress-ledger.ts` to return the computed `rowHash`.
+* [ ] ~~Update `EgressSink` interface and mocks to support returning the row hash.~~ **Not doing this** — `EgressSink` is the executor's seam and targeted fetch does not go through it (`assemble.ts` wires `recordSyncEgress` as a direct closure). See the design's "Where it is written".
+* [ ] Add `outcome` to the `MARKER_SOURCE_TYPES` union in `egress-source-type.ts`.
+* [ ] Implement the `items.fetch.outcome` write site in `targetedFetch` (swallow-and-warn try/catch around a SYNCHRONOUS append — the seam's `undefined` return type exists to make an `async` implementation a compile error, and that must survive the widening).
+* [ ] Add `egress-source-type.test.ts` asserts for `outcome`.
+* [ ] Verify `security-invariants.test.ts` (I29) passes without modifying `COVERAGE_CLASSES`.
+* [ ] Implement unit tests in `outcome-egress.test.ts` or `targeted-fetch.test.ts` to verify:
+  * Exact row shape of the outcome marker.
+  * Correlation via `source_id = authorizing row_hash`.
+  * Swallow-and-warn behavior if writing the outcome row fails.
+  * Absence of outcome rows for early-exit arms (unsupported URLs, not configured, etc.).

--- a/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design.md
+++ b/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design.md
@@ -100,6 +100,16 @@ already commits to, it is stable in a way a local rowid is not, and every
 consumer of `GET /v1/egress` already receives `rowHash` on every row — so the
 join needs no new field on the wire.
 
+**The summary survives redaction, verified rather than assumed.**
+`redactEgressSummary` caps at 256 bytes and redacts two ways: by KEY, against
+`/(token|key|secret|password|credential|bearer|auth|^pat$)/i`, and by VALUE,
+against credential-shaped patterns (GitHub, OpenAI, Anthropic, Slack, bearer).
+None of `status`, `itemId` or `reason` matches the key pattern, and an item id
+(`github:acme/web#482`) matches no value pattern. `formatAuditPayload` truncates
+rather than stripping fields, and this payload is far below the cap. So the
+summary is stored as written — and in the impossible case where an id did look
+like a credential, redacting it is the correct outcome anyway.
+
 **Why `resultStatus: "authorized"`.** The column means "was this action allowed",
 not "did it succeed". Markers legitimately carry `authorized` — `pruneEgress`
 does — and reusing it to mean "the fetch worked" would give one column two
@@ -141,12 +151,53 @@ in that set today, so this arm is unreachable through `targetedFetch`, but it is
 modelled rather than asserted away so a future local-only fetchable cannot
 silently produce an orphan outcome row.
 
+`appendEgressEntry` (`egress/egress-ledger.ts`) already computes `rowHash`
+internally before its INSERT; it returns `void` today and returns
+`{ rowHash: string }` after this change. `recordSyncEgress` passes that through.
+
+**`EgressSink` is deliberately NOT changed.** It is the executor's DI seam
+(`ToolExecutor`, chatops), and targeted fetch does not go through it —
+`assemble.ts` wires `recordSyncEgress` as a direct closure. Widening
+`EgressSink.append` would touch every executor wiring site and `NULL_EGRESS_SINK`
+to deliver a value nothing on that path consumes.
+
 **Its synchronous return type stays load-bearing.** That seam is typed to return
 `undefined` rather than `void` specifically so an `async` implementation is a
 compile error: an async append's rejection would surface after `targetedFetch`
 had already moved past the call, breaking the fail-closed contract. Widening it
 to a value type must not weaken that — the new type is a plain object, never a
 promise, and the existing doc comment explaining why is kept and extended.
+
+## The pair can straddle a page boundary
+
+An outcome row is appended after its authorising row, so it carries a HIGHER id.
+`GET /v1/egress` reads newest-first, which means **the outcome arrives before the
+row it describes** — and a page boundary can fall between them. A consumer will
+therefore see, routinely:
+
+- an outcome row whose authorising row is on the NEXT (older) page, and
+- an authorising row whose outcome was on the PREVIOUS (newer) page.
+
+Neither is corruption; it is what paging a two-row record looks like. The
+consumer's rule is the same one it already applies to attribution: **render only
+what the page supports.** An authorising row with no outcome IN THIS PAGE reads
+exactly like one with no outcome at all — "not recorded" — because from the
+page's own evidence those are the same thing. An orphan outcome row is not
+rendered as a row of its own; it has no time, service or action of its own worth
+showing that its authorising row does not show better.
+
+This is a consequence of the row-pair design and belongs in **U3b**, not here.
+It is recorded in this document because a reader of the gateway spec needs to
+know the pair is not guaranteed to travel together.
+
+**Nesting the outcome inside the authorising row was considered and rejected.**
+It would remove the join, but the route would have to look OUTSIDE the requested
+window to find an outcome written after `until` — which breaks the property U1
+worked to establish, that `rowsTotal` and the returned rows describe the same
+window. It would also make the route synthesise a shape the ledger does not
+hold, and the C4.1 posture is that the client reads the gateway's record rather
+than a derived view that can drift from it. The join is a `Map` over one page;
+the honesty property is worth more than saving it.
 
 ## Failure posture, deliberately asymmetric
 

--- a/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design.md
+++ b/docs/superpowers/specs/2026-08-24-egress-outcome-rows-design.md
@@ -1,0 +1,220 @@
+# How a targeted fetch ended: outcome rows on the egress ledger (U3)
+
+> **Status:** design, approved 2026-08-24. Closes the last unmet half of the web
+> clipper's C4.1 done-when. Supersedes **U2b** (item identity on the authorising
+> row), which is dropped — see "What this replaces".
+>
+> The consumer-side design lives in the `nimbus-web-clipper` repo at
+> `docs/superpowers/specs/2026-08-23-gateway-activity-ledger-design.md`. This
+> document is the gateway half.
+
+## The gap this closes
+
+The web clipper's **C4.1** brief promised an activity view listing every
+gateway-side fetch "with time, target and outcome". Three of those four are
+shipped: **U1** (Nimbus#1319) gave the ledger an HTTP read surface, **U2a**
+(Nimbus#1322) made a targeted fetch name the client that asked for it, and the
+browser's Activity page (nimbus-web-clipper#70) renders them.
+
+**Outcome is the piece that is structurally absent.** `targetedFetch` appends
+its egress row BEFORE calling the connector — deliberately, because I29 is
+fail-closed: no row, no fetch. So `result_status` records the *authorisation*
+decision, not what came back. A fetch that 404s, times out, or is refused by the
+provider still reads `authorized`, and nothing in the ledger ever says otherwise.
+
+## What the ledger can and cannot say today
+
+Reading `main` at `8611b5c7`.
+
+### Finding 1 — the outcome vocabulary is small, and already exists
+
+Only three arms can occur AFTER the append, because the others return before it:
+
+| Arm | Reachable after the append? |
+| --- | --- |
+| `indexed` (carries `itemId`) | yes |
+| `not_found` (carries a `FetchMissReason`) | yes |
+| `rate_limited` (a provider 429 from `fetchOne`) | yes |
+| `unsupported_url` | no — refused by the pre-append `willAttempt` check |
+| `no_targeted_fetch` | no — refused before the append |
+| `not_configured` | no — refused by the host boundary before the append |
+
+So the outcome vocabulary is three values, and each already exists in
+`TargetedFetchOutcome`. Nothing new needs inventing.
+
+### Finding 2 — item identity is free after the fetch
+
+`{ status: "indexed", itemId }` carries the item id directly. Before the fetch it
+does not exist, which is why **U2b** proposed deriving it by parsing the URL — and
+why that was expensive: each connector's parser is private and connector-shaped
+(`parseGithubPrUrl` returns `{ owner, repo, num }`; only a boolean wrapper is
+exported), so it meant exporting a normalised parser from five connectors and
+renegotiating the no-raw-URL rule for `payload_summary`.
+
+After the fetch, none of that is needed.
+
+### Finding 3 — a second row must not count as egress
+
+`MARKER_SOURCE_TYPES` (`prune`, `boot`, `degraded`) exists precisely so
+bookkeeping is not miscounted as outbound: prune tombstones were inflating the
+reported figure before that exclusion landed. An outcome row is bookkeeping about
+an egress that has ALREADY been counted, so counting it again would double every
+targeted fetch — inflating the exact number I29 exists to state honestly.
+
+### Finding 4 — the source-type union is frozen, and prescribes its own ceremony
+
+`egress-source-type.ts` says a further class "needs an explicit decision recorded
+here; it is not a casual append", and both `mcp` and `http` carry a paragraph
+justifying themselves. Widening the union is not a chain break —
+`verifyEgressChain` recomputes each row's hash from that row's OWN stored columns
+— but the vocabulary is permanent in the data, so the decision is deliberate.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Row class | A new marker member, `outcome`. |
+| Scope | Targeted fetch only. |
+| Correlation | The authorising row's `row_hash`, carried in `source_id`. |
+| Absent outcome | Means *not recorded*. Never *in flight*. |
+| Append failure | Swallow and warn, never propagate. |
+| U2b (identity on the authorising row) | Dropped, superseded. |
+
+## The row
+
+```text
+sourceType:      "outcome"
+sourceId:        <authorising row's row_hash>
+destination:     <the same service id the authorising row named>
+method:          "items.fetch.outcome"
+payloadSummary:  redactEgressSummary({ status, itemId? , reason? })
+hitlStatus:      "not_required"
+resultStatus:    "authorized"
+```
+
+**Why `row_hash` as the correlation key, in `source_id`.** Prune tombstones
+already carry an attested boundary hash in `source_id`
+(`verifyEgressChain`'s pre-scan reads it), so a marker using that column as a
+correlation key is established rather than novel. The hash is the value the chain
+already commits to, it is stable in a way a local rowid is not, and every
+consumer of `GET /v1/egress` already receives `rowHash` on every row — so the
+join needs no new field on the wire.
+
+**Why `resultStatus: "authorized"`.** The column means "was this action allowed",
+not "did it succeed". Markers legitimately carry `authorized` — `pruneEgress`
+does — and reusing it to mean "the fetch worked" would give one column two
+meanings across row classes. The fetch's success lives in `payloadSummary.status`,
+which is the field that actually has three values.
+
+## The union decision, recorded
+
+`outcome` is the eleventh member, and it is a MARKER rather than an egress class.
+That distinction is the whole argument:
+
+- It records bookkeeping about an outbound call the ledger has already counted.
+  Counting it again double-counts every targeted fetch.
+- Because it joins `MARKER_SOURCE_TYPES`, `COVERAGE_CLASSES` is untouched — and
+  the existing invariant test *"I29: COVERAGE_CLASSES is exactly the non-marker
+  source types"* (`security-invariants.test.ts`) proves the two lists stayed in
+  step, which is exactly the silent mismatch the union's header warns about.
+- It therefore claims no coverage granularity and needs no `THIS_BINARY_COVERAGE`
+  raise. There is no appender-without-a-claim and no claim-without-an-appender.
+
+Reusing `sync` with a reserved `method` was rejected: `sync` is not a marker, so
+every outcome row would count as outbound unless the counting predicate grew a
+method-level special case — reintroducing by hand exactly the miscount
+`MARKER_SOURCE_TYPES` exists to make structural.
+
+## Where it is written
+
+In `targetedFetch`, after `fetchOneWithRetry` returns — the only point that holds
+both the authorising row's identity and the result.
+
+This needs one seam change: `TargetedFetchDeps.appendEgress` currently returns
+`undefined`, and the outcome row must name the row it is about. It becomes
+`(row) => { rowHash: string } | undefined`, still synchronous.
+
+`undefined` means **no authorising row was written**, and therefore no outcome row
+may be either — there would be nothing for it to name. `recordSyncEgress` already
+returns without appending for `LOCAL_ONLY_SYNC_SERVICES`; no fetchable service is
+in that set today, so this arm is unreachable through `targetedFetch`, but it is
+modelled rather than asserted away so a future local-only fetchable cannot
+silently produce an orphan outcome row.
+
+**Its synchronous return type stays load-bearing.** That seam is typed to return
+`undefined` rather than `void` specifically so an `async` implementation is a
+compile error: an async append's rejection would surface after `targetedFetch`
+had already moved past the call, breaking the fail-closed contract. Widening it
+to a value type must not weaken that — the new type is a plain object, never a
+promise, and the existing doc comment explaining why is kept and extended.
+
+## Failure posture, deliberately asymmetric
+
+The authorising append is **fail-closed**: it throws, the fetch never happens.
+
+The outcome append is **swallow-and-warn**. By the time it runs the request has
+already left the machine, so there is nothing to abort; propagating would turn a
+fetch that genuinely succeeded into a 500, and the caller would retry — causing
+MORE egress than the failure it was reporting. `appendBootMarkerOrWarn` is the
+documented precedent for exactly this shape, and its rule applies here too:
+swallowing must never be silent. The warning names the failure.
+
+## What a reader may conclude
+
+An authorising row with no outcome beside it means **the outcome was not
+recorded**. It does not mean the fetch is still running.
+
+The ledger cannot support the stronger claim: a row written by a gateway that
+predates this change is indistinguishable from one whose outcome append was lost.
+Rather than infer from age — which would report a slow provider as a lost outcome
+— the consumer says only what the record supports. This matches the posture the
+whole C4.1 design takes: attribution is exact match and never inference,
+verification is claimed only when checked.
+
+## What this replaces
+
+**U2b is dropped.** Its purpose was to let the Activity page name the item a
+fetch was for; the outcome row does that with `itemId`, at no parsing cost. The
+five connector parsers, and the argument about putting a `{service, type, id}`
+triple through a redacted summary field, are no longer needed.
+
+The cost is stated rather than hidden: a fetch whose outcome never lands — a lost
+append, or an older gateway — names no item at all. That is the same window in
+which the outcome itself is unavailable, so the page is not made inconsistent by
+it; there is simply less to show.
+
+## Testing
+
+- `egress-source-type.test.ts`: the union is eleven members; `outcome` is in
+  `MARKER_SOURCE_TYPES`; `isMarkerSourceType("outcome")` is true.
+- `security-invariants.test.ts`: the existing COVERAGE_CLASSES identity test must
+  pass UNCHANGED. If it fails, the member was added to the wrong list.
+- `sync-egress.test.ts` / a new `outcome-egress.test.ts`: the row's exact shape;
+  `source_id` is the authorising hash; the chain still verifies across the pair.
+- `targeted-fetch.test.ts`: one outcome row per completed fetch, carrying the
+  right status; `itemId` present on `indexed` and absent otherwise; NO outcome row
+  for the three arms that return before the authorising append; a throwing outcome
+  append does not fail the fetch, and warns.
+- `countOutboundEgress`: a fetch plus its outcome counts as ONE outbound event.
+  This is the double-count guard, and it is the test that would catch `outcome`
+  being placed outside `MARKER_SOURCE_TYPES`.
+
+## Slices
+
+- **U3a (this repo)** — the union member, the seam returning its row hash, the
+  appender, the write site, the I29 note.
+- **U3b (`nimbus-web-clipper`)** — the Activity page renders an outcome column,
+  joining outcome rows to authorising rows by `rowHash`, and says "not recorded"
+  where none exists. Also folds in three code comments that now overstate the
+  attribution gap, having been written before U2a landed
+  (`src/shared/egress.ts:28` and `:204`, `src/ledger/ledger-view.ts:115`).
+
+## Out of scope
+
+- Outcome rows for any class other than targeted fetch. Agent runs over HTTP have
+  their own async run lifecycle with their own terminal states; "outcome" would
+  mean two different things in one row class. Scheduled syncs and model calls
+  serve nobody's stated need — nobody waits on a background sync the way they wait
+  on a fetch they just triggered.
+- Any change to `egress.prune`, which keeps its owner-HITL gate and its absence
+  from both the LAN allowlist and the HTTP surface.

--- a/packages/gateway/src/egress/egress-ledger.test.ts
+++ b/packages/gateway/src/egress/egress-ledger.test.ts
@@ -28,6 +28,15 @@ beforeEach(() => {
 afterEach(() => db.close());
 
 describe("appendEgressEntry", () => {
+  test("returns the row hash it stored, so a later row can name this one", () => {
+    const out = appendEgressEntry(db, entry({ method: "a.x", timestamp: 1 }));
+    const stored = db.query(`SELECT row_hash FROM egress_ledger ORDER BY id ASC`).get() as {
+      row_hash: string;
+    };
+    expect(out.rowHash).toBe(stored.row_hash);
+    expect(out.rowHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   test("the first row chains from GENESIS_HASH with a 64-char hex row_hash", () => {
     appendEgressEntry(db, entry());
     const row = db.query(`SELECT prev_hash, row_hash FROM egress_ledger ORDER BY id ASC`).get() as {

--- a/packages/gateway/src/egress/egress-ledger.ts
+++ b/packages/gateway/src/egress/egress-ledger.ts
@@ -51,7 +51,14 @@ function readHeadHash(db: Database): string {
  * camelCase EgressEntry fields are mapped explicitly to snake_case columns; the spread is NEVER
  * used to avoid silently writing camelCase keys as column names.
  */
-export function appendEgressEntry(db: Database, entry: EgressEntry): void {
+/**
+ * Append one chained row, and return the hash it was stored under.
+ *
+ * The hash is returned because a later MARKER row may need to name this one — see
+ * `outcome-egress.ts`. It is the value the chain already commits to, so a correlation key built on
+ * it cannot drift from the row it points at.
+ */
+export function appendEgressEntry(db: Database, entry: EgressEntry): { rowHash: string } {
   const prevHash = readHeadHash(db);
   const rowHash = computeEgressRowHash({
     prevHash,
@@ -81,6 +88,7 @@ export function appendEgressEntry(db: Database, entry: EgressEntry): void {
       prevHash,
     ],
   );
+  return { rowHash };
 }
 
 /** The DI seam wired into `ToolExecutor` — appends to the given DB. */

--- a/packages/gateway/src/egress/egress-source-type.test.ts
+++ b/packages/gateway/src/egress/egress-source-type.test.ts
@@ -23,7 +23,11 @@ describe("EGRESS_SOURCE_TYPES — frozen union", () => {
   // review moment, same rejected shortcut (`session` again), plus one reason of its own: it is
   // named for the VERIFIABLE TRANSPORT rather than a caller-declared client kind, so folding it
   // into `mcp` would have merged two different attribution strengths under one permanent string.
-  test("is exactly these ten members, in this order", () => {
+  //
+  // `outcome` is the ELEVENTH, and the first admitted as a MARKER rather than an egress class. It
+  // records how a targeted fetch ended, which the authorising row structurally cannot say: that row
+  // is appended BEFORE the connector call, so its `result_status` is an authorisation decision.
+  test("is exactly these eleven members, in this order", () => {
     expect(EGRESS_SOURCE_TYPES).toEqual([
       "task",
       "prune",
@@ -35,11 +39,19 @@ describe("EGRESS_SOURCE_TYPES — frozen union", () => {
       "boot",
       "degraded",
       "http",
+      "outcome",
     ]);
   });
 
-  test("marker types are the three bookkeeping classes", () => {
-    expect([...MARKER_SOURCE_TYPES].sort()).toEqual(["boot", "degraded", "prune"]);
+  test("marker types are the four bookkeeping classes", () => {
+    expect([...MARKER_SOURCE_TYPES].sort()).toEqual(["boot", "degraded", "outcome", "prune"]);
+  });
+
+  test("outcome is a MARKER, so it can never be counted as outbound egress", () => {
+    // The whole argument for admitting an eleventh member. An outcome row is
+    // bookkeeping about an outbound call the ledger has ALREADY counted;
+    // counting it again would double every targeted fetch.
+    expect(isMarkerSourceType("outcome")).toBe(true);
   });
 
   test("isMarkerSourceType: markers true, egress-bearing false, unknown false", () => {

--- a/packages/gateway/src/egress/egress-source-type.ts
+++ b/packages/gateway/src/egress/egress-source-type.ts
@@ -41,6 +41,25 @@
  * Like `mcp`, the class covers LESS than its name suggests: it is agent briefs served over HTTP,
  * NOT "everything on the HTTP API". The narrowing is recorded machine-readably in
  * `THIS_BINARY_COVERAGE` (egress-coverage.ts), which is what a consumer actually reads.
+ *
+ * `outcome` is the eleventh member, and the FIRST admitted as a MARKER rather than an egress class.
+ * It records how a targeted fetch ended. The authorising row structurally cannot say: `targetedFetch`
+ * appends it BEFORE calling the connector — fail-closed, no row means no fetch — so its
+ * `result_status` records the authorisation decision, and a fetch that 404s or times out still
+ * reads `authorized`.
+ *
+ * Marker, not egress class, IS the decision. The row is bookkeeping about an outbound call this
+ * ledger has already counted; counting it again would double every targeted fetch and inflate the
+ * exact number I29 exists to state honestly. Because it joins `MARKER_SOURCE_TYPES` it claims no
+ * coverage granularity, `COVERAGE_CLASSES` is untouched, and the existing
+ * "COVERAGE_CLASSES is exactly the non-marker source types" invariant proves the two lists stayed
+ * in step — the silent mismatch this header warns about.
+ *
+ * The freeze's own prescription — reuse an existing member with a reserved `method` — was rejected
+ * for the third time, and here for a new reason: the natural candidate is `sync`, which is NOT a
+ * marker, so every outcome row would count as outbound unless the counting predicate grew a
+ * method-level special case. That would reintroduce by hand the miscount `MARKER_SOURCE_TYPES`
+ * exists to make structural.
  */
 export const EGRESS_SOURCE_TYPES = [
   "task", // gated connector action
@@ -53,6 +72,7 @@ export const EGRESS_SOURCE_TYPES = [
   "boot", // per-process marker carrying the coverage vector
   "degraded", // lost-append recovery marker
   "http", // agent brief served over the local HTTP API
+  "outcome", // how a targeted fetch ended — a marker, never counted as egress
 ] as const;
 
 export type EgressSourceType = (typeof EGRESS_SOURCE_TYPES)[number];
@@ -68,6 +88,7 @@ export const MARKER_SOURCE_TYPES: ReadonlySet<EgressSourceType> = new Set<Egress
   "prune",
   "boot",
   "degraded",
+  "outcome",
 ]);
 
 /** Marker test over a raw DB string. Unknown values are NOT markers — an unknown row counts. */

--- a/packages/gateway/src/egress/outcome-egress.test.ts
+++ b/packages/gateway/src/egress/outcome-egress.test.ts
@@ -1,0 +1,126 @@
+// packages/gateway/src/egress/outcome-egress.test.ts
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
+import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
+import { appendEgressEntry } from "./egress-ledger.ts";
+import type { EgressEntry } from "./egress-record.ts";
+import { countOutboundEgress, listEgress, verifyEgressChain } from "./egress-verify.ts";
+import { recordFetchOutcomeEgress } from "./outcome-egress.ts";
+
+let db: Database;
+beforeEach(() => {
+  db = new Database(":memory:");
+  runIndexedSchemaMigrations(db, CURRENT_SCHEMA_VERSION);
+});
+afterEach(() => {
+  try {
+    db.close();
+  } catch {
+    /* already closed by a test that needed it shut */
+  }
+});
+
+/** The authorising row a targeted fetch appends before calling the connector. */
+function authorising(over: Partial<EgressEntry> = {}): { rowHash: string } {
+  return appendEgressEntry(db, {
+    timestamp: 1_000,
+    sourceType: "sync",
+    sourceId: "asafs-browser",
+    destination: "github",
+    method: "items.fetch",
+    payloadSummary: "{}",
+    hitlStatus: "not_required",
+    resultStatus: "authorized",
+    ...over,
+  });
+}
+
+describe("recordFetchOutcomeEgress", () => {
+  test("writes one outcome marker naming the authorising row by hash", () => {
+    const authorized = authorising();
+
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: authorized.rowHash,
+      status: "indexed",
+      itemId: "github:acme/web#482",
+      now: 2_000,
+    });
+
+    const rows = listEgress(db, {});
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({
+      sourceType: "outcome",
+      // The correlation key. Prune tombstones already carry an attested hash in
+      // `source_id`, so a marker using that column this way is established.
+      sourceId: authorized.rowHash,
+      destination: "github",
+      method: "items.fetch.outcome",
+      hitlStatus: "not_required",
+      // "was this allowed", not "did it work" — the fetch's result lives in the
+      // summary, which is the field that actually has three values.
+      resultStatus: "authorized",
+    });
+    expect(rows[1]?.payloadSummary).toContain("indexed");
+    expect(rows[1]?.payloadSummary).toContain("github:acme/web#482");
+  });
+
+  test("carries the miss reason on not_found, and no itemId", () => {
+    recordFetchOutcomeEgress(db, {
+      destination: "jira",
+      authorizingRowHash: "a".repeat(64),
+      status: "not_found",
+      reason: "deleted",
+      now: 2_000,
+    });
+    const summary = listEgress(db, {})[0]?.payloadSummary ?? "";
+    expect(summary).toContain("not_found");
+    expect(summary).toContain("deleted");
+    expect(summary).not.toContain("itemId");
+  });
+
+  test("an outcome row does NOT count as outbound egress", () => {
+    // The double-count guard. A fetch and its outcome are ONE outbound event —
+    // this is the test that fails if `outcome` is ever moved out of
+    // MARKER_SOURCE_TYPES.
+    authorising({ sourceId: null });
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: "b".repeat(64),
+      status: "rate_limited",
+      now: 2_000,
+    });
+    expect(listEgress(db, {})).toHaveLength(2);
+    expect(countOutboundEgress(db, {})).toBe(1);
+  });
+
+  test("the chain still verifies across the pair", () => {
+    const first = authorising({ sourceId: null });
+    recordFetchOutcomeEgress(db, {
+      destination: "github",
+      authorizingRowHash: first.rowHash,
+      status: "indexed",
+      itemId: "github:acme/web#1",
+      now: 2_000,
+    });
+    const verdict = verifyEgressChain(db);
+    expect(verdict.ok).toBe(true);
+    expect(verdict.verifiedRows).toBe(2);
+  });
+
+  test("a throwing append propagates — the caller owns the swallow", () => {
+    // Swallowing lives at the call site (targeted-fetch.ts), following
+    // `appendBootMarkerOrWarn`. This function must not hide a failure from a
+    // caller that may want to warn about it.
+    db.close();
+    expect(() =>
+      recordFetchOutcomeEgress(db, {
+        destination: "github",
+        authorizingRowHash: "c".repeat(64),
+        status: "indexed",
+        now: 2_000,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/gateway/src/egress/outcome-egress.ts
+++ b/packages/gateway/src/egress/outcome-egress.ts
@@ -1,0 +1,59 @@
+import type { Database } from "bun:sqlite";
+import { appendEgressEntry } from "./egress-ledger.ts";
+import { redactEgressSummary } from "./egress-record.ts";
+
+/**
+ * How a targeted fetch ended, for the three arms reachable AFTER the egress append.
+ *
+ * The other three `TargetedFetchOutcome` arms — `unsupported_url`, `no_targeted_fetch` and
+ * `not_configured` — are refused BEFORE any row is written, so no outcome row can ever describe
+ * them: there would be nothing for one to name, and nothing left the machine to report on.
+ */
+export type FetchOutcomeStatus = "indexed" | "not_found" | "rate_limited";
+
+/**
+ * Append ONE `outcome` marker describing a completed targeted fetch.
+ *
+ * A MARKER, never an egress class. This is bookkeeping about an outbound call the ledger has
+ * ALREADY counted — the authorising row `targetedFetch` appends before calling the connector.
+ * Counting it again would double every targeted fetch and inflate the exact number I29 exists to
+ * state honestly; `MARKER_SOURCE_TYPES` makes that structural rather than a rule to remember.
+ *
+ * `authorizingRowHash` goes in `source_id` — the column prune tombstones already use to carry an
+ * attested hash. It is the value the chain commits to, so a correlation key built on it cannot
+ * drift from the row it points at, and every consumer of `GET /v1/egress` already receives it as
+ * `rowHash`, so the join needs no new field on the wire.
+ *
+ * Throws on append failure rather than swallowing. The swallow belongs at the call site, which has
+ * the context to say what was lost — see `appendBootMarkerOrWarn` for the shape.
+ */
+export function recordFetchOutcomeEgress(
+  db: Database,
+  args: {
+    readonly destination: string;
+    readonly authorizingRowHash: string;
+    readonly status: FetchOutcomeStatus;
+    readonly itemId?: string | undefined;
+    readonly reason?: string | undefined;
+    readonly now: number;
+  },
+): undefined {
+  appendEgressEntry(db, {
+    timestamp: args.now,
+    sourceType: "outcome",
+    sourceId: args.authorizingRowHash,
+    destination: args.destination,
+    method: "items.fetch.outcome",
+    payloadSummary: redactEgressSummary({
+      status: args.status,
+      ...(args.itemId === undefined ? {} : { itemId: args.itemId }),
+      ...(args.reason === undefined ? {} : { reason: args.reason }),
+    }),
+    hitlStatus: "not_required",
+    // "was this action allowed", not "did it succeed". Markers legitimately carry `authorized`, and
+    // reusing this column to mean "the fetch worked" would give it two meanings across row classes.
+    // The fetch's result lives in `payload_summary.status`, which has three values.
+    resultStatus: "authorized",
+  });
+  return undefined;
+}

--- a/packages/gateway/src/egress/sync-egress.test.ts
+++ b/packages/gateway/src/egress/sync-egress.test.ts
@@ -20,7 +20,9 @@ afterEach(() => db.close());
 describe("recordSyncEgress", () => {
   test("appends one authorized, not_required `sync` row destined at the service id", () => {
     const out = recordSyncEgress(db, { destination: "github", method: "sync.run", now: 1_000 });
-    expect(out).toBeUndefined();
+    // Was `toBeUndefined()` before the appender started returning its row hash,
+    // which an outcome marker needs in order to name the row it describes.
+    expect(out?.rowHash).toMatch(/^[0-9a-f]{64}$/);
     const rows = listEgress(db, {});
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
@@ -31,6 +33,19 @@ describe("recordSyncEgress", () => {
       resultStatus: "authorized",
     });
     expect(rows[0]?.sourceId).toBeNull();
+  });
+
+  test("returns the appended row's hash", () => {
+    const out = recordSyncEgress(db, { destination: "github", method: "items.fetch", now: 1_000 });
+    expect(out?.rowHash).toBe(listEgress(db, {})[0]?.rowHash);
+  });
+
+  test("returns undefined for a local-only destination, because no row was written", () => {
+    // The caller uses this to decide whether an outcome row may be written at
+    // all: with no authorising row there is nothing for one to name.
+    expect(
+      recordSyncEgress(db, { destination: "filesystem", method: "items.fetch", now: 1_000 }),
+    ).toBeUndefined();
   });
 
   test("a caller-initiated row carries the caller's label", () => {

--- a/packages/gateway/src/egress/sync-egress.ts
+++ b/packages/gateway/src/egress/sync-egress.ts
@@ -81,11 +81,11 @@ export function recordSyncEgress(
      */
     readonly sourceId?: string | undefined;
   },
-): undefined {
+): { rowHash: string } | undefined {
   if (LOCAL_ONLY_SYNC_SERVICES.has(args.destination)) {
     return undefined;
   }
-  appendEgressEntry(db, {
+  return appendEgressEntry(db, {
     timestamp: args.now,
     sourceType: "sync",
     // Empty collapses to null: an empty string would read as "attributed to a
@@ -97,5 +97,4 @@ export function recordSyncEgress(
     hitlStatus: "not_required",
     resultStatus: "authorized",
   });
-  return undefined;
 }

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -2238,7 +2238,9 @@ function bootTargetedFetchIntoHttpSidecar(deps: {
         contextFor: (service) => syncScheduler.syncContextFor(service),
         httpOriginFor: (service) => httpOrigins.get(service) ?? null,
         urlIsSupported: (service, u) => fetchOneUrlIsSupported(service, u, jiraBaseUrl),
-        appendEgress: (row) => recordSyncEgress(db, { ...row, now: Date.now() }),
+        // The returned row hash is discarded here and consumed once the seam is widened to
+        // carry it — an outcome marker names the row it describes by that hash.
+        appendEgress: (row) => void recordSyncEgress(db, { ...row, now: Date.now() }),
         sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
       },
       url,

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -111,6 +111,7 @@ import { createDecisionRefresher, type DecisionRefresher } from "../decisions/de
 import { appendBootMarker } from "../egress/egress-boot-marker.ts";
 import { type CoverageVector, THIS_BINARY_COVERAGE } from "../egress/egress-coverage.ts";
 import { makeEgressSink } from "../egress/egress-ledger.ts";
+import { recordFetchOutcomeEgress } from "../egress/outcome-egress.ts";
 import { recordSyncEgress } from "../egress/sync-egress.ts";
 import { createEmbeddingRuntimeNonBlocking } from "../embedding/create-embedding-runtime.ts";
 import {
@@ -2217,8 +2218,11 @@ function bootTargetedFetchIntoHttpSidecar(deps: {
   vault: NimbusVault;
   syncScheduler: SyncScheduler;
   httpSidecarOpts: HttpSidecarOpts;
+  /** Narrowed to the one method used, as `appendBootMarkerOrWarn` does: this is only ever the
+   *  destination for a swallowed outcome-append failure. */
+  logger: Pick<Logger, "warn">;
 }): void {
-  const { db, vault, syncScheduler } = deps;
+  const { db, vault, syncScheduler, logger } = deps;
   // `callerLabel` is threaded, not dropped. A closure taking only `url` stays ASSIGNABLE to the
   // surface's `(url, callerLabel?)` type — TypeScript permits fewer parameters — so omitting it
   // here would typecheck cleanly and silently leave every targeted-fetch row unattributed.
@@ -2238,9 +2242,9 @@ function bootTargetedFetchIntoHttpSidecar(deps: {
         contextFor: (service) => syncScheduler.syncContextFor(service),
         httpOriginFor: (service) => httpOrigins.get(service) ?? null,
         urlIsSupported: (service, u) => fetchOneUrlIsSupported(service, u, jiraBaseUrl),
-        // The returned row hash is discarded here and consumed once the seam is widened to
-        // carry it — an outcome marker names the row it describes by that hash.
-        appendEgress: (row) => void recordSyncEgress(db, { ...row, now: Date.now() }),
+        appendEgress: (row) => recordSyncEgress(db, { ...row, now: Date.now() }),
+        appendOutcome: (row) => recordFetchOutcomeEgress(db, { ...row, now: Date.now() }),
+        warn: (err, message) => logger.warn(err, message),
         sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
       },
       url,
@@ -2581,7 +2585,13 @@ export async function assemblePlatformServices(
 
   // Targeted fetch-on-miss (Task 11). Unconditional, like agents: reaching it requires the
   // `fetch` scope, which no legacy token carries and `nimbus clip pair --scopes` must name.
-  bootTargetedFetchIntoHttpSidecar({ db, vault, syncScheduler, httpSidecarOpts });
+  bootTargetedFetchIntoHttpSidecar({
+    db,
+    vault,
+    syncScheduler,
+    httpSidecarOpts,
+    logger: syncLogger,
+  });
 
   // IMPORTANT 1 fix: wires `GET /v1/items/resolve`'s `fetchable` predicate. Unconditional, same
   // as the fetch seam above — the route itself still requires the `resolve` scope.

--- a/packages/gateway/src/sync/targeted-fetch.test.ts
+++ b/packages/gateway/src/sync/targeted-fetch.test.ts
@@ -17,13 +17,24 @@ type EgressRow = {
   readonly sourceId?: string | undefined;
 };
 
+/** The outcome marker's row, as the write site hands it to the injected appender. */
+type OutcomeRow = {
+  readonly destination: FetchableService;
+  readonly authorizingRowHash: string;
+  readonly status: string;
+  readonly itemId?: string | undefined;
+  readonly reason?: string | undefined;
+};
+
 type DepsOverrides = {
   hostMap?: ReadonlyMap<string, FetchableService>;
   /** Full override — takes precedence over `syncable` when both are given. */
   syncableFor?: (service: FetchableService) => Syncable | undefined;
   /** Shorthand: builds a trivial fixture `Syncable` with this `fetchOne` (or none at all). */
   syncable?: { fetchOne?: Syncable["fetchOne"] };
-  appendEgress?: (row: EgressRow) => undefined;
+  appendEgress?: (row: EgressRow) => { rowHash: string } | undefined;
+  appendOutcome?: (row: OutcomeRow) => undefined;
+  warn?: (err: unknown, message: string) => void;
   sleep?: (ms: number) => Promise<void>;
   /** Fake for `ctx.rateLimiter.tryAcquire`. Defaults to always-succeeds-immediately. */
   tryAcquire?: (service: FetchableService) => Promise<boolean>;
@@ -90,12 +101,127 @@ function depsWith(overrides: DepsOverrides = {}): TargetedFetchDeps {
     contextFor: () => fakeCtx,
     httpOriginFor: overrides.httpOriginFor ?? (() => null),
     appendEgress: overrides.appendEgress ?? (() => undefined),
+    appendOutcome: overrides.appendOutcome ?? (() => undefined),
+    warn: overrides.warn ?? (() => undefined),
     sleep: overrides.sleep ?? (() => Promise.resolve()),
     urlIsSupported: overrides.urlIsSupported ?? (() => true),
   };
 }
 
 describe("targetedFetch", () => {
+  test("an indexed fetch writes one outcome row naming the authorising row, with the item id", async () => {
+    const outcomes: OutcomeRow[] = [];
+    const deps = depsWith({
+      hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+      appendEgress: () => ({ rowHash: "d".repeat(64) }),
+      appendOutcome: (r) => {
+        outcomes.push(r);
+        return undefined;
+      },
+      syncableFor: (service) => ({
+        serviceId: service,
+        defaultIntervalMs: 60_000,
+        initialSyncDepthDays: 30,
+        async sync() {
+          throw new Error("not exercised");
+        },
+        fetchOne: async (): Promise<FetchOneResult> => ({
+          status: "indexed",
+          itemId: "github:acme/web#482",
+        }),
+      }),
+    });
+
+    await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({
+      destination: "github",
+      authorizingRowHash: "d".repeat(64),
+      status: "indexed",
+      itemId: "github:acme/web#482",
+    });
+  });
+
+  test("a miss writes an outcome carrying the reason and no item id", async () => {
+    const outcomes: OutcomeRow[] = [];
+    const deps = depsWith({
+      hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+      appendEgress: () => ({ rowHash: "d".repeat(64) }),
+      appendOutcome: (r) => {
+        outcomes.push(r);
+        return undefined;
+      },
+      syncableFor: (service) => ({
+        serviceId: service,
+        defaultIntervalMs: 60_000,
+        initialSyncDepthDays: 30,
+        async sync() {
+          throw new Error("not exercised");
+        },
+        fetchOne: async (): Promise<FetchOneResult> => ({
+          status: "not_found",
+          reason: "absent",
+        }),
+      }),
+    });
+
+    await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+    expect(outcomes[0]).toMatchObject({ status: "not_found", reason: "absent" });
+    expect(outcomes[0]?.itemId).toBeUndefined();
+  });
+
+  test("the arms that return BEFORE the authorising append write no outcome row", async () => {
+    // There is nothing for an outcome to name: no egress row was written,
+    // because nothing left the machine.
+    const outcomes: OutcomeRow[] = [];
+    const deps = depsWith({
+      hostMap: new Map(),
+      appendOutcome: (r) => {
+        outcomes.push(r);
+        return undefined;
+      },
+    });
+
+    const out = await targetedFetch(deps, "https://unclaimed.example/o/r/pull/1");
+
+    expect(out).toEqual({ status: "not_configured" });
+    expect(outcomes).toHaveLength(0);
+  });
+
+  test("a throwing outcome append does not fail the fetch, and warns", async () => {
+    // The request has already left the machine. Propagating would turn a fetch
+    // that genuinely succeeded into a 500, and the caller would retry — causing
+    // MORE egress than the failure it reports.
+    const warnings: unknown[] = [];
+    const deps = depsWith({
+      hostMap: new Map<string, FetchableService>([["github.com", "github"]]),
+      appendEgress: () => ({ rowHash: "d".repeat(64) }),
+      appendOutcome: () => {
+        throw new Error("disk full");
+      },
+      warn: (err, message) => void warnings.push({ err, message }),
+      syncableFor: (service) => ({
+        serviceId: service,
+        defaultIntervalMs: 60_000,
+        initialSyncDepthDays: 30,
+        async sync() {
+          throw new Error("not exercised");
+        },
+        fetchOne: async (): Promise<FetchOneResult> => ({
+          status: "indexed",
+          itemId: "github:acme/web#482",
+        }),
+      }),
+    });
+
+    const out = await targetedFetch(deps, "https://github.com/acme/web/pull/482");
+
+    expect(out).toEqual({ status: "indexed", itemId: "github:acme/web#482" });
+    expect(warnings).toHaveLength(1);
+  });
+
   test("the caller's label reaches the egress row, and its absence leaves it unattributed", async () => {
     // Typecheck cannot catch this: a closure taking only `url` stays assignable
     // to `(url, callerLabel?)`, so a dropped label compiles clean and silently

--- a/packages/gateway/src/sync/targeted-fetch.ts
+++ b/packages/gateway/src/sync/targeted-fetch.ts
@@ -1,5 +1,6 @@
 // packages/gateway/src/sync/targeted-fetch.ts
 
+import type { FetchOutcomeStatus } from "../egress/outcome-egress.ts";
 import { canonicalizeUrl } from "../util/url-canonical.ts";
 import { type FetchableService, serviceForHost } from "./fetch-host-boundary.ts";
 import type { FetchMissReason, FetchOneResult, Syncable, SyncContext } from "./types.ts";
@@ -89,7 +90,28 @@ export interface TargetedFetchDeps {
     /** The verified label of the client that asked. Server-derived by the route; never a body
      *  field, or one client could file its egress under another's name. */
     readonly sourceId?: string | undefined;
+  }) => { rowHash: string } | undefined;
+  /**
+   * Appends ONE `outcome` marker after the connector call, naming the authorising row by its hash.
+   *
+   * Injected for the same D22 reason `appendEgress` is: `appendEgressEntry` is confined to
+   * `egress/*`. Synchronous for the same reason too — see the note above.
+   */
+  readonly appendOutcome: (row: {
+    readonly destination: FetchableService;
+    readonly authorizingRowHash: string;
+    readonly status: FetchOutcomeStatus;
+    readonly itemId?: string | undefined;
+    readonly reason?: string | undefined;
   }) => undefined;
+  /**
+   * Where a swallowed outcome-append failure is reported.
+   *
+   * Injected rather than reached through `ctx.logger`: every other collaborator this module has is
+   * injected, and narrowing to the one method actually used is what `appendBootMarkerOrWarn` does
+   * too (`Pick<Logger, "warn">`).
+   */
+  readonly warn: (err: unknown, message: string) => void;
   /** Injected so the acquire poll loop below is testable without real time. */
   readonly sleep: (ms: number) => Promise<void>;
 }
@@ -307,12 +329,39 @@ export async function targetedFetch(
 
   // BEFORE the outbound call. A throw here propagates and no fetch happens — fail-closed, no row
   // means no fetch.
-  deps.appendEgress({
+  const authorizing = deps.appendEgress({
     destination: service,
     sourceType: "sync",
     method: "items.fetch",
     ...(callerLabel === undefined ? {} : { sourceId: callerLabel }),
   });
 
-  return fetchOneWithRetry(fetchOne, ctx, canonical);
+  const result = await fetchOneWithRetry(fetchOne, ctx, canonical);
+
+  // AFTER the call, and deliberately the OPPOSITE posture to the append above. The request has
+  // already left the machine, so there is nothing left to abort; propagating would turn a fetch
+  // that genuinely succeeded into a failure and make the caller retry — more egress than the
+  // failure it reports. Swallow and warn, never silently (`appendBootMarkerOrWarn`'s precedent).
+  //
+  // `authorizing === undefined` means no row was written (a local-only destination), so there is
+  // nothing for an outcome to name.
+  if (authorizing !== undefined && result.status !== "unsupported_url") {
+    try {
+      deps.appendOutcome({
+        destination: service,
+        authorizingRowHash: authorizing.rowHash,
+        status: result.status,
+        ...("itemId" in result ? { itemId: result.itemId } : {}),
+        ...("reason" in result ? { reason: result.reason } : {}),
+      });
+    } catch (err) {
+      deps.warn(
+        { err },
+        "I29: failed to append the targeted-fetch outcome marker — the ledger will report this " +
+          "fetch as authorised with no recorded outcome",
+      );
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

The egress ledger can now say **how a targeted fetch ended**, not just that one was authorised.

`targetedFetch` appends its row BEFORE calling the connector — deliberately, because I29 is fail-closed: no row, no fetch. The consequence is that `result_status` records the *authorisation decision*, so a fetch that 404s, times out, or is refused by the provider still reads `authorized`, and nothing in the ledger ever said otherwise. A completed fetch now appends a second row carrying the status (`indexed` / `not_found` / `rate_limited`) and, on success, the item id.

This closes the last unmet half of the web clipper's C4.1 done-when. Follows #1319 (the ledger's HTTP read surface) and #1322 (which client asked).

Five commits, each TDD, plus the design, its review and the plan.

## Related Issue

No tracking issue. Design, review and plan are committed here:

- `docs/superpowers/specs/2026-08-24-egress-outcome-rows-design.md`
- `docs/superpowers/specs/2026-08-24-egress-outcome-rows-design-review.md`
- `docs/superpowers/plans/2026-08-24-egress-outcome-rows.md`

The consumer-side half (rendering the outcome column) is U3b in `nimbus-web-clipper`, not in this PR.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] Biome passes — clean across 3517 files. Run as `bunx biome check packages scripts`, because `bun run lint` reports "0 files processed" and exits 1 inside `.claude/worktrees/`
- [x] All existing tests pass — `20215 pass / 161 skip / 0 fail` across 1570 files, on the tree with `main` merged in
- [x] New behaviour is covered by tests — 5 in `outcome-egress.test.ts`, 4 in `targeted-fetch.test.ts`, 3 in `egress-source-type.test.ts`, 3 across the two appenders
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values in logs, IPC messages, config, or fixtures — the summary is redacted by key AND value pattern before storage; verified against `SENSITIVE_KEY` and `SENSITIVE_VALUE_PATTERNS` in the design doc
- [x] Platform-specific code behind `PlatformServices` — N/A
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable — no gate is touched. `egress.prune` keeps its owner-HITL gate and gains nothing
- [x] `docs/README.md` untouched

## Coverage (if engine/ or vault/ was changed)

Neither `engine/` nor `vault/` was modified.

## Testing

Full suite, typecheck, Biome and markdownlint above. `security-invariants.test.ts` passes **with no edit to it** — see the first reviewer note, which is the point.

## Notes for Reviewers

**1. The union gains an eleventh member, and the existing invariant validates the choice.** `egress-source-type.ts` says a new class "needs an explicit decision recorded here; it is not a casual append", so one is recorded. The argument is that `outcome` is a **MARKER**, not an egress class: it is bookkeeping about an outbound call the ledger has already counted, and counting it again would double every targeted fetch — inflating the exact number I29 exists to state honestly.

That framing is not just prose. Because `outcome` joins `MARKER_SOURCE_TYPES`, `COVERAGE_CLASSES` is untouched, and the existing `I29: COVERAGE_CLASSES is exactly the non-marker source types` test passes **unchanged**. Had it gone in as an egress class, that test would have failed — which is precisely the silent mismatch the union's header warns about. There is also a direct double-count guard: `countOutboundEgress` returns **1** for a fetch plus its outcome.

The freeze's own prescription — reuse a member with a reserved `method` — was rejected for a third time, here for a new reason: the natural candidate is `sync`, which is not a marker, so every outcome row would count as outbound unless the counting predicate grew a method-level special case. That reintroduces by hand the miscount `MARKER_SOURCE_TYPES` makes structural.

**2. The two appends have deliberately opposite failure postures.** The authorising append stays fail-closed — it throws, the fetch never happens. The outcome append swallows and warns, because by the time it runs the request has already left the machine: propagating would turn a fetch that genuinely succeeded into a 500, and the caller would retry, causing MORE egress than the failure it reports. `appendBootMarkerOrWarn` is the precedent, and its rule holds — swallowing is never silent.

A reader seeing an authorising row with no outcome may conclude only that the outcome was **not recorded**, never that the fetch is in flight: a row written by a gateway predating this change is indistinguishable from one whose outcome append was lost, and inferring from age would report a slow provider as a lost outcome.

**3. `resultStatus` stays `authorized` on the outcome row.** Tempting to use `blocked` to mean "the fetch failed", and wrong: the column means *was this allowed*, not *did it work*. Markers legitimately carry `authorized` — `pruneEgress` does — and overloading it would give one column two meanings across row classes. The result lives in `payload_summary.status`, which is the field that actually has three values.

**4. The correlation key is the authorising row's `row_hash`, in `source_id`.** Prune tombstones already carry an attested hash in that column, so a marker using it this way is established rather than novel. It is the value the chain commits to, so the key cannot drift from the row it names, and every consumer of `GET /v1/egress` already receives it as `rowHash` — the join needs no new field on the wire.

**5. `appendEgressEntry` now returns the hash it already computed.** One line; it was computing `rowHash` before its INSERT and discarding it. `EgressSink` is deliberately NOT widened — it is the executor's seam and targeted fetch does not go through it, so changing it would touch every executor wiring site plus `NULL_EGRESS_SINK` to deliver a value nothing on that path consumes.

**What U3 replaces.** The originally-designed U2b — item identity on the *authorising* row — is dropped as superseded. It would have required exporting a normalised URL parser from five connectors and renegotiating the no-raw-URL rule for `payload_summary`, because before the fetch the item id does not exist. After the fetch it is simply there. The stated cost: a fetch whose outcome never lands names no item either — the same window in which the outcome is unavailable anyway.

**A caveat worth knowing for the consumer.** An outcome row carries a HIGHER id than the row it describes, and `GET /v1/egress` reads newest-first, so the outcome arrives *first* and a page boundary can fall between the pair. That is a client concern (U3b) and is written up in the design's "The pair can straddle a page boundary".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
