### PR TITLE
fix(jenkins): build headers with Headers so a hostile crumb cannot reach a prototype

### DIFF
--- a/packages/mcp-connectors/jenkins/src/jenkins-api.test.ts
+++ b/packages/mcp-connectors/jenkins/src/jenkins-api.test.ts
@@ -142,23 +142,26 @@ describe("jenkinsFetchJson", () => {
 });
 
 describe("jenkinsPost", () => {
+  // `jenkinsPost` builds a `Headers`, not a plain object, so the crumb name can never be a
+  // computed property write. These assertions read the real transport shape rather than an object
+  // literal; `Headers` lower-cases field names, hence "authorization".
   test("adds the crumb header when a crumb is provided", async () => {
-    let seen: Record<string, string> = {};
+    let seen = new Headers();
     globalThis.fetch = (async (_url: string, init: RequestInit) => {
-      seen = init.headers as Record<string, string>;
+      seen = init.headers as Headers;
       return { ok: true, status: 200, text: async () => "" } as Response;
     }) as unknown as typeof fetch;
     await jenkinsPost("https://ci/do", "Basic x", { field: "Jenkins-Crumb", value: "abc" });
-    expect(seen["Jenkins-Crumb"]).toBe("abc");
+    expect(seen.get("Jenkins-Crumb")).toBe("abc");
   });
   test("omits the crumb header when crumb is null", async () => {
-    let seen: Record<string, string> = {};
+    let seen = new Headers();
     globalThis.fetch = (async (_url: string, init: RequestInit) => {
-      seen = init.headers as Record<string, string>;
+      seen = init.headers as Headers;
       return { ok: true, status: 200, text: async () => "" } as Response;
     }) as unknown as typeof fetch;
     await jenkinsPost("https://ci/do", "Basic x", null);
-    expect(Object.keys(seen)).toEqual(["Authorization"]);
+    expect([...seen.keys()]).toEqual(["authorization"]);
   });
 });
 
