### PR TITLE
docs: extraction lands in nimbus-mcp-servers, boundary reverses to thin, Plan 2

### DIFF
--- a/docs/superpowers/plans/2026-08-25-connector-extraction.md
+++ b/docs/superpowers/plans/2026-08-25-connector-extraction.md
@@ -1,0 +1,332 @@
+# Connector Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `packages/mcp-connectors/**` out of the monorepo into `nimbus-agent/nimbus-mcp-servers`, publish it as `@nimbus-dev/connectors`, and have the gateway consume it from npm — without the compiled binary losing the ability to start a connector.
+
+**Architecture:** The gateway's *only* runtime coupling to the connector tree is one generated file, `packages/gateway/src/connectors/bundled-connector-registry.ts`, which maps each id to a dynamic `import()`. The extraction changes those specifiers from relative paths to `@nimbus-dev/connectors/<id>` and changes nothing else about how a connector is spawned. `bun build --compile` embeds bare-specifier dynamic imports, so the compiled binary keeps working — and `test:connector-boot` is the gate that proves it rather than the assumption that carries it.
+
+**Tech Stack:** Bun 1.2+, TypeScript 7 strict, Biome, npm (`@nimbus-dev` scope), GitHub Actions.
+
+**Spec:** [`docs/superpowers/specs/2026-08-24-connector-extraction-design.md`](../specs/2026-08-24-connector-extraction-design.md) — §2a (destination), §4a (why thin), §7 (gates), §8 (release choreography).
+
+**Scope:** This is **Plan 2 of 2**. Plan 1 — the `SyncContext` narrowing — shipped in #1333 and is a prerequisite, not part of this. The boundary is **thin**: only `packages/mcp-connectors/**` moves. Nothing under `packages/gateway/src/` relocates, which is what keeps `SyncContext` an internal interface rather than a published contract.
+
+## Global Constraints
+
+- **Destination is `nimbus-agent/nimbus-mcp-servers`** — it exists, empty, created 2026-06-18 for exactly this. Do not create a new repo.
+- **Package is `@nimbus-dev/connectors`; bin is `nimbus-connector`.** Both verified free on npm 2026-08-24. `nimbus-mcp` belongs to an unrelated third party and must never be used — see #1323.
+- **ONE package, not 94.** The scaffold's README proposes `npx @nimbus/mcp-github`; §2a records why that is overridden.
+- **Delete the monorepo copy LAST**, only after `test:connector-boot` is green against the *published* artifact. A deletion that precedes the proof is unrecoverable in the same PR.
+- **The gateway must not import connector source directly** — that rule predates this plan (`connectors/_lib/apple-caldav-fetch.ts:11`). The generated registry is the only route, and it stays the only route.
+- No `any`. TypeScript strict. Every task ends with `bun run preflight:fast` plus the named checks.
+- **Verify with the CI command, not a scoped one:** `bun test packages/gateway packages/cli packages/mcp-connectors scripts`. A `src`-only run cost four red rounds on #1333.
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `scripts/gen-bundled-connector-registry.ts` | emits the id → `import()` map; the entire runtime coupling | 1, 5 |
+| `packages/mcp-connectors/package.json` **(new)** | the publishable `@nimbus-dev/connectors` manifest + `exports` map | 2 |
+| `scripts/connector-boot-smoke.ts` | `test:connector-boot` — proves the compiled binary starts a connector | 1, 6 |
+| `nimbus-mcp-servers` repo | destination; its README is stale and misleading | 3, 4 |
+| `packages/gateway/package.json` | gains the `@nimbus-dev/connectors` dependency | 6 |
+| `scripts/audit/connector-version-skew.ts` **(new)** | fails when the gateway's pin lags the registry | 7 |
+| the 92 path references + 5 gates | rewritten or retargeted | 5, 8 |
+
+---
+
+### Task 1: Prove the seam BEFORE anything moves
+
+The whole plan rests on one unproven claim: that a compiled binary can start a connector imported by **bare specifier** from a published package, rather than by relative path. Prove it against a locally-packed tarball, in the monorepo, with nothing moved and nothing published. If this fails, the design is wrong and no files should move.
+
+**Files:**
+
+- Modify: `scripts/gen-bundled-connector-registry.ts`
+- Test: `scripts/connector-boot-smoke.ts` (existing gate, run unchanged)
+
+**Interfaces:**
+
+- Produces: evidence, in the form of a green `test:connector-boot` against a tarball-installed package. Nothing else in this task is kept.
+
+- [ ] **Step 1: Record the baseline so the comparison is real**
+
+```bash
+bun run gen:connector-registry
+bun run build            # produces dist/nimbus-gateway
+bun run test:connector-boot
+```
+
+Expected: PASS, with the CURRENT relative-path registry. Write the number of connectors it booted into the task notes — a later "PASS" that boots fewer is not a pass.
+
+- [ ] **Step 2: Pack the connector tree as it stands**
+
+```bash
+cd packages/mcp-connectors
+bun pm pack --destination /tmp        # or `npm pack` if bun's differs
+```
+
+There is no `package.json` at that path yet, so this fails. That failure is the point: it tells you Task 2 is a prerequisite of the proof, not of the move. **Do Task 2 Step 1–3 now, then return here.**
+
+- [ ] **Step 3: Install the tarball into a scratch consumer and re-point the generator**
+
+Teach the generator to emit bare specifiers behind a flag, so the change is reversible and reviewable:
+
+```ts
+const SPECIFIER =
+  process.env["NIMBUS_CONNECTOR_SPECIFIER"] === "package"
+    ? (id: string) => `@nimbus-dev/connectors/${id}`
+    : (id: string) => `../../../mcp-connectors/${id}/src/server.ts`;
+```
+
+- [ ] **Step 4: Rebuild and run the gate against the packaged form**
+
+```bash
+NIMBUS_CONNECTOR_SPECIFIER=package bun run gen:connector-registry
+bun run build
+bun run test:connector-boot
+```
+
+Expected: PASS, booting the SAME number of connectors as Step 1.
+
+**If it fails, stop and report.** The likely causes, in order: `bun build --compile` not embedding a bare-specifier dynamic import (the assumption under test); the `exports` map not resolving subpaths; or a connector reaching a file the package does not ship. Each is a design problem, not a packaging detail.
+
+- [ ] **Step 5: Revert the generator to relative paths and commit only the flag**
+
+The flag stays; the default does not change until Task 6.
+
+```bash
+git add scripts/gen-bundled-connector-registry.ts packages/mcp-connectors/package.json
+git commit -m "feat(build): connector registry can emit package specifiers, proven by connector-boot"
+```
+
+---
+
+### Task 2: Make `packages/mcp-connectors` a publishable package
+
+**Files:**
+
+- Create: `packages/mcp-connectors/package.json`
+- Modify: `packages/mcp-connectors/README.md` (or create)
+
+**Interfaces:**
+
+- Produces: `@nimbus-dev/connectors` with a subpath `exports` map, consumed as `@nimbus-dev/connectors/<id>` by the generated registry.
+
+- [ ] **Step 1: Write the manifest**
+
+```jsonc
+{
+  "name": "@nimbus-dev/connectors",
+  "version": "0.0.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "bin": { "nimbus-connector": "./standalone/src/bin.ts" },
+  "files": ["*/src/**", "*/nimbus.extension.json", "shared/**", "standalone/**", "NOTICE"],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "@nimbus-dev/sdk": "^1.20.0"
+  }
+}
+```
+
+`private: true` until Task 4 publishes deliberately — the 94 connector packages were left publishable for months and #1323 had to disarm them.
+
+- [ ] **Step 2: Generate the exports map rather than hand-writing 94 entries**
+
+A hand-maintained map of 94 subpaths is a drift source with no gate. Emit it from the same directory scan the registry generator already uses:
+
+```ts
+// scripts/gen-connector-exports.ts
+const exportsMap = Object.fromEntries(
+  bundledConnectorIds().map((id) => [`./${id}`, `./${id}/src/server.ts`]),
+);
+```
+
+- [ ] **Step 3: Verify the package resolves before trusting it**
+
+```bash
+bun run gen:connector-exports
+bun -e 'import("@nimbus-dev/connectors/github").then(() => console.log("resolves"))'
+```
+
+Expected: `resolves`. Then return to Task 1 Step 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/mcp-connectors/package.json scripts/gen-connector-exports.ts
+git commit -m "feat(connectors): publishable package manifest with a generated exports map"
+```
+
+---
+
+### Task 3: Populate the destination repo
+
+**Files:** the `nimbus-mcp-servers` repo (exists, empty apart from `.gitignore`, `LICENSE`, `README.md`, `NEW-SESSION-PROMPT.md`).
+
+- [ ] **Step 1: Preserve history for the moved tree**
+
+A plain copy discards 209 test files' worth of blame. Use a subtree split so the connector history survives:
+
+```bash
+git subtree split --prefix=packages/mcp-connectors -b connectors-split
+```
+
+- [ ] **Step 2: Push into the destination**
+
+```bash
+git remote add mcp-servers git@github.com:nimbus-agent/nimbus-mcp-servers.git
+git push mcp-servers connectors-split:main --force-with-lease
+```
+
+`--force-with-lease` rather than `--force`: the repo has four files on `main` and clobbering someone else's push is not a risk worth taking for convenience.
+
+- [ ] **Step 3: Restore the four scaffold files the split overwrote**
+
+`LICENSE` (AGPL, 34KB) must survive — it is the licence the published package claims. `NEW-SESSION-PROMPT.md` can go; it is a build prompt for work now done.
+
+- [ ] **Step 4: Rewrite the README, which is actively misleading**
+
+It says *"Status: SCAFFOLD — not yet built"* and lists three decisions "to make first" that Project B already answered and shipped:
+
+| Its open question | Answer, and where it shipped |
+| --- | --- |
+| Share vs vendor vs fork | Extraction, one package — this plan |
+| Credential model outside the Vault | Env vars + consent kit — #1318 |
+| AGPL implications downstream | `NOTICE` security tiering — #1318 |
+| "Candidate first connectors: github, linear" | All 94 are standalone-eligible — #1321 |
+
+Also correct `npx @nimbus/mcp-github` to `npx @nimbus-dev/connectors <id>`, and carry over the client-support matrix from `standalone/README.md` — **Claude Desktop has no elicitation, so writes do not appear there**, which is the first thing a user of this repo will hit.
+
+- [ ] **Step 5: CI in the new repo**
+
+Port the connector-relevant gates only: `bun test`, `lint`, `typecheck`, and `audit:connector-consent` (which #1321 wired into CI after it ran nowhere at all). The coverage floor and the 3-OS matrix are gateway concerns and do not follow.
+
+---
+
+### Task 4: Publish `0.1.0`
+
+- [ ] **Step 1: Flip `private` and set the version**
+
+- [ ] **Step 2: Dry-run first and read the file list**
+
+```bash
+npm publish --dry-run --access public
+```
+
+Check for two specific failures: `shared/**` present (166+ files import it by relative path — if it is missing every connector breaks at runtime, not at install), and no `*.test.ts` shipped.
+
+- [ ] **Step 3: Publish, then verify from outside**
+
+```bash
+npm publish --access public
+cd $(mktemp -d) && npm init -y >/dev/null && npm i @nimbus-dev/connectors
+bun -e 'import("@nimbus-dev/connectors/github").then(() => console.log("ok"))'
+```
+
+Installing into a scratch directory is the only check that catches a `files` field that works locally because the source tree is there anyway.
+
+---
+
+### Task 5: Retarget the monorepo's references and gates
+
+**Files:** `scripts/gen-bundled-connector-registry.ts`, the five path-resolving gates, ~92 files referencing the path.
+
+- [ ] **Step 1: Derive the reference list mechanically**
+
+The spec's §7 warns that "84 references" is not a checklist — a recount gave 92. Derive it:
+
+```bash
+grep -rl 'packages/mcp-connectors\|mcp-connectors/' --include=*.ts --include=*.json --include=*.md --include=*.yml . \
+  | grep -v node_modules | grep -v '^./packages/mcp-connectors/' | sort > /tmp/refs.txt
+wc -l /tmp/refs.txt
+```
+
+- [ ] **Step 2: Classify before editing**
+
+Three kinds, and only one is mechanical: **docs** (rewrite to point at the new repo), **gates** (retarget or retire), **`biome.json` / `knip.json` / `.github/labeler.yml`** (drop the path). Anything that does not fit those three is a finding — report it rather than guessing.
+
+- [ ] **Step 3: The five gates, one at a time**
+
+`gen:connector-registry` and `test:connector-boot` retarget to the package. `audit:connector-entrypoints`, `audit:connector-deps` and `audit:connector-registry-drift` move to the new repo — but `audit:connector-deps` must check the gateway's **resolved dependency tree**, not source manifests, because a native transitive dependency silently breaks the compiled binary and a source-manifest check cannot see it.
+
+- [ ] **Step 4: The cross-platform parity test**
+
+`scripts/ci/cross-platform-parity.test.ts` asserts `packages/mcp-connectors` appears in the `bun test` path list of **both** `ci.yml` and `_test-suite.yml`. Both lists lose the path together, and the assertion is rewritten rather than deleted — that equality is load-bearing and only became true on 2026-08-23.
+
+---
+
+### Task 6: Consume the published package
+
+- [ ] **Step 1: Add the dependency and flip the generator default**
+
+- [ ] **Step 2: The proof gate, against the PUBLISHED artifact**
+
+```bash
+bun install && bun run gen:connector-registry && bun run build && bun run test:connector-boot
+```
+
+Expected: PASS, booting the same count as Task 1 Step 1. This is the gate the whole plan exists to satisfy; Task 1 proved it against a tarball, this proves it against what users install.
+
+- [ ] **Step 3: Full CI-parity verification**
+
+```bash
+bun test packages/gateway packages/cli scripts    # mcp-connectors is gone from this list
+bun run preflight
+```
+
+---
+
+### Task 7: The version-skew gate, before the deletion
+
+Spec §8 requires this and calls it required, not optional — `@nimbus-dev/sdk` is pinned at four different floors inside this one repo today.
+
+- [ ] **Step 1: Write it**
+
+Compare the `@nimbus-dev/connectors` version pinned in `packages/gateway/package.json` against the registry's latest. Fail on a **major or minor** gap; warn on patch. A minor gap means the gateway is missing a connector capability that already shipped.
+
+- [ ] **Step 2: Wire it into BOTH the manifest and a workflow, in one commit**
+
+`scripts/lib/preflight-gates.ts` **and** `.github/workflows/_test-suite.yml`. #1318 added `audit:connector-consent` to the manifest and to no workflow, so it ran nowhere and the PR passed *because the gate never executed*. `preflight-gates.test.ts` guards that class now; satisfy it.
+
+---
+
+### Task 8: Delete the monorepo copy — last
+
+- [ ] **Step 1: Confirm the preconditions, explicitly**
+
+Do not proceed unless all four hold: Task 6 Step 2 green against the published package; the new repo's CI green; `audit:connector-version-skew` live; and the published tarball verified from a scratch install (Task 4 Step 3).
+
+- [ ] **Step 2: Delete, and update the workspace**
+
+```bash
+git rm -r packages/mcp-connectors
+```
+
+Remove it from the root `package.json` workspaces, then `bun install` and **commit the lockfile** — a workspace removal changes it, and CI installs `--frozen-lockfile`.
+
+- [ ] **Step 3: Verify the deletion did not take something with it**
+
+```bash
+bun run preflight
+bun test packages/gateway packages/cli scripts
+bun run build && bun run test:connector-boot
+```
+
+- [ ] **Step 4: Update CLAUDE.md and GEMINI.md**
+
+Both list `packages/mcp-connectors/*` under Subsystems and must gain `nimbus-mcp-servers` in the satellite-repo list. They mirror each other; edit both or the drift gate fires.
+
+## Self-Review
+
+**Spec coverage.** §2a destination → Task 3. §4a thin boundary → the scope note and Task 5's classification. §7 gates → Tasks 5 and 7. §8 release choreography → Tasks 4, 6, 7. §9 sequencing → Tasks 1 (prove), 3–5 (move), 6 (consume), 8 (delete last).
+
+**Placeholders.** None. Task 2 Step 1 carries the actual manifest; Task 1 Step 3 the actual generator change. The two tasks that cannot be fully scripted — the 92 references and the five gates — carry the derivation command and a classification rule instead of a fabricated list, because the spec explicitly warns that a stale count is not a checklist.
+
+**Type consistency.** `@nimbus-dev/connectors` and the `nimbus-connector` bin are named identically throughout. `bundledConnectorIds()` is reused by the exports generator rather than a second directory scan, so the two cannot disagree about which directories are connectors.
+
+**The ordering that matters, and why.** Task 1 proves the riskiest assumption — bare-specifier dynamic imports surviving `--compile` — **before** any file moves, any repo is populated, or anything is published. Task 8 deletes only after the published artifact has booted a connector from a compiled binary. Everything between is reversible; those two are not, which is why they bracket the plan.
+
+**Known weakness.** Task 3's subtree split preserves history for the moved tree but leaves the monorepo's own history containing the connectors forever. That is correct — rewriting monorepo history is far more dangerous than a duplicated ancestry — but it means `git log --follow` across the boundary will not work, and anyone bisecting a connector bug older than the split needs the monorepo.

--- a/docs/superpowers/specs/2026-08-24-connector-extraction-design.md
+++ b/docs/superpowers/specs/2026-08-24-connector-extraction-design.md
@@ -17,16 +17,51 @@ order of importance:
    path-resolving gates and 209 connector test files.
 3. **Monorepo hygiene** — the gateway repo gets smaller and faster to navigate.
 
-Goal 2 is why this design takes the **fat move** (§4). A thin extraction would deliver 1 and 3 and
-leave "add a connector" as majority-gateway work, which is most of what makes it slow today.
+**Goal 2 is only partly delivered, and that is now a deliberate choice.** This design originally
+took the **fat move** — relocating the per-service sync and mapping code too — precisely so that
+"add a connector" would stop being majority-gateway work. §11's pre-registered condition then fired
+against it (see §4a), and the boundary is now **thin**. Adding a connector still touches both
+repos.
 
 ## 2. Decisions already taken
 
 | Decision | Choice | Consequence |
 | --- | --- | --- |
+| **Destination repo** | **`nimbus-agent/nimbus-mcp-servers`** — no new repo | It already exists for exactly this and has been an empty scaffold since 2026-06-18. See §2a. |
 | Package granularity | **One package**, `@nimbus-dev/connectors`, with a launcher | One version, one release, one changelog. `shared/` never crosses a package boundary, which deletes §12's largest objection outright. |
-| Repo boundary | **Fat** — sync and mapping move too | A connector becomes self-contained. Requires the injection design in §5. |
+| Repo boundary | **Thin** — only the MCP tool surface moves | Reversed from fat on the evidence in §4a. Sync/mapping stay in the gateway, so `SyncContext` stays an INTERNAL interface rather than a published contract. |
 | Entry point | `npx @nimbus-dev/connectors <connector-id>` | Single discoverable command. |
+
+## 2a. The destination already exists — and this design nearly missed it
+
+An earlier draft of this section said "its own repo" and named none, because it was written without
+checking the organisation first. That was a real gap: **`nimbus-agent/nimbus-mcp-servers`** was
+created on 2026-06-18 for precisely this purpose — *"Standalone MCP servers from Nimbus connectors,
+usable by any MCP client"* — and has sat empty ever since. Creating `nimbus-connectors` alongside it
+would have left two repos with one purpose and no way to tell which was real.
+
+The organisation has **20 repos, six of them scaffolds from that same 2026-06-18 batch**
+(`nimbus-mcp-servers`, `nimbus-connector-registry`, `nimbus-statuspage`, `nimbus-raycast`,
+`nimbus-recipes`, `nimbus-benchmarks`), none built. Project A is not "add a repo"; it is **filling
+in one that already exists**. The other five deserve a build-or-archive decision on their own
+schedule — `nimbus-connector-registry` in particular overlaps the S3 marketplace row and may be a
+real destination rather than dead weight.
+
+**That scaffold's README is stale in a way that misleads.** It still says *"Status: SCAFFOLD — not
+yet built"* and lists "the decision to make first" — share-vs-vendor-vs-fork, the credential model
+outside the Vault, and the AGPL implications for downstream clients. All three were answered by
+Project B and shipped in #1318 / #1321: the connectors are consent-gated standalone, credentials
+come from the environment, and `mcp-connectors/NOTICE` states the security tiering. Its "candidate
+first connectors: github, linear" is overtaken too — all 94 are standalone-eligible. Refreshing it
+is part of this work, not a follow-up, because a reader today is told the project is blocked on
+questions that are closed.
+
+**One packaging conflict, resolved deliberately rather than quietly.** That README proposes
+`npx @nimbus/mcp-github` — a package per connector. This design chooses ONE package. The scaffold is
+the older statement of intent, so the override is recorded here rather than left implicit: 94
+packages means 94 releases and 94 changelogs, and it forces `shared/` to become a versioned
+dependency that 166 files currently import by relative path. The discovery argument that motivated
+per-connector packages is also weaker than it looks — see the discovery note below.
 
 **Discovery note.** A single package is weaker on npm search than 94 packages would be. That
 matters less than it appears: MCP servers are discovered through the **MCP Registry**, where this
@@ -52,16 +87,47 @@ loaded gun; §9 disarms it.
 
 ## 4. What moves, and what does not
 
-**Moves to the connector repo:**
+## 4a. Why the boundary reversed from fat to thin
+
+§11 of the first draft pre-registered the condition that would make the fat move wrong:
+
+> If step 3 shows `SyncContext` needs more than roughly a dozen members, the sync code is more
+> entangled with the gateway than the census suggests, and the thin move becomes correct.
+
+**It needs 19.** Plan 1 shipped (#1333) and the final count is in `sync/sync-capabilities.ts`.
+Six of the nineteen serve only one or two connectors each — `prEnrichCandidates` and
+`itemMetadata` are GitHub-only, `listIndexedMetadataValues` serves CircleCI, GitHub Actions and
+GitLab, `writeObsidianVault` and `writeApiEndpointsForSpec` serve one connector apiece.
+
+Under the fat move those nineteen become a **published SDK contract**: third parties depend on
+them, we version them, and every future capability is a breaking-change decision made in public.
+Under the thin move they stay internal and free to change. That is the whole difference, and it is
+not a small one for an interface that grew from five to nineteen inside a single plan.
+
+**The narrowing was not wasted work, and this reversal does not diminish it.** Plan 1's value was
+never the extraction — it was that `ctx.vault` went from 83 users to zero, so a connector can no
+longer read another connector's credentials. That shipped, it is enforced by static rule D24, and
+it stands whether or not a single file ever moves repositories.
+
+**What this costs:** goal 2. A connector author still edits `<service>-sync.ts` and
+`<service>-mapping.ts` in the gateway repo. The honest framing is that the extraction delivers
+third-party distribution and monorepo hygiene, and improves contributor velocity only for the MCP
+tool surface.
+
+## 4b. What moves
+
+**Moves to `nimbus-agent/nimbus-mcp-servers`:**
 
 - `packages/mcp-connectors/**` — 188 source files, 209 test files, plus `shared/` and `standalone/`.
-- `packages/gateway/src/connectors/<service>-sync.ts` and `<service>-mapping.ts` — the per-service
-  sync intelligence, the bulk of the 351 files in that directory.
+  That is the whole move. Nothing under `packages/gateway/src/` relocates.
 
 **Stays in the gateway, deliberately:**
 
-- Every security-invariant enforcement site. Named explicitly because this is the risk the fat move
-  creates and the design's job is to neutralise it:
+- **`packages/gateway/src/connectors/<service>-sync.ts` and `<service>-mapping.ts`** — the
+  per-service sync intelligence, roughly 351 files. Under the fat boundary these moved; under thin
+  they do not, which is what keeps `SyncContext` an internal interface. §4a.
+- Every security-invariant enforcement site — unchanged by the reversal, and worth naming because
+  they are what a reader will check first:
   - `index/item-store.ts` — `upsertIndexedItemForSync`, the **V48/V49** body-depth chokepoint.
   - `db/write.ts` — **I14**.
   - `egress/sync-egress.ts` — **I29**'s per-run sync appender.
@@ -108,7 +174,7 @@ The static import surface, for completeness — accurate, but not the whole coup
 scoped capabilities.** The connector repo declares the interface; the gateway implements it.
 
 ```ts
-// @nimbus-dev/sdk — declared in the connector repo, implemented by the gateway
+// @nimbus-dev/sdk — declared in nimbus-mcp-servers, implemented by the gateway
 export interface SyncContext {
   // --- unchanged, already safe to expose ---
   logger: Logger;
@@ -267,7 +333,7 @@ Each step ends green and independently reviewable. No step both moves files and 
    land first even if A stalls.
 4. **Prove the seam** — `test:connector-boot` against a locally-packed tarball of the new package,
    before any repo exists.
-5. **Move** — create the repo, move files, rewrite the 84 references and five gates.
+5. **Move** — populate `nimbus-mcp-servers` (it exists, empty), move files, rewrite the path references and five gates.
 6. **Consume** — gateway depends on the published package; delete the monorepo copy **last**, only
    once step 4's gate is green against the published artifact.
 
@@ -297,9 +363,10 @@ by the existing test suite.
 
 Recorded so the decision can be revisited on evidence rather than sentiment:
 
-- If step 3 shows `SyncContext` needs more than roughly a dozen members, the sync code is more
-  entangled with the gateway than the census suggests, and the thin move becomes correct. Note the
-  first census was wrong in exactly this direction — it read static imports and missed the context —
-  so the bar for "one more member" should be suspicion, not accommodation.
+- ~~If step 3 shows `SyncContext` needs more than roughly a dozen members … the thin move becomes
+  correct.~~ **FIRED.** It needed 19; the boundary reversed to thin. Recorded in §4a. Worth noting
+  that this is the pre-registered condition working as intended: it was written before the count was
+  knowable and it changed the decision when the evidence arrived, rather than being explained away.
 - If the two-repo release sequence produces skew incidents in its first quarter despite the §8 gate,
-  the single-repo property was worth more than contributor velocity.
+  the single-repo property was worth more than contributor velocity — which the thin boundary now
+  only partly delivers anyway, making the single-repo option cheaper to fall back to.


### PR DESCRIPTION
## Answers "do we need another repo?" — no

`nimbus-agent/nimbus-mcp-servers` **already exists for exactly this** and has been empty since
2026-06-18: *"Standalone MCP servers from Nimbus connectors, usable by any MCP client."* The design
said "its own repo" and named none, because I wrote it without checking the organisation first.
Creating `nimbus-connectors` alongside it would have left two repos with one purpose.

The org has **20 repos and six are scaffolds from that same day** — `nimbus-mcp-servers`,
`nimbus-connector-registry`, `nimbus-statuspage`, `nimbus-raycast`, `nimbus-recipes`,
`nimbus-benchmarks`. Project A is not "add a repo", it is filling in one that exists. The other five
deserve a build-or-archive decision on their own schedule.

**That scaffold's README actively misleads.** It says "Status: SCAFFOLD — not yet built" and lists
three decisions "to make first" that Project B already answered and shipped:

| Its open question | Shipped in |
| --- | --- |
| Share vs vendor vs fork | this plan |
| Credential model outside the Vault | #1318 |
| AGPL implications downstream | #1318 (`NOTICE`) |
| "Candidate first connectors: github, linear" | #1321 — all 94 are eligible |

It also proposes a package per connector (`npx @nimbus/mcp-github`). This design overrides that in
favour of one package, and the override is now **recorded** rather than left implicit — the scaffold
is the older statement of intent and deserved an explicit answer.

## The boundary reversed: fat → thin

§11 of the design pre-registered the condition that would make the fat move wrong:

> If `SyncContext` needs more than roughly a dozen members, the sync code is more entangled with the
> gateway than the census suggests, and the thin move becomes correct.

**Plan 1 finished at nineteen**, six of them serving one or two connectors each — `prEnrichCandidates`
is GitHub-only, `writeObsidianVault` serves one. Under the fat move those become a **published SDK
contract** third parties depend on and we version; under thin they stay internal and mutable.

The condition worked as designed: written before the count was knowable, and it changed the decision
when the evidence arrived rather than being explained away.

**This does not diminish Plan 1.** Its value was never the extraction — `ctx.vault` went from 83
users to zero, enforced by static rule D24, and that stands whether or not a file ever moves. What
thin costs is goal 2: a connector author still edits sync and mapping in the gateway repo. The
design now says so plainly instead of claiming velocity it will not deliver.

## Plan 2

The whole runtime coupling turns out to be **one generated file** —
`bundled-connector-registry.ts`, mapping each id to a relative dynamic `import()`. The extraction
changes those specifiers to `@nimbus-dev/connectors/<id>` and changes nothing else about how a
connector spawns, which makes the move far more tractable than 188 source files suggests.

So the plan brackets itself with its two irreversible steps:

- **Task 1 proves the risky assumption first** — bare-specifier dynamic imports surviving
  `bun build --compile` — via `test:connector-boot` against a locally-packed tarball, before any
  file moves, any repo is populated, or anything is published. If it fails, the design is wrong and
  nothing should move.
- **Task 8 deletes the monorepo copy last**, only after the *published* artifact has booted a
  connector from a compiled binary.

Everything between is reversible. Those two are not.

## Verification

- `preflight:fast` PASSED
- Every factual claim in the plan re-derived rather than inherited: 188 source / 209 test files,
  190 relative `shared/` importers, 92 path references (the spec's older "84" is explicitly called
  out as not-a-checklist), and the six `audit:connector-*` / `gen:` / `test:connector-boot` gates.
