### PR TITLE
fix(llm): enforce_air_gap now refuses the remote classifier instead of doing nothing

### DIFF
--- a/.claude/commands/nimbus-ipc.md
+++ b/.claude/commands/nimbus-ipc.md
@@ -519,9 +519,17 @@ Handlers: `packages/gateway/src/ipc/clip-rpc.ts`. CLI: `nimbus clip pair|status|
 | -32002 | `ERR_GAS_LIMIT` | `maxToolCallsPerSession` exceeded |
 | -32003 | `ERR_VAULT_LOCKED` | Vault unavailable (e.g. screen locked on macOS) |
 | -32004 | `ERR_CONNECTOR_UNAVAILABLE` | Connector not running or unauthenticated |
-| -32005 | `ERR_AIR_GAP` | Outbound HTTP blocked by `enforce_air_gap = true` |
+| -32005 | `ERR_AIR_GAP` | *Reserved, not implemented.* Air-gap refusal on the `ask` path surfaces as a `GatewayAgentUnavailableError` with `reason: "air_gap"`, not as this code. |
 | -32021 | `EMBEDDING_WARMING_RPC_CODE` | The local embedding model is still loading, so a semantic request cannot be answered YET. Carries `data.code = "embedding_warming"` + `data.readiness` (state / elapsedMs / model / dims / download progress / reason). Raised by `index.searchRanked` when `semantic` is not `false`; retry, or pass `semantic: false` for keyword-only results. Transient by definition — `disabled`/`unavailable` are served normally. |
 
+
+**Five of the codes above are RESERVED, not implemented** — verified by grepping
+`packages/gateway/src` and `packages/cli/src` for each name: `ERR_HITL_REJECTED`,
+`ERR_GAS_LIMIT`, `ERR_VAULT_LOCKED`, `ERR_CONNECTOR_UNAVAILABLE` and `ERR_AIR_GAP`
+appear in no production file. Only `ERR_METHOD_NOT_ALLOWED` and
+`EMBEDDING_WARMING_RPC_CODE` are wired. Do not write a client branch against a reserved
+code expecting it to fire; check the condition you actually care about instead. If you
+implement one, delete its "reserved" mention here in the same commit.
 ---
 
 ## Tauri UI Allowlist

--- a/packages/docs/src/content/docs/faq.mdx
+++ b/packages/docs/src/content/docs/faq.mdx
@@ -9,7 +9,9 @@ By default the only outbound traffic Nimbus generates is connector OAuth flows (
 
 Telemetry is **opt-in and disabled by default** (`[telemetry] enabled = false` in `nimbus.toml`). When enabled it sends aggregate counters only — sync durations, error rates, query latency percentiles. No content, no file names, no identifiers are ever included in telemetry payloads.
 
-Air-gap mode (`[llm] enforce_air_gap = true`) blocks all outbound HTTP for the duration of an `ask` round-trip, including connector API calls. This makes Nimbus operate entirely on already-indexed data. A local LLM (Ollama or llama.cpp) is required to make air-gap mode useful — without one, queries fall back to the configured remote provider and `enforce_air_gap` prevents that call from completing.
+Air-gap mode (`[llm] enforce_air_gap = true`) refuses every remote LLM call on the `ask` path. The intent classifier and the provider router both decline rather than reach a vendor, so your question text does not leave the machine. A local LLM (Ollama or llama.cpp) is what makes the mode useful — without one, `ask` answers from the already-indexed context alone instead of falling back to a remote provider.
+
+What air-gap mode does **not** cover, stated plainly because this answer used to claim otherwise: it does not stop connector syncs, and it does not stop embedding uploads when `openai.api_key` is set. Those are separate outbound paths on their own schedules rather than part of an `ask` round-trip, and a flag scoped to one round-trip was never able to govern them. Use `nimbus prove` to see what actually left the machine.
 
 ### Can I run Nimbus offline?
 

--- a/packages/gateway/src/engine/gateway-agent-error.ts
+++ b/packages/gateway/src/engine/gateway-agent-error.ts
@@ -6,6 +6,10 @@ export type AgentUnavailableReason =
   | "model_not_found"
   | "provider_error"
   | "network_error"
+  // The owner set `[llm] enforce_air_gap = true`. Distinct from `no_api_key`: a key may well be
+  // configured and reachable — we refuse to use it. Callers that degrade to a local answer treat
+  // this the same as a missing key, which is why it is a reason and not a thrown TypeError.
+  | "air_gap"
   | "unknown";
 
 export type AgentProviderName = "anthropic" | "openai";
@@ -88,6 +92,8 @@ function buildAgentErrorMessage(init: AgentUnavailableInit): string {
     }
     case "network_error":
       return `Could not reach ${provider}. Check your network connection.`;
+    case "air_gap":
+      return "Air-gap mode is on ([llm] enforce_air_gap = true), so the remote intent classifier was not called. Configure a local model ([llm] local_model with Ollama or llama.cpp) to answer without leaving the machine, or unset enforce_air_gap.";
     case "unknown":
       return "Agent unavailable. Check the gateway log for details.";
   }

--- a/packages/gateway/src/engine/router.test.ts
+++ b/packages/gateway/src/engine/router.test.ts
@@ -78,7 +78,7 @@ describe("classifyIntent — empty input", () => {
       return jsonResponse({});
     });
 
-    const result = await classifyIntent("");
+    const result = await classifyIntent("", { enforceAirGap: false });
     expect(result).toEqual({
       intent: "unknown",
       entities: {},
@@ -96,7 +96,7 @@ describe("classifyIntent — empty input", () => {
       return jsonResponse({});
     });
 
-    const result = await classifyIntent("   \n\t  ");
+    const result = await classifyIntent("   \n\t  ", { enforceAirGap: false });
     expect(result.intent).toBe("unknown");
     expect(result.confidence).toBe(1);
     expect(fetchCalled).toBe(false);
@@ -117,7 +117,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find markdown files");
+    const result = await classifyIntent("find markdown files", { enforceAirGap: false });
     expect(result.intent).toBe("file_search");
     expect(result.entities).toEqual({ pattern: "*.md" });
     expect(result.requiresHITL).toBe(false);
@@ -134,7 +134,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       );
     });
 
-    await classifyIntent("hi");
+    await classifyIntent("hi", { enforceAirGap: false });
     expect(capturedReq).toBeDefined();
     expect(capturedReq?.url).toBe("https://api.anthropic.com/v1/messages");
     expect(capturedReq?.method).toBe("POST");
@@ -149,7 +149,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       '```json\n{"intent":"file_organize","entities":{"source":"a","destination":"b"},"requiresHITL":true,"confidence":0.7}\n```';
     stubFetch(async () => anthropicTextResponse(fenced));
 
-    const result = await classifyIntent("move a to b");
+    const result = await classifyIntent("move a to b", { enforceAirGap: false });
     expect(result.intent).toBe("file_organize");
     expect(result.entities).toEqual({ source: "a", destination: "b" });
     expect(result.requiresHITL).toBe(true);
@@ -161,7 +161,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       '```\n{"intent":"file_search","entities":{"pattern":"x"},"requiresHITL":false,"confidence":0.5}\n```';
     stubFetch(async () => anthropicTextResponse(fenced));
 
-    const result = await classifyIntent("find x");
+    const result = await classifyIntent("find x", { enforceAirGap: false });
     expect(result.intent).toBe("file_search");
     expect(result.entities).toEqual({ pattern: "x" });
   });
@@ -172,7 +172,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       'Sure, here is the classification: {"intent":"unknown","entities":{},"requiresHITL":false,"confidence":0.3} hope this helps.';
     stubFetch(async () => anthropicTextResponse(prose));
 
-    const result = await classifyIntent("?");
+    const result = await classifyIntent("?", { enforceAirGap: false });
     expect(result.intent).toBe("unknown");
     expect(result.confidence).toBeCloseTo(0.3, 5);
   });
@@ -189,7 +189,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("move x to y");
+    const result = await classifyIntent("move x to y", { enforceAirGap: false });
     expect(result.intent).toBe("file_organize");
     expect(result.requiresHITL).toBe(true);
   });
@@ -206,7 +206,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find foo");
+    const result = await classifyIntent("find foo", { enforceAirGap: false });
     expect(result.requiresHITL).toBe(false);
   });
 
@@ -223,7 +223,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("hi");
+    const result = await classifyIntent("hi", { enforceAirGap: false });
     expect(result.confidence).toBe(0);
   });
 
@@ -240,7 +240,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("hi");
+    const result = await classifyIntent("hi", { enforceAirGap: false });
     expect(result.confidence).toBe(1);
   });
 
@@ -257,7 +257,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("hi");
+    const result = await classifyIntent("hi", { enforceAirGap: false });
     expect(result.confidence).toBe(0);
   });
 
@@ -274,7 +274,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find foo");
+    const result = await classifyIntent("find foo", { enforceAirGap: false });
     expect(result.entities).toEqual({ pattern: "foo", ok: "yes" });
   });
 
@@ -291,7 +291,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find foo");
+    const result = await classifyIntent("find foo", { enforceAirGap: false });
     expect(result.entities).toEqual({});
   });
 
@@ -308,7 +308,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find foo");
+    const result = await classifyIntent("find foo", { enforceAirGap: false });
     expect(result.entities).toEqual({});
   });
 
@@ -325,7 +325,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("?");
+    const result = await classifyIntent("?", { enforceAirGap: false });
     expect(result.intent).toBe("unknown");
   });
 
@@ -341,7 +341,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
       );
     });
 
-    await classifyIntent("hi");
+    await classifyIntent("hi", { enforceAirGap: false });
     const body = JSON.parse(capturedBody) as { model: string };
     expect(body.model).toBe("claude-haiku-4-5");
   });
@@ -358,7 +358,7 @@ describe("classifyIntent — Anthropic happy paths", () => {
     });
 
     const longInput = "x".repeat(10_000);
-    await classifyIntent(longInput);
+    await classifyIntent(longInput, { enforceAirGap: false });
     const body = JSON.parse(capturedBody) as { messages: Array<{ content: string }> };
     expect(body.messages[0]?.content).toHaveLength(8000);
   });
@@ -371,7 +371,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -386,7 +386,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -402,7 +402,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -419,7 +419,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -433,7 +433,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -447,7 +447,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -464,7 +464,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -478,7 +478,7 @@ describe("classifyIntent — Anthropic error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -501,7 +501,7 @@ describe("classifyIntent — OpenAI happy paths", () => {
       ),
     );
 
-    const result = await classifyIntent("find ts files");
+    const result = await classifyIntent("find ts files", { enforceAirGap: false });
     expect(result.intent).toBe("file_search");
     expect(result.entities).toEqual({ pattern: "*.ts" });
     expect(result.confidence).toBeCloseTo(0.85, 5);
@@ -519,7 +519,7 @@ describe("classifyIntent — OpenAI happy paths", () => {
       );
     });
 
-    await classifyIntent("hi");
+    await classifyIntent("hi", { enforceAirGap: false });
     expect(capturedReq).toBeDefined();
     expect(capturedReq?.url).toBe("https://api.openai.com/v1/chat/completions");
     expect(capturedReq?.method).toBe("POST");
@@ -546,7 +546,7 @@ describe("classifyIntent — OpenAI happy paths", () => {
       '```json\n{"intent":"file_organize","entities":{"source":"a","destination":"b"},"requiresHITL":true,"confidence":0.6}\n```';
     stubFetch(async () => openaiChatResponse(fenced));
 
-    const result = await classifyIntent("move a to b");
+    const result = await classifyIntent("move a to b", { enforceAirGap: false });
     expect(result.intent).toBe("file_organize");
     expect(result.requiresHITL).toBe(true);
   });
@@ -559,7 +559,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -574,7 +574,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -590,7 +590,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -605,7 +605,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -619,7 +619,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -633,7 +633,7 @@ describe("classifyIntent — OpenAI error paths", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -655,7 +655,7 @@ describe("classifyIntent — provider selection", () => {
       );
     });
 
-    await classifyIntent("hi");
+    await classifyIntent("hi", { enforceAirGap: false });
     expect(capturedUrl).toBe("https://api.anthropic.com/v1/messages");
   });
 
@@ -671,7 +671,7 @@ describe("classifyIntent — provider selection", () => {
       );
     });
 
-    await classifyIntent("hi");
+    await classifyIntent("hi", { enforceAirGap: false });
     expect(capturedUrl).toBe("https://api.openai.com/v1/chat/completions");
   });
 });
@@ -686,7 +686,7 @@ describe("classifyIntent — no API key", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
@@ -700,11 +700,89 @@ describe("classifyIntent — no API key", () => {
 
     let caught: unknown;
     try {
-      await classifyIntent("hi");
+      await classifyIntent("hi", { enforceAirGap: false });
     } catch (e) {
       caught = e;
     }
     expect(caught).toBeInstanceOf(GatewayAgentUnavailableError);
     expect((caught as GatewayAgentUnavailableError).reason).toBe("no_api_key");
+  });
+});
+
+describe("classifyIntent — [llm] enforce_air_gap", () => {
+  test("refuses WITHOUT making any network call, with a live key configured", async () => {
+    // The bug this pins. `enforce_air_gap` was consulted nowhere on this path, so an owner who set
+    // it and had ANTHROPIC_API_KEY in the environment shipped every `ask` to Anthropic anyway.
+    //
+    // Asserting only that it throws would NOT catch a version that calls out first and throws
+    // afterwards — by then the user's text has already left the machine, which is the entire thing
+    // air-gap exists to prevent. So the load-bearing assertion here is the call count, not the
+    // rejection.
+    setEnv("ANTHROPIC_API_KEY", "sk-ant-live-key-not-real");
+    let calls = 0;
+    stubFetch(async () => {
+      calls += 1;
+      return jsonResponse({});
+    });
+
+    await expect(
+      classifyIntent("what changed this week", { enforceAirGap: true }),
+    ).rejects.toBeInstanceOf(GatewayAgentUnavailableError);
+    expect(calls).toBe(0);
+  });
+
+  test("reports air_gap, not no_api_key — a key IS present and we refuse to use it", async () => {
+    setEnv("ANTHROPIC_API_KEY", "sk-ant-live-key-not-real");
+    stubFetch(async () => jsonResponse({}));
+
+    const err = await classifyIntent("hi", { enforceAirGap: true }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(GatewayAgentUnavailableError);
+    expect((err as GatewayAgentUnavailableError).reason).toBe("air_gap");
+  });
+
+  test("refuses on the OpenAI arm too, not just the first provider checked", async () => {
+    // Anthropic is tried first, so a guard placed inside the Anthropic branch alone would pass the
+    // test above and still egress for an OpenAI-only user.
+    setEnv("ANTHROPIC_API_KEY", undefined);
+    setEnv("OPENAI_API_KEY", "sk-openai-not-real");
+    let calls = 0;
+    stubFetch(async () => {
+      calls += 1;
+      return jsonResponse({});
+    });
+
+    const err = await classifyIntent("hi", { enforceAirGap: true }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect((err as GatewayAgentUnavailableError).reason).toBe("air_gap");
+    expect(calls).toBe(0);
+  });
+
+  test("air-gap OFF still egresses — the guard is the flag, not a blanket refusal", async () => {
+    // Without this, deleting the whole remote path would satisfy every assertion above.
+    setEnv("ANTHROPIC_API_KEY", "sk-ant-live-key-not-real");
+    let calls = 0;
+    stubFetch(async (url: string) => {
+      calls += 1;
+      expect(url).toContain("api.anthropic.com");
+      return jsonResponse({
+        content: [{ type: "text", text: JSON.stringify({ intent: "search", entities: {} }) }],
+      });
+    });
+
+    await classifyIntent("find markdown files", { enforceAirGap: false });
+    expect(calls).toBe(1);
+  });
+
+  test("empty input answers locally under air-gap rather than refusing", async () => {
+    // Nothing would have egressed, so there is nothing to refuse. Turning air-gap on must not
+    // convert a purely local answer into an error.
+    const result = await classifyIntent("   	 ", { enforceAirGap: true });
+    expect(result.intent).toBe("unknown");
+    expect(result.confidence).toBe(1);
   });
 });

--- a/packages/gateway/src/engine/router.ts
+++ b/packages/gateway/src/engine/router.ts
@@ -184,7 +184,28 @@ async function llmClassify(
   return classifiedFromObject(o);
 }
 
-export async function classifyIntent(userText: string): Promise<ClassifiedIntent> {
+/**
+ * What this classifier is permitted to reach.
+ *
+ * REQUIRED, and deliberately not an optional parameter defaulting to permissive. This function
+ * reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` straight from the process environment and POSTs the
+ * user's text to a vendor — it is the one path in the gateway that egresses without going through
+ * `LlmRouter`, which has honoured `enforceAirGap` all along. A default would make "forgot to pass
+ * the policy" indistinguishable from "policy says egress is fine", and the first is the bug that
+ * shipped: `[llm] enforce_air_gap = true` did nothing here, while the published FAQ said it
+ * "blocks all outbound HTTP for the duration of an `ask` round-trip".
+ *
+ * Required means a new caller is a COMPILE error rather than a silent hole.
+ */
+export type ClassifierEgressPolicy = {
+  /** `[llm] enforce_air_gap`. True refuses the call outright — see {@link LlmRouter.enforcesAirGap}. */
+  readonly enforceAirGap: boolean;
+};
+
+export async function classifyIntent(
+  userText: string,
+  policy: ClassifierEgressPolicy,
+): Promise<ClassifiedIntent> {
   const trimmed = userText.trim();
   if (trimmed.length === 0) {
     return {
@@ -193,6 +214,14 @@ export async function classifyIntent(userText: string): Promise<ClassifiedIntent
       requiresHITL: false,
       confidence: 1,
     };
+  }
+
+  // BEFORE the environment is read, not after. Reading the key first and refusing later would
+  // still be correct, but this ordering makes the refusal impossible to get wrong when a future
+  // provider arm is added below: a new arm added under this guard cannot egress, and one added
+  // above it would have to step over the guard visibly.
+  if (policy.enforceAirGap) {
+    throw new GatewayAgentUnavailableError({ reason: "air_gap" });
   }
 
   const anthropicKey = processEnvGet("ANTHROPIC_API_KEY");

--- a/packages/gateway/src/engine/run-ask.test.ts
+++ b/packages/gateway/src/engine/run-ask.test.ts
@@ -62,9 +62,19 @@ function fakeConversationalAgent(reply = "agent reply"): Agent {
   } as unknown as Agent;
 }
 