@@ -180,13 +183,13 @@ describe("a hostile crumb field name never reaches the header object", () => {
     ["__proto__", "__proto__"],
     ["header injection", "X-Evil: v\r\nX-Other"],
   ])("jenkinsPost drops a %s crumb field", async (_label, field) => {
-    let seen: Record<string, string> = {};
+    let seen = new Headers();
     globalThis.fetch = (async (_url: string, init: RequestInit) => {
-      seen = init.headers as Record<string, string>;
+      seen = init.headers as Headers;
       return { ok: true, status: 200, text: async () => "" } as Response;
     }) as unknown as typeof fetch;
     await jenkinsPost("https://ci/do", "Basic x", { field, value: "pwned" });
-    expect(Object.keys(seen)).toEqual(["Authorization"]);
+    expect([...seen.keys()]).toEqual(["authorization"]);
     // Nothing reached Object.prototype either.
     expect(Object.getPrototypeOf({})).toBe(Object.prototype);
     expect(({} as Record<string, unknown>)["pwned"]).toBeUndefined();

--- a/packages/mcp-connectors/jenkins/src/jenkins-api.ts
+++ b/packages/mcp-connectors/jenkins/src/jenkins-api.ts
@@ -133,14 +133,22 @@ export async function jenkinsPost(
   authHeader: string,
   crumb: JenkinsCrumb | null,
 ): Promise<{ ok: boolean; status: number; text: string }> {
-  const headers: Record<string, string> = {
-    Authorization: authHeader,
-  };
-  // Guarded again at the sink, not only where the crumb is parsed: this function is exported and
-  // takes the crumb as an argument, so the write below must be safe for any caller, not only for
-  // one that went through `getJenkinsCrumb`.
+  // A `Headers` instance, NOT a plain object with a computed write.
+  //
+  // The crumb field name is chosen by the REMOTE Jenkins, so it is attacker-controlled on a hostile
+  // server. Writing it as `obj[name] = value` on an object literal reaches `Object.prototype`
+  // through the accessor for `__proto__` — the shape `tssecurity:S6109` exists to catch, and which
+  // it still reported against the guarded version of this code because a taint analyser cannot see
+  // that `isSafeHeaderName` sanitises.
+  //
+  // `Headers.set` cannot write a prototype: the name goes into the header map, never onto an
+  // object, so the class of bug is gone by construction rather than by a guard the analyser has to
+  // recognise. It also validates the name itself per RFC 7230 and THROWS on an invalid one, which
+  // is why `isSafeHeaderName` stays in front of it — a hostile crumb should mean "no crumb", not a
+  // thrown TypeError out of `jenkinsPost`.
+  const headers = new Headers({ Authorization: authHeader });
   if (crumb !== null && isSafeHeaderName(crumb.field)) {
-    headers[crumb.field] = crumb.value;
+    headers.set(crumb.field, crumb.value);
   }
   const res = await fetch(url, { method: "POST", headers });
   const text = await res.text();

--- a/packages/mcp-connectors/standalone/src/launcher.ts
+++ b/packages/mcp-connectors/standalone/src/launcher.ts
@@ -6,28 +6,39 @@ import { fileURLToPath } from "node:url";
 const ID_RE = /^[a-z0-9-]+$/;
 
 /**
+ * Does this source register a write tool?
+ *
  * A registration CALL, or the registrar handed to a shared kit — not a bare substring, which the
  * registrar's own `const registerWriteTool = ...` would satisfy even with nothing registered.
- * Kept in step with check-connector-consent.ts's WRITE_CALL_RE.
+ * Kept in step with the twin in check-connector-consent.ts.
  *
- * The indentation class is `[^\S\r\n]` (horizontal whitespace), NOT `\s`. `\s` matches a newline,
- * and under `/m` the engine restarts the match at every line start — so a run of n newlines gave n
- * start positions each able to consume the whole run, which is quadratic: measured on this exact
- * pattern, 32k newlines took ~1.2s and 128k took ~21s, growing 4x per doubling. A class that cannot
- * cross a line terminator bounds each attempt to that line's own indentation, which is linear (the
- * same inputs: 0.08ms and 0.9ms). The set of strings matched is unchanged — a position `\s*` could
- * only reach by spanning newlines is reachable from the following line start anyway.
+ * Deliberately NOT a regular expression. The previous pattern was
+ * `^\s*register[A-Za-z]*WriteTool\(` under `/m`, and it drew two rounds of ReDoS reports. The
+ * first was real: `\s` matches a newline, so under `/m` a run of n newlines gave n start
+ * positions each able to consume the whole run — quadratic, measured at 21s for 128k newlines.
+ * Narrowing the class to horizontal whitespace made it linear, and bounding the star to
+ * `{0,40}` kept it linear, but `typescript:S8786` reported both: a star immediately followed by
+ * a literal built from the same character class is the shape the rule looks for, bounded or not,
+ * and the shape is worth avoiding even where this engine happens not to backtrack.
  *
- * The {0,40} bound is not decoration. An UNBOUNDED [A-Za-z]* immediately followed by the
- * literal WriteTool, whose characters are themselves in [A-Za-z], is the shape
- * typescript:S8786 flags: the star and the literal compete for the same characters.
- * Measured on V8 it is linear -- 8k to 128k trailing letters ran 0.078 ms to 0.270 ms,
- * doubling with the input -- so that report was a FALSE POSITIVE rather than a live ReDoS.
- * A bounded quantifier is provably linear instead of measurably linear, and costs nothing:
- * the longest real middle segment is "Onedrive" at 8 characters, against a bound of 40.
+ * Scanning line by line removes the construct rather than arguing with the analyser. Each line is
+ * bounded work, no star sits next to an overlapping literal, and the accepted language is
+ * unchanged — including the trailing-comma form, which still requires the comma to end the line.
  */
-const WRITE_CALL_RE =
-  /^[^\S\r\n]*register[A-Za-z]{0,40}WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
+function registersWriteTool(src: string): boolean {
+  for (const line of src.split("\n")) {
+    const t = line.trimStart();
+    if (t === "registerWriteTool,") return true;
+    if (!t.startsWith("register")) continue;
+    const at = t.indexOf("WriteTool(");
+    if (at < 0) continue;
+    // Everything between `register` and `WriteTool(` must be letters, so `registerFoo.WriteTool(`
+    // does not count. Anchored at BOTH ends with nothing following, so it carries none of the
+    // ambiguity the old pattern did.
+    if (/^[A-Za-z]*$/.test(t.slice("register".length, at))) return true;
+  }
+  return false;
+}
 
 function connectorsDir(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -107,7 +118,7 @@ export function standaloneEligibility(
     }
   }
 
-  if (WRITE_CALL_RE.test(src)) {
+  if (registersWriteTool(src)) {
     return { eligible: true, reason: "hardened" };
   }
 

--- a/packages/mcp-connectors/standalone/src/launcher.ts
+++ b/packages/mcp-connectors/standalone/src/launcher.ts
@@ -17,8 +17,17 @@ const ID_RE = /^[a-z0-9-]+$/;
  * cross a line terminator bounds each attempt to that line's own indentation, which is linear (the
  * same inputs: 0.08ms and 0.9ms). The set of strings matched is unchanged — a position `\s*` could
  * only reach by spanning newlines is reachable from the following line start anyway.
+ *
+ * The {0,40} bound is not decoration. An UNBOUNDED [A-Za-z]* immediately followed by the
+ * literal WriteTool, whose characters are themselves in [A-Za-z], is the shape
+ * typescript:S8786 flags: the star and the literal compete for the same characters.
+ * Measured on V8 it is linear -- 8k to 128k trailing letters ran 0.078 ms to 0.270 ms,
+ * doubling with the input -- so that report was a FALSE POSITIVE rather than a live ReDoS.
+ * A bounded quantifier is provably linear instead of measurably linear, and costs nothing:
+ * the longest real middle segment is "Onedrive" at 8 characters, against a bound of 40.
  */
-const WRITE_CALL_RE = /^[^\S\r\n]*register[A-Za-z]*WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
+const WRITE_CALL_RE =
+  /^[^\S\r\n]*register[A-Za-z]{0,40}WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
 
 function connectorsDir(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");

--- a/scripts/structure-audit/check-connector-consent.ts
+++ b/scripts/structure-audit/check-connector-consent.ts
@@ -86,33 +86,39 @@ function codeOnly(src: string): string {
 }
 
 /**
- * A connector has routed its writes through the consent kit if EITHER form appears:
+ * Does this source register a write tool?
  *
- *   1. a registration call — `registerWriteTool(` or a composing wrapper like
- *      `registerGithubWriteTool(`, at the start of a line;
- *   2. the registrar handed to a shared kit as `registerWriteTool,` — imap, protonmail and apple
- *      register their send tool through `shared/imap-tool-kit.ts`, and construct the registrar
- *      themselves precisely so it is visible in their own files.
+ * A registration CALL, or the registrar handed to a shared kit — not a bare substring, which the
+ * registrar's own `const registerWriteTool = ...` would satisfy even with nothing registered.
+ * Kept in step with the twin in the standalone launcher's copy.
  *
- * Deliberately not a bare substring match: the registrar's own `const registerWriteTool = ...`
- * satisfies that, so a connector kept passing this gate after every one of its write
- * registrations had been reverted. Red-proving caught it.
+ * Deliberately NOT a regular expression. The previous pattern was
+ * `^\s*register[A-Za-z]*WriteTool\(` under `/m`, and it drew two rounds of ReDoS reports. The
+ * first was real: `\s` matches a newline, so under `/m` a run of n newlines gave n start
+ * positions each able to consume the whole run — quadratic, measured at 21s for 128k newlines.
+ * Narrowing the class to horizontal whitespace made it linear, and bounding the star to
+ * `{0,40}` kept it linear, but `typescript:S8786` reported both: a star immediately followed by
+ * a literal built from the same character class is the shape the rule looks for, bounded or not,
+ * and the shape is worth avoiding even where this engine happens not to backtrack.
  *
- * The indentation class is `[^\S\r\n]` (horizontal whitespace), NOT `\s`, for the reason spelled
- * out on `standalone/src/launcher.ts`'s copy: `\s` matches a newline, so under `/m` a run of n
- * newlines gave n start positions each able to consume the whole run — quadratic. Same matched
- * language, linear time. Change both copies together.
- *
- * The {0,40} bound is not decoration. An UNBOUNDED [A-Za-z]* immediately followed by the
- * literal WriteTool, whose characters are themselves in [A-Za-z], is the shape
- * typescript:S8786 flags: the star and the literal compete for the same characters.
- * Measured on V8 it is linear -- 8k to 128k trailing letters ran 0.078 ms to 0.270 ms,
- * doubling with the input -- so that report was a FALSE POSITIVE rather than a live ReDoS.
- * A bounded quantifier is provably linear instead of measurably linear, and costs nothing:
- * the longest real middle segment is "Onedrive" at 8 characters, against a bound of 40.
+ * Scanning line by line removes the construct rather than arguing with the analyser. Each line is
+ * bounded work, no star sits next to an overlapping literal, and the accepted language is
+ * unchanged — including the trailing-comma form, which still requires the comma to end the line.
  */
-const WRITE_CALL_RE =
-  /^[^\S\r\n]*register[A-Za-z]{0,40}WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
+function registersWriteTool(src: string): boolean {
+  for (const line of src.split("\n")) {
+    const t = line.trimStart();
+    if (t === "registerWriteTool,") return true;
+    if (!t.startsWith("register")) continue;
+    const at = t.indexOf("WriteTool(");
+    if (at < 0) continue;
+    // Everything between `register` and `WriteTool(` must be letters, so `registerFoo.WriteTool(`
+    // does not count. Anchored at BOTH ends with nothing following, so it carries none of the
+    // ambiguity the old pattern did.
+    if (/^[A-Za-z]*$/.test(t.slice("register".length, at))) return true;
+  }
+  return false;
+}
 
 /** `packages/mcp-connectors/<name>/...` → `<name>`. */
 function connectorOf(rel: string): string {
@@ -163,7 +169,7 @@ export function checkConnectorConsent(
       // A CALL, not the declaration. `const registerWriteTool = createWriteToolRegistrar(...)`
       // contains the identifier too, so a substring check called a connector hardened even after
       // every one of its write registrations had been reverted — caught by red-proving this gate.
-      if (WRITE_CALL_RE.test(src)) hardened.add(connectorOf(rel));
+      if (registersWriteTool(src)) hardened.add(connectorOf(rel));
     }
   }
   // Per CONNECTOR, not per file: a connector's write registration lives in one of its files and

--- a/scripts/structure-audit/check-connector-consent.ts
+++ b/scripts/structure-audit/check-connector-consent.ts
@@ -102,8 +102,17 @@ function codeOnly(src: string): string {
  * out on `standalone/src/launcher.ts`'s copy: `\s` matches a newline, so under `/m` a run of n
  * newlines gave n start positions each able to consume the whole run — quadratic. Same matched
  * language, linear time. Change both copies together.
+ *
+ * The {0,40} bound is not decoration. An UNBOUNDED [A-Za-z]* immediately followed by the
+ * literal WriteTool, whose characters are themselves in [A-Za-z], is the shape
+ * typescript:S8786 flags: the star and the literal compete for the same characters.
+ * Measured on V8 it is linear -- 8k to 128k trailing letters ran 0.078 ms to 0.270 ms,
+ * doubling with the input -- so that report was a FALSE POSITIVE rather than a live ReDoS.
+ * A bounded quantifier is provably linear instead of measurably linear, and costs nothing:
+ * the longest real middle segment is "Onedrive" at 8 characters, against a bound of 40.
  */
-const WRITE_CALL_RE = /^[^\S\r\n]*register[A-Za-z]*WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
+const WRITE_CALL_RE =
+  /^[^\S\r\n]*register[A-Za-z]{0,40}WriteTool\(|^[^\S\r\n]*registerWriteTool,$/m;
 
 /** `packages/mcp-connectors/<name>/...` → `<name>`. */
 function connectorOf(rel: string): string {


### PR DESCRIPTION
Clears the one open **security** finding on `main`, and the one code smell that
`#1327` left behind on the same subject. Two findings, opposite conclusions.

## The BLOCKER was real, and `#1327` did not clear it

`tssecurity:S6109` at `jenkins-api.ts` is a **taint** rule. `#1327` added
`isSafeHeaderName` and guarded the write at both the parse site and the sink, which does
close the vulnerability — but a taint analyser cannot see that an arbitrary predicate
sanitises, so it kept reporting.

This was checked rather than assumed. SonarCloud's analysis at 15:59 today re-mapped the
issue from line 112 to line **143**, which is the guarded code, so it was re-analysed and
re-flagged rather than left stale.

`jenkinsPost` now builds a `Headers` instance and calls `headers.set(...)`. The crumb
field name is chosen by the **remote** Jenkins, so it is attacker-controlled on a hostile
or compromised server, and writing it as `obj[name] = value` reaches `Object.prototype`
through the `__proto__` accessor. A header map is not an object, so the class of bug is
gone **by construction** rather than behind a guard the analyser has to trust.

`isSafeHeaderName` stays in front of it deliberately. `Headers.set` validates names per
RFC 7230 and **throws** on an invalid one — and a hostile crumb should mean "no crumb",
not a `TypeError` thrown out of `jenkinsPost`. The predicate also still guards the parse
site, where it decides the crumb is unusable in the first place.

Five tests asserted on a plain object. They now assert `headers.get(...)` and
`[...headers.keys()]`, which is the shape actually put on the wire — a stronger check
than the one they replaced.

## The ReDoS report: measured linear, and the construct removed anyway

`typescript:S8786` on the standalone launcher regex was a **true** positive before `#1327`
and did not reproduce as a real defect after it. Measured rather than argued, because the
previous PR claimed it fixed:

| input | time |
| --- | --- |
| 8,000 trailing letters | 0.078 ms |
| 128,000 trailing letters | 0.270 ms |
| 2,000 near-miss lines | 0.172 ms |
| 8,000 near-miss lines | 0.733 ms |

Doubling the input doubles the time — linear on V8.

Bounding the quantifier to `{0,40}` did **not** clear the rule, and that is the useful
correction: `S8786` objects to the *shape* — a star immediately followed by a literal built
from the same character class — not to the star being unbounded. Being linear on this
engine does not make the shape safe on engines that do backtrack.

So the construct is gone rather than re-argued. `registersWriteTool()` scans line by line
with `trimStart` / `startsWith` / `indexOf`; the only regex remaining is `/^[A-Za-z]*$/`,
anchored at both ends with nothing following, which carries no ambiguity at all.

This is the third change to these seven lines, so the accepted language was **proved, not
assumed**: the old pattern and the new function were run side by side over every connector
source — **411 files, zero verdict differences**. `audit:connector-consent` decides which
connectors count as hardened from this, so a silent language change would be worse than
the smell it replaced.

Nothing was marked "won't fix" and no suppression was added.

## Verified

- `bun run typecheck:no-docs` — exit 0
- `bun run lint` — exit 0
- `bun run preflight:fast` — PASSED
- `bun run audit:connector-consent` — exit 0
- whole suite — **20357 pass, 161 skip, 0 fail**

## Not in this PR

`typescript:S3776` in `sync/targeted-fetch.ts` — cognitive complexity 20 against 15, from
the recent `U2a`/`U3a` egress work. Clearing it takes the project to zero open Sonar
issues, but it is a refactor of freshly-shipped code and does not belong inside a security
fix. Worth its own PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
