### PR TITLE
feat(ci): gate on native dependencies reaching the gateway binary

### DIFF
--- a/.github/workflows/_test-suite.yml
+++ b/.github/workflows/_test-suite.yml
@@ -138,6 +138,11 @@ jobs:
         # passed BECAUSE the gate never executed. See the note above this block.
         run: bun run audit:connector-version-skew
 
+      - name: Gateway native dependencies (the compiled binary cannot bundle one)
+        # Wired here AND in preflight-gates.ts in the same commit. #1318 put a gate in the manifest
+        # and no workflow, so it ran nowhere and that PR passed because the gate never executed.
+        run: bun run audit:gateway-native-deps
+
       - name: import.meta path confinement (compiled-binary asset resolution)
         # A source-tree-relative path derived from import.meta.dir resolves inside the read-only
         # bunfs root in a compiled binary. Two such sites made the admin console and the OpenAPI

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "audit:platform-test-gaps": "bun scripts/ci/platform-test-gaps.ts",
     "audit:connector-registry-drift": "bun scripts/structure-audit/check-connector-registry-drift.ts",
     "audit:connector-version-skew": "bun scripts/structure-audit/check-connector-version-skew.ts",
+    "audit:gateway-native-deps": "bun scripts/structure-audit/check-gateway-native-deps.ts",
     "audit:import-meta-dir": "bun scripts/structure-audit/check-import-meta-dir.ts",
     "gen:connector-registry": "bun scripts/gen-bundled-connector-registry.ts",
     "test:connector-boot": "bun scripts/connector-boot-smoke.ts dist/nimbus-gateway",

--- a/scripts/lib/preflight-gates.ts
+++ b/scripts/lib/preflight-gates.ts
@@ -64,6 +64,18 @@ const FAST: readonly Gate[] = [
     tier: "fast",
   },
   {
+    // The gateway ships as a `bun build --compile` binary, which cannot bundle a native module: it
+    // either fails the compile or produces a binary that cannot load its shared library, where the
+    // only symptom is a connector that never works. sqlite-vec is the one native dependency and is
+    // handled deliberately, as a sidecar the compile step copies.
+    //
+    // Declared dependencies only — see the scope bound in the script. The transitive case is
+    // covered empirically by `test:connector-boot`.
+    name: "audit:gateway-native-deps",
+    cmd: ["bun", "run", "audit:gateway-native-deps"],
+    tier: "fast",
+  },
+  {
     // A source-tree-relative path derived from `import.meta.dir` resolves inside the read-only
     // bunfs root in a compiled binary, so it silently points at nothing. Two such sites made the
     // admin console and the OpenAPI route unreachable in every released binary.

--- a/scripts/structure-audit/check-gateway-native-deps.test.ts
+++ b/scripts/structure-audit/check-gateway-native-deps.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkGatewayNativeDeps, nativeEvidence, report } from "./check-gateway-native-deps.ts";
+
+/** A manifest plus a node_modules tree beside it. */
+function fixture(deps: Record<string, string>, files: Record<string, string[]>): string {
+  const root = mkdtempSync(join(tmpdir(), "native-deps-"));
+  writeFileSync(join(root, "package.json"), JSON.stringify({ dependencies: deps }));
+  for (const [pkg, names] of Object.entries(files)) {
+    const dir = join(root, "node_modules", ...pkg.split("/"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: pkg }));
+    for (const f of names) {
+      const p = join(dir, f);
+      mkdirSync(join(p, ".."), { recursive: true });
+      writeFileSync(p, "");
+    }
+  }
+  return join(root, "package.json");
+}
+
+describe("checkGatewayNativeDeps", () => {
+  test("the real gateway manifest is clean", () => {
+    expect(checkGatewayNativeDeps()).toEqual([]);
+  });
+
+  test("a prebuilt .node is a finding", () => {
+    const m = fixture({ evil: "^1.0.0" }, { evil: ["build/Release/evil.node"] });
+    expect(checkGatewayNativeDeps(m).map((f) => f.pkg)).toEqual(["evil"]);
+  });
+
+  test("a binding.gyp is a finding even with no built binary", () => {
+    const m = fixture({ evil: "^1.0.0" }, { evil: ["binding.gyp"] });
+    expect(checkGatewayNativeDeps(m).map((f) => f.pkg)).toEqual(["evil"]);
+  });
+
+  test("a pure-JS dependency is not", () => {
+    const m = fixture({ good: "^1.0.0" }, { good: ["index.js", "README.md"] });
+    expect(checkGatewayNativeDeps(m)).toEqual([]);
+  });
+
+  test("sqlite-vec is allowed — it ships as a sidecar the compile step copies", () => {
+    const m = fixture({ "sqlite-vec": "^1.0.0" }, { "sqlite-vec": ["build/vec0.node"] });
+    expect(checkGatewayNativeDeps(m)).toEqual([]);
+  });
+
+  // A dependency's own dependencies are separate packages. Attributing their artefacts to the
+  // hoister would blame whoever happened to be installed first.
+  test("a nested node_modules is not attributed to the outer package", () => {
+    const m = fixture({ good: "^1.0.0" }, { good: ["node_modules/inner/build/x.node"] });
+    expect(checkGatewayNativeDeps(m)).toEqual([]);
+  });
+
+  test("optionalDependencies are checked too — they install by default", () => {
+    const root = mkdtempSync(join(tmpdir(), "native-opt-"));
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ optionalDependencies: { evil: "^1.0.0" } }),
+    );
+    const dir = join(root, "node_modules", "evil");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), "{}");
+    writeFileSync(join(dir, "evil.node"), "");
+    expect(checkGatewayNativeDeps(join(root, "package.json")).map((f) => f.pkg)).toEqual(["evil"]);
+  });
+
+  test("nativeEvidence reports nothing for a missing directory rather than throwing", () => {
+    expect(nativeEvidence(join(tmpdir(), "does-not-exist-native"))).toEqual([]);
+  });
+
+  test("report exits 1 on a finding and 0 when clean", () => {
+    expect(report([{ pkg: "evil", evidence: ["evil.node"] }], 1)).toBe(1);
+    expect(report([], 19)).toBe(0);
+  });
+});

