### PR TITLE
feat(ci): gate on connector version skew between the gateway and npm

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -150,6 +150,12 @@ jobs:
         # CI passed on #1318 because this never ran.
         run: bun run audit:connector-consent
 
+      - name: Connector version skew (gateway pin vs. published package)
+        # Added to the manifest AND here in the same commit, deliberately. #1318 put
+        # audit:connector-consent in the manifest and no workflow, so it ran nowhere and that PR
+        # passed BECAUSE the gate never executed. See the note above this block.
+        run: bun run audit:connector-version-skew
+
       - name: import.meta path confinement (compiled-binary asset resolution)
         # A source-tree-relative path derived from import.meta.dir resolves inside the read-only
         # bunfs root in a compiled binary. Two such sites made the admin console and the OpenAPI

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "audit:connector-deps": "bun scripts/structure-audit/check-connector-deps.ts",
     "audit:connector-registry-drift": "bun scripts/structure-audit/check-connector-registry-drift.ts",
     "audit:connector-consent": "bun scripts/structure-audit/check-connector-consent.ts",
+    "audit:connector-version-skew": "bun scripts/structure-audit/check-connector-version-skew.ts",
     "audit:import-meta-dir": "bun scripts/structure-audit/check-import-meta-dir.ts",
     "gen:connector-registry": "bun scripts/gen-bundled-connector-registry.ts",
     "test:connector-boot": "bun scripts/connector-boot-smoke.ts dist/nimbus-gateway",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -77,6 +77,17 @@ const FAST: readonly Gate[] = [
     tier: "fast",
   },
   {
+    // The connectors ship from their own repo now, so the gateway can silently fall behind a
+    // capability that has already been published. A MINOR gap fails: a connector the shipped
+    // binary cannot load is indistinguishable, to a user, from a connector that does not work. A
+    // patch gap warns. An unreachable registry is INDETERMINATE, never a failure — offline
+    // development and a registry outage are not skew, and a gate that reds for them is one people
+    // learn to ignore.
+    name: "audit:connector-version-skew",
+    cmd: ["bun", "run", "audit:connector-version-skew"],
+    tier: "fast",
+  },
+  {
     // A source-tree-relative path derived from `import.meta.dir` resolves inside the read-only
     // bunfs root in a compiled binary, so it silently points at nothing. Two such sites made the
     // admin console and the OpenAPI route unreachable in every released binary.

--- a/scripts/structure-audit/check-connector-version-skew.test.ts
+++ b/scripts/structure-audit/check-connector-version-skew.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { checkVersionSkew, classify, floorOf, report } from "./check-connector-version-skew.ts";
+
+describe("floorOf", () => {
+  test.each([
+    ["^0.1.1", "0.1.1"],
+    ["~2.3.4", "2.3.4"],
+    ["1.0.0", "1.0.0"],
+    [" ^0.1.1 ", "0.1.1"],
+  ])("%s -> %s", (range, want) => {
+    expect(floorOf(range)).toBe(want);
+  });
+
+  // Anything this does not recognise must return undefined so the audit degrades to indeterminate.
+  // Guessing a floor here would mean comparing a number nobody wrote.
+  test.each(["*", "latest", ">=1.0.0 <2.0.0", "workspace:*", "npm:other@1.0.0", ""])(
+    "%s is unrecognised",
+    (range) => {
+      expect(floorOf(range)).toBeUndefined();
+    },
+  );
+});
+
+describe("classify", () => {
+  test("equal is ok", () => {
+    expect(classify("0.1.1", "0.1.1").kind).toBe("ok");
+  });
+
+  // A release in flight pins the new version before it is published. Failing that would red every
+  // PR between the bump and the publish.
+  test("ahead of the registry is ok, not a failure", () => {
+    expect(classify("0.2.0", "0.1.9").kind).toBe("ok");
+  });
+
+  test("a patch gap warns", () => {
+    expect(classify("0.1.1", "0.1.4").kind).toBe("patch");
+  });
+
+  // A minor gap means a connector capability shipped that this gateway cannot load.
+  test("a minor gap fails", () => {
+    expect(classify("0.1.1", "0.2.0").kind).toBe("behind");
+  });
+
+  test("a major gap fails", () => {
+    expect(classify("0.9.9", "1.0.0").kind).toBe("behind");
+  });
+
+  test("an unparseable version is indeterminate, not a failure", () => {
+    expect(classify("0.1.1", "not-a-version").kind).toBe("indeterminate");
+  });
+});
+
+describe("checkVersionSkew", () => {
+  test("reads the real gateway pin and agrees with the registry shape", async () => {
+    const skew = await checkVersionSkew(async () => "0.1.1");
+    expect(skew.kind).toBe("ok");
+  });
+
+  test("detects a minor gap against the real pin", async () => {
+    const skew = await checkVersionSkew(async () => "9.9.9");
+    expect(skew.kind).toBe("behind");
+  });
+
+  // An unreachable registry must never fail this gate. Offline development and a registry outage
+  // are not version skew, and a gate that reds for them is one people learn to ignore.
+  test("an unreachable registry is indeterminate, not a failure", async () => {
+    const skew = await checkVersionSkew(async () => {
+      throw new Error("ENOTFOUND registry.npmjs.org");
+    });
+    expect(skew.kind).toBe("indeterminate");
+    if (skew.kind === "indeterminate") expect(skew.reason).toContain("registry unreachable");
+  });
+});
+
+describe("report", () => {
+  test("behind exits non-zero", () => {
+    expect(report({ kind: "behind", pinned: "0.1.1", latest: "0.2.0" })).toBe(1);
+  });
+
+  // The three non-failing verdicts must all exit 0. A patch gap and an unreachable registry are
+  // information, not grounds to red a PR.
+  test.each([
+    { kind: "ok", pinned: "0.1.1", latest: "0.1.1" } as const,
+    { kind: "patch", pinned: "0.1.1", latest: "0.1.4" } as const,
+    { kind: "indeterminate", reason: "registry unreachable: offline" } as const,
+  ])("$kind exits zero", (skew) => {
+    expect(report(skew)).toBe(0);
+  });
+});

--- a/scripts/structure-audit/check-connector-version-skew.ts
+++ b/scripts/structure-audit/check-connector-version-skew.ts
@@ -89,7 +89,11 @@ export async function checkVersionSkew(
 }
 
 async function defaultFetchLatest(): Promise<string> {
-  const r = await fetch(`${REGISTRY}/${PACKAGE_NAME.replace("/", "%2F")}`, {
+  // replaceAll, not replace: the single-argument form substitutes only the FIRST occurrence, so a
+  // package name with two separators would be under-encoded and the request would silently address
+  // the wrong path. Correct today by accident — `@nimbus-dev/connectors` has exactly one slash —
+  // which is precisely the shape CodeQL's incomplete-sanitization rule exists to catch.
+  const r = await fetch(`${REGISTRY}/${PACKAGE_NAME.replaceAll("/", "%2F")}`, {
     headers: { accept: "application/vnd.npm.install-v1+json" },
     signal: AbortSignal.timeout(15_000),
   });

--- a/scripts/structure-audit/check-connector-version-skew.ts
+++ b/scripts/structure-audit/check-connector-version-skew.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GATEWAY_PKG = join(REPO_ROOT, "packages", "gateway", "package.json");
+const PACKAGE_NAME = "@nimbus-dev/connectors";
+const REGISTRY = "https://registry.npmjs.org";
+
+export type Skew =
+  | { readonly kind: "ok"; readonly pinned: string; readonly latest: string }
+  | { readonly kind: "patch"; readonly pinned: string; readonly latest: string }
+  | { readonly kind: "behind"; readonly pinned: string; readonly latest: string }
+  | { readonly kind: "indeterminate"; readonly reason: string };
+
+/**
+ * The lowest version a range admits — `^0.1.1` → `0.1.1`.
+ *
+ * Deliberately not a semver-range parser. The gateway pins this package with a caret or an exact
+ * version and nothing else; anything unrecognised returns undefined and the audit degrades to
+ * indeterminate rather than guessing a number it will then compare.
+ */
+export function floorOf(range: string): string | undefined {
+  const m = /^\s*[\^~]?\s*(\d+)\.(\d+)\.(\d+)\s*$/.exec(range);
+  return m === null ? undefined : `${m[1]}.${m[2]}.${m[3]}`;
+}
+
+function parts(v: string): [number, number, number] | undefined {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v);
+  return m === null ? undefined : [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * Classify the gap between what the gateway pins and what the registry serves.
+ *
+ * A MINOR gap is a failure, not a warning: a connector capability has shipped that this gateway
+ * cannot load. A PATCH gap is a warning — a fix the gateway has not picked up yet, worth saying and
+ * not worth blocking a PR over. Ahead-of-registry is `ok`: that is what a release in flight looks
+ * like, and failing it would red every PR between the version bump and the publish.
+ */
+export function classify(pinned: string, latest: string): Skew {
+  const p = parts(pinned);
+  const l = parts(latest);
+  if (p === undefined || l === undefined) {
+    return {
+      kind: "indeterminate",
+      reason: `unparseable version: pinned=${pinned} latest=${latest}`,
+    };
+  }
+  if (p[0] < l[0] || (p[0] === l[0] && p[1] < l[1])) return { kind: "behind", pinned, latest };
+  if (p[0] === l[0] && p[1] === l[1] && p[2] < l[2]) return { kind: "patch", pinned, latest };
+  return { kind: "ok", pinned, latest };
+}
+
+export async function checkVersionSkew(
+  fetchLatest: () => Promise<string> = defaultFetchLatest,
+): Promise<Skew> {
+  let pinnedRange: unknown;
+  try {
+    const pkg: unknown = JSON.parse(readFileSync(GATEWAY_PKG, "utf8"));
+    if (typeof pkg !== "object" || pkg === null) throw new Error("manifest is not an object");
+    const deps = (pkg as Record<string, unknown>)["dependencies"];
+    if (typeof deps !== "object" || deps === null) throw new Error("no dependencies block");
+    pinnedRange = (deps as Record<string, unknown>)[PACKAGE_NAME];
+  } catch (e) {
+    return { kind: "indeterminate", reason: `cannot read ${GATEWAY_PKG}: ${String(e)}` };
+  }
+  if (typeof pinnedRange !== "string") {
+    return {
+      kind: "indeterminate",
+      reason: `${PACKAGE_NAME} is not pinned in the gateway manifest`,
+    };
+  }
+  const pinned = floorOf(pinnedRange);
+  if (pinned === undefined) {
+    return { kind: "indeterminate", reason: `unrecognised version range: ${pinnedRange}` };
+  }
+
+  let latest: string;
+  try {
+    latest = await fetchLatest();
+  } catch (e) {
+    // An unreachable registry is an OBSERVATION failure, not skew. Offline development and a
+    // registry outage must not fail a gate about version drift — the alternative is a gate people
+    // learn to ignore, which is worse than no gate.
+    return { kind: "indeterminate", reason: `registry unreachable: ${String(e)}` };
+  }
+  return classify(pinned, latest);
+}
+
+async function defaultFetchLatest(): Promise<string> {
+  const r = await fetch(`${REGISTRY}/${PACKAGE_NAME.replace("/", "%2F")}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+  const body: unknown = await r.json();
+  const tags =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>)["dist-tags"]
+      : undefined;
+  const latest =
+    typeof tags === "object" && tags !== null
+      ? (tags as Record<string, unknown>)["latest"]
+      : undefined;
+  if (typeof latest !== "string") throw new Error("registry response has no dist-tags.latest");
+  return latest;
+}
+
+/**
+ * Print the verdict and return the process exit code.
+ *
+ * Split out, and written as guards rather than a `switch`, because the two linters disagree about
+ * a switch here: `process.exit()` returns `never`, so tsc calls a following `break` unreachable
+ * code, while biome — which does not model that — calls the case without one a fallthrough. There
+ * is no arrangement of the switch that satisfies both. Returning a code satisfies both and makes
+ * the reporting testable without spawning a process.
+ */
+export function report(skew: Skew): number {
+  if (skew.kind === "behind") {
+    console.error(
+      `::error file=packages/gateway/package.json::${PACKAGE_NAME} is pinned at ${skew.pinned} but ${skew.latest} is published — a connector capability has shipped that this gateway cannot load`,
+    );
+    console.log(`connector version skew: BEHIND (${skew.pinned} < ${skew.latest})`);
+    return 1;
+  }
+  if (skew.kind === "patch") {
+    console.warn(
+      `::warning file=packages/gateway/package.json::${PACKAGE_NAME} is pinned at ${skew.pinned}; ${skew.latest} is published`,
+    );
+    console.log(`connector version skew: patch behind (${skew.pinned} < ${skew.latest})`);
+    return 0;
+  }
+  if (skew.kind === "indeterminate") {
+    console.log(`connector version skew: indeterminate — ${skew.reason}`);
+    return 0;
+  }
+  console.log(`connector version skew: ok (pinned ${skew.pinned}, latest ${skew.latest})`);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(report(await checkVersionSkew()));
+}


### PR DESCRIPTION
Reopens #1344, which GitHub auto-closed when squash-merging #1343 deleted its base branch. Same commit, cherry-picked onto `main`.

The connectors ship from [their own repo](https://github.com/nimbus-agent/nimbus-mcp-servers) now, so the gateway can silently fall behind a capability that has already been published. Nothing would have said so.

## Verdicts, and why they differ

| Gap | Verdict | Reasoning |
| --- | --- | --- |
| **minor / major** | **fail** | A connector the shipped binary cannot load is indistinguishable, to a user, from a connector that does not work. |
| **patch** | warn | A fix not yet picked up is worth saying and not worth blocking a PR over. |
| **ahead of registry** | ok | That is what a release in flight looks like — the version is bumped before it is published. Failing it would red every PR between the bump and the publish. |
| **registry unreachable** | indeterminate | Offline development and a registry outage are not version skew. **A gate that reds for them is one people learn to ignore**, which is worse than no gate. |

`floorOf()` recognises only a caret, tilde or exact version — what the gateway actually uses. Anything else returns `undefined` and the audit degrades to indeterminate rather than guessing a number it would then compare against the registry.

## Wiring

`package.json`, `scripts/lib/preflight-gates.ts` **and** `.github/workflows/_test-suite.yml`, in one commit.

#1318 put `audit:connector-consent` in the manifest and no workflow. It ran in no CI job, and that PR passed *because the gate never executed*. `preflight-gates.test.ts` guards the class now — I red-proved it by deleting the workflow entry and confirming the test fails.

## One implementation note

`report()` is split out and written as guards rather than a `switch`, because the two linters disagree about a switch here: `process.exit()` returns `never`, so tsc calls a following `break` unreachable code, while biome — which does not model that — calls the case without one a fallthrough. There is no arrangement that satisfies both. Returning an exit code satisfies both, and makes the reporting testable without spawning a process.

## Tests

23 cases. The network is **injected**, so the gate's own tests never depend on the registry being reachable — including the test asserting that an unreachable registry is indeterminate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated connector version-skew auditing against the package registry.
  * Major and minor version gaps now block validation; patch gaps generate warnings.
  * Unavailable or invalid version data is reported as indeterminate.

* **Bug Fixes**
  * Added CI checks and preflight validation to detect connector version drift consistently.

* **Tests**
  * Added coverage for version parsing, drift classification, registry failures, and exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->