-function fakeLocalRouter(calls: string[], reply = "local reply", preferLocal = true): LlmRouter {
+function fakeLocalRouter(
+  calls: string[],
+  reply = "local reply",
+  preferLocal = true,
+  enforceAirGap = false,
+): LlmRouter {
   return {
     prefersLocal: () => preferLocal,
+    // Added when `classifyIntent` grew a required egress policy. A double that omits a method the
+    // production caller invokes does not fail typecheck — this object reaches `LlmRouter` through
+    // an `as unknown as` cast — it fails at runtime, which is how 20 tests in this file went red
+    // at once. Keep this in step with LlmRouter.
+    enforcesAirGap: () => enforceAirGap,
     generate: async (opts: { prompt: string }) => {
       calls.push(opts.prompt);
       return {
@@ -190,6 +200,59 @@ describe("runAsk", () => {
 
     expect(appended).toHaveLength(0);
     localIndex.close();
+  });
+
+  test("air-gap ON answers locally and makes no remote call", async () => {
+    // The integration half of the guard in `router.ts`. `classify` is deliberately NOT injected,
+    // so the REAL classifyIntent runs and the policy has to travel router -> run-ask -> guard for
+    // this to pass. Injecting a stub would test the stub.
+    //
+    // ANTHROPIC_API_KEY is SET on purpose. The test preload blanks it, and with it blank this test
+    // would go green through the `no_api_key` path without air-gap doing anything at all — passing
+    // for the wrong reason. With a key present, air-gap is the only thing that can stop the call.
+    //
+    // This file has no lifecycle hooks, so the env and fetch are restored here.
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, body_preview, url, modified_at, synced_at)
+       VALUES ('github:zaalgol/helpdesk#issue-1', 'github', 'issue', 'zaalgol/helpdesk#issue-1', 'add a smoke test', 'Create a basic smoke test for the helpdesk app.', 'https://github.com/zaalgol/helpdesk/issues/1', 1, 1)`,
+    );
+    const localIndex = new LocalIndex(db);
+    const prompts: string[] = [];
+    const reached: string[] = [];
+
+    const originalFetch = globalThis.fetch;
+    const originalKey = process.env["ANTHROPIC_API_KEY"];
+    process.env["ANTHROPIC_API_KEY"] = "sk-ant-not-real";
+    globalThis.fetch = (async (input: unknown) => {
+      reached.push(String(input));
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const out = await runAsk({
+        input: "What should I do for the smoke test issue?",
+        stream: false,
+        clientId: "test-client",
+        paths: stubPaths,
+        consentCoordinator: stubConsent,
+        localIndex,
+        dispatcher: stubDispatcher,
+        egressSink: NULL_EGRESS_SINK,
+        sendChunk: () => {},
+        llmRouter: fakeLocalRouter(prompts, "Answered from the local index.", true, true),
+      });
+
+      expect(out.reply).toBe("Answered from the local index.");
+      expect(out.modelMeta?.isLocal).toBe(true);
+      // The assertion the whole fix exists for.
+      expect(reached).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalKey === undefined) delete process.env["ANTHROPIC_API_KEY"];
+      else process.env["ANTHROPIC_API_KEY"] = originalKey;
+    }
   });
 
   test("uses local LLM router when remote classifier has no API key", async () => {

--- a/packages/gateway/src/engine/run-ask.ts
+++ b/packages/gateway/src/engine/run-ask.ts
@@ -24,7 +24,7 @@ import { GatewayAgentUnavailableError } from "./gateway-agent-error.ts";
 import { indexCountFor, indexCountLine } from "./index-count-question.ts";
 import { type PlanResult, planFromIntent } from "./planner.ts";
 import { fallbackSearchTerms, questionSearchTerms } from "./question-search-terms.ts";
-import { type ClassifiedIntent, classifyIntent } from "./router.ts";
+import { type ClassifiedIntent, type ClassifierEgressPolicy, classifyIntent } from "./router.ts";
 import { runConversationalAgent } from "./run-conversational-agent.ts";
 import { wrapToolOutput } from "./tool-output-envelope.ts";
 import type { ConnectorDispatcher, PlannedAction } from "./types.ts";
@@ -134,9 +134,12 @@ function emptyIndexGuidanceIfNeeded(
   return { reply: EMPTY_INDEX_GUIDANCE };
 }
 
-async function classifyIntentForAsk(input: string): Promise<ClassifiedIntent> {
+async function classifyIntentForAsk(
+  input: string,
+  policy: ClassifierEgressPolicy,
+): Promise<ClassifiedIntent> {
   try {
-    return await classifyIntent(input);
+    return await classifyIntent(input, policy);
   } catch (e) {
     if (e instanceof GatewayAgentUnavailableError) {
       throw e;
@@ -214,8 +217,14 @@ function shouldAnswerFromLocalIndexedContext(p: RunAskParams): boolean {
 }
 
 async function classifyIntentForAskWithLocalFallback(p: RunAskParams): Promise<ClassifiedIntent> {
+  // Resolved from the router, which owns `[llm]`. Absent a router there is no configuration to
+  // read, so the policy is the permissive one — the same posture that shipped before this guard
+  // existed. Every production path builds a router (`platform/assemble.ts`).
+  const policy: ClassifierEgressPolicy = {
+    enforceAirGap: p.llmRouter?.enforcesAirGap() ?? false,
+  };
   try {
-    return await (p.classify ?? classifyIntentForAsk)(p.input);
+    return await (p.classify ?? ((input) => classifyIntentForAsk(input, policy)))(p.input);
   } catch (e) {
     if (
       p.llmRouter === undefined ||
@@ -224,7 +233,10 @@ async function classifyIntentForAskWithLocalFallback(p: RunAskParams): Promise<C
     ) {
       throw e;
     }
-    if (e.reason !== "no_api_key" && e.reason !== "invalid_api_key") {
+    // `air_gap` joins the two key-shaped reasons: all three mean "no remote classification is
+    // going to happen", and the caller's recovery is identical — answer from the local index.
+    // Without it, turning air-gap ON would turn a working local ask into a hard error.
+    if (e.reason !== "no_api_key" && e.reason !== "invalid_api_key" && e.reason !== "air_gap") {
       throw e;
     }
     runAskLog.warn(

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -89,6 +89,19 @@ export class LlmRouter {
     return this.config.preferLocal;
   }
 
+  /**
+   * Whether `[llm] enforce_air_gap` is set.
+   *
+   * Mirrors {@link prefersLocal}, and the distinction between the two is the whole point:
+   * `preferLocal` is a PREFERENCE and is allowed to fall back to a remote provider, while this is
+   * a REFUSAL. `selectProvider` already honours it by skipping every non-local provider; this
+   * accessor exists so paths that do NOT go through the router — `engine/router.ts`
+   * `classifyIntent` is the one that mattered — can be held to the same rule.
+   */
+  enforcesAirGap(): boolean {
+    return this.config.enforceAirGap;
+  }
+
   // `opts.preferLocal` overrides `config.preferLocal` for this call only (e.g. research briefs
   // honoring `[briefs].prefer_local` independently of `[llm].prefer_local` — source text is
   // privacy-sensitive enough to warrant its own knob). Omitted, behavior is unchanged.


### PR DESCRIPTION
## The bug

`[llm] enforce_air_gap = true` did not stop the `ask` path from calling a vendor.

`enforceAirGap` was consulted in exactly **one** production site — `extensions/auto-update.ts`,
which suppresses extension update checks. It was consulted nowhere in `engine/router.ts`,
`engine/run-ask.ts`, or `embedding/openai-embedder.ts`. `LlmRouter` has honoured it correctly all
along, which is why brief synthesis, glossary and decisions were never affected; the ask path is
the one place that egresses **without** going through the router.

`classifyIntent` read `ANTHROPIC_API_KEY` straight from the process environment and POSTed up to
8,000 characters of the user's question to `api.anthropic.com`, falling back to OpenAI. No
configuration was consulted first — not air-gap, not `prefer_local`.

Two details make this worse than a disabled flag:

- **`prefer_local` defaults to `true`.** This was the default posture, not an opt-in
  misconfiguration. `classifyIntentForAskWithLocalFallback` consulted `prefersLocal()` only inside
  its `catch`, and only for `no_api_key` / `invalid_api_key` — so with a key in the environment the
  request had already been sent before any preference was read.
- **The published FAQ claimed the opposite**, in the exact scenario that failed: "without [a local
  LLM], queries fall back to the configured remote provider and `enforce_air_gap` prevents that
  call from completing." That is precisely the path where the call completed.

For a project whose pitch is provable non-egress, a false published guarantee is the part that
matters most.

## The fix

`classifyIntent` refuses **before it reads the environment**, via a `ClassifierEgressPolicy` that
is a **required** parameter rather than an optional one defaulting to permissive. A default would
make "forgot to pass the policy" indistinguishable from "policy says egress is fine", and the first
is the bug that shipped. Required means a new caller is a compile error — the same idiom `I29` uses
for its `ClientKind` map. It turned all 39 existing call sites into compile errors, which is the
forcing function working as intended.

The guard sits above the provider arms, so a future provider added below it cannot egress and one
added above would have to step over it visibly.

`LlmRouter.enforcesAirGap()` mirrors the existing `prefersLocal()`. The distinction is the point:
`preferLocal` is a preference allowed to fall back to a remote provider; air-gap is a refusal.
`run-ask` resolves the policy from the router and treats the new `air_gap` reason alongside
`no_api_key` / `invalid_api_key`, so turning air-gap **on** degrades to a local indexed answer
rather than converting a working ask into a hard error.

## Tests, red-proven

Five unit tests plus one integration test, all proven against a real mutation rather than assumed.

The load-bearing assertion is `expect(calls).toBe(0)`. Asserting only that it *throws* would pass a
version that calls Anthropic first and throws afterwards — by then the text has already left, which
is the entire thing air-gap exists to prevent.

Removing the guard fails 3 of the 5 unit tests. The two that keep passing are deliberate: "air-gap
OFF still egresses" and "empty input still answers locally" exist so the guard cannot be satisfied
by simply deleting the remote path.

The integration test runs `runAsk` **without** injecting `classify`, so the policy has to travel
router to run-ask to guard for it to pass; injecting a stub would test the stub. It sets
`ANTHROPIC_API_KEY` on purpose — the test preload blanks it, and with it blank the test would go
green through `no_api_key` while air-gap did nothing, passing for the wrong reason.

## One thing the fix broke, and why it is worth naming

The first full-suite run was **25 failures**, not green. `run-ask.test.ts` fakes `LlmRouter` through
an `as unknown as LlmRouter` cast, so adding a method to the real class did not break the cast — it
broke at runtime, in 20 tests at once, because the double never implemented it. The type system was
satisfied precisely because the fake was allowed to lie. Fixed in the shared `fakeLocalRouter`
helper, with a comment to keep it in step, so the next method added breaks one place and not twenty.

## Docs

- The FAQ now states what is true, **including what air-gap does not cover**: it does not stop
  connector syncs, and it does not stop embedding uploads when `openai.api_key` is set. Those are
  separate outbound paths on their own schedules, which a flag scoped to one round-trip was never
  able to govern.
- `ERR_AIR_GAP` is documented in the IPC error catalogue and implemented nowhere. Checking the rest
  of that table: **five of six** codes do not exist in any production file — `ERR_HITL_REJECTED`,
  `ERR_GAS_LIMIT`, `ERR_VAULT_LOCKED`, `ERR_CONNECTOR_UNAVAILABLE`, `ERR_AIR_GAP`. Only
  `ERR_METHOD_NOT_ALLOWED` and `EMBEDDING_WARMING_RPC_CODE` are wired. The table is annotated
  accordingly — correcting only my row would have implied the other four were verified.

## Known gaps

- **The OpenAI embedder still uploads under air-gap.** Threading the flag there touches
  `create-embedding-runtime` and roughly ten test call sites, and the FAQ scopes air-gap to an `ask`
  round-trip, so this PR makes the docs honest about it instead of widening a bug fix into an
  indexing change. Worth its own PR.
- **Connector syncs are not air-gap aware either**, and the FAQ no longer claims they are. Whether
  air-gap should mean "no inference leaves" or "no packet leaves" is a product decision, not a bug.
- **No `egress_ledger` row is appended for the classifier call.** The `model` coverage class still
  cannot fire, because the remote path here does not go through `LlmRouter`. A user with air-gap off
  and a key set still egresses unledgered — that is unchanged by this PR and is the next thing to
  close.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