--- a/scripts/structure-audit/check-gateway-native-deps.ts
+++ b/scripts/structure-audit/check-gateway-native-deps.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GATEWAY_MANIFEST = join(REPO_ROOT, "packages", "gateway", "package.json");
+
+/**
+ * Dependencies of the gateway that legitimately carry native code.
+ *
+ * `sqlite-vec` is the only one, and it is handled deliberately rather than bundled:
+ * `compile-gateway.ts` copies its platform sidecar (`vec0.dll` / `.so` / `.dylib`) next to the
+ * binary. That is the pattern a native dependency has to follow here — the compiled binary cannot
+ * contain one, so it must be shipped alongside and loaded at runtime.
+ *
+ * Adding an entry means committing to that sidecar work on all three platforms. "It built on Linux
+ * CI" is not evidence that it loads on a user's Windows machine.
+ */
+const ALLOWED_NATIVE: ReadonlySet<string> = new Set(["sqlite-vec"]);
+
+export type NativeFinding = { readonly pkg: string; readonly evidence: readonly string[] };
+
+/** Native artefacts a package ships: a prebuilt binary, or the gyp recipe to build one. */
+export function nativeEvidence(dir: string): string[] {
+  const hits: string[] = [];
+  if (existsSync(join(dir, "binding.gyp"))) hits.push("binding.gyp");
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop() as string;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      // Never descend into a nested node_modules: those are OTHER packages. Counting their
+      // artefacts here would attribute a dependency's native code to whoever hoisted it.
+      if (e.isDirectory() && e.name !== "node_modules") stack.push(join(cur, e.name));
+      else if (e.isFile() && e.name.endsWith(".node")) {
+        hits.push(e.name);
+        return hits;
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Every package the gateway DECLARES, checked for native artefacts.
+ *
+ * SCOPE BOUND, stated plainly because it is narrower than it first appears: this reads the
+ * gateway's own manifest and does NOT walk the transitive graph.
+ *
+ * That is not laziness — it is what is reliably computable here. A transitive walk was written
+ * first and silently under-reported: `@mastra/core` declares 32 dependencies under npm ALIASES
+ * (`@ai-sdk/provider-utils-v5` and friends), which resolve through bun's isolated `.bun` store.
+ * Neither directory-walking `node_modules` nor `Bun.resolveSync` finds them from the package's own
+ * directory, and `bun.lock` is JSONC that `Bun.file().json()` refuses. The walk reported a
+ * 20-package closure for a tree of ~1,400 — a green result that meant "I could not see anything",
+ * which is the worst kind of gate.
+ *
+ * What this DOES catch is the realistic regression: someone adds a native dependency to the
+ * gateway's manifest, or bumps one that starts shipping a `.node`. The transitive case is covered
+ * empirically instead, by `test:connector-boot` — it boots all 94 connectors out of the actually
+ * compiled binary, so a native module that breaks loading fails there. That backstop is weaker on
+ * one axis worth knowing: it runs on CI Linux, so it would not catch a module that loads there and
+ * not on a user's Windows machine.
+ */
+export function checkGatewayNativeDeps(manifestPath: string = GATEWAY_MANIFEST): NativeFinding[] {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  const declared = Object.keys({ ...manifest.dependencies, ...manifest.optionalDependencies });
+  const nodeModules = join(manifestPath, "..", "node_modules");
+  const out: NativeFinding[] = [];
+  for (const pkg of declared) {
+    if (ALLOWED_NATIVE.has(pkg)) continue;
+    const dir = join(nodeModules, ...pkg.split("/"));
+    if (!existsSync(dir)) continue;
+    const evidence = nativeEvidence(dir);
+    if (evidence.length > 0) out.push({ pkg, evidence });
+  }
+  return out.sort((a, b) => a.pkg.localeCompare(b.pkg));
+}
+
+export function report(findings: readonly NativeFinding[], checked: number): number {
+  for (const f of findings) {
+    console.error(
+      `::error file=packages/gateway/package.json::${f.pkg} ships native artefacts (${f.evidence.join(", ")}) — the gateway compiles to a single binary, which cannot bundle a native module. Ship it as a sidecar the way sqlite-vec is, or drop it`,
+    );
+  }
+  console.log(
+    findings.length === 0
+      ? `gateway native deps: ok (${String(checked)} declared dependencies checked)`
+      : `gateway native deps: ${String(findings.length)} violation(s)`,
+  );
+  return findings.length > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  const manifest = JSON.parse(readFileSync(GATEWAY_MANIFEST, "utf8")) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  const count = Object.keys({ ...manifest.dependencies, ...manifest.optionalDependencies }).length;
+  process.exit(report(checkGatewayNativeDeps(), count));
+}


### PR DESCRIPTION
The last open item from the extraction plan. Its Task 5 asked for a check on the gateway's **resolved** dependency tree — a native transitive dependency silently breaks the compiled binary, and a source-manifest check cannot see it. When `audit:connector-deps` moved to the connectors repo, nothing replaced it here.

## The resolved-tree version does not work, and I deleted it rather than ship it

The first attempt walked `node_modules` upward from each package. It reported a **20-package closure for a tree of ~1,400**.

`@mastra/core` alone declares 32 dependencies under npm **aliases** (`@ai-sdk/provider-utils-v5` and friends) that resolve through bun's isolated `.bun` store. Neither directory walking nor `Bun.resolveSync` finds them from the package's own directory, and `bun.lock` is JSONC that `Bun.file().json()` refuses to parse.

That version would have reported **green because it could not see anything** — the failure mode this repo has been bitten by repeatedly, and the worst kind of gate. It is gone.

## What landed, and what it actually claims

The gateway's **declared** dependencies, checked for `.node` binaries and `binding.gyp`. The script states that bound rather than implying more.

It catches the realistic regression: someone adds a native dependency, or bumps one that starts shipping a `.node`.

The transitive case is covered **empirically** instead, by `test:connector-boot` — it boots all 94 connectors out of the actually compiled binary, so a native module that breaks loading fails there. Its own bound, worth stating: it runs on CI Linux, so it would not catch a module that loads there and not on a user's Windows machine.

`sqlite-vec` is allow-listed. It is the one native dependency and is handled deliberately — `compile-gateway.ts` copies its platform sidecar next to the binary, which is the pattern any future native dependency has to follow.

## Wiring and proof

`package.json`, `scripts/lib/preflight-gates.ts` **and** `.github/workflows/_test-suite.yml`, in one commit — #1318 put a gate in the manifest and no workflow, so it ran nowhere and that PR passed because the gate never executed.

Nine tests, each red-proved: a prebuilt `.node`, a `binding.gyp` with no built binary, a pure-JS package, the `sqlite-vec` exemption, a nested `node_modules` **not** being attributed to whoever hoisted it, and `optionalDependencies` being checked because they install by default.

`preflight:fast` green; 1596 script tests pass.
