### PR TITLE
feat(llm)!: route the LLM by (provider, model) instead of provider kind

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,46 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-08-27 — The router's unit becomes a `(provider, model)` route, not a provider kind, and
+  ships zero cloud vendors.** `LlmRouter` used to key on a closed `LlmProviderKind` union
+  (`"ollama" | "llamacpp" | "remote"`), so registering a second provider under an already-used kind
+  silently evicted the first — "qwen3 for reasoning, gemma for classification" on one Ollama daemon
+  was unrepresentable. It now keys on `routeId` (`"<providerId>/<modelName>"`), an open `ProviderId`
+  vendor string, and a live per-route availability probe that checks the daemon **and** that the
+  route's specific model is among what it reports — a shared daemon missing one of two configured
+  models now fails only that route, not its sibling. `[llm.local.<name>]` config entries register N
+  local routes at once; `[llm].route_priority` names an explicit try-first order. The migration
+  shims this landed with — the `LlmProviderKind` alias and `LlmRouter.registerProvider` — are now
+  deleted; every call site is on `registerRoute`/`addRoute`. **What did not ship:** no cloud vendor
+  — `packages/gateway/src/llm/` still registers only `OllamaProvider` and `LlamaCppProvider` in
+  production, so the open `ProviderId` string and the route-keyed registry are the precondition for
+  a remote provider, not the provider itself, and the `[agents] synthesis = "allow-remote"` path and
+  I29's `model` egress class remain reachable by exactly nothing. Two correctness fixes shipped
+  alongside the key change, and they are NOT symmetric: the egress destination now names the vendor
+  (`providerId`) instead of the literal string `"model"` — that gap is closed outright. The
+  context-overflow fallback (`LlmRouter.generate()`, on context overflow, when the preferred route's
+  prompt does not fit) was rewritten to walk routes in priority order instead of looking up a
+  literal `"remote"` key that nothing ever registered under — but `generate()` still calls the
+  resolved route's provider directly, with **no egress append and no `[agents] synthesis` check**.
+  That is a narrower key with a **wider reachable blast radius**: before this slice the fallback was
+  reachable in code but unreachable in practice (the `"remote"` slot was never filled); after it, any
+  registered non-local route satisfies the key, so the day a remote route is registered this path
+  goes live with no further code change. It is now a named, hard blocker on the next slice — a
+  remote provider may not be registered in production until `LlmRouter.generate()` either gets I29
+  `model`-class coverage or `docs/SECURITY-INVARIANTS.md` states precisely which calls it excludes,
+  with the standard wiring + docs + test triple either way. Both fixes are **unit-proven only**: no
+  remote route exists yet to exercise either one against a real outbound call, so "unit-tested" is
+  the honest ceiling on this claim until a vendor lands. **A known bound, left open rather than
+  silently closed:** `packages/cli`'s `nimbus llm status` keeps a hand-maintained private copy of
+  the route-status type (`RouteStatus` in `packages/cli/src/commands/llm.ts`) — `packages/cli` has
+  no source dependency on the gateway (IPC-only, per the dependency rules), so there is no shared
+  type to import, and the CLI's own tests mock the IPC client wholesale rather than dispatching
+  against a real handler. This already broke once in this branch: a caller kept reading
+  `res.decisions.classification` after `llm.status` became a route list, and the whole suite stayed
+  green. A gateway-side test now pins the exact `llm.status` payload shape (`llm-rpc.test.ts`), which
+  catches a reshape on the gateway half; an end-to-end CLI-against-gateway test that would catch it
+  on the CLI half too is out of scope for this slice.
+
 - **2026-08-24 — What a standalone connector actually gives you, measured per client rather than
   assumed.** Off-gateway consent rests entirely on the MCP `elicitation` capability, and whether a
   client implements it had never been checked against a real client. It is now, and the answer is a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -956,7 +956,11 @@ These subsystems are active development in Phase 4 (Presence). They extend the e
 
 ### Model Router (Local LLM)
 
-The Model Router is assembled with the Gateway platform services and exposed to the Engine and the `llm.*` IPC namespace. It selects the inference backend for each invocation based on task type and available models.
+The Model Router is assembled with the Gateway platform services and exposed to the Engine and the `llm.*` IPC namespace. It selects a **route** for each invocation — a `(provider, model)` pair, not a provider alone — based on task type, config-driven priority, and per-route availability.
+
+`LlmRouter` keys its registry on `routeId` (`"<providerId>/<modelName>"`, e.g. `"ollama/qwen3:8b"`), not on the provider vendor id. A provider vendor id (`ProviderId`, an open string — `"ollama"`, `"llamacpp"`, and, once slice 2 lands a remote provider, values like `"gemini"`/`"bedrock"`) can back several routes at once: `[llm.local.<name>]` config entries let one Ollama daemon serve multiple named models (`ollama/qwen3:8b` and `ollama/gemma3:12b` side by side), each tracked as an independent route with its own availability. This replaced an earlier design where the router keyed on a closed, three-member provider-kind union (`"ollama" | "llamacpp" | "remote"`) and could hold at most one provider per kind — registering a second model under an already-used kind silently evicted the first.
+
+Route selection walks an ordered list — an optional explicit `[llm].route_priority` prefix, then every other route ordered by `prefer_local` — filtering out routes that fail `enforce_air_gap`, the reasoning capability floor (`min_reasoning_params`), or a live per-route availability probe (the daemon must be reachable **and** report the route's specific model; a shared daemon missing one of its two configured models fails only that route, not the sibling sharing its process).
 
 | Task | Default backend | Air-gapped mode |
 |---|---|---|
@@ -969,12 +973,12 @@ The Model Router is assembled with the Gateway platform services and exposed to 
 
 | Backend | Discovery | `nimbus.toml` key |
 |---|---|---|
-| Ollama | Default `http://127.0.0.1:11434` | `[llm].local_model` set to any pulled Ollama model name; `prefer_local = true` to route to it |
+| Ollama | Default `http://127.0.0.1:11434` | `[llm].local_model`, or one or more `[llm.local.<name>]` entries, set to a pulled Ollama model name; `prefer_local = true` to route to it |
 | llama.cpp (GGUF) | `llama-server` HTTP endpoint, default `http://127.0.0.1:8080` | `[llm].llamacpp_server_path` stores the HTTP base URL, not the binary path |
-| Anthropic (remote) | `ANTHROPIC_API_KEY` in env | `[llm].remote_model = "claude-sonnet-4-6"` (provider inferred from `claude-*` prefix) |
-| OpenAI (remote) | `OPENAI_API_KEY` in env | `[llm].remote_model = "gpt-4o"` (provider inferred from `gpt-*` / `o1-*` / `o3-*` / `o4-*` prefix) |
 
-Model lifecycle (list, pull, load, unload, status) is managed via the `llm.*` IPC method namespace (`llm.listModels`, `llm.getStatus`, `llm.pullModel`, `llm.loadModel`, `llm.unloadModel`, `llm.setDefault`, `llm.getRouterStatus`). The router dispatches to a loaded backend or falls back per the table above; it never calls an LLM provider API directly.
+Anthropic and OpenAI rows do **not** appear above: `packages/gateway/src/llm/` ships only `OllamaProvider` and `LlamaCppProvider` today, so a remote route is not yet reachable in production — the open `ProviderId` string and the route-keyed registry above are the precondition for a remote provider, not the provider itself. See `docs/CHANGELOG.md`'s 2026-08-27 entry and `docs/roadmap.md` § Active (Spine S2) for what a remote route still needs before it ships.
+
+Model lifecycle (list, pull, load, unload, status) is managed via the `llm.*` IPC method namespace. `llm.status` returns every registered route (`routeId`, `providerId`, `modelName`, `isLocal`, `available`, `reason`, and an optional `contextWindow`) with its own live availability — not a single per-task decision. `llm.getRouterStatus` is kept for the older per-task-type decision payload (`{ decisions: {...} }`, one entry per `LlmTaskType`) that predates the route list; the two shapes have diverged and are not interchangeable. `llm.listModels`, `llm.pullModel`, `llm.loadModel`, `llm.unloadModel`, and `llm.setDefault` round out the namespace. The router dispatches to a resolved route's provider or falls back per the priority walk above; it never calls an LLM provider API directly.
 
 ### Multi-Agent Orchestration
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2243,8 +2243,11 @@ nimbus admin token
 
 ### `nimbus llm status`
 
-Show which LLM provider and model is selected for each task type, whether the provider
-is reachable, and why it was chosen.
+Show every LLM route registered with the Gateway — a `(provider, model)` pair, e.g.
+`ollama/qwen3:8b` — and that route's own live availability. One provider vendor (e.g.
+`ollama`, backed by a single daemon) can register several routes at once via
+`[llm.local.<name>]`; each is listed and probed independently, so a shared daemon
+missing one of its two configured models shows only that route as unavailable.
 
 ```text
 nimbus llm status [--json]
@@ -2254,15 +2257,26 @@ nimbus llm status [--json]
 
 | Column    | Description |
 |-----------|-------------|
-| Task type | One of `classification`, `reasoning`, `summarisation`, `agent_step` |
-| Provider  | `ollama`, `llamacpp`, or `remote` |
-| Model     | Model name from config (`llm.local_model` or `llm.remote_model`) |
-| Available | Whether the provider responded to an availability check |
-| Reason    | `prefer-local`, `prefer-remote`, `air-gap`, `no-local-provider`, `no-remote-provider`, or `local-below-reasoning-floor` |
+| Route     | The route id, `"<providerId>/<modelName>"` |
+| Provider  | The provider vendor id, e.g. `ollama`, `llamacpp` |
+| Model     | The model name this route registers |
+| Local     | Whether the route's provider runs on this machine (`provider.isLocal`) |
+| Available | Whether this specific route is reachable right now |
+| Context   | The route's configured context window, or `—` when not reported |
 
-The Provider/Model/Reason columns describe the **preferred** provider for each task (the
-configured intent). When that provider is unavailable, the Reason cell also names the provider
-the router would actually fall back to at generation time — `… (falls back to remote/<model>)`.
+**Available column detail:** `yes`, or one of two distinguishable failure reasons —
+`no (provider unreachable)` when the daemon itself did not respond, or
+`no (model not pulled)` when the daemon is up but this route's specific model is not
+among the models it reports. These are deliberately kept apart (`provider_unreachable`
+vs. `model_absent`) because the fix differs: start the daemon vs. pull the model. An
+unrecognised reason string degrades to `no (<reason>)` rather than a fixed label, so a
+future reason value is still legible.
+
+There is no per-task-type decision or `Reason` column any more, and no
+`falls back to …` text — every route is listed on equal footing with its own
+availability; which one `generate()` would actually pick for a given task is a
+function of `[llm].prefer_local`, `[llm].route_priority`, and the reasoning
+capability floor, not something this command renders per row.
 
 **Flags:**
 
@@ -2273,36 +2287,40 @@ the router would actually fall back to at generation time — `… (falls back t
 **Example — table:**
 
 ```text
-Task type      Provider   Model                    Available  Reason
--------------------------------------------------------------------------------
-classification ollama     llama3.2                 yes        prefer-local
-reasoning      ollama     llama3.2                 no         prefer-local (falls back to remote/claude-sonnet-4-6)
-summarisation  ollama     llama3.2                 yes        prefer-local
-agent_step     —          —                        no         unavailable
+Route                 Provider  Model               Local  Available                 Context
+------------------------------------------------------------------------------------------------
+ollama/qwen3:8b       ollama    qwen3:8b            yes    yes                       8192
+ollama/gemma3:12b     ollama    gemma3:12b          yes    no (model not pulled)     —
+llamacpp/model.gguf   llamacpp  model.gguf          yes    no (provider unreachable) —
 ```
 
 **Example — JSON:**
 
 ```json
-{
-  "classification": {
+[
+  {
+    "routeId": "ollama/qwen3:8b",
     "providerId": "ollama",
-    "modelName": "llama3.2",
-    "isAvailable": true,
-    "reason": "prefer-local"
+    "modelName": "qwen3:8b",
+    "isLocal": true,
+    "available": true,
+    "reason": "ok",
+    "contextWindow": 8192
   },
-  "reasoning": {
+  {
+    "routeId": "ollama/gemma3:12b",
     "providerId": "ollama",
-    "modelName": "llama3.2",
-    "isAvailable": false,
-    "reason": "prefer-local",
-    "fallback": { "providerId": "remote", "modelName": "claude-sonnet-4-6" }
+    "modelName": "gemma3:12b",
+    "isLocal": true,
+    "available": false,
+    "reason": "model_absent"
   }
-}
+]
 ```
 
-The `fallback` field is present only when the preferred provider is unavailable but another
-provider can serve the task.
+The JSON form is the gateway's `routes` array emitted verbatim — a route with no
+reported `contextWindow` simply omits the key (never a fabricated `null` or `0`),
+which is why the table above renders `—` for it instead of a number.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
@@ -1,0 +1,53 @@
+# LLM Model Routes — Implementation Plan Review
+
+**Date:** 2026-08-27  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Under Review  
+**Target Plan:** [2026-08-27-llm-model-routes.md](file:///C:/gitrep/Nimbus/docs/superpowers/plans/2026-08-27-llm-model-routes.md)
+
+---
+
+## 1. Summary of Review
+
+The implementation plan is exceptionally thorough, structured sequentially, and matches the approved design spec. The tasks compile and test incrementally, avoiding giant-step changes. 
+
+The following suggestions address cache longevity, sorting robustness, config URL resolution, and error routing details to prevent minor edge cases during execution.
+
+---
+
+## 2. Improvements & Suggestions
+
+### 2.1 Task 3: Ordering of Remaining Unpinned Routes
+*   **Context:** Task 3 outlines sorting routes via `orderedRoutes`:
+    ```typescript
+    const ordered = explicit.map((id) => byId.get(id)).filter((r): r is ModelRoute => r !== undefined);
+    const named = new Set(ordered.map((r) => r.routeId));
+    return [...ordered, ...all.filter((r) => !named.has(r.routeId))];
+    ```
+*   **Suggestion:** The remaining routes appended to the end of the priority list should also respect `preferLocal`. Update the return value to sort the remaining routes before appending:
+    ```typescript
+    const remaining = all.filter((r) => !named.has(r.routeId));
+    const local = remaining.filter((r) => r.provider.isLocal);
+    const remote = remaining.filter((r) => !r.provider.isLocal);
+    const sortedRemaining = preferLocal ? [...local, ...remote] : [...remote, ...local];
+    return [...ordered, ...sortedRemaining];
+    ```
+
+### 2.2 Task 5: Availability Cache Persistence
+*   **Context:** The TTL-based caching in `RouteAvailabilityProbe` is only effective if the probe instance persists.
+*   **Suggestion:** Explicitly state in Task 5 that the `RouteAvailabilityProbe` must be instantiated once as a private member on `LlmRouter` (e.g., `private readonly availabilityProbe = new RouteAvailabilityProbe();`) rather than dynamically inside `firstAvailableRoute` or walk methods, which would discard the cache instantly.
+
+### 2.3 Task 8: Resolved Base URL Collisions
+*   **Context:** Task 8 checks for duplicate `llamacpp` `base_url`s.
+*   **Suggestion:** If a route omits `base_url`, it defaults to the runtime's default host (e.g. `http://127.0.0.1:8080`). The collision check should compare the *resolved* base URLs (accounting for defaults) rather than raw string values, otherwise two routes omitting `base_url` will bypass the check and collide at runtime.
+
+### 2.4 Task 10: Call Site Audits for Dropped RPC Helpers
+*   **Context:** Task 10 drops `requireLocalProvider` and `LOCAL_PROVIDERS`.
+*   **Suggestion:** Ensure we list exactly where these functions are called outside `llm-rpc.ts` (e.g., in auth/security gates or debug tools) and document how they will retrieve local-ness from the router's registered provider instance instead.
+
+---
+
+## 3. Open Questions
+
+1.  **Throw Behavior on Malformed Configurations:**
+    Task 8 notes: *"a malformed value keeps the silent-ignore behaviour, while an unresolvable route reference throws."* Does throwing during TOML parsing completely block gateway startup (fail-fast), or is it caught and surfaced via standard config diagnostics? Fail-fast is safer, but we should align with Nimbus's boot sequence.

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
@@ -9,7 +9,7 @@
 
 ## 1. Summary of Review
 
-The implementation plan is exceptionally thorough, structured sequentially, and matches the approved design spec. The tasks compile and test incrementally, avoiding giant-step changes. 
+The implementation plan is exceptionally thorough, structured sequentially, and matches the approved design spec. The tasks compile and test incrementally, avoiding giant-step changes.
 
 The following suggestions address cache longevity, sorting robustness, config URL resolution, and error routing details to prevent minor edge cases during execution.
 
@@ -18,13 +18,17 @@ The following suggestions address cache longevity, sorting robustness, config UR
 ## 2. Improvements & Suggestions
 
 ### 2.1 Task 3: Ordering of Remaining Unpinned Routes
-*   **Context:** Task 3 outlines sorting routes via `orderedRoutes`:
+
+* **Context:** Task 3 outlines sorting routes via `orderedRoutes`:
+
     ```typescript
     const ordered = explicit.map((id) => byId.get(id)).filter((r): r is ModelRoute => r !== undefined);
     const named = new Set(ordered.map((r) => r.routeId));
     return [...ordered, ...all.filter((r) => !named.has(r.routeId))];
     ```
-*   **Suggestion:** The remaining routes appended to the end of the priority list should also respect `preferLocal`. Update the return value to sort the remaining routes before appending:
+
+* **Suggestion:** The remaining routes appended to the end of the priority list should also respect `preferLocal`. Update the return value to sort the remaining routes before appending:
+
     ```typescript
     const remaining = all.filter((r) => !named.has(r.routeId));
     const local = remaining.filter((r) => r.provider.isLocal);
@@ -34,20 +38,23 @@ The following suggestions address cache longevity, sorting robustness, config UR
     ```
 
 ### 2.2 Task 5: Availability Cache Persistence
-*   **Context:** The TTL-based caching in `RouteAvailabilityProbe` is only effective if the probe instance persists.
-*   **Suggestion:** Explicitly state in Task 5 that the `RouteAvailabilityProbe` must be instantiated once as a private member on `LlmRouter` (e.g., `private readonly availabilityProbe = new RouteAvailabilityProbe();`) rather than dynamically inside `firstAvailableRoute` or walk methods, which would discard the cache instantly.
+
+* **Context:** The TTL-based caching in `RouteAvailabilityProbe` is only effective if the probe instance persists.
+* **Suggestion:** Explicitly state in Task 5 that the `RouteAvailabilityProbe` must be instantiated once as a private member on `LlmRouter` (e.g., `private readonly availabilityProbe = new RouteAvailabilityProbe();`) rather than dynamically inside `firstAvailableRoute` or walk methods, which would discard the cache instantly.
 
 ### 2.3 Task 8: Resolved Base URL Collisions
-*   **Context:** Task 8 checks for duplicate `llamacpp` `base_url`s.
-*   **Suggestion:** If a route omits `base_url`, it defaults to the runtime's default host (e.g. `http://127.0.0.1:8080`). The collision check should compare the *resolved* base URLs (accounting for defaults) rather than raw string values, otherwise two routes omitting `base_url` will bypass the check and collide at runtime.
+
+* **Context:** Task 8 checks for duplicate `llamacpp` `base_url`s.
+* **Suggestion:** If a route omits `base_url`, it defaults to the runtime's default host (e.g. `http://127.0.0.1:8080`). The collision check should compare the *resolved* base URLs (accounting for defaults) rather than raw string values, otherwise two routes omitting `base_url` will bypass the check and collide at runtime.
 
 ### 2.4 Task 10: Call Site Audits for Dropped RPC Helpers
-*   **Context:** Task 10 drops `requireLocalProvider` and `LOCAL_PROVIDERS`.
-*   **Suggestion:** Ensure we list exactly where these functions are called outside `llm-rpc.ts` (e.g., in auth/security gates or debug tools) and document how they will retrieve local-ness from the router's registered provider instance instead.
+
+* **Context:** Task 10 drops `requireLocalProvider` and `LOCAL_PROVIDERS`.
+* **Suggestion:** Ensure we list exactly where these functions are called outside `llm-rpc.ts` (e.g., in auth/security gates or debug tools) and document how they will retrieve local-ness from the router's registered provider instance instead.
 
 ---
 
 ## 3. Open Questions
 
-1.  **Throw Behavior on Malformed Configurations:**
+1. **Throw Behavior on Malformed Configurations:**
     Task 8 notes: *"a malformed value keeps the silent-ignore behaviour, while an unresolvable route reference throws."* Does throwing during TOML parsing completely block gateway startup (fail-fast), or is it caught and surfaced via standard config diagnostics? Fail-fast is safer, but we should align with Nimbus's boot sequence.

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes-review.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-27  
 **Reviewer:** Antigravity (AI Coding Assistant)  
 **Status:** Under Review  
-**Target Plan:** [2026-08-27-llm-model-routes.md](file:///C:/gitrep/Nimbus/docs/superpowers/plans/2026-08-27-llm-model-routes.md)
+**Target Plan:** [2026-08-27-llm-model-routes.md](./2026-08-27-llm-model-routes.md)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes.md
@@ -1,0 +1,1130 @@
+# LLM Model Routes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the LLM router able to hold N `(provider, model)` routes at once, so two local models can serve different tasks — and so slice 2's cloud vendors have a seat to land in.
+
+**Architecture:** `LlmRouter` currently keys `providers` on `LlmProviderKind`, a closed three-member union, so registering a second provider of a kind evicts the first. This plan replaces that key with a `routeId` (`${providerId}/${modelName}`) and keys the map on routes instead. Provider *implementations do not change* — two models means two instances of the same provider class sharing a `providerId`. Alongside the key change, three latent defects are closed while no remote route exists to exercise them: route availability that never checks the model, an egress destination hardcoded to the literal `"model"`, and lifecycle methods that would break on the new map.
+
+**Tech Stack:** Bun 1.2+, TypeScript 7 strict, Biome, `bun:sqlite`, `bun:test`.
+
+**Spec:** [`docs/superpowers/specs/2026-08-27-llm-model-routes-design.md`](../specs/2026-08-27-llm-model-routes-design.md) — §3.1 (routing unit), §3.2 (`isLocal`), §3.3 (resolution order), §3.4 (availability), §3.5 (lifecycle), §3.6 (config), §4 (the two correctness fixes). Review that shaped it: [`…-design-review.md`](../specs/2026-08-27-llm-model-routes-design-review.md).
+
+## Global Constraints
+
+- **No `any`.** Use `unknown` for external data. TypeScript strict is non-negotiable.
+- **Ships zero cloud vendors.** No provider adapter for Anthropic/OpenAI/Gemini/xAI/Bedrock in this plan. If a task seems to need one, stop — it is slice 2.
+- **No schema migration.** `llm_models` already keys `ON CONFLICT(provider, model_name)`; `llm_task_defaults` already stores both columns. If you find yourself writing a `V57`, stop and re-read §3.7.
+- **No new `ALLOWED_METHODS` entry.** Eight `llm.*` methods are already renderer-exposed. Adding one means updating `packages/ui/src-tauri/src/gateway_bridge.rs` and its count assertion in the same commit (invariant **I7**) — this plan adds none.
+- **No new invariant or `D`-rule.** The one-definition-of-`isLocal` rule ships as a test (spec Open decision 1).
+- **Total config back-compat.** Existing `local_model` / `remote_model` / `prefer_local` keys must keep working unchanged and synthesise a single route.
+- **`routeId` is opaque inside the router** — never `.split("/")` it there. Parse only at the config/CLI boundary, on the FIRST slash (§3.1).
+- **Verify with the CI command, not a scoped one:** `bun test packages/gateway packages/cli scripts`. A `packages/gateway/src`-only run does not load `packages/gateway/test/**` — that gap cost three red legs on #1333.
+- **Every task ends with `bun run preflight:fast`** plus the named checks. It does NOT include the coverage floor; that is `verify:docker --changed`.
+- Branch: `dev/asaf/llm-model-routes` (already created). Never commit on `main`.
+
+## File Structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `packages/gateway/src/llm/types.ts` | `ProviderId`, `ModelRoute`, required `isLocal` on `LlmProvider` | 1 |
+| `packages/gateway/src/llm/route-id.ts` **(new)** | `makeRouteId` / `parseRouteRef` — the ONLY place a route string is split | 2 |
+| `packages/gateway/src/llm/router.ts` | route map, priority walk, gates, `tryRemoteFallback`, `modelNameFor` | 3, 4, 7 |
+| `packages/gateway/src/llm/route-availability.ts` **(new)** | per-route availability + short-TTL cache | 5 |
+| `packages/gateway/src/llm/registry.ts` | drop 3 hardcoded id arrays; lifecycle keys on `providerId` | 6 |
+| `packages/gateway/src/egress/synthesis-egress.ts` | `destination` = `providerId` | 7 |
+| `packages/gateway/src/agents/_lib/synthesis-llm.ts` | widen `RecordSynthesisEgressFn` param | 7 |
+| `packages/gateway/src/config/nimbus-toml.ts` | `[llm.local.<name>]`, `route_priority` | 8 |
+| `packages/gateway/src/platform/assemble.ts` | build N routes from config | 9 |
+| `packages/gateway/src/ipc/llm-rpc.ts` | drop `VALID_LLM_PROVIDERS` / `LOCAL_PROVIDERS`; route-shaped status | 10 |
+
+Ordering rationale: types → the one parsing helper → router core → availability → registry → egress → config → wiring → surface. Each task compiles and tests green on its own.
+
+---
+
+### Task 1: Open the provider id and require `isLocal`
+
+The union `LlmProviderKind = "ollama" | "llamacpp" | "remote"` is what caps the router at one provider per kind. Opening it is the precondition for everything else. `isLocal` becomes a required interface field so the three copies of that fact (Task 6, Task 10) have one place to collapse into.
+
+**Files:**
+- Modify: `packages/gateway/src/llm/types.ts`
+- Modify: `packages/gateway/src/llm/ollama-provider.ts` (add one field)
+- Modify: `packages/gateway/src/llm/llamacpp-provider.ts` (add one field)
+- Test: `packages/gateway/src/llm/types.test.ts` **(new)**
+
+**Interfaces:**
+- Produces: `type ProviderId = string`; `LlmProvider.isLocal: boolean` (required); `type ModelRoute = { routeId: string; provider: LlmProvider; modelName: string; meta: ProviderMeta }`. `LlmProviderKind` is retained as a deprecated alias of `ProviderId` so Tasks 3–10 can migrate call sites incrementally rather than in one commit.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/gateway/src/llm/types.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { LlamaCppProvider } from "./llamacpp-provider.ts";
+import { OllamaProvider } from "./ollama-provider.ts";
+import type { LlmProvider } from "./types.ts";
+
+describe("LlmProvider.isLocal", () => {
+  test("both shipped providers declare themselves local", () => {
+    const providers: LlmProvider[] = [new OllamaProvider(), new LlamaCppProvider()];
+    for (const p of providers) {
+      expect(p.isLocal).toBe(true);
+    }
+  });
+
+  test("a provider that omits isLocal does not satisfy the interface", () => {
+    // Compile-time proof, asserted at runtime so the test is not vacuous: an object
+    // literal missing `isLocal` is not assignable to LlmProvider. If this ever
+    // compiles without the field, the interface has been weakened back to optional.
+    const withoutIsLocal = {
+      providerId: "fake",
+      isAvailable: async () => true,
+      listModels: async () => [],
+      generate: async () => ({
+        text: "",
+        tokensIn: 0,
+        tokensOut: 0,
+        modelUsed: "fake",
+        isLocal: false,
+        provider: "fake",
+      }),
+    };
+    // @ts-expect-error isLocal is required on LlmProvider
+    const bad: LlmProvider = withoutIsLocal;
+    expect(bad.isLocal).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/llm/types.test.ts`
+Expected: FAIL — `p.isLocal` is `undefined` on both providers, and the `@ts-expect-error` is unused (no error to suppress), which `typecheck` flags as `TS2578: Unused '@ts-expect-error' directive`.
+
+- [ ] **Step 3: Open the id and require the field**
+
+In `packages/gateway/src/llm/types.ts`, replace the union and extend the interface:
+
+```ts
+/**
+ * A provider VENDOR id — `"ollama"`, `"llamacpp"`, and (slice 2) `"gemini"`,
+ * `"bedrock"`, ... Deliberately an open string, not a union: the closed union it
+ * replaced capped `LlmRouter.providers` at one provider per kind, so registering a
+ * second vendor silently evicted the first.
+ *
+ * NOT unique across routes — two Ollama routes share `"ollama"`. Route identity is
+ * `ModelRoute.routeId`. This is the value that reaches the egress ledger as
+ * `destination`, so it names a place data can go.
+ */
+export type ProviderId = string;
+
+/** @deprecated Alias kept so call sites migrate incrementally. Use `ProviderId`. */
+export type LlmProviderKind = ProviderId;
+
+export type ModelRoute = {
+  readonly routeId: string;
+  readonly provider: LlmProvider;
+  readonly modelName: string;
+  readonly meta: ProviderMeta;
+};
+
+export type ProviderMeta = {
+  parameterCount?: number;
+  contextWindow?: number;
+};
+```
+
+Add to the `LlmProvider` interface:
+
+```ts
+export interface LlmProvider {
+  readonly providerId: ProviderId;
+  /**
+   * Whether this provider runs on this machine. REQUIRED, so omitting it is a
+   * compile error rather than a silent `undefined`.
+   *
+   * Declared by the provider rather than looked up in a module-private set,
+   * because that set existed in three places that had to agree. Note the failure
+   * direction is safe either way: an unset value is falsy, i.e. REMOTE — which
+   * air-gap refuses and the egress appender ledgers.
+   */
+  readonly isLocal: boolean;
+  isAvailable(): Promise<boolean>;
+  listModels(): Promise<LlmModelInfo[]>;
+  generate(opts: LlmGenerateOptions): Promise<LlmGenerateResult>;
+  pullModel?(
+    modelName: string,
+    opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void },
+  ): Promise<void>;
+}
+```
+
+`ProviderMeta` moves here from `router.ts`; re-export it from `router.ts` (`export type { ProviderMeta } from "./types.ts";`) so existing importers keep compiling.
+
+In `ollama-provider.ts`, beside `readonly providerId = "ollama" as const;` add:
+
+```ts
+  readonly isLocal = true;
+```
+
+In `llamacpp-provider.ts`, beside `readonly providerId = "llamacpp" as const;` add:
+
+```ts
+  readonly isLocal = true;
+```
+
+- [ ] **Step 4: Run tests and typecheck**
+
+Run: `bun test packages/gateway/src/llm/` then `bun run typecheck`
+Expected: types.test.ts PASSES. Other `llm/` tests still pass — `makeFakeProvider` in `router.test.ts` does not yet set `isLocal`, so **typecheck fails there**. Fix it in the same step by adding `isLocal: id !== "remote"` to the object `makeFakeProvider` returns.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/types.ts packages/gateway/src/llm/ollama-provider.ts \
+        packages/gateway/src/llm/llamacpp-provider.ts packages/gateway/src/llm/types.test.ts \
+        packages/gateway/src/llm/router.test.ts packages/gateway/src/llm/router.ts
+git commit -m "refactor(llm): open ProviderId and require isLocal on LlmProvider"
+```
+
+---
+
+### Task 2: The one place a route string is parsed
+
+Model names contain slashes — `LlamaCppProvider` defaults to `"model.gguf"` and realistically holds a path; Ollama accepts `hf.co/user/model`. A naive `split("/")` breaks both. This helper is the only sanctioned parser, so Task 3 can treat `routeId` as opaque.
+
+**Files:**
+- Create: `packages/gateway/src/llm/route-id.ts`
+- Test: `packages/gateway/src/llm/route-id.test.ts`
+
+**Interfaces:**
+- Produces: `makeRouteId(providerId: ProviderId, modelName: string): string`; `parseRouteRef(raw: string): { providerId: ProviderId; modelName: string }` — **throws** `Error` on a malformed ref rather than returning `undefined`, so a bad `route_priority` entry surfaces at config load instead of degrading to default ordering.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/gateway/src/llm/route-id.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { makeRouteId, parseRouteRef } from "./route-id.ts";
+
+describe("makeRouteId", () => {
+  test("joins provider and model on a slash", () => {
+    expect(makeRouteId("ollama", "qwen3:8b")).toBe("ollama/qwen3:8b");
+  });
+
+  test("rejects a providerId containing a slash", () => {
+    // The delimiter is only unambiguous because the LEFT side cannot contain it.
+    expect(() => makeRouteId("bad/vendor", "m")).toThrow(/providerId/);
+  });
+});
+
+describe("parseRouteRef", () => {
+  test("splits on the FIRST slash, leaving the rest to the model name", () => {
+    expect(parseRouteRef("ollama/hf.co/user/model")).toEqual({
+      providerId: "ollama",
+      modelName: "hf.co/user/model",
+    });
+  });
+
+  test("keeps a Windows path intact as a model name", () => {
+    expect(parseRouteRef("llamacpp/C:\\models\\Llama-3-8B.gguf")).toEqual({
+      providerId: "llamacpp",
+      modelName: "C:\\models\\Llama-3-8B.gguf",
+    });
+  });
+
+  test("keeps a POSIX path intact as a model name", () => {
+    expect(parseRouteRef("llamacpp//models/meta-llama/Llama-3-8B.gguf")).toEqual({
+      providerId: "llamacpp",
+      modelName: "/models/meta-llama/Llama-3-8B.gguf",
+    });
+  });
+
+  test("throws on a ref with no slash", () => {
+    expect(() => parseRouteRef("ollama")).toThrow(/expected "<provider>\/<model>"/);
+  });
+
+  test("throws on an empty provider or model half", () => {
+    expect(() => parseRouteRef("/qwen3")).toThrow(/provider/);
+    expect(() => parseRouteRef("ollama/")).toThrow(/model/);
+  });
+
+  test("round-trips a model name containing slashes", () => {
+    const id = makeRouteId("ollama", "hf.co/user/model");
+    expect(parseRouteRef(id)).toEqual({ providerId: "ollama", modelName: "hf.co/user/model" });
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/llm/route-id.test.ts`
+Expected: FAIL — `Cannot find module './route-id.ts'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`packages/gateway/src/llm/route-id.ts`:
+
+```ts
+// packages/gateway/src/llm/route-id.ts
+
+import type { ProviderId } from "./types.ts";
+
+/**
+ * The ONLY place a route reference string is built or split.
+ *
+ * `routeId` is opaque INSIDE the router — `ModelRoute` already carries `providerId`
+ * and `modelName` as separate fields, so parsing the key there would re-derive data
+ * the struct holds. Parsing belongs only where a human typed a string:
+ * `[llm] route_priority` entries and (slice 4) `nimbus llm use <ref>`.
+ *
+ * The split is on the FIRST slash and that is load-bearing: model names legitimately
+ * contain slashes. `LlamaCppProvider`'s model name defaults to `"model.gguf"` and is
+ * realistically a path (`/models/meta-llama/Llama-3-8B.gguf`, or a Windows path with
+ * backslashes and a drive colon), and Ollama accepts namespaced tags like
+ * `hf.co/user/model`. The delimiter is unambiguous only because the LEFT half cannot
+ * contain it, which `makeRouteId` enforces.
+ */
+export function makeRouteId(providerId: ProviderId, modelName: string): string {
+  if (providerId.includes("/")) {
+    throw new Error(`providerId must not contain "/": ${providerId}`);
+  }
+  if (providerId === "") throw new Error("providerId must not be empty");
+  if (modelName === "") throw new Error("modelName must not be empty");
+  return `${providerId}/${modelName}`;
+}
+
+/**
+ * Parse a human-supplied route reference. THROWS on anything malformed rather than
+ * returning `undefined`: a `route_priority` entry that silently vanished would
+ * degrade the router to default ordering with no signal, which is the "a supplied
+ * flag decaying into an omitted filter" shape — invisible from the outside.
+ */
+export function parseRouteRef(raw: string): { providerId: ProviderId; modelName: string } {
+  const i = raw.indexOf("/");
+  if (i === -1) {
+    throw new Error(`malformed route reference "${raw}": expected "<provider>/<model>"`);
+  }
+  const providerId = raw.slice(0, i);
+  const modelName = raw.slice(i + 1); // may itself contain slashes — deliberate
+  if (providerId === "") throw new Error(`malformed route reference "${raw}": empty provider`);
+  if (modelName === "") throw new Error(`malformed route reference "${raw}": empty model`);
+  return { providerId, modelName };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test packages/gateway/src/llm/route-id.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/route-id.ts packages/gateway/src/llm/route-id.test.ts
+git commit -m "feat(llm): route-id helper that splits on the first slash only"
+```
+
+---
+
+### Task 3: Key the router on routes — red-prove the eviction bug first
+
+This is the core change. Write the test that fails on today's code **first**, so the defect is demonstrated rather than assumed.
+
+**Files:**
+- Modify: `packages/gateway/src/llm/router.ts`
+- Test: `packages/gateway/src/llm/router.test.ts`
+
+**Interfaces:**
+- Consumes: `ModelRoute`, `ProviderId` (Task 1); `makeRouteId` (Task 2).
+- Produces: `LlmRouter.registerRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void`; `LlmRouter.routes(): readonly ModelRoute[]`; `LlmRouter.routeFor(routeId: string): ModelRoute | undefined`. `registerProvider(provider, meta)` is kept as a shim calling `registerRoute(provider, <config default model for that provider>, meta)` so Tasks 6–10 migrate incrementally.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/gateway/src/llm/router.test.ts`. Note `makeFakeProvider` gains a model parameter — update the existing helper in place:
+
+```ts
+function makeFakeRouteProvider(id: string, isLocal: boolean, available: boolean): LlmProvider {
+  return {
+    providerId: id,
+    isLocal,
+    isAvailable: async () => available,
+    listModels: async () => [],
+    generate: async () => ({
+      text: `response from ${id}`,
+      tokensIn: 1,
+      tokensOut: 1,
+      modelUsed: id,
+      isLocal,
+      provider: id,
+    }),
+  };
+}
+
+describe("LlmRouter route registration", () => {
+  test("two models on ONE runtime both survive registration", async () => {
+    // RED-PROVE: on the pre-refactor Map<LlmProviderKind, LlmProvider> the second
+    // register overwrote the first, so this asserted 1 where it should assert 2.
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "gemma3:12b");
+
+    const ids = router.routes().map((r) => r.routeId).sort();
+    expect(ids).toEqual(["ollama/gemma3:12b", "ollama/qwen3:8b"]);
+  });
+
+  test("a route is addressable by its id", () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    expect(router.routeFor("ollama/qwen3:8b")?.modelName).toBe("qwen3:8b");
+    expect(router.routeFor("ollama/nope")).toBeUndefined();
+  });
+
+  test("re-registering the SAME routeId replaces it rather than duplicating", () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b", {
+      parameterCount: 8,
+    });
+    expect(router.routes()).toHaveLength(1);
+    expect(router.routes()[0]?.meta.parameterCount).toBe(8);
+  });
+
+  test("selectProvider prefers a local route when preferLocal=true", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    const provider = await router.selectProvider("agent_step");
+    expect(provider?.providerId).toBe("ollama");
+  });
+
+  test("enforceAirGap skips every non-local route, whatever its id", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    // A vendor id this code has never seen must still be refused, because isLocal
+    // is declared false — not because "gemini" is on a list somewhere.
+    const provider = await router.selectProvider("agent_step");
+    expect(provider).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails for the RIGHT reason**
+
+Run: `bun test packages/gateway/src/llm/router.test.ts -t "route registration"`
+Expected: FAIL — `router.registerRoute is not a function`. That is a missing-method failure, not the eviction bug. To red-prove the *eviction* specifically, temporarily rewrite the first test against today's API and confirm it reports one provider, then restore:
+
+```ts
+// TEMPORARY red-prove, delete after observing the failure:
+const r = new LlmRouter(DEFAULT_CONFIG);
+r.registerProvider(makeFakeProvider("ollama", true));
+r.registerProvider(makeFakeProvider("ollama", true));
+// @ts-expect-error reaching into the private map to count seats
+expect((r as unknown as { providers: Map<string, unknown> }).providers.size).toBe(2); // FAILS: 1
+```
+
+Record the observed `1` in your task notes. Delete the temporary block before proceeding.
+
+- [ ] **Step 3: Implement the route map**
+
+In `packages/gateway/src/llm/router.ts`:
+
+Delete `LOCAL_PROVIDER_IDS` and rewrite `isLocalProviderKind` as a route-level read. Keep the exported name only if `grep -rn "isLocalProviderKind" packages/gateway/src --include=*.ts | grep -v test` shows a non-test caller; if it shows none, delete the export and its import in `router.test.ts`.
+
+Replace the two maps with one:
+
+```ts
+  private readonly routeMap = new Map<string, ModelRoute>();
+
+  registerRoute(provider: LlmProvider, modelName: string, meta: ProviderMeta = {}): void {
+    const routeId = makeRouteId(provider.providerId, modelName);
+    this.routeMap.set(routeId, { routeId, provider, modelName, meta });
+  }
+
+  routes(): readonly ModelRoute[] {
+    return [...this.routeMap.values()];
+  }
+
+  routeFor(routeId: string): ModelRoute | undefined {
+    return this.routeMap.get(routeId);
+  }
+
+  /** @deprecated Migration shim for call sites not yet on `registerRoute`. */
+  registerProvider(provider: LlmProvider, meta: ProviderMeta = {}): void {
+    const modelName = provider.isLocal ? this.config.localModel : this.config.remoteModel;
+    this.registerRoute(provider, modelName, meta);
+  }
+```
+
+Rewrite `providerPriority` to return ordered `ModelRoute`s. `routePriority` is a new optional field on `LlmRouterConfig` (`readonly routePriority?: readonly string[]`); add it with a default of `undefined` and update `DEFAULT_CONFIG` in the test file:
+
+```ts
+  private orderedRoutes(preferLocal: boolean = this.config.preferLocal): ModelRoute[] {
+    const all = this.routes();
+    const explicit = this.config.routePriority;
+    if (explicit !== undefined && explicit.length > 0) {
+      const byId = new Map(all.map((r) => [r.routeId, r]));
+      // An unresolvable entry threw at config load (Task 8); anything still missing
+      // here was unregistered at runtime, so skipping is correct.
+      const ordered = explicit.map((id) => byId.get(id)).filter((r): r is ModelRoute => r !== undefined);
+      const named = new Set(ordered.map((r) => r.routeId));
+      return [...ordered, ...all.filter((r) => !named.has(r.routeId))];
+    }
+    const local = all.filter((r) => r.provider.isLocal);
+    const remote = all.filter((r) => !r.provider.isLocal);
+    return preferLocal ? [...local, ...remote] : [...remote, ...local];
+  }
+```
+
+Rewrite `firstAvailable` to walk routes, keeping the skip-during-walk shape (do NOT pre-filter a pool — see spec §3.3):
+
+```ts
+  private async firstAvailableRoute(
+    task: LlmTaskType,
+    isAvailable: (route: ModelRoute) => Promise<boolean>,
+    preferLocal?: boolean,
+  ): Promise<ModelRoute | undefined> {
+    for (const route of this.orderedRoutes(preferLocal)) {
+      if (this.config.enforceAirGap && !route.provider.isLocal) continue;
+      if (!this.meetsCapabilityFloor(route, task)) continue;
+      if (await isAvailable(route)) return route;
+    }
+    return undefined;
+  }
+```
+
+`meetsCapabilityFloor` takes a `ModelRoute` and reads `route.meta.parameterCount`; keep the documented fail-open when it is `undefined`. `modelNameFor` is deleted — a route knows its own model name. `resolveForSynthesis` returns `{ providerId: route.provider.providerId, modelName: route.modelName, isLocal: route.provider.isLocal }`. `generateMarkdown` resolves via `routeFor(makeRouteId(resolved.providerId, resolved.modelName))` and throws the same "no longer registered" error when absent.
+
+- [ ] **Step 4: Run the full llm suite**
+
+Run: `bun test packages/gateway/src/llm/`
+Expected: PASS. Existing `selectProvider` / `getStatus` tests must still pass through the `registerProvider` shim — if one fails, the shim's model-name default is wrong, not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/router.ts packages/gateway/src/llm/router.test.ts
+git commit -m "feat(llm): key the router on (provider, model) routes"
+```
+
+---
+
+### Task 4: Route-aware context-overflow fallback
+
+`tryRemoteFallback` does `this.providers.get("remote")` — a key that no longer exists. Spec §4.1: rewrite it as "next fitting route in priority order". No remote route exists in this slice, so this is a pure refactor; the point is to close it before slice 2 makes it live.
+
+**Files:**
+- Modify: `packages/gateway/src/llm/router.ts`
+- Test: `packages/gateway/src/llm/router.test.ts`
+
+**Interfaces:**
+- Consumes: `firstAvailableRoute`, `orderedRoutes` (Task 3).
+- Produces: no new public surface. `tryRemoteFallback` is deleted; `fitPromptOrFallback` returns `{ kind: "route"; route: ModelRoute; opts: LlmGenerateOptions }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe("LlmRouter context overflow", () => {
+  test("falls through to a route whose context window fits", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, preferLocal: true });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+      contextWindow: 100,
+    });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "big", {
+      contextWindow: 100_000,
+    });
+    const result = await router.generate({
+      task: "reasoning",
+      prompt: "x".repeat(40_000), // ~10k tokens: overflows "small", fits "big"
+      });
+    expect(result.text).toContain("ollama");
+  });
+
+  test("air-gap still refuses a non-local route on overflow", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+      contextWindow: 100,
+    });
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "big", {
+      contextWindow: 100_000,
+    });
+    // Must truncate onto the local route, never reach the remote one.
+    const result = await router.generate({ task: "reasoning", prompt: "x".repeat(40_000) });
+    expect(result.provider).toBe("ollama");
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/llm/router.test.ts -t "context overflow"`
+Expected: FAIL — the first test truncates on `small` instead of moving to `big`, because `tryRemoteFallback` looks up a `"remote"` key that no route provides.
+
+- [ ] **Step 3: Implement**
+
+Delete `tryRemoteFallback`. In `fitPromptOrFallback`, when the prompt overflows the selected route's window and the task is `reasoning` / `agent_step`, walk `orderedRoutes` for the next route that is available, passes the air-gap and capability gates, **and** whose `meta.contextWindow` is `undefined` or large enough. If none is found, truncate on the original route exactly as today. Keep the existing air-gap `throw` for the case where truncation is not acceptable.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test packages/gateway/src/llm/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/router.ts packages/gateway/src/llm/router.test.ts
+git commit -m "fix(llm): context-overflow fallback walks routes, not a 'remote' key"
+```
+
+---
+
+### Task 5: Availability means the model answers, not the daemon is up
+
+Spec §3.4. `OllamaProvider.isAvailable()` returns `resp.ok` from `GET /api/tags` without checking `this.modelName` is among them. With one route that is a confusing error; with a priority walk it halts at the first route that lies instead of falling through to one that works.
+
+**Files:**
+- Create: `packages/gateway/src/llm/route-availability.ts`
+- Modify: `packages/gateway/src/llm/router.ts` (use it in the walk)
+- Test: `packages/gateway/src/llm/route-availability.test.ts`
+
+**Interfaces:**
+- Consumes: `ModelRoute` (Task 1).
+- Produces: `type RouteAvailability = { available: boolean; reason: "ok" | "provider_unreachable" | "model_absent" }`; `class RouteAvailabilityProbe { constructor(ttlMs?: number); check(route: ModelRoute): Promise<RouteAvailability>; }`. The two failure reasons stay distinct because they have different fixes — reporting both as "unavailable" sends the user to the wrong one.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { RouteAvailabilityProbe } from "./route-availability.ts";
+import type { LlmModelInfo, LlmProvider, ModelRoute } from "./types.ts";
+
+function route(
+  modelName: string,
+  opts: { reachable: boolean; models: string[]; onList?: () => void },
+): ModelRoute {
+  const provider: LlmProvider = {
+    providerId: "ollama",
+    isLocal: true,
+    isAvailable: async () => opts.reachable,
+    listModels: async (): Promise<LlmModelInfo[]> => {
+      opts.onList?.();
+      return opts.models.map((m) => ({ provider: "ollama", modelName: m }));
+    },
+    generate: async () => {
+      throw new Error("not called");
+    },
+  };
+  return { routeId: `ollama/${modelName}`, provider, modelName, meta: {} };
+}
+
+describe("RouteAvailabilityProbe", () => {
+  test("a reachable daemon WITHOUT the model is unavailable", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("gemma3:12b", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r).toEqual({ available: false, reason: "model_absent" });
+  });
+
+  test("a reachable daemon WITH the model is available", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3:8b", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r).toEqual({ available: true, reason: "ok" });
+  });
+
+  test("an unreachable provider is distinguished from an absent model", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3:8b", { reachable: false, models: [] }));
+    expect(r).toEqual({ available: false, reason: "provider_unreachable" });
+  });
+
+  test("a tag matches when the route omits the :tag suffix", async () => {
+    // `local_model = "qwen3"` against a daemon reporting "qwen3:8b" must match, or
+    // every existing config breaks on upgrade.
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r.available).toBe(true);
+  });
+
+  test("listModels is called ONCE for two routes on the same provider within the TTL", async () => {
+    let calls = 0;
+    const probe = new RouteAvailabilityProbe(60_000);
+    const opts = { reachable: true, models: ["a", "b"], onList: () => { calls += 1; } };
+    await probe.check(route("a", opts));
+    await probe.check(route("b", opts));
+    expect(calls).toBe(1);
+  });
+
+  test("a listModels rejection is unavailable, not a thrown probe", async () => {
+    const provider: LlmProvider = {
+      providerId: "ollama",
+      isLocal: true,
+      isAvailable: async () => true,
+      listModels: async () => {
+        throw new Error("boom");
+      },
+      generate: async () => {
+        throw new Error("not called");
+      },
+    };
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check({ routeId: "ollama/a", provider, modelName: "a", meta: {} });
+    expect(r.available).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/llm/route-availability.test.ts`
+Expected: FAIL — `Cannot find module './route-availability.ts'`.
+
+- [ ] **Step 3: Implement**
+
+`packages/gateway/src/llm/route-availability.ts` — cache keyed on `providerId` (the model list is a property of the daemon, not of one route), short TTL so four routes cost one `/api/tags`, and a rejection is caught and reported unavailable rather than propagated. Match on exact name first, then `name.startsWith(`${modelName}:`)` — mirroring the existing tag-tolerant match in `registry.refreshProviderMeta`.
+
+- [ ] **Step 4: Wire it into the walk and run tests**
+
+In `router.ts`, `probeAvailable` becomes a `RouteAvailabilityProbe.check(route).available` call, keeping the existing catch-to-false. Add a router-level test:
+
+```ts
+test("the walk falls THROUGH a route whose model is not pulled", async () => {
+  // Without per-route availability this stops at the first route and returns it,
+  // because the daemon is up. That is the whole defect.
+  const absent = makeFakeRouteProvider("ollama", true, true);
+  absent.listModels = async () => [{ provider: "ollama", modelName: "other" }];
+  const present = makeFakeRouteProvider("ollama", true, true);
+  present.listModels = async () => [{ provider: "ollama", modelName: "present" }];
+  const router = new LlmRouter({ ...DEFAULT_CONFIG, routePriority: ["ollama/missing", "ollama/present"] });
+  router.registerRoute(absent, "missing");
+  router.registerRoute(present, "present");
+  const chosen = await router.selectRoute("reasoning");
+  expect(chosen?.modelName).toBe("present");
+});
+```
+
+Note this needs the two fakes to have distinct provider objects; the availability cache is keyed on `providerId`, so give the second `providerId: "ollama2"` or inject a zero TTL. Prefer a zero TTL — a second vendor id would not reflect reality.
+
+Run: `bun test packages/gateway/src/llm/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/route-availability.ts packages/gateway/src/llm/route-availability.test.ts \
+        packages/gateway/src/llm/router.ts packages/gateway/src/llm/router.test.ts
+git commit -m "fix(llm): route availability checks the model, not just the daemon"
+```
+
+---
+
+### Task 6: Registry — drop the hardcoded id lists, key lifecycle on providerId
+
+Three arrays hardcode the closed union (`registry.ts:44`, `:67`, `:87`) and four method signatures hardcode `"ollama" | "llamacpp"`. Spec §3.5: lifecycle keys on `providerId`, model stays an argument — keying on `routeId` would make it impossible to pull a model that has no route yet.
+
+**Files:**
+- Modify: `packages/gateway/src/llm/registry.ts`
+- Test: `packages/gateway/src/llm/registry.test.ts`
+
+**Interfaces:**
+- Consumes: `routes()`, `routeFor()` (Task 3).
+- Produces: `addRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void`; `pullModel(providerId: ProviderId, modelName: string, opts?): Promise<void>` — note `providerId` widens from the union to `ProviderId`. `loadModel` / `unloadModel` / `setDefault` widen identically.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("pullModel works for a model that has NO route", async () => {
+  // The primary use of pull: fetch a model BEFORE configuring a route for it.
+  // Keying lifecycle on routeId would make this impossible.
+  const pulled: string[] = [];
+  const provider = makeRegistryFakeProvider("ollama", true);
+  provider.pullModel = async (m) => { pulled.push(m); };
+  const registry = new LlmRegistry({ config: BASE_CONFIG });
+  registry.addRoute(provider, "qwen3:8b");
+  await registry.pullModel("ollama", "a-model-with-no-route");
+  expect(pulled).toEqual(["a-model-with-no-route"]);
+});
+
+test("listAllModels covers a vendor id the registry has never heard of", async () => {
+  const registry = new LlmRegistry({ config: BASE_CONFIG });
+  registry.addRoute(makeRegistryFakeProvider("gemini", false), "gemini-2.5-pro");
+  const models = await registry.listAllModels();
+  expect(models.some((m) => m.provider === "gemini")).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/llm/registry.test.ts -t "no route"`
+Expected: FAIL — `registry.addRoute is not a function`; and once added, `listAllModels` returns `[]` for `gemini` because its `providerIds` array names only the three known kinds.
+
+- [ ] **Step 3: Implement**
+
+Replace both `const providerIds = ["ollama", "llamacpp", "remote"] as const` loops with iteration over `this.router.routes()`, deduplicating by `providerId` for `checkAvailability`. Delete the `(this.router as unknown as { providers: Map<...> })` casts — `routes()` is public, so the reach-through is no longer needed. `refreshProviderMeta` iterates routes with `provider.isLocal` instead of the `["ollama","llamacpp"]` literal. Lifecycle methods resolve `this.router.routes().find((r) => r.provider.providerId === providerId)?.provider` and keep the existing "Provider not registered" / "does not support pullModel" errors.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test packages/gateway/src/llm/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/llm/registry.ts packages/gateway/src/llm/registry.test.ts
+git commit -m "refactor(llm): registry iterates routes; lifecycle keys on providerId"
+```
+
+---
+
+### Task 7: Egress destination names the vendor
+
+Spec §4.2. `synthesis-egress.ts` hardcodes `destination: "model"` and its parameter type structurally drops `providerId`, though the call site has it. With five vendors, `nimbus prove` would report that "a prompt went to a model".
+
+**Files:**
+- Modify: `packages/gateway/src/egress/synthesis-egress.ts`
+- Modify: `packages/gateway/src/agents/_lib/synthesis-llm.ts` (widen `RecordSynthesisEgressFn`)
+- Test: `packages/gateway/src/egress/synthesis-egress.test.ts`
+
+**Interfaces:**
+- Consumes: `ResolvedSynthesisProvider` (already carries `providerId`).
+- Produces: `recordSynthesisEgress(db, { briefKind, provider: { providerId, modelName, isLocal }, now })`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("destination is the vendor, not the literal 'model'", () => {
+  const db = openTestDb();
+  recordSynthesisEgress(db, {
+    briefKind: "why",
+    provider: { providerId: "gemini", modelName: "gemini-2.5-pro", isLocal: false },
+    now: 1_700_000_000_000,
+  });
+  const row = db.query("SELECT destination, source_type FROM egress_ledger").get() as {
+    destination: string;
+    source_type: string;
+  };
+  expect(row.destination).toBe("gemini");
+  expect(row.source_type).toBe("model"); // the CLASS stays "model"; the DESTINATION is the vendor
+});
+
+test("a local provider still appends nothing", () => {
+  const db = openTestDb();
+  recordSynthesisEgress(db, {
+    briefKind: "why",
+    provider: { providerId: "ollama", modelName: "qwen3:8b", isLocal: true },
+    now: 1,
+  });
+  expect(db.query("SELECT COUNT(*) AS n FROM egress_ledger").get()).toEqual({ n: 0 });
+});
+```
+
+Reuse the existing test file's DB helper rather than writing a new one — read the top of `synthesis-egress.test.ts` first.
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/egress/synthesis-egress.test.ts`
+Expected: FAIL — `destination` is `"model"`, and the object literal has an excess `providerId` property the parameter type rejects.
+
+- [ ] **Step 3: Implement**
+
+Widen the parameter to `{ readonly providerId: ProviderId; readonly modelName: string; readonly isLocal: boolean }` and set `destination: args.provider.providerId`. **Do not touch the `if (args.provider.isLocal) return;` guard** — deriving locality here rather than accepting a caller boolean is the property that makes a false zero unrepresentable, and it is documented at length in that file. Mirror the widened type in `RecordSynthesisEgressFn` in `synthesis-llm.ts`; the call site already passes the full `resolved` object, so no call-site change is needed.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test packages/gateway/src/egress/ packages/gateway/src/agents/_lib/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/egress/synthesis-egress.ts packages/gateway/src/egress/synthesis-egress.test.ts \
+        packages/gateway/src/agents/_lib/synthesis-llm.ts
+git commit -m "fix(egress): synthesis destination names the vendor, not the literal 'model'"
+```
+
+---
+
+### Task 8: Config — `[llm.local.<name>]` and `route_priority`
+
+Spec §3.6. Total back-compat: existing keys must still work.
+
+**Files:**
+- Modify: `packages/gateway/src/config/nimbus-toml.ts`
+- Test: `packages/gateway/src/config/nimbus-toml.test.ts`
+
+**Interfaces:**
+- Consumes: `parseRouteRef` (Task 2).
+- Produces: `NimbusLlmToml.localRoutes: ReadonlyMap<string, { runtime: string; model: string; baseUrl?: string }>` and `NimbusLlmToml.routePriority: readonly string[]`. Both default to empty in `DEFAULT_NIMBUS_LLM_TOML`, so `loadNimbusLlmFromPath` yields an empty map/array while `parseNimbusTomlLlmSection` (a `Partial`) yields `undefined` when unset. Task 9 consumes the defaults-merged form.
+
+- [ ] **Step 1: Write the failing test**
+
+The existing raw-string entry point is **`parseNimbusTomlLlmSection(source): Partial<NimbusLlmToml>`**
+— note `Partial`, so an unset field is `undefined`, not a default. `loadNimbusLlmFromPath` is the
+defaults-merged variant and takes a *path*. Both are already imported by
+`nimbus-toml.test.ts`; use them rather than inventing a parser.
+
+`parseNimbusTomlLlmSection` delegates to `forEachSectionEntry(source, "[llm]", …)`, which matches a
+table header by **exact string equality** — so it sees only `[llm]` keys and cannot observe
+`[llm.local.*]` at all. The sub-table scan is genuinely new code, not a switch-case addition.
+
+```ts
+test("parses [llm.local.<name>] sub-tables", () => {
+  const toml = `
+[llm]
+prefer_local = true
+
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.gemma]
+runtime = "ollama"
+model = "gemma3:12b"
+`;
+  const cfg = parseNimbusTomlLlmSection(toml);
+  expect([...(cfg.localRoutes ?? new Map()).keys()].sort()).toEqual(["gemma", "qwen3"]);
+  expect(cfg.localRoutes?.get("qwen3")?.model).toBe("qwen3:8b");
+});
+
+test("legacy local_model still parses and defines no sub-table route", () => {
+  const cfg = parseNimbusTomlLlmSection(`[llm]\nlocal_model = "llama3.2"\n`);
+  expect(cfg.localModel).toBe("llama3.2");
+  // Partial<>: absent, not an empty map. assemble.ts synthesises the route (Task 9).
+  expect(cfg.localRoutes).toBeUndefined();
+});
+
+test("defaults-merged load exposes an empty route map, not undefined", () => {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-llm-"));
+  writeFileSync(join(dir, "nimbus.toml"), `[llm]\nlocal_model = "llama3.2"\n`);
+  const cfg = loadNimbusLlmFromConfigDir(dir);
+  expect(cfg.localRoutes.size).toBe(0);
+  expect(cfg.routePriority).toEqual([]);
+});
+
+test("route_priority with a model name containing slashes round-trips", () => {
+  const cfg = parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama/hf.co/user/model"]\n`);
+  expect(cfg.routePriority).toEqual(["ollama/hf.co/user/model"]);
+});
+
+test("a malformed route_priority entry throws at load, it does not vanish", () => {
+  expect(() => parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama"]\n`)).toThrow(/route/);
+});
+
+test("two llamacpp routes sharing a base_url are rejected", () => {
+  // llama.cpp's generate() sends no model field — the server answers with whatever
+  // it was launched with, so two routes at one URL would report different names
+  // while hitting identical weights.
+  const toml = `
+[llm.local.a]
+runtime = "llamacpp"
+model = "a.gguf"
+base_url = "http://127.0.0.1:8080"
+
+[llm.local.b]
+runtime = "llamacpp"
+model = "b.gguf"
+base_url = "http://127.0.0.1:8080"
+`;
+  expect(() => parseNimbusTomlLlmSection(toml)).toThrow(/base_url/);
+});
+
+test("a malformed sub-table does not discard the rest of [llm]", () => {
+  // Mirrors the [ownership] precedent (nimbus-toml.ts ~1907): one bad block must
+  // not zero the section.
+  const cfg = parseNimbusTomlLlmSection(`[llm]\nprefer_local = false\n\n[llm.local.]\nmodel = "x"\n`);
+  expect(cfg.preferLocal).toBe(false);
+});
+```
+
+**Throwing vs. the section's house style — resolve before implementing.** Two tests above expect a
+`throw`, but `parseNimbusTomlLlmSection` currently never throws; `applyNimbusLlmKey` silently
+ignores a bad value, and the `[ownership]` precedent explicitly catches so one malformed block does
+not discard a section. Reconcile: a malformed *value* keeps the silent-ignore behaviour, while an
+unresolvable *route reference* throws — because a dropped `route_priority` entry silently changes
+which model answers, which is a different class of failure from a dropped boolean. If review
+prefers no new throw, surface it as a loaded-config validation error at `assemble.ts` instead
+(Task 9) — but it must not be silent either way.
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/src/config/nimbus-toml.test.ts -t "llm.local"`
+Expected: FAIL — `cfg.localRoutes` is `undefined`.
+
+- [ ] **Step 3: Implement**
+
+`accumulateServiceTables` / `resolveServiceTableId` in `config/service-config-toml.ts` are module-private. Export them from there (they are pure and already tested) and import into `nimbus-toml.ts` with `LLM_LOCAL_TABLE_PREFIX = "[llm.local."`, rather than writing a second copy. Add `localRoutes` and `routePriority` to `NimbusLlmToml` and `DEFAULT_NIMBUS_LLM_TOML` (empty map, empty array). Validate every `routePriority` entry through `parseRouteRef`, and reject duplicate `llamacpp` `base_url`s.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test packages/gateway/src/config/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/config/nimbus-toml.ts packages/gateway/src/config/nimbus-toml.test.ts \
+        packages/gateway/src/config/service-config-toml.ts
+git commit -m "feat(config): [llm.local.<name>] routes and route_priority"
+```
+
+---
+
+### Task 9: Wire N routes at assembly
+
+**Files:**
+- Modify: `packages/gateway/src/platform/assemble.ts:1277-1311`
+- Test: `packages/gateway/test/integration/llm-routes.integration.test.ts` **(new)**
+
+**Interfaces:**
+- Consumes: `NimbusLlmToml.localRoutes` (Task 8), `LlmRegistry.addRoute` (Task 6).
+- Produces: a registry whose `routes()` reflects config.
+
+- [ ] **Step 1: Write the failing test**
+
+An integration test writing a real `nimbus.toml` to a temp dir and asserting `buildLlmRegistryFromToml` produces two routes. **Place it under `packages/gateway/test/integration/`** — and note that tree is NOT loaded by `bun test packages/gateway/src`, so run the CI command to see it. Use `os.tmpdir()` + `path.join`, never a hardcoded separator.
+
+Assert: two `[llm.local.*]` entries → two routes; a config with only legacy `local_model` → exactly one Ollama route plus the llama.cpp route, matching today's behaviour.
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `bun test packages/gateway/test/integration/llm-routes.integration.test.ts`
+Expected: FAIL — one route per runtime regardless of config.
+
+- [ ] **Step 3: Implement**
+
+In `buildLlmRegistryFromToml`, when `localRoutes` is non-empty, register one route per entry, constructing `OllamaProvider(baseUrl ?? "http://127.0.0.1:11434", model, llmToml.localContextTokens)` or `LlamaCppProvider(baseUrl, model)` by `runtime`. When it is empty, register exactly today's two providers via `addRoute(provider, llmToml.localModel)` so behaviour is unchanged. Pass `routePriority` into the `LlmRegistry` config. Keep the fire-and-forget `refreshProviderMeta` call, now iterating routes.
+
+- [ ] **Step 4: Run the CI command**
+
+Run: `bun test packages/gateway packages/cli scripts`
+Expected: PASS. This is the first task where a `src`-only run would miss the new test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/platform/assemble.ts packages/gateway/test/integration/llm-routes.integration.test.ts
+git commit -m "feat(llm): assemble registers one route per configured model"
+```
+
+---
+
+### Task 10: IPC surface + the one-definition test
+
+**Files:**
+- Modify: `packages/gateway/src/ipc/llm-rpc.ts:20-28`
+- Test: `packages/gateway/src/ipc/llm-rpc.test.ts`
+- Test: `packages/gateway/src/llm/local-definition.test.ts` **(new)**
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `llm.status` returns `{ routes: Array<{ routeId, providerId, modelName, isLocal, available, reason, contextWindow }> }`. No new method.
+
+- [ ] **Step 1: Write the failing tests**
+
+The one-definition structural test (spec Open decision 1 — a test, not a `D`-rule):
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+const FILES = [
+  "packages/gateway/src/llm/router.ts",
+  "packages/gateway/src/llm/registry.ts",
+  "packages/gateway/src/ipc/llm-rpc.ts",
+];
+
+describe("local-ness has exactly one definition", () => {
+  test("no file re-derives the local provider set from literals", async () => {
+    const offenders: string[] = [];
+    for (const f of FILES) {
+      const src = await Bun.file(f).text();
+      // The three copies this refactor collapsed: a literal pair of local ids.
+      if (/\["ollama",\s*"llamacpp"\]/.test(src)) offenders.push(f);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("isLocal is read from the provider, never inferred from an id", async () => {
+    const src = await Bun.file("packages/gateway/src/llm/router.ts").text();
+    expect(src).not.toContain("LOCAL_PROVIDER_IDS");
+  });
+});
+```
+
+Plus an `llm-rpc` test asserting `llm.status` lists every route and that an absent-model route reports its reason.
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `bun test packages/gateway/src/llm/local-definition.test.ts`
+Expected: FAIL — `llm-rpc.ts` still contains `["ollama", "llamacpp"]` as `LOCAL_PROVIDERS`.
+
+- [ ] **Step 3: Implement**
+
+Delete `VALID_LLM_PROVIDERS`, `LOCAL_PROVIDERS`, `LocalProvider` and `requireLocalProvider`. `requireModelParams` accepts any non-empty `provider` string and defaults to `"ollama"`; validity is the registry's answer (`Provider not registered`), not a hardcoded set. Reshape `llm.status` to the route list. **Do not add a method** — the eight allowlisted `llm.*` names stay exactly as they are.
+
+- [ ] **Step 4: Run the CI command + full preflight**
+
+```bash
+bun test packages/gateway packages/cli scripts
+bun run preflight:fast
+bun run typecheck && bun run typecheck:tests
+```
+
+Expected: all PASS. `typecheck:tests` is **advisory on win32** — it prints violations and exits 0 — and is Linux-authoritative, so a clean local run is not proof. Confirm with `bun run verify:docker --changed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/ipc/llm-rpc.ts packages/gateway/src/ipc/llm-rpc.test.ts \
+        packages/gateway/src/llm/local-definition.test.ts
+git commit -m "refactor(ipc): llm.status lists routes; drop the last local-id copy"
+```
+
+---
+
+### Task 11: Coverage floor, docs, and the deprecated alias
+
+**Files:**
+- Modify: `packages/gateway/src/llm/types.ts` (delete the `LlmProviderKind` alias)
+- Modify: `docs/architecture.md` (LLM routing section)
+- Modify: `docs/CHANGELOG.md` (dated entry)
+
+- [ ] **Step 1: Remove the migration shims**
+
+Delete the `LlmProviderKind` deprecated alias and `LlmRouter.registerProvider`. Run `bun run typecheck` and fix every resulting error — if any remain, a call site was missed in Tasks 3–10.
+
+- [ ] **Step 2: Run the Linux-authoritative coverage floor**
+
+Run: `bun run verify:docker --changed`
+Expected: PASS. `llm/` is under the Engine ≥85% gate; new files must clear ≥85% line and ≥80% branch. A narrow run cannot reproduce cross-file `mock.module` contamination, so green here is evidence about these files, not the suite.
+
+- [ ] **Step 3: Update the docs**
+
+`docs/architecture.md`: the LLM section describing provider kinds. `docs/CHANGELOG.md`: a dated entry at the top of "Post-Phase-6 deliveries" stating what shipped **and what did not** — no cloud vendor, no per-task CLI, and that the egress-destination and overflow fixes are unit-proven only because no remote route exists yet.
+
+- [ ] **Step 4: Full preflight**
+
+```bash
+bun run preflight
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add -u
+git commit -m "docs: record model-routes delivery and its bounds"
+git push -u origin dev/asaf/llm-model-routes
+```
+
+PR title must carry the conventional-commit type — it is what release-please parses, and the squash commit is built from the PR title and body, not from these commit messages. Suggested: `feat(llm)!: route the LLM by (provider, model) instead of provider kind`. Check the body for unbalanced parentheses before opening; that has broken release-please three times.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3.1 → Tasks 1, 2, 3. §3.2 → Tasks 1, 10. §3.3 → Task 3. §3.4 → Task 5. §3.5 → Task 6. §3.6 → Task 8. §3.7 (no migration) → Global Constraints. §4.1 → Task 4. §4.2 → Task 7. §6 testing → distributed. Open decision 1 (test not `D`-rule) → Task 10. Open decision 2 (`llm status`) → Task 10. Open decisions 3–4 are slice 2, correctly absent.
+
+**Known gap, stated rather than hidden:** the spec's §3.3 task-pin gating is only partially exercised — `llm_task_defaults` pins have no surface until slice 4, so Task 3 implements the ordering and Task 4 tests the air-gap gate, but no test pins a task through config. The `enforceAirGap` route test covers the security property; the pin path is covered when slice 4 gives it an entry point.
+
+**Type consistency:** `ProviderId` (Task 1) is used in Tasks 6, 7. `ModelRoute` (Task 1) in Tasks 3, 4, 5, 6. `makeRouteId`/`parseRouteRef` (Task 2) in Tasks 3, 8. `registerRoute` (Task 3) / `addRoute` (Task 6) are deliberately different names — router-level vs registry-level, matching the existing `registerProvider`/`addProvider` split. `RouteAvailability` (Task 5) in Task 10's status shape.

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes.md
@@ -47,12 +47,14 @@ Ordering rationale: types → the one parsing helper → router core → availab
 The union `LlmProviderKind = "ollama" | "llamacpp" | "remote"` is what caps the router at one provider per kind. Opening it is the precondition for everything else. `isLocal` becomes a required interface field so the three copies of that fact (Task 6, Task 10) have one place to collapse into.
 
 **Files:**
+
 - Modify: `packages/gateway/src/llm/types.ts`
 - Modify: `packages/gateway/src/llm/ollama-provider.ts` (add one field)
 - Modify: `packages/gateway/src/llm/llamacpp-provider.ts` (add one field)
 - Test: `packages/gateway/src/llm/types.test.ts` **(new)**
 
 **Interfaces:**
+
 - Produces: `type ProviderId = string`; `LlmProvider.isLocal: boolean` (required); `type ModelRoute = { routeId: string; provider: LlmProvider; modelName: string; meta: ProviderMeta }`. `LlmProviderKind` is retained as a deprecated alias of `ProviderId` so Tasks 3–10 can migrate call sites incrementally rather than in one commit.
 
 - [ ] **Step 1: Write the failing test**
@@ -195,10 +197,12 @@ git commit -m "refactor(llm): open ProviderId and require isLocal on LlmProvider
 Model names contain slashes — `LlamaCppProvider` defaults to `"model.gguf"` and realistically holds a path; Ollama accepts `hf.co/user/model`. A naive `split("/")` breaks both. This helper is the only sanctioned parser, so Task 3 can treat `routeId` as opaque.
 
 **Files:**
+
 - Create: `packages/gateway/src/llm/route-id.ts`
 - Test: `packages/gateway/src/llm/route-id.test.ts`
 
 **Interfaces:**
+
 - Produces: `makeRouteId(providerId: ProviderId, modelName: string): string`; `parseRouteRef(raw: string): { providerId: ProviderId; modelName: string }` — **throws** `Error` on a malformed ref rather than returning `undefined`, so a bad `route_priority` entry surfaces at config load instead of degrading to default ordering.
 
 - [ ] **Step 1: Write the failing test**
@@ -334,6 +338,7 @@ git commit -m "feat(llm): route-id helper that splits on the first slash only"
 This is the core change. Write the test that fails on today's code **first**, so the defect is demonstrated rather than assumed.
 
 **Files:**
+
 - Modify: `packages/gateway/src/llm/router.ts`
 - Modify: `packages/gateway/src/decisions/decision-llm-adapter.ts:159`
 - Modify: `packages/gateway/src/glossary/glossary-llm-adapter.ts:44`
@@ -341,6 +346,7 @@ This is the core change. Write the test that fails on today's code **first**, so
 - Test: `packages/gateway/src/decisions/decision-llm-adapter.test.ts`, `packages/gateway/src/glossary/glossary-llm-adapter.test.ts` (existing — confirm the local-only refusal still holds)
 
 **Interfaces:**
+
 - Consumes: `ModelRoute`, `ProviderId` (Task 1); `makeRouteId` (Task 2).
 - Produces: `LlmRouter.registerRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void`; `LlmRouter.routes(): readonly ModelRoute[]`; `LlmRouter.routeFor(routeId: string): ModelRoute | undefined`. `registerProvider(provider, meta)` is kept as a shim calling `registerRoute(provider, <config default model for that provider>, meta)` so Tasks 6–10 migrate incrementally.
 
@@ -574,10 +580,12 @@ git commit -m "feat(llm): key the router on (provider, model) routes"
 `tryRemoteFallback` does `this.providers.get("remote")` — a key that no longer exists. Spec §4.1: rewrite it as "next fitting route in priority order". No remote route exists in this slice, so this is a pure refactor; the point is to close it before slice 2 makes it live.
 
 **Files:**
+
 - Modify: `packages/gateway/src/llm/router.ts`
 - Test: `packages/gateway/src/llm/router.test.ts`
 
 **Interfaces:**
+
 - Consumes: `firstAvailableRoute`, `orderedRoutes` (Task 3).
 - Produces: no new public surface. `tryRemoteFallback` is deleted; `fitPromptOrFallback` returns `{ kind: "route"; route: ModelRoute; opts: LlmGenerateOptions }`.
 
@@ -643,11 +651,13 @@ git commit -m "fix(llm): context-overflow fallback walks routes, not a 'remote' 
 Spec §3.4. `OllamaProvider.isAvailable()` returns `resp.ok` from `GET /api/tags` without checking `this.modelName` is among them. With one route that is a confusing error; with a priority walk it halts at the first route that lies instead of falling through to one that works.
 
 **Files:**
+
 - Create: `packages/gateway/src/llm/route-availability.ts`
 - Modify: `packages/gateway/src/llm/router.ts` (use it in the walk)
 - Test: `packages/gateway/src/llm/route-availability.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ModelRoute` (Task 1).
 - Produces: `type RouteAvailability = { available: boolean; reason: "ok" | "provider_unreachable" | "model_absent" }`; `class RouteAvailabilityProbe { constructor(ttlMs?: number); check(route: ModelRoute): Promise<RouteAvailability>; }`. The two failure reasons stay distinct because they have different fixes — reporting both as "unavailable" sends the user to the wrong one.
 
@@ -819,10 +829,12 @@ git commit -m "fix(llm): route availability checks the model, not just the daemo
 Three arrays hardcode the closed union (`registry.ts:44`, `:67`, `:87`) and four method signatures hardcode `"ollama" | "llamacpp"`. Spec §3.5: lifecycle keys on `providerId`, model stays an argument — keying on `routeId` would make it impossible to pull a model that has no route yet.
 
 **Files:**
+
 - Modify: `packages/gateway/src/llm/registry.ts`
 - Test: `packages/gateway/src/llm/registry.test.ts`
 
 **Interfaces:**
+
 - Consumes: `routes()`, `routeFor()` (Task 3).
 - Produces: `addRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void`; `pullModel(providerId: ProviderId, modelName: string, opts?): Promise<void>` — note `providerId` widens from the union to `ProviderId`. `loadModel` / `unloadModel` / `setDefault` widen identically.
 
@@ -877,11 +889,13 @@ git commit -m "refactor(llm): registry iterates routes; lifecycle keys on provid
 Spec §4.2. `synthesis-egress.ts` hardcodes `destination: "model"` and its parameter type structurally drops `providerId`, though the call site has it. With five vendors, `nimbus prove` would report that "a prompt went to a model".
 
 **Files:**
+
 - Modify: `packages/gateway/src/egress/synthesis-egress.ts`
 - Modify: `packages/gateway/src/agents/_lib/synthesis-llm.ts` (widen `RecordSynthesisEgressFn`)
 - Test: `packages/gateway/src/egress/synthesis-egress.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ResolvedSynthesisProvider` (already carries `providerId`).
 - Produces: `recordSynthesisEgress(db, { briefKind, provider: { providerId, modelName, isLocal }, now })`.
 
@@ -945,10 +959,12 @@ git commit -m "fix(egress): synthesis destination names the vendor, not the lite
 Spec §3.6. Total back-compat: existing keys must still work.
 
 **Files:**
+
 - Modify: `packages/gateway/src/config/nimbus-toml.ts`
 - Test: `packages/gateway/src/config/nimbus-toml.test.ts`
 
 **Interfaces:**
+
 - Consumes: `parseRouteRef` (Task 2).
 - Produces: `NimbusLlmToml.localRoutes: ReadonlyMap<string, { runtime: string; model: string; baseUrl?: string }>` and `NimbusLlmToml.routePriority: readonly string[]`. Both default to empty in `DEFAULT_NIMBUS_LLM_TOML`, so `loadNimbusLlmFromPath` yields an empty map/array while `parseNimbusTomlLlmSection` (a `Partial`) yields `undefined` when unset. Task 9 consumes the defaults-merged form.
 
@@ -1111,10 +1127,12 @@ git commit -m "feat(config): [llm.local.<name>] routes and route_priority"
 ### Task 9: Wire N routes at assembly
 
 **Files:**
+
 - Modify: `packages/gateway/src/platform/assemble.ts:1277-1311`
 - Test: `packages/gateway/test/integration/llm-routes.integration.test.ts` **(new)**
 
 **Interfaces:**
+
 - Consumes: `NimbusLlmToml.localRoutes` (Task 8), `LlmRegistry.addRoute` (Task 6).
 - Produces: a registry whose `routes()` reflects config.
 
@@ -1235,11 +1253,13 @@ git commit -m "feat(llm): assemble registers one route per configured model"
 ### Task 10: IPC surface + the one-definition test
 
 **Files:**
+
 - Modify: `packages/gateway/src/ipc/llm-rpc.ts:20-28`
 - Test: `packages/gateway/src/ipc/llm-rpc.test.ts`
 - Test: `packages/gateway/src/llm/local-definition.test.ts` **(new)**
 
 **Interfaces:**
+
 - Consumes: everything above.
 - Produces: `llm.status` returns `{ routes: Array<{ routeId, providerId, modelName, isLocal, available, reason, contextWindow }> }`. No new method.
 
@@ -1308,6 +1328,7 @@ git commit -m "refactor(ipc): llm.status lists routes; drop the last local-id co
 ### Task 11: Coverage floor, docs, and the deprecated alias
 
 **Files:**
+
 - Modify: `packages/gateway/src/llm/types.ts` (delete the `LlmProviderKind` alias)
 - Modify: `docs/architecture.md` (LLM routing section)
 - Modify: `docs/CHANGELOG.md` (dated entry)

--- a/docs/superpowers/plans/2026-08-27-llm-model-routes.md
+++ b/docs/superpowers/plans/2026-08-27-llm-model-routes.md
@@ -335,7 +335,10 @@ This is the core change. Write the test that fails on today's code **first**, so
 
 **Files:**
 - Modify: `packages/gateway/src/llm/router.ts`
+- Modify: `packages/gateway/src/decisions/decision-llm-adapter.ts:159`
+- Modify: `packages/gateway/src/glossary/glossary-llm-adapter.ts:44`
 - Test: `packages/gateway/src/llm/router.test.ts`
+- Test: `packages/gateway/src/decisions/decision-llm-adapter.test.ts`, `packages/gateway/src/glossary/glossary-llm-adapter.test.ts` (existing — confirm the local-only refusal still holds)
 
 **Interfaces:**
 - Consumes: `ModelRoute`, `ProviderId` (Task 1); `makeRouteId` (Task 2).
@@ -431,7 +434,29 @@ Record the observed `1` in your task notes. Delete the temporary block before pr
 
 In `packages/gateway/src/llm/router.ts`:
 
-Delete `LOCAL_PROVIDER_IDS` and rewrite `isLocalProviderKind` as a route-level read. Keep the exported name only if `grep -rn "isLocalProviderKind" packages/gateway/src --include=*.ts | grep -v test` shows a non-test caller; if it shows none, delete the export and its import in `router.test.ts`.
+**Delete both `LOCAL_PROVIDER_IDS` and the exported `isLocalProviderKind`.** The audit is already
+done — do not re-run it as a conditional:
+
+| Caller | Line | Becomes |
+| --- | --- | --- |
+| `decisions/decision-llm-adapter.ts` | `159` — `if (!isLocalProviderKind(provider.providerId)) return null;` | `if (!provider.isLocal) return null;` |
+| `glossary/glossary-llm-adapter.ts` | `44` — same shape | `if (!provider.isLocal) return null;` |
+| `llm/router.ts` | `142` — inside `resolveForSynthesis` | `isLocal: route.provider.isLocal` |
+| `llm/router.test.ts` | `386-399` | delete the `describe`; the property is covered by Task 1 and Task 10 |
+
+**These two call sites are security gates, not conveniences** — they are how the glossary and
+decisions extraction passes refuse to send indexed private prose to a remote provider. Migrate them
+in this task, in this commit; leaving them on a string-keyed predicate is not acceptable as
+follow-up work.
+
+**`isLocalProviderKind` must not survive in any form.** Once `ProviderId` is an open string, a
+function answering "is this id local?" can only work by consulting a list — which is precisely the
+copy this refactor exists to delete, reintroduced at a security gate. Locality is a property of the
+registered provider instance; ask the instance.
+
+(For completeness on review item 2.4: `requireLocalProvider`, `LOCAL_PROVIDERS` and the
+`LocalProvider` type are confined to `ipc/llm-rpc.ts` and have no callers elsewhere — verified by
+grep across `packages/`. Task 10 deletes them with no migration needed.)
 
 Replace the two maps with one:
 
@@ -470,12 +495,43 @@ Rewrite `providerPriority` to return ordered `ModelRoute`s. `routePriority` is a
       // here was unregistered at runtime, so skipping is correct.
       const ordered = explicit.map((id) => byId.get(id)).filter((r): r is ModelRoute => r !== undefined);
       const named = new Set(ordered.map((r) => r.routeId));
-      return [...ordered, ...all.filter((r) => !named.has(r.routeId))];
+      // The unnamed tail still honours preferLocal. Leaving it in registration order
+      // would make the fallback order depend on config-file ordering, which is
+      // arbitrary — and would quietly ignore prefer_local for exactly the routes the
+      // user did not think to rank. Appending them at all (rather than dropping) is
+      // deliberate: a route added to [llm.local.*] but forgotten in route_priority
+      // should still be reachable, not invisible.
+      return [...ordered, ...byPreference(all.filter((r) => !named.has(r.routeId)), preferLocal)];
     }
-    const local = all.filter((r) => r.provider.isLocal);
-    const remote = all.filter((r) => !r.provider.isLocal);
+    return byPreference(all, preferLocal);
+  }
+
+  private static byPreference(routes: ModelRoute[], preferLocal: boolean): ModelRoute[] {
+    const local = routes.filter((r) => r.provider.isLocal);
+    const remote = routes.filter((r) => !r.provider.isLocal);
     return preferLocal ? [...local, ...remote] : [...remote, ...local];
   }
+```
+
+Add the matching test:
+
+```ts
+test("the unnamed tail after route_priority still honours preferLocal", async () => {
+  const router = new LlmRouter({
+    ...DEFAULT_CONFIG,
+    preferLocal: true,
+    routePriority: ["gemini/gemini-2.5-pro"], // an explicit remote FIRST choice
+  });
+  router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+  router.registerRoute(makeFakeRouteProvider("xai", false, true), "grok-4");
+  router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+  // Registration order puts xai (remote) before ollama (local); preferLocal must
+  // reorder the tail so the local route is tried before the unranked remote one.
+  const ids = (router as unknown as { orderedRoutes(p?: boolean): ModelRoute[] })
+    .orderedRoutes(true)
+    .map((r) => r.routeId);
+  expect(ids).toEqual(["gemini/gemini-2.5-pro", "ollama/qwen3:8b", "xai/grok-4"]);
+});
 ```
 
 Rewrite `firstAvailable` to walk routes, keeping the skip-during-walk shape (do NOT pre-filter a pool — see spec §3.3):
@@ -505,7 +561,9 @@ Expected: PASS. Existing `selectProvider` / `getStatus` tests must still pass th
 - [ ] **Step 5: Commit**
 
 ```bash
-git add packages/gateway/src/llm/router.ts packages/gateway/src/llm/router.test.ts
+git add packages/gateway/src/llm/router.ts packages/gateway/src/llm/router.test.ts \
+        packages/gateway/src/decisions/decision-llm-adapter.ts \
+        packages/gateway/src/glossary/glossary-llm-adapter.ts
 git commit -m "feat(llm): key the router on (provider, model) routes"
 ```
 
@@ -685,7 +743,45 @@ Expected: FAIL — `Cannot find module './route-availability.ts'`.
 
 - [ ] **Step 4: Wire it into the walk and run tests**
 
-In `router.ts`, `probeAvailable` becomes a `RouteAvailabilityProbe.check(route).available` call, keeping the existing catch-to-false. Add a router-level test:
+**The probe must be a single long-lived field on `LlmRouter`**, not constructed inside the walk:
+
+```ts
+  private readonly availability = new RouteAvailabilityProbe();
+```
+
+Constructing it inside `firstAvailableRoute` would discard the cache on every call, which defeats
+the entire purpose — four routes would still cost four `/api/tags` round trips. `probeAvailable`
+becomes `(await this.availability.check(route)).available`, keeping the existing catch-to-false.
+
+Three consequences of a long-lived cache that the implementation must handle:
+
+1. **TTL is `30_000` ms**, a named constant, not a magic number. Long enough that resolving a
+   four-route table costs one round trip; short enough that a model removed out-of-band
+   (`ollama rm`) is noticed without a restart.
+2. **A successful `pullModel` must invalidate the cache for that `providerId`.** Otherwise
+   `nimbus llm pull gemma3` followed immediately by a request that should use it keeps reporting
+   `model_absent` for up to 30 seconds — a bug that looks exactly like the pull having failed.
+   `RouteAvailabilityProbe.invalidate(providerId: ProviderId): void`, called from
+   `LlmRegistry.pullModel` on success (Task 6 — add it there when this lands).
+3. **`getStatus()` already has its own per-call `availabilityCache`** (`Map<…, Promise<boolean>>`)
+   built to probe each provider at most once per status call. Delete it — it is now redundant, and
+   two caching layers with different lifetimes over the same question is how they drift apart.
+
+Add the invalidation test to Task 5's file:
+
+```ts
+test("invalidate() forces the next check to re-list", async () => {
+  let calls = 0;
+  const probe = new RouteAvailabilityProbe(60_000);
+  const opts = { reachable: true, models: ["a"], onList: () => { calls += 1; } };
+  await probe.check(route("a", opts));
+  probe.invalidate("ollama");
+  await probe.check(route("a", opts));
+  expect(calls).toBe(2);
+});
+```
+
+Add a router-level test:
 
 ```ts
 test("the walk falls THROUGH a route whose model is not pulled", async () => {
@@ -910,22 +1006,22 @@ test("a malformed route_priority entry throws at load, it does not vanish", () =
   expect(() => parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama"]\n`)).toThrow(/route/);
 });
 
-test("two llamacpp routes sharing a base_url are rejected", () => {
-  // llama.cpp's generate() sends no model field — the server answers with whatever
-  // it was launched with, so two routes at one URL would report different names
-  // while hitting identical weights.
+test("both llamacpp sub-tables are parsed; collision is Task 9's to catch", () => {
+  // The collision check moved to assemble.ts with the rest of validation. Compare
+  // RESOLVED base URLs there: two routes that both OMIT base_url resolve to the
+  // same default and collide, which a raw-string comparison would miss entirely.
   const toml = `
 [llm.local.a]
 runtime = "llamacpp"
 model = "a.gguf"
-base_url = "http://127.0.0.1:8080"
 
 [llm.local.b]
 runtime = "llamacpp"
 model = "b.gguf"
-base_url = "http://127.0.0.1:8080"
 `;
-  expect(() => parseNimbusTomlLlmSection(toml)).toThrow(/base_url/);
+  const cfg = parseNimbusTomlLlmSection(toml);
+  expect([...(cfg.localRoutes ?? new Map()).keys()].sort()).toEqual(["a", "b"]);
+  expect(cfg.localRoutes?.get("a")?.baseUrl).toBeUndefined();
 });
 
 test("a malformed sub-table does not discard the rest of [llm]", () => {
@@ -936,14 +1032,57 @@ test("a malformed sub-table does not discard the rest of [llm]", () => {
 });
 ```
 
-**Throwing vs. the section's house style — resolve before implementing.** Two tests above expect a
-`throw`, but `parseNimbusTomlLlmSection` currently never throws; `applyNimbusLlmKey` silently
-ignores a bad value, and the `[ownership]` precedent explicitly catches so one malformed block does
-not discard a section. Reconcile: a malformed *value* keeps the silent-ignore behaviour, while an
-unresolvable *route reference* throws — because a dropped `route_priority` entry silently changes
-which model answers, which is a different class of failure from a dropped boolean. If review
-prefers no new throw, surface it as a loaded-config validation error at `assemble.ts` instead
-(Task 9) — but it must not be silent either way.
+> **⚠ The parser MUST NOT throw. Do not write the two `toThrow` tests above as shown — they are
+> superseded by the block below.** They are left visible only so the reasoning is not lost.
+
+**Why a throw here is dangerous, not merely unidiomatic.** `loadTomlSection`
+(`config/nimbus-toml.ts:23-32`) wraps every section parse in a **bare catch that returns the
+defaults**:
+
+```ts
+try { return parse(readFileSync(tomlPath, "utf8")); }
+catch { return structuredClone(fallback); }
+```
+
+A throw from `parseNimbusTomlLlmSection` is therefore swallowed, and the **entire `[llm]` section
+reverts to `DEFAULT_NIMBUS_LLM_TOML`** — silently. That discards `prefer_local`, `local_model`,
+`min_reasoning_params` and, critically, `enforce_air_gap`, whose default is **`false`**. So a typo
+in one `route_priority` entry would silently disable air-gap on a machine configured for it. That
+is a strictly worse outcome than either fail-fast or a diagnostic, and it is invisible.
+
+**Therefore validation is a two-stage split:**
+
+1. **Parse stage (this task) never throws.** `parseNimbusTomlLlmSection` collects `route_priority`
+   entries verbatim into `routePriority: string[]` and `[llm.local.*]` blocks into `localRoutes`,
+   applying no cross-field validation. A structurally unusable sub-table (empty id) is skipped, as
+   the `[ownership]` precedent skips a malformed entry rather than discarding the section.
+2. **Validation stage (Task 9, `assemble.ts`) reports and refuses.** Against the loaded config,
+   run each `routePriority` entry through `parseRouteRef` and check it resolves to a registered
+   route, and check the resolved-`base_url` collision rule. A failure logs an explicit error
+   naming the offending entry and **omits that entry**, rather than reverting anything.
+
+Write the two config tests as non-throwing instead:
+
+```ts
+test("route_priority entries are collected verbatim, without validation", () => {
+  // Validation lives in assemble.ts (Task 9). Throwing here would be swallowed by
+  // loadTomlSection's bare catch and silently revert the WHOLE [llm] section to
+  // defaults — including enforce_air_gap, which defaults to false.
+  const cfg = parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama", "ollama/qwen3"]\n`);
+  expect(cfg.routePriority).toEqual(["ollama", "ollama/qwen3"]);
+});
+
+test("a malformed sub-table is skipped without discarding the section", () => {
+  const cfg = parseNimbusTomlLlmSection(
+    `[llm]\nenforce_air_gap = true\n\n[llm.local.]\nmodel = "x"\n`,
+  );
+  expect(cfg.enforceAirGap).toBe(true); // the security-relevant key SURVIVES
+  expect(cfg.localRoutes ?? new Map()).not.toHaveProperty("");
+});
+```
+
+The second test is the regression guard for the hazard above: assert the *security* key survives a
+malformed neighbour, not merely that some key survives.
 
 - [ ] **Step 2: Run it and verify it fails**
 
@@ -992,7 +1131,92 @@ Expected: FAIL — one route per runtime regardless of config.
 
 - [ ] **Step 3: Implement**
 
-In `buildLlmRegistryFromToml`, when `localRoutes` is non-empty, register one route per entry, constructing `OllamaProvider(baseUrl ?? "http://127.0.0.1:11434", model, llmToml.localContextTokens)` or `LlamaCppProvider(baseUrl, model)` by `runtime`. When it is empty, register exactly today's two providers via `addRoute(provider, llmToml.localModel)` so behaviour is unchanged. Pass `routePriority` into the `LlmRegistry` config. Keep the fire-and-forget `refreshProviderMeta` call, now iterating routes.
+In `buildLlmRegistryFromToml`, when `localRoutes` is non-empty, register one route per entry, constructing `OllamaProvider(baseUrl ?? "http://127.0.0.1:11434", model, llmToml.localContextTokens)` or `LlamaCppProvider(baseUrl, model)` by `runtime`. When it is empty, register exactly today's two providers via `addRoute(provider, llmToml.localModel)` so behaviour is unchanged. Keep the fire-and-forget `refreshProviderMeta` call, now iterating routes.
+
+**Then the validation stage that Task 8 deliberately does not perform.** It lives here because a
+throw inside the parser is swallowed by `loadTomlSection`'s bare catch and silently reverts the
+whole `[llm]` section to defaults — including `enforce_air_gap`.
+
+Resolve base URLs **before** comparing them, per review item 2.3 — two routes that both omit
+`base_url` resolve to the same default and collide, which a raw-string comparison misses because
+both values are `undefined`:
+
+```ts
+const LLAMACPP_DEFAULT_BASE_URL = "http://127.0.0.1:8080";
+
+function resolveBaseUrl(runtime: string, baseUrl: string | undefined): string {
+  const explicit = baseUrl?.trim() ?? "";
+  if (explicit !== "") return explicit.replace(/\/$/, "");
+  return runtime === "llamacpp" ? LLAMACPP_DEFAULT_BASE_URL : "http://127.0.0.1:11434";
+}
+```
+
+Two rules, each logging the offending entry by name and **omitting only that entry**:
+
+1. **A `llamacpp` resolved base URL claimed twice is an error.** `LlamaCppProvider.generate()`
+   sends no model field — the server answers with whatever weights it was launched with — so two
+   llama.cpp routes at one URL report different model names while hitting identical weights: a
+   route table that lies. Keep the first, drop the rest, log both names and the URL. Ollama is
+   exempt: `generate()` sends `this.modelName` to a shared daemon, so many routes at one base URL
+   is the normal case.
+2. **A `route_priority` entry that fails `parseRouteRef` or names no registered route is dropped
+   with an explicit log line** naming the entry. It must not be silent — a vanished priority entry
+   changes which model answers with no outward sign.
+
+Neither rule aborts boot. The gateway starts with a correct-but-reduced route table and a loud
+log, which is the same posture `refreshProviderMeta` takes when a provider is down.
+
+Add to the integration test:
+
+```ts
+test("two llamacpp routes that BOTH omit base_url collide and one is dropped", () => {
+  // The case a raw-string comparison misses: both values are `undefined`.
+  writeConfig(`
+[llm.local.a]
+runtime = "llamacpp"
+model = "a.gguf"
+
+[llm.local.b]
+runtime = "llamacpp"
+model = "b.gguf"
+`);
+  const registry = buildLlmRegistryFromToml(db, tomlPath);
+  const llamacpp = registry.llmRouter.routes().filter((r) => r.provider.providerId === "llamacpp");
+  expect(llamacpp).toHaveLength(1);
+});
+
+test("many ollama routes on one base URL are all kept", () => {
+  // Ollama sends the model name per request, so sharing a daemon is correct.
+  writeConfig(`
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.gemma]
+runtime = "ollama"
+model = "gemma3:12b"
+`);
+  const registry = buildLlmRegistryFromToml(db, tomlPath);
+  expect(registry.llmRouter.routes()).toHaveLength(2);
+});
+
+test("an unresolvable route_priority entry is dropped, and the rest of [llm] survives", () => {
+  writeConfig(`
+[llm]
+enforce_air_gap = true
+route_priority = ["ollama/nope", "ollama/qwen3:8b"]
+
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+`);
+  const registry = buildLlmRegistryFromToml(db, tomlPath);
+  // The security-relevant key MUST survive a bad neighbour — this is the regression
+  // guard for loadTomlSection's swallow-and-revert behaviour.
+  expect(registry.llmRouter.enforcesAirGap()).toBe(true);
+  expect(registry.llmRouter.routes()).toHaveLength(1);
+});
+```
 
 - [ ] **Step 4: Run the CI command**
 

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
@@ -18,34 +18,42 @@ Below are detailed suggestions, improvements, and open questions to ensure edge 
 ## 2. Improvements & Suggestions
 
 ### 2.1 Route ID Parsing & Slash Robustness (HuggingFace/Registry Model Names)
-*   **Issue:** The proposed route ID format is `${providerId}/${modelName}`. In some cases, model names themselves contain slashes (e.g., HuggingFace repositories like `meta-llama/Llama-3-8b` or local custom tags). If the router split logic simply splits on `/`, it could break or incorrectly identify the provider.
-*   **Suggestion:** Ensure that the parsing logic splits on the **first** slash only.
+
+* **Issue:** The proposed route ID format is `${providerId}/${modelName}`. In some cases, model names themselves contain slashes (e.g., HuggingFace repositories like `meta-llama/Llama-3-8b` or local custom tags). If the router split logic simply splits on `/`, it could break or incorrectly identify the provider.
+* **Suggestion:** Ensure that the parsing logic splits on the **first** slash only.
+
     ```typescript
     const slashIdx = routeId.indexOf('/');
     const providerId = routeId.substring(0, slashIdx);
     const modelName = routeId.substring(slashIdx + 1);
     ```
+
     This should be explicitly specified in the implementation details to avoid fragile string splits.
 
 ### 2.2 Model Lifecycle Management on Shared Runtimes
-*   **Issue:** When running multiple local models on the same runtime (e.g., `ollama/qwen3` and `ollama/gemma3`), there will be two separate `OllamaProvider` instances. `LlmRegistry` has lifecycle methods such as `loadModel`, `unloadModel`, and `pullModel`.
-*   **Question:** Do lifecycle actions execute against the specific instance (which holds the model name state)?
-*   **Suggestion:** Yes. Since the providers are lightweight and hold the model configuration, the registry should route the lifecycle operations to the specific provider instance matching the `routeId`. This keeps the provider implementation clean without needing to thread model arguments through the registry methods.
+
+* **Issue:** When running multiple local models on the same runtime (e.g., `ollama/qwen3` and `ollama/gemma3`), there will be two separate `OllamaProvider` instances. `LlmRegistry` has lifecycle methods such as `loadModel`, `unloadModel`, and `pullModel`.
+* **Question:** Do lifecycle actions execute against the specific instance (which holds the model name state)?
+* **Suggestion:** Yes. Since the providers are lightweight and hold the model configuration, the registry should route the lifecycle operations to the specific provider instance matching the `routeId`. This keeps the provider implementation clean without needing to thread model arguments through the registry methods.
 
 ### 2.3 Context Overflow and Ledger Accuracy
-*   **Issue:** When the router triggers `tryRemoteFallback` (rewritten to walk the next available fitting routes in priority order), we must ensure that the egress ledger correctly reflects the model that *actually* executes.
-*   **Recommendation:**
-    1.  The fallback selection must happen **before** calling `recordSynthesisEgress`.
-    2.  If a fallback route is selected, the egress ledger row must use the fallback route's `providerId` as the destination.
-    3.  If no fallback route is found (or if all fitting routes are filtered out by air-gap / synthesis restrictions), the execution should fail-closed prior to ledgering or model execution.
+
+* **Issue:** When the router triggers `tryRemoteFallback` (rewritten to walk the next available fitting routes in priority order), we must ensure that the egress ledger correctly reflects the model that *actually* executes.
+* **Recommendation:**
+    1. The fallback selection must happen **before** calling `recordSynthesisEgress`.
+    2. If a fallback route is selected, the egress ledger row must use the fallback route's `providerId` as the destination.
+    3. If no fallback route is found (or if all fitting routes are filtered out by air-gap / synthesis restrictions), the execution should fail-closed prior to ledgering or model execution.
 
 ### 2.4 Priority Walk vs. Capability & Security Filtering
-*   **Issue:** The priority order resolution is defined as: `Explicit task pin` -> `route_priority` -> `default ordering`, followed by filters for air-gap, capability floor, and availability.
-*   **Clarification:** To ensure security and correctness, filtering (especially security constraints like air-gaps) must act as a strict gate. The route selection algorithm should filter the candidate pool *first*, or skip any selected route during the priority walk if it fails the security/capability checks.
+
+* **Issue:** The priority order resolution is defined as: `Explicit task pin` -> `route_priority` -> `default ordering`, followed by filters for air-gap, capability floor, and availability.
+* **Clarification:** To ensure security and correctness, filtering (especially security constraints like air-gaps) must act as a strict gate. The route selection algorithm should filter the candidate pool *first*, or skip any selected route during the priority walk if it fails the security/capability checks.
 
 ### 2.5 CLI Surface Layout (`nimbus llm status`)
-*   **Suggestion:** Since `nimbus llm status` will now list multiple routes, we should output a clean tabular format.
-    ```
+
+* **Suggestion:** Since `nimbus llm status` will now list multiple routes, we should output a clean tabular format.
+
+    ```text
     ROUTE ID          PROVIDER    MODEL       TYPE      STATUS    CONTEXT WINDOW
     ollama/qwen3      ollama      qwen3:8b    local     active    8,192
     ollama/gemma      ollama      gemma3:12b  local     inactive  131,072
@@ -55,7 +63,7 @@ Below are detailed suggestions, improvements, and open questions to ensure edge 
 
 ## 3. Open Questions for Slice 2 & Beyond
 
-1.  **Opt-in Mechanism for Remote Vendors:**
+1. **Opt-in Mechanism for Remote Vendors:**
     To implement the "explicit opt-in flag" discussed in Open Decision 3, will we introduce an `enabled = true` property inside the individual `[llm.remote.<vendor>]` TOML configuration tables?
-2.  **Telemetry and Error Handling for Unavailable Local Models:**
+2. **Telemetry and Error Handling for Unavailable Local Models:**
     If a configured local route's model is not yet pulled (e.g., `ollama/gemma3` is configured but not present in the local daemon), does `firstAvailable` automatically fall back to the next route, or does it trigger a pull/error?

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-27  
 **Reviewer:** Antigravity (AI Coding Assistant)  
 **Status:** Under Review  
-**Target Spec:** [2026-08-27-llm-model-routes-design.md](file:///C:/gitrep/Nimbus/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md)
+**Target Spec:** [2026-08-27-llm-model-routes-design.md](./2026-08-27-llm-model-routes-design.md)
 
 ---
 

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design-review.md
@@ -1,0 +1,61 @@
+# LLM Model Routes — Design Review
+
+**Date:** 2026-08-27  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Under Review  
+**Target Spec:** [2026-08-27-llm-model-routes-design.md](file:///C:/gitrep/Nimbus/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md)
+
+---
+
+## 1. Summary of Review
+
+The proposed design for model routes is robust, elegant, and successfully addresses the current single-seat limitation of the LLM router by transitioning to a route-aware `(provider, model)` architecture. By making `isLocal` a required, provider-level property, the design also eliminates the risks associated with multiple definitions of local-ness.
+
+Below are detailed suggestions, improvements, and open questions to ensure edge cases are handled before starting the implementation.
+
+---
+
+## 2. Improvements & Suggestions
+
+### 2.1 Route ID Parsing & Slash Robustness (HuggingFace/Registry Model Names)
+*   **Issue:** The proposed route ID format is `${providerId}/${modelName}`. In some cases, model names themselves contain slashes (e.g., HuggingFace repositories like `meta-llama/Llama-3-8b` or local custom tags). If the router split logic simply splits on `/`, it could break or incorrectly identify the provider.
+*   **Suggestion:** Ensure that the parsing logic splits on the **first** slash only.
+    ```typescript
+    const slashIdx = routeId.indexOf('/');
+    const providerId = routeId.substring(0, slashIdx);
+    const modelName = routeId.substring(slashIdx + 1);
+    ```
+    This should be explicitly specified in the implementation details to avoid fragile string splits.
+
+### 2.2 Model Lifecycle Management on Shared Runtimes
+*   **Issue:** When running multiple local models on the same runtime (e.g., `ollama/qwen3` and `ollama/gemma3`), there will be two separate `OllamaProvider` instances. `LlmRegistry` has lifecycle methods such as `loadModel`, `unloadModel`, and `pullModel`.
+*   **Question:** Do lifecycle actions execute against the specific instance (which holds the model name state)?
+*   **Suggestion:** Yes. Since the providers are lightweight and hold the model configuration, the registry should route the lifecycle operations to the specific provider instance matching the `routeId`. This keeps the provider implementation clean without needing to thread model arguments through the registry methods.
+
+### 2.3 Context Overflow and Ledger Accuracy
+*   **Issue:** When the router triggers `tryRemoteFallback` (rewritten to walk the next available fitting routes in priority order), we must ensure that the egress ledger correctly reflects the model that *actually* executes.
+*   **Recommendation:**
+    1.  The fallback selection must happen **before** calling `recordSynthesisEgress`.
+    2.  If a fallback route is selected, the egress ledger row must use the fallback route's `providerId` as the destination.
+    3.  If no fallback route is found (or if all fitting routes are filtered out by air-gap / synthesis restrictions), the execution should fail-closed prior to ledgering or model execution.
+
+### 2.4 Priority Walk vs. Capability & Security Filtering
+*   **Issue:** The priority order resolution is defined as: `Explicit task pin` -> `route_priority` -> `default ordering`, followed by filters for air-gap, capability floor, and availability.
+*   **Clarification:** To ensure security and correctness, filtering (especially security constraints like air-gaps) must act as a strict gate. The route selection algorithm should filter the candidate pool *first*, or skip any selected route during the priority walk if it fails the security/capability checks.
+
+### 2.5 CLI Surface Layout (`nimbus llm status`)
+*   **Suggestion:** Since `nimbus llm status` will now list multiple routes, we should output a clean tabular format.
+    ```
+    ROUTE ID          PROVIDER    MODEL       TYPE      STATUS    CONTEXT WINDOW
+    ollama/qwen3      ollama      qwen3:8b    local     active    8,192
+    ollama/gemma      ollama      gemma3:12b  local     inactive  131,072
+    ```
+
+---
+
+## 3. Open Questions for Slice 2 & Beyond
+
+1.  **Opt-in Mechanism for Remote Vendors:**
+    To implement the "explicit opt-in flag" discussed in Open Decision 3, will we introduce an `enabled = true` property inside the individual `[llm.remote.<vendor>]` TOML configuration tables?
+2.  **Telemetry and Error Handling for Unavailable Local Models:**
+    If a configured local route's model is not yet pulled (e.g., `ollama/gemma3` is configured but not present in the local daemon), does `firstAvailable` automatically fall back to the next route, or does it trigger a pull/error?

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-08-27
 **Status:** approved design, not yet planned
 **Slot:** Spine S2 — Local Compute Fleet, row *"bring-your-own-frontier-model routing with local fallback"*
-**Slice:** 1 of 4 (see [Decomposition](#decomposition))
+**Slice:** 1 of 4 (see [Decomposition](#8-decomposition))
 
 ---
 
@@ -63,7 +63,7 @@ instead of a dormant one.
 - `nimbus llm use <vendor>/<model>` and per-task pinning **as a CLI/config surface** — slice 4.
   (Slice 1 does change `nimbus llm status`; see §7.)
 - Any change to how `[agents] synthesis` decides `off` / `local` / `allow-remote`.
-- Any new HITL gate on inference. See [Open decision 3](#open-decisions).
+- Any new HITL gate on inference. See [Open decision 3](#7-open-decisions).
 
 ---
 
@@ -364,7 +364,7 @@ All paths above are relative to `packages/gateway/src/`. Test files are not list
   (`packages/ui/src-tauri/src/gateway_bridge.rs`); slice 1 adds none, so the I7 count assertion is
   untouched. Response *shapes* change for `llm.listModels` and `llm.getRouterStatus`, so the
   desktop UI consumers need checking.
-- **No new invariant.** See [Open decision 1](#open-decisions).
+- **No new invariant.** See [Open decision 1](#7-open-decisions).
 
 ---
 
@@ -426,7 +426,7 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
    two states with different fixes, so "daemon unreachable" and "model not pulled" (§3.4) must be
    distinguishable. A sketch, not a contract:
 
-   ```
+   ```text
    ROUTE ID       PROVIDER  MODEL       LOCAL  AVAILABLE            CONTEXT
    ollama/qwen3   ollama    qwen3:8b    yes    yes                  8192
    ollama/gemma   ollama    gemma3:12b  yes    no (model not pulled) —

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -122,10 +122,16 @@ Two rules, and the first is what actually makes it safe:
    const modelName  = raw.slice(i + 1);   // may itself contain slashes
    ```
 
-A route reference that matches no registered route is a **config error reported at load**, not a
-silently dropped entry — a `route_priority` entry that quietly vanishes would degrade to the
-default ordering with no signal, which is the "supplied flag degrading into an omitted filter"
-shape.
+A route reference that matches no registered route is **named in a `warn` log and dropped at
+assembly, and boot continues** — never a silently dropped entry. (Corrected after the fact: this
+paragraph originally said "a config error reported at load", which reads as a refusal. Nothing
+refuses. It cannot: a throw inside the `[llm]` parser is swallowed by `loadTomlSection`'s bare
+catch and silently reverts the WHOLE section to defaults, `enforce_air_gap` included — a far worse
+failure than the one it would be reporting. So `platform/assemble.ts` validates AFTER the parse,
+warn-logs the offending entry by name, drops it, and carries on.) The property that matters is
+unchanged and is what the tests assert: the entry never vanishes without a word. A `route_priority`
+entry that quietly disappeared would degrade to the default ordering with no signal, which is the
+"supplied flag degrading into an omitted filter" shape.
 
 #### llama.cpp cannot host two models at one base URL
 
@@ -179,14 +185,21 @@ prefer_local  = true
 route_priority = ["ollama/qwen3", "ollama/gemma3"]   # optional; when set, it IS the order
 ```
 
-Resolution for a task: **explicit task pin → `route_priority` → default ordering**. That sequence
-chooses the candidate **order** only. Air-gap, the reasoning capability floor, and availability are
-**gates applied to every candidate**, including an explicit pin — a pin selects which route is tried
-first, never that it is tried unconditionally.
+Resolution for a task, as designed: **explicit task pin → `route_priority` → default ordering**.
+That sequence chooses the candidate **order** only. Air-gap, the reasoning capability floor, and
+availability are **gates applied to every candidate**, including an explicit pin — a pin selects
+which route is tried first, never that it is tried unconditionally.
+
+> **What slice 1 actually shipped: the task-pin stage does NOT exist.** `LlmRouter.orderedRoutes`
+> implements `route_priority` → `byPreference` and nothing before it; the router never consults
+> `LlmRegistry.getDefault` or `llm_task_defaults`. Nothing regressed — pins were inert before this
+> slice too — but the pin stage was never written, so the rest of this section describes a rule
+> that has no code behind it yet. Slice 4 must implement it (see the corrected §8 row).
 
 Stated explicitly because the earlier wording ("then filtered by…") could be read as filtering only
 the fallback chain: if `[llm.tasks] reasoning = "gemini/gemini-2.5-pro"` is pinned and
-`enforce_air_gap = true`, the pin is **skipped**, not honoured. A pin that could defeat air-gap
+`enforce_air_gap = true`, the pin must be **skipped**, not honoured. This is a requirement ON
+slice 4, not a property of slice 1 — with no pin stage there is nothing yet to gate. A pin that could defeat air-gap
 would make a preference setting override a refusal setting, which inverts the whole point of
 keeping those two knobs distinct (`router.ts` `enforcesAirGap` documents that distinction at
 length).
@@ -196,9 +209,12 @@ inside the loop via `continue`, rather than pre-filtering a pool. The routes ver
 shape.
 
 Absent `route_priority`, the default ordering reproduces today's semantics exactly: local routes
-first when `prefer_local = true`, remote first otherwise. Task pins are read from
-`llm_task_defaults` and are inert until slice 4 gives them a surface; the resolution step exists in
-slice 1 so slice 4 is a surface change rather than a router change.
+first when `prefer_local = true`, remote first otherwise — and that is the whole of what slice 1
+resolves. Task pins remain inert: `llm_task_defaults` is still written and read by
+`LlmRegistry.getDefault`, but no router path calls it. The original claim here — "the resolution
+step exists in slice 1 so slice 4 is a surface change rather than a router change" — is
+**withdrawn**: the resolution step was not built, so slice 4 changes the router as well as the
+surface.
 
 ### 3.4 Route availability must mean "this model answers", not "the daemon is up"
 
@@ -271,7 +287,8 @@ working and synthesise a single route each. No user config breaks.
 `registry.setDefault` and `registry.getDefault` already read and write both columns. What is
 missing is that `LlmRouter.modelNameFor()` never consults them — it returns the single global
 `config.localModel` / `config.remoteModel`, and its own inline comment says so. Slice 1 makes the
-router route-aware; slice 4 wires the per-task pins to a CLI.
+router route-aware; slice 4 wires the per-task pins into BOTH the router (the resolution stage
+§3.3 said slice 1 would build, and did not) and a CLI.
 
 ---
 
@@ -413,14 +430,20 @@ All paths above are relative to `packages/gateway/src/`. Test files are not list
   `listModels()`, the route reports unavailable and the walk **continues to the next route**. Prove
   this red first — on a model-blind `isAvailable()` the walk stops at the absent model, which is
   the whole defect.
-- **A pinned route is still gated (§3.3):** a task pin naming a non-local route under
-  `enforce_air_gap = true` is skipped, not honoured.
+- ~~**A pinned route is still gated (§3.3):** a task pin naming a non-local route under
+  `enforce_air_gap = true` is skipped, not honoured.~~ **Not written, because the pin stage it
+  would cover does not exist in slice 1** (see the §3.3 correction). This test moves to slice 4 and
+  must land in the same change as the pin stage itself — a gate and the path it guards are not
+  separable work.
 - **`routeId` slash handling (§3.1):** a model name containing slashes (`hf.co/user/model`, a
-  `.gguf` path) round-trips through `route_priority` parsing; an unresolvable entry raises at
-  config load rather than being dropped.
+  `.gguf` path) round-trips through `route_priority` parsing; an unresolvable entry is warn-logged
+  **by name** and dropped (it does not raise — see the §3.1 correction), and the rest of `[llm]`,
+  `enforce_air_gap` included, survives it.
 - **Lifecycle by `providerId` (§3.5):** `pullModel("ollama", "a-model-with-no-route")` succeeds.
   This is the case that keying on `routeId` would break.
-- **Two llama.cpp routes on one `base_url`** are rejected at config load.
+- **Two llama.cpp routes on one `base_url`** are dropped (first wins) and named in the warn log,
+  at assembly rather than at parse — same correction as above. Likewise two entries deriving the
+  same `<runtime>/<model>` route id.
 - Config: `[llm.local.<name>]` round-trip; legacy `local_model` still yields one working route;
   malformed sub-table does not discard the whole `[llm]` section (matching the `[ownership]`
   precedent at `nimbus-toml.ts` ≈1907).
@@ -488,7 +511,7 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
 | **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, and a route-walked (still **un-ledgered** — see §4.1) overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
 | **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. **Blocked on resolving `LlmRouter.generate()`'s I29 coverage (§4.1) before the first remote route registers.** | not started |
 | **3. Bedrock** | SigV4 signing, region, static creds *or* profile/role chain. Kept separate because it shares no auth shape with slice 2; reuses the `aws.*` credential fields connectors already have. | not started |
-| **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. | not started |
+| **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. **A ROUTER change, not the surface-only change originally promised:** slice 1 did not build the task-pin resolution stage (§3.3 correction), so slice 4 adds it to `orderedRoutes` — together with the §6 test that a pin is still gated by air-gap. | not started |
 
 ---
 

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -1,0 +1,334 @@
+# LLM Model Routes — Design
+
+**Date:** 2026-08-27
+**Status:** approved design, not yet planned
+**Slot:** Spine S2 — Local Compute Fleet, row *"bring-your-own-frontier-model routing with local fallback"*
+**Slice:** 1 of 4 (see [Decomposition](#decomposition))
+
+---
+
+## 1. Problem
+
+The gateway can register exactly **one** remote LLM provider, and that seat has never been
+filled.
+
+`LlmProviderKind` is a closed union — `"ollama" | "llamacpp" | "remote"` (`llm/types.ts`) — and
+`LlmRouter.providers` is a `Map<LlmProviderKind, LlmProvider>` (`llm/router.ts`). One provider per
+kind. Registering Gemini and then Bedrock does not give two providers; the second call to
+`registerProvider` **evicts the first**, silently, because `Map.set` on the same key overwrites.
+
+`platform/assemble.ts` (`buildLlmRegistryFromToml`) registers `OllamaProvider` and
+`LlamaCppProvider` and nothing else, so `"remote"` is a reserved slot that no production code path
+has ever occupied. `[llm] remote_model` even defaults to `"claude-sonnet-4-6"` — a model name for a
+provider that does not exist.
+
+The same single-seat constraint applies one level down, to local models. `OllamaProvider` takes a
+model name in its constructor (default `"llama3.2"`, `llm/ollama-provider.ts:106`) and there is no
+model allowlist anywhere, so `[llm] local_model = "qwen3"` already works. What does not work is
+running **two local models at once** — "qwen3 for reasoning, gemma for classification" is
+unrepresentable, because the seat is per *runtime* and the model is a single global config string.
+
+So the user-facing asks — *configure Claude / ChatGPT / Gemini / Grok / Bedrock, pick which model,
+pick which local model, route tasks to different ones* — all reduce to one change:
+
+> **The router's unit must be a `(provider, model)` route, not a provider kind.**
+
+### Why this slice ships no cloud vendor
+
+Doing the refactor first means every vendor after it is a thin adapter against a proven interface,
+and — more importantly — it means two known correctness gaps are closed **while zero bytes leave the
+machine**. Both are described in §4. Landing vendors first would mean patching a live egress path
+instead of a dormant one.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Register N `(provider, model)` routes simultaneously, including several routes on the same
+  runtime.
+- Resolve a route per task by an explicit order, preserving today's `prefer_local` semantics when
+  no order is configured.
+- Collapse the three independent definitions of "is this provider local" into one.
+- Make the egress destination name the vendor, not the word `model`.
+- Close the un-ledgered context-overflow fallback path.
+
+**Non-goals (deferred, and to which slice)**
+
+- Any cloud provider adapter — slice 2 (bearer-key: Anthropic, OpenAI, Gemini, xAI) and slice 3
+  (Bedrock, SigV4).
+- `nimbus llm use <vendor>/<model>` and per-task pinning **as a CLI/config surface** — slice 4.
+  (Slice 1 does change `nimbus llm status`; see §7.)
+- Any change to how `[agents] synthesis` decides `off` / `local` / `allow-remote`.
+- Any new HITL gate on inference. See [Open decision 3](#open-decisions).
+
+---
+
+## 3. Design
+
+### 3.1 The routing unit
+
+```ts
+type ProviderId = string;              // open — no closed union
+
+type ModelRoute = {
+  readonly routeId: string;            // `${providerId}/${modelName}`
+  readonly provider: LlmProvider;
+  readonly modelName: string;
+  readonly meta: ProviderMeta;         // parameterCount, contextWindow
+};
+```
+
+`LlmRouter` keys its map on `routeId` rather than `providerId`.
+
+**`LlmProvider.generate()` keeps its signature.** `OllamaProvider` is already constructed with a
+fixed model name, so two models means **two instances** — same `providerId: "ollama"`, distinct
+`routeId`s (`ollama/qwen3`, `ollama/gemma3`). No provider implementation changes; only the map key
+does. This is deliberately the smallest change that removes the seat limit: threading a model name
+through `generate()` would touch every provider and every call site for no additional capability.
+
+`providerId` survives as the **vendor label** — it is what egress `destination` and local/remote
+classification key on, and it is intentionally not unique across routes.
+
+### 3.2 `isLocal` is declared by the provider, and defined once
+
+Local-ness is currently encoded in three places that must agree:
+
+| Site | Form |
+| --- | --- |
+| `llm/router.ts` | `LOCAL_PROVIDER_IDS: ReadonlySet<LlmProviderKind>` |
+| `ipc/llm-rpc.ts` | `LOCAL_PROVIDERS = ["ollama", "llamacpp"] as const` |
+| `llm/registry.ts` | a bare `["ollama", "llamacpp"] as const` inside `refreshProviderMeta` |
+
+Three copies of a security-relevant fact is the shape that produced the hardcoded-environment bug
+in the Windows sandbox work (three copies of one env wire). It becomes a **required** field on the
+`LlmProvider` interface:
+
+```ts
+interface LlmProvider {
+  readonly providerId: ProviderId;
+  readonly isLocal: boolean;     // required — omitting it is a compile error
+  // ...unchanged
+}
+```
+
+Required rather than optional so omission fails at compile time. Note that even if it were
+optional, an unset value would be falsy and therefore classified **remote** — the mistake falls in
+the safe direction either way, and that ordering is intentional.
+
+This preserves the single best property of the current design: **anything not explicitly local is
+treated as remote**, automatically, by air-gap enforcement, by `[agents] synthesis = "local"`, and
+by the I29 appender — for vendors that do not exist yet. `isLocalProviderKind()` is replaced by
+reading `route.provider.isLocal`; the exported predicate is kept as a thin wrapper only if an
+external caller still needs it (verify at implementation time — the doc comment claims
+`engine/router.ts` `classifyIntent` is the caller that mattered).
+
+### 3.3 Resolution order
+
+```toml
+[llm]
+prefer_local  = true
+route_priority = ["ollama/qwen3", "ollama/gemma3"]   # optional; when set, it IS the order
+```
+
+Resolution for a task: **explicit task pin → `route_priority` → default ordering**, then filtered
+by air-gap, the reasoning capability floor, and availability, in that order — matching what
+`firstAvailable` does today.
+
+Absent `route_priority`, the default ordering reproduces today's semantics exactly: local routes
+first when `prefer_local = true`, remote first otherwise. Task pins are read from
+`llm_task_defaults` and are inert until slice 4 gives them a surface; the resolution step exists in
+slice 1 so slice 4 is a surface change rather than a router change.
+
+### 3.4 Config
+
+`[llm.local.<name>]` sub-tables:
+
+```toml
+[llm.local.qwen3]
+runtime = "ollama"
+model   = "qwen3:8b"
+
+[llm.local.gemma]
+runtime = "ollama"
+model   = "gemma3:12b"
+```
+
+The dynamic sub-table pattern already exists in `config/service-config-toml.ts`
+(`CI_SERVICE_TABLE_PREFIX = "[ci.service."`, consumed by `accumulateServiceTables` /
+`resolveServiceTableId`). **Those helpers are module-private**, so slice 1 either extracts them to
+a shared module or writes the `[llm.local.` equivalent alongside them — an implementation choice,
+but the parser machinery is not new work either way.
+
+**Back-compat is total.** Existing `local_model` / `remote_model` / `prefer_local` keys keep
+working and synthesise a single route each. No user config breaks.
+
+### 3.5 Database
+
+**No migration.** Both tables were already built for pairs; only the router forgot:
+
+- `llm_models` — `ON CONFLICT(provider, model_name)`, a composite key.
+- `llm_task_defaults` — stores `(task_type, provider, model_name, updated_at)`.
+
+`registry.setDefault` and `registry.getDefault` already read and write both columns. What is
+missing is that `LlmRouter.modelNameFor()` never consults them — it returns the single global
+`config.localModel` / `config.remoteModel`, and its own inline comment says so. Slice 1 makes the
+router route-aware; slice 4 wires the per-task pins to a CLI.
+
+---
+
+## 4. Two correctness fixes that belong in this slice
+
+Both are latent today and become load-bearing the moment slice 2 lands. Fixing them here means
+fixing them against a dormant path.
+
+### 4.1 The context-overflow fallback is un-ledgered
+
+`LlmRouter.fitPromptOrFallback` → `tryRemoteFallback` does `this.providers.get("remote")` and
+generates directly. This is already flagged in the tree: a comment in
+`agents/_lib/synthesis-llm.ts` (≈line 216) notes that this path "can reach a REMOTE provider on
+context overflow with NO egress row."
+
+With routes there is no `"remote"` key at all, so the path must be rewritten as *"the next
+available route whose context window fits, in priority order"* and made to go through the same
+append path as any other resolution.
+
+**In slice 1 this is a pure refactor with zero behavioural change**, because no remote route
+exists to fall back to. That is precisely the argument for doing it now.
+
+### 4.2 The egress destination does not name the vendor
+
+`egress/synthesis-egress.ts` hardcodes `destination: "model"`, and its parameter type is
+`{ readonly modelName: string; readonly isLocal: boolean }` — it structurally **drops**
+`providerId`, even though the call site in `synthesis-llm.ts` passes a full
+`ResolvedSynthesisProvider` that has it.
+
+With five vendors, `nimbus prove` would report that "a prompt went to a model", which is #1321's
+lesson restated: *"email" is not a place data can go, "gmail" is.* `serviceOf()`-style prefix
+identity is what makes an egress destination meaningful.
+
+The fix is small — widen the parameter to carry `providerId` and use it as `destination`. What must
+**not** change is the appender deriving `isLocal` itself rather than accepting a caller boolean;
+that property is documented at length in the appender and is the reason a false zero cannot be
+written into the ledger.
+
+**Honest bound:** in slice 1 both fixes are provable only by unit test, because zero rows are
+appended either way with no remote route registered. Neither can be demonstrated end-to-end until
+slice 2. The spec states this rather than letting a green test suite imply more than it proves.
+
+---
+
+## 5. Blast radius
+
+Non-test files that reference the symbols being changed (`LlmProviderKind`, `registerProvider`,
+`providerFor`, `resolveForSynthesis`, `generateMarkdown`, `isLocalProviderKind`, `LlmRegistry`):
+
+**Directly rewritten**
+
+- `llm/types.ts` — open provider id, `ModelRoute`, required `isLocal`
+- `llm/router.ts` — route map, priority walk, `tryRemoteFallback`, `modelNameFor`, `getStatus`
+- `llm/registry.ts` — three hardcoded id arrays, plus `"ollama" | "llamacpp"` literal types on
+  `loadModel` / `unloadModel` / `pullModel` / `setDefault`
+- `ipc/llm-rpc.ts` — `VALID_LLM_PROVIDERS`, `LOCAL_PROVIDERS`, `requireLocalProvider`
+- `egress/synthesis-egress.ts` — destination
+- `agents/_lib/synthesis-llm.ts` — `RecordSynthesisEgressFn` param type widening
+- `platform/assemble.ts` — `buildLlmRegistryFromToml` registers N routes
+- `config/nimbus-toml.ts` — `[llm.local.<name>]`, `route_priority`
+
+**Consumers to check, not necessarily change** — `engine/run-ask.ts`,
+`engine/run-conversational-agent.ts`, `ipc/server/dispatchers.ts`, `ipc/server/options.ts`,
+`agents/_lib/{synthesize,agent-synthesis-runner}.ts`, `agent-runs/agent-http-invoke.ts`,
+`briefs/brief-llm-adapter.ts`, `glossary/glossary-llm-adapter.ts`,
+`decisions/decision-llm-adapter.ts`, `platform/types.ts`, `gateway-main.ts`.
+
+All paths above are relative to `packages/gateway/src/`. Test files are not listed individually;
+32 files in total reference the changed symbols, of which roughly half are tests — see §6.
+
+**Surface**
+
+- **No `ALLOWED_METHODS` change.** Eight `llm.*` methods are renderer-exposed
+  (`packages/ui/src-tauri/src/gateway_bridge.rs`); slice 1 adds none, so the I7 count assertion is
+  untouched. Response *shapes* change for `llm.listModels` and `llm.getRouterStatus`, so the
+  desktop UI consumers need checking.
+- **No new invariant.** See [Open decision 1](#open-decisions).
+
+---
+
+## 6. Testing
+
+- **Red-prove the seat bug first.** Register two Ollama routes with different models and assert
+  both resolve. On today's code the second evicts the first, so this test must fail before the
+  refactor and pass after. Per repo convention, prove it red by reverting, not by observing green.
+- Router: priority walk across N routes; air-gap skips every non-local route; the reasoning
+  capability floor still fires per route; `getStatus` reports the route that `generate()` would
+  actually use.
+- Context overflow picks the next fitting route in priority order and appends through the normal
+  path — asserted with a local-only route set, where the correct row count is zero.
+- Egress: `destination` equals the `providerId`, asserted against a fake remote provider
+  (`isLocal: false`) registered in-test. This is the only way to exercise §4.2 in slice 1.
+- **One definition of local-ness:** a structural test asserting `isLocal` has exactly one
+  definition site and that `ipc/llm-rpc.ts` / `llm/registry.ts` no longer carry their own copies.
+- Config: `[llm.local.<name>]` round-trip; legacy `local_model` still yields one working route;
+  malformed sub-table does not discard the whole `[llm]` section (matching the `[ownership]`
+  precedent at `nimbus-toml.ts` ≈1907).
+
+Coverage: `llm/` sits under the Engine ≥85% gate. `audit:coverage-floor` is CI-Linux-authoritative
+— verify with `verify:docker --changed`, not a local run.
+
+---
+
+## 7. Open decisions
+
+Decided rather than left blank, so the plan is actionable. Each is cheap to reverse.
+
+1. **No new static `D`-rule in slice 1.** The one-definition-of-local-ness rule ships as a
+   structural **test**, not as an entry in `scripts/structure-audit/check-nimbus-invariants.ts`.
+   Rationale: this strengthens I29's derivation rather than adding an invariant, and the repo's
+   rule is that a `D` number arrives with the full triple (wiring + docs + test in one commit). It
+   is worth **promoting to a `D`-rule in slice 2**, when it confines five vendor adapters instead
+   of two local ones — at two members a static rule has almost no teeth.
+
+2. **Slice 1 does change `nimbus llm status`, minimally.** It lists all routes rather than one
+   entry per kind. No new subcommands (`nimbus llm use` stays in slice 4). Rationale: once several
+   routes exist, a status command that reports one per kind is not merely incomplete, it is
+   **wrong** — and shipping a surface that under-reports its own state is the failure mode this
+   project treats most seriously.
+
+3. **Consent posture — carried to slice 2, unresolved here, and it does not block slice 1**
+   (slice 1 opens no new egress path). The working assumption to confirm before any vendor lands:
+   *configuration is consent; there is no per-call HITL on inference*, on the precedent that
+   `openai.api_key` already sends indexed prose to OpenAI for embeddings with no prompt, and
+   because per-call approval would make agent briefs unusable. **One thing should change about
+   that precedent:** today embeddings route remote the moment a key exists. A capability that turns
+   itself on as a side effect of a credential being present is the same shape as the air-gap defect
+   (#1334) — so enabling a remote vendor must require an explicit opt-in flag, never be inferred
+   from key presence.
+
+---
+
+## 8. Decomposition
+
+| Slice | Content | Status |
+| --- | --- | --- |
+| **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, ledgered overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
+| **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. | not started |
+| **3. Bedrock** | SigV4 signing, region, static creds *or* profile/role chain. Kept separate because it shares no auth shape with slice 2; reuses the `aws.*` credential fields connectors already have. | not started |
+| **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. | not started |
+
+---
+
+## 9. Risks
+
+- **A wide type change across ~20 non-test files.** `bun` does not typecheck at runtime, so a green
+  test run says nothing about type correctness — `typecheck` and `typecheck:tests` are both
+  required, and the latter is **advisory on win32** (prints violations, exits 0) and
+  Linux-authoritative. Verify in Docker before calling it green.
+- **`mock.module` contamination.** Several consumers are dispatcher-driven; prefer dependency
+  injection over `mock.module`, per the repo's standing preference and the CI-Linux-only failure
+  class it causes.
+- **The gateway `test/**` tree is not loaded by a `packages/gateway/src` run.** Verify with the CI
+  command verbatim: `bun test packages/gateway packages/cli scripts`.
+- **Desktop UI consumers of the changed response shapes** may break without any TypeScript error
+  crossing the IPC boundary, since the renderer talks JSON-RPC. Check `llm.listModels` and
+  `llm.getRouterStatus` consumers in `packages/ui` explicitly.

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -53,6 +53,8 @@ instead of a dormant one.
 - Collapse the three independent definitions of "is this provider local" into one.
 - Make the egress destination name the vendor, not the word `model`.
 - Close the un-ledgered context-overflow fallback path.
+- Make route availability mean "this model answers", not "the daemon is up" (§3.4) — a fail-open
+  that only becomes harmful once a priority walk exists, i.e. one this slice creates.
 
 **Non-goals (deferred, and to which slice)**
 
@@ -90,6 +92,44 @@ through `generate()` would touch every provider and every call site for no addit
 
 `providerId` survives as the **vendor label** — it is what egress `destination` and local/remote
 classification key on, and it is intentionally not unique across routes.
+
+#### `routeId` is opaque internally and parsed only at the boundary
+
+Model names contain slashes. This is not hypothetical: `LlamaCppProvider`'s model name defaults to
+`"model.gguf"` and is realistically a **file path** (`/models/meta-llama/Llama-3-8B.gguf`, or a
+Windows path with backslashes and a drive colon), and Ollama accepts namespaced tags such as
+`hf.co/user/model`. A naive `routeId.split("/")` breaks on all of these.
+
+Two rules, and the first is what actually makes it safe:
+
+1. **`routeId` is never parsed inside the router.** `ModelRoute` already carries `providerId` and
+   `modelName` as separate fields; `routeId` is an opaque map key, only ever compared for equality.
+   Parsing it internally would be re-deriving data the struct already holds.
+2. **Parsing happens only where a human typed a string** — `route_priority` entries and (slice 4)
+   `nimbus llm use <vendor>/<model>`. There it splits on the **first** slash, which is unambiguous
+   because `providerId` is drawn from a known set and is validated to contain no slash:
+
+   ```ts
+   const i = raw.indexOf("/");
+   const providerId = raw.slice(0, i);
+   const modelName  = raw.slice(i + 1);   // may itself contain slashes
+   ```
+
+A route reference that matches no registered route is a **config error reported at load**, not a
+silently dropped entry — a `route_priority` entry that quietly vanishes would degrade to the
+default ordering with no signal, which is the "supplied flag degrading into an omitted filter"
+shape.
+
+#### llama.cpp cannot host two models at one base URL
+
+`LlamaCppProvider.generate()` sends no model field — the server answers with whatever it was
+launched with (`llamacpp-provider.ts`, the `/completion` body has `prompt`/`n_predict`/
+`temperature`/`stream` only). So two llama.cpp routes at the same `baseUrl` would both hit the same
+loaded weights while reporting different model names: a route table that lies.
+
+Multi-model on llama.cpp therefore requires **one server per model at distinct base URLs**, and
+config must express that. Ollama has no such limit — `generate()` sends `this.modelName` to a shared
+daemon. Slice 1 must reject, at config load, two llama.cpp routes sharing a `base_url`.
 
 ### 3.2 `isLocal` is declared by the provider, and defined once
 
@@ -132,16 +172,66 @@ prefer_local  = true
 route_priority = ["ollama/qwen3", "ollama/gemma3"]   # optional; when set, it IS the order
 ```
 
-Resolution for a task: **explicit task pin → `route_priority` → default ordering**, then filtered
-by air-gap, the reasoning capability floor, and availability, in that order — matching what
-`firstAvailable` does today.
+Resolution for a task: **explicit task pin → `route_priority` → default ordering**. That sequence
+chooses the candidate **order** only. Air-gap, the reasoning capability floor, and availability are
+**gates applied to every candidate**, including an explicit pin — a pin selects which route is tried
+first, never that it is tried unconditionally.
+
+Stated explicitly because the earlier wording ("then filtered by…") could be read as filtering only
+the fallback chain: if `[llm.tasks] reasoning = "gemini/gemini-2.5-pro"` is pinned and
+`enforce_air_gap = true`, the pin is **skipped**, not honoured. A pin that could defeat air-gap
+would make a preference setting override a refusal setting, which inverts the whole point of
+keeping those two knobs distinct (`router.ts` `enforcesAirGap` documents that distinction at
+length).
+
+No behaviour change is implied for the existing walk: `firstAvailable` already applies both gates
+inside the loop via `continue`, rather than pre-filtering a pool. The routes version keeps that
+shape.
 
 Absent `route_priority`, the default ordering reproduces today's semantics exactly: local routes
 first when `prefer_local = true`, remote first otherwise. Task pins are read from
 `llm_task_defaults` and are inert until slice 4 gives them a surface; the resolution step exists in
 slice 1 so slice 4 is a surface change rather than a router change.
 
-### 3.4 Config
+### 3.4 Route availability must mean "this model answers", not "the daemon is up"
+
+**This is a fail-open that slice 1 creates, so slice 1 must close it.**
+
+`OllamaProvider.isAvailable()` issues `GET /api/tags` and returns `resp.ok`. It never checks that
+`this.modelName` is among the tags. `LlamaCppProvider.isAvailable()` pings `/health`, likewise
+model-blind. So a route configured for a model that was never pulled reports **available**, the
+priority walk stops there, and the call fails at `generate()`.
+
+With one route that is merely a confusing error — the only configured model is wrong, and nothing
+else could have run. With N routes it is materially worse: the walk halts at the first route that
+falsely claims availability **instead of falling through to a route that would have worked**. The
+degradation is invisible, and it exists only because this slice introduced the walk.
+
+Fix: availability is per **route**, not per provider — `daemon reachable AND modelName present in
+listModels()`. `OllamaProvider.listModels()` already parses the daemon's tag list, so the data is
+free; what it needs is a short-TTL cache so resolving four routes does not issue four `/api/tags`
+round trips. `LlamaCppProvider.listModels()` returns its own configured name unconditionally, which
+is honest only under the one-server-per-model rule above.
+
+**No auto-pull on a miss.** Falling through to the next route is correct; silently initiating a
+multi-gigabyte download because a config entry named a model is not. Pulling stays explicit
+(`llm.pullModel`, already wired). A route unavailable *because its model is absent* must be
+distinguishable in `nimbus llm status` from one unavailable because the daemon is down — those have
+different fixes, and reporting both as "unavailable" sends the user to the wrong one.
+
+### 3.5 Lifecycle operations key on `providerId`, not `routeId`
+
+`registry.pullModel` / `loadModel` / `unloadModel` currently resolve `providers.get(provider)` by
+kind, which no longer exists after the refactor. They key on **`providerId`** — any registered
+instance of that runtime — and the model name stays an explicit argument.
+
+Keying them on `routeId` would be wrong, not merely redundant: `OllamaProvider.pullModel(modelName)`
+posts that **argument** to the shared daemon's `/api/pull` and ignores `this.modelName`, so any
+instance can pull any model. Requiring a matching route would make it impossible to pull a model
+that has no route yet — which is the primary use of pull, and the exact thing a user does before
+adding a route for it.
+
+### 3.6 Config
 
 `[llm.local.<name>]` sub-tables:
 
@@ -164,7 +254,7 @@ but the parser machinery is not new work either way.
 **Back-compat is total.** Existing `local_model` / `remote_model` / `prefer_local` keys keep
 working and synthesise a single route each. No user config breaks.
 
-### 3.5 Database
+### 3.7 Database
 
 **No migration.** Both tables were already built for pairs; only the router forgot:
 
@@ -196,6 +286,29 @@ append path as any other resolution.
 
 **In slice 1 this is a pure refactor with zero behavioural change**, because no remote route
 exists to fall back to. That is precisely the argument for doing it now.
+
+**Which path this is, precisely — because it is easy to get backwards.** Brief synthesis does *not*
+reach this hazard. `synthesis-llm.ts` deliberately calls `router.generateMarkdown(prompt, resolved)`
+and never `router.generate()`, with an inline instruction not to unify the two, exactly so the
+overflow fallback cannot bypass the ledger append and the `[agents] synthesis` mode check. So on the
+synthesis path there is no fallback to ledger, by construction.
+
+The hazard is in **`LlmRouter.generate()`**, whose callers are `engine/run-ask.ts`,
+`briefs/brief-llm-adapter.ts`, `glossary/glossary-llm-adapter.ts` and
+`decisions/decision-llm-adapter.ts` — none of which append an egress row today, because I29's
+`model` coverage class is scoped to built-in agent brief synthesis and has never claimed more.
+
+**That scoping is sound today and becomes a hole the moment slice 2 lands.** With a remote route
+registered, `nimbus ask` and the glossary/decisions passes can send indexed private content to a
+vendor through `generate()` with **no `egress_ledger` row**, while `nimbus prove` reports only the
+synthesis calls. A ledger that is silent about real outbound traffic is the precise failure this
+subsystem exists to prevent.
+
+**Therefore: a named blocker on slice 2, not a slice 1 deliverable.** Before the first remote route
+is registered, slice 2 must either extend the `model` coverage class to `LlmRouter.generate()` or
+state in `docs/SECURITY-INVARIANTS.md` exactly which LLM calls the class does not cover. Widening
+I29's coverage is a deliberate invariant change requiring the wiring + docs + test triple; it is
+recorded here so slice 2 cannot land without confronting it.
 
 ### 4.2 The egress destination does not name the vendor
 
@@ -269,6 +382,18 @@ All paths above are relative to `packages/gateway/src/`. Test files are not list
   (`isLocal: false`) registered in-test. This is the only way to exercise §4.2 in slice 1.
 - **One definition of local-ness:** a structural test asserting `isLocal` has exactly one
   definition site and that `ipc/llm-rpc.ts` / `llm/registry.ts` no longer carry their own copies.
+- **Availability is per route (§3.4):** with a daemon reachable but a model absent from
+  `listModels()`, the route reports unavailable and the walk **continues to the next route**. Prove
+  this red first — on a model-blind `isAvailable()` the walk stops at the absent model, which is
+  the whole defect.
+- **A pinned route is still gated (§3.3):** a task pin naming a non-local route under
+  `enforce_air_gap = true` is skipped, not honoured.
+- **`routeId` slash handling (§3.1):** a model name containing slashes (`hf.co/user/model`, a
+  `.gguf` path) round-trips through `route_priority` parsing; an unresolvable entry raises at
+  config load rather than being dropped.
+- **Lifecycle by `providerId` (§3.5):** `pullModel("ollama", "a-model-with-no-route")` succeeds.
+  This is the case that keying on `routeId` would break.
+- **Two llama.cpp routes on one `base_url`** are rejected at config load.
 - Config: `[llm.local.<name>]` round-trip; legacy `local_model` still yields one working route;
   malformed sub-table does not discard the whole `[llm]` section (matching the `[ownership]`
   precedent at `nimbus-toml.ts` ≈1907).
@@ -295,6 +420,18 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
    **wrong** — and shipping a surface that under-reports its own state is the failure mode this
    project treats most seriously.
 
+   **Tabular, with the exact columns deferred to implementation**, but two constraints on them:
+   `contextWindow` is frequently `undefined` (it is why `meetsCapabilityFloor` fail-opens), so that
+   column renders `—` and never a fabricated default; and a single availability column collapses
+   two states with different fixes, so "daemon unreachable" and "model not pulled" (§3.4) must be
+   distinguishable. A sketch, not a contract:
+
+   ```
+   ROUTE ID       PROVIDER  MODEL       LOCAL  AVAILABLE            CONTEXT
+   ollama/qwen3   ollama    qwen3:8b    yes    yes                  8192
+   ollama/gemma   ollama    gemma3:12b  yes    no (model not pulled) —
+   ```
+
 3. **Consent posture — carried to slice 2, unresolved here, and it does not block slice 1**
    (slice 1 opens no new egress path). The working assumption to confirm before any vendor lands:
    *configuration is consent; there is no per-call HITL on inference*, on the precedent that
@@ -305,6 +442,16 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
    (#1334) — so enabling a remote vendor must require an explicit opt-in flag, never be inferred
    from key presence.
 
+   **Shape of that flag, answering the review's question:** `enabled = false` by default inside
+   each `[llm.remote.<vendor>]` table, matching the `[briefs]` and `[code_execution]` default-off
+   precedent — a per-vendor switch rather than one global remote toggle, so enabling Gemini does
+   not silently enable Bedrock because an `aws.*` credential happened to be present for a
+   connector. Confirm when slice 2 is specced; recorded here so it is not re-litigated.
+
+4. **Slice 2 is blocked on the `LlmRouter.generate()` coverage question** in §4.1 — extend I29's
+   `model` class to cover it, or document precisely what it excludes. Not optional, and not
+   deferrable past the first remote route.
+
 ---
 
 ## 8. Decomposition
@@ -312,7 +459,7 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
 | Slice | Content | Status |
 | --- | --- | --- |
 | **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, ledgered overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
-| **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. | not started |
+| **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. **Blocked on resolving `LlmRouter.generate()`'s I29 coverage (§4.1) before the first remote route registers.** | not started |
 | **3. Bedrock** | SigV4 signing, region, static creds *or* profile/role chain. Kept separate because it shares no auth shape with slice 2; reuses the `aws.*` credential fields connectors already have. | not started |
 | **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. | not started |
 

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -142,7 +142,10 @@ loaded weights while reporting different model names: a route table that lies.
 
 Multi-model on llama.cpp therefore requires **one server per model at distinct base URLs**, and
 config must express that. Ollama has no such limit — `generate()` sends `this.modelName` to a shared
-daemon. Slice 1 must reject, at config load, two llama.cpp routes sharing a `base_url`.
+daemon. Slice 1 therefore drops the colliding llama.cpp routes at assembly — keeping the first,
+warn-logging both entry names and the shared URL, and letting boot continue. It does not *reject*
+the config: nothing throws and the gateway starts with a correct-but-reduced route table, for the
+reason given at line 127 above.
 
 ### 3.2 `isLocal` is declared by the provider, and defined once
 

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -36,9 +36,14 @@ pick which local model, route tasks to different ones* — all reduce to one cha
 ### Why this slice ships no cloud vendor
 
 Doing the refactor first means every vendor after it is a thin adapter against a proven interface,
-and — more importantly — it means two known correctness gaps are closed **while zero bytes leave the
-machine**. Both are described in §4. Landing vendors first would mean patching a live egress path
-instead of a dormant one.
+and — more importantly — it means both known correctness gaps get fixed **while zero bytes leave the
+machine**, because no remote route exists yet to exercise either one. Both are described in §4, and
+they land differently: §4.2's destination-naming gap is fixed outright. §4.1's un-ledgered
+context-overflow fallback is only **structurally narrowed, not closed** — the key that reaches it is
+narrower (a route id instead of a literal `"remote"` string that never resolved), but the reachable
+surface is wider (any registered non-local route, not a slot nothing could ever fill), and it remains
+a named blocker on slice 2 rather than a slice 1 deliverable. See §4.1's corrected framing below.
+Landing vendors first would mean patching a live egress path instead of a dormant one.
 
 ---
 
@@ -52,7 +57,9 @@ instead of a dormant one.
   no order is configured.
 - Collapse the three independent definitions of "is this provider local" into one.
 - Make the egress destination name the vendor, not the word `model`.
-- Close the un-ledgered context-overflow fallback path.
+- Rewrite the un-ledgered context-overflow fallback to walk routes instead of a literal `"remote"`
+  key. This narrows what could ever reach it — it does **not** close the un-ledgered gap itself;
+  see §4.1.
 - Make route availability mean "this model answers", not "the daemon is up" (§3.4) — a fail-open
   that only becomes harmful once a priority walk exists, i.e. one this slice creates.
 
@@ -273,19 +280,33 @@ router route-aware; slice 4 wires the per-task pins to a CLI.
 Both are latent today and become load-bearing the moment slice 2 lands. Fixing them here means
 fixing them against a dormant path.
 
-### 4.1 The context-overflow fallback is un-ledgered
+### 4.1 The context-overflow fallback is un-ledgered — narrowed, NOT closed
 
 `LlmRouter.fitPromptOrFallback` → `tryRemoteFallback` does `this.providers.get("remote")` and
 generates directly. This is already flagged in the tree: a comment in
 `agents/_lib/synthesis-llm.ts` (≈line 216) notes that this path "can reach a REMOTE provider on
 context overflow with NO egress row."
 
-With routes there is no `"remote"` key at all, so the path must be rewritten as *"the next
-available route whose context window fits, in priority order"* and made to go through the same
-append path as any other resolution.
+With routes there is no `"remote"` key at all, so the path is rewritten as *"the next available
+route whose context window fits, in priority order"*.
 
-**In slice 1 this is a pure refactor with zero behavioural change**, because no remote route
-exists to fall back to. That is precisely the argument for doing it now.
+**Corrected from an earlier draft of this section, which is why this heading says so explicitly:**
+that rewrite is **all** slice 1 does here. `LlmRouter.generate()` — reached by this fallback and by
+every other caller in this section — still calls the resolved route's provider directly, with
+**no egress append and no `[agents] synthesis` check**. Slice 1 does not make it "go through the
+same append path as any other resolution"; no such path exists on this method yet. The accurate
+framing is: **structurally narrower key, materially wider blast radius.** Before this slice, the
+key was a literal `"remote"` string that `buildLlmRegistryFromToml` never registered anything
+under — the path was *reachable in code* but unreachable in practice, i.e. never, on any
+production config. After this slice, the key is a `routeId`, and **any** registered non-local
+route satisfies it — the day slice 2 registers a first remote route, this path becomes live on
+whatever config already exists, with no further code change required to reach it. Narrowing what
+*kind* of key opens the path while widening *how many* configurations can trigger it is a trade
+that only pays off if the blocker below is honored.
+
+**In slice 1 this remains a pure refactor with zero *observable* behavioural change**, because no
+remote route exists to register yet — but "no behavioural change" describes today's empty
+registry, not a property of the code path itself.
 
 **Which path this is, precisely — because it is easy to get backwards.** Brief synthesis does *not*
 reach this hazard. `synthesis-llm.ts` deliberately calls `router.generateMarkdown(prompt, resolved)`
@@ -304,11 +325,17 @@ vendor through `generate()` with **no `egress_ledger` row**, while `nimbus prove
 synthesis calls. A ledger that is silent about real outbound traffic is the precise failure this
 subsystem exists to prevent.
 
-**Therefore: a named blocker on slice 2, not a slice 1 deliverable.** Before the first remote route
-is registered, slice 2 must either extend the `model` coverage class to `LlmRouter.generate()` or
-state in `docs/SECURITY-INVARIANTS.md` exactly which LLM calls the class does not cover. Widening
-I29's coverage is a deliberate invariant change requiring the wiring + docs + test triple; it is
-recorded here so slice 2 cannot land without confronting it.
+**Therefore: a named, HARD blocker on slice 2, not a slice 1 deliverable, and not weakened by
+anything above.** Before the first remote route is registered — literally, before the commit that
+adds the first non-local `LlmProvider` to `buildLlmRegistryFromToml` merges — slice 2 must either
+extend the `model` coverage class to `LlmRouter.generate()` (all four callers, not just the
+overflow-fallback branch) or state in `docs/SECURITY-INVARIANTS.md` exactly which LLM calls the
+class does not cover, with the same rigor I29's existing exclusions already document. Landing a
+remote provider registration in the same slice or PR as this coverage fix is the wrong order: the
+coverage fix must be provably in place — wiring, docs, and enforcement test, the standard triple —
+*before* a remote route can be registered by any code path, not merely before it is expected to be
+exercised. Widening I29's coverage is a deliberate invariant change requiring the wiring + docs + test
+triple; it is recorded here so slice 2 cannot land without confronting it.
 
 ### 4.2 The egress destination does not name the vendor
 
@@ -458,7 +485,7 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
 
 | Slice | Content | Status |
 | --- | --- | --- |
-| **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, ledgered overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
+| **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, and a route-walked (still **un-ledgered** — see §4.1) overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
 | **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. **Blocked on resolving `LlmRouter.generate()`'s I29 coverage (§4.1) before the first remote route registers.** | not started |
 | **3. Bedrock** | SigV4 signing, region, static creds *or* profile/role chain. Kept separate because it shares no auth shape with slice 2; reuses the `aws.*` credential fields connectors already have. | not started |
 | **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. | not started |

--- a/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
+++ b/docs/superpowers/specs/2026-08-27-llm-model-routes-design.md
@@ -1,7 +1,7 @@
 # LLM Model Routes — Design
 
 **Date:** 2026-08-27
-**Status:** approved design, not yet planned
+**Status:** delivered — slice 1 implemented on `dev/asaf/llm-model-routes` (PR #1352)
 **Slot:** Spine S2 — Local Compute Fleet, row *"bring-your-own-frontier-model routing with local fallback"*
 **Slice:** 1 of 4 (see [Decomposition](#8-decomposition))
 
@@ -423,8 +423,10 @@ All paths above are relative to `packages/gateway/src/`. Test files are not list
 - Router: priority walk across N routes; air-gap skips every non-local route; the reasoning
   capability floor still fires per route; `getStatus` reports the route that `generate()` would
   actually use.
-- Context overflow picks the next fitting route in priority order and appends through the normal
-  path — asserted with a local-only route set, where the correct row count is zero.
+- Context overflow picks the next fitting route in priority order — asserted with a local-only
+  route set, where the correct egress row count is ZERO. Note this verifies route fallback only:
+  per §4.1 `LlmRouter.generate()` appends nothing at all, so there is no append to assert here.
+  Egress coverage for this path is deferred to the remote-route slice.
 - Egress: `destination` equals the `providerId`, asserted against a fake remote provider
   (`isLocal: false`) registered in-test. This is the only way to exercise §4.2 in slice 1.
 - **One definition of local-ness:** a structural test asserting `isLocal` has exactly one
@@ -511,7 +513,7 @@ Decided rather than left blank, so the plan is actionable. Each is cheap to reve
 
 | Slice | Content | Status |
 | --- | --- | --- |
-| **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, and a route-walked (still **un-ledgered** — see §4.1) overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | approved, planning next |
+| **1. Model routes** | This document. `(provider, model)` routes, one definition of `isLocal`, vendor-named egress destination, and a route-walked (still **un-ledgered** — see §4.1) overflow fallback. Ships multi-local-model routing and **zero** cloud vendors. | delivered (PR #1352) |
 | **2. Bearer-key clouds** | Anthropic, OpenAI, Gemini, xAI. One adapter shape, four configs, four Vault keys, the explicit opt-in flag from Open decision 3, and the `D`-rule promotion from Open decision 1. First slice where an `egress_ledger` `model` row is ever written. **Blocked on resolving `LlmRouter.generate()`'s I29 coverage (§4.1) before the first remote route registers.** | not started |
 | **3. Bedrock** | SigV4 signing, region, static creds *or* profile/role chain. Kept separate because it shares no auth shape with slice 2; reuses the `aws.*` credential fields connectors already have. | not started |
 | **4. Selection surface** | `[llm.tasks]` per-task pinning, `nimbus llm use <vendor>/<model>` writing to `llm_task_defaults`, full `nimbus llm status`. **A ROUTER change, not the surface-only change originally promised:** slice 1 did not build the task-pin resolution stage (§3.3 correction), so slice 4 adds it to `orderedRoutes` — together with the §6 test that a pin is still gated by air-gap. | not started |

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -108,7 +108,7 @@ AUTOMATION & EXTENSIONS
 CONFIG & DIAGNOSTICS
   nimbus config validate | list [--json] | edit
   nimbus profile create|list|switch|delete
-  nimbus llm status [--json]   Selected LLM provider/model per task type, and availability
+  nimbus llm status [--json]   Every registered LLM route (provider/model) and its availability
   nimbus serve [--port 7474]   Start gateway with NIMBUS_HTTP_PORT (read-only HTTP sidecar)
   nimbus db verify | repair --yes | snapshot | snapshots list | backups list | restore <snap> --yes
   nimbus diag [--json] | diag slow-queries [--limit N] [--since 7d]

--- a/packages/cli/src/commands/llm.test.ts
+++ b/packages/cli/src/commands/llm.test.ts
@@ -88,6 +88,28 @@ describe("runLlmStatusImpl", () => {
     expect(out.stdout).toContain("no routes registered");
   });
 
+  it("reports a clear message when the payload has no routes array", async () => {
+    // Unguarded this threw a raw TypeError on `.length` inside the table renderer.
+    const ipc = createMockIpcClient([{}]);
+    await expect(runLlmStatusImpl(ipc.client, { json: false })).rejects.toThrow(
+      /no `routes` array/,
+    );
+  });
+
+  it("reports a clear message when a ROW is malformed, rather than crashing in pad()", async () => {
+    const ipc = createMockIpcClient([{ routes: [{ providerId: "ollama" }] }]);
+    await expect(runLlmStatusImpl(ipc.client, { json: false })).rejects.toThrow(
+      /route 0 is missing routeId/,
+    );
+    // Nothing half-rendered before the refusal.
+    expect(out.stdout).not.toContain("ollama");
+  });
+
+  it("guards the envelope on the --json path too", async () => {
+    const ipc = createMockIpcClient([{ routes: "not-an-array" }]);
+    await expect(runLlmStatusImpl(ipc.client, { json: true })).rejects.toThrow(/no `routes` array/);
+  });
+
   it("emits the route list faithfully as JSON, contextWindow omitted when absent", async () => {
     const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
     await runLlmStatusImpl(ipc.client, { json: true });

--- a/packages/cli/src/commands/llm.test.ts
+++ b/packages/cli/src/commands/llm.test.ts
@@ -12,93 +12,98 @@ afterAll(() => {
   out.restore();
 });
 
-const MOCK_DECISIONS = {
-  classification: {
+const MOCK_ROUTES = [
+  {
+    routeId: "ollama/llama3.2",
     providerId: "ollama",
     modelName: "llama3.2",
-    isAvailable: true,
-    reason: "prefer-local",
+    isLocal: true,
+    available: true,
+    reason: "ok",
+    contextWindow: 128000,
   },
-  reasoning: {
+  {
+    routeId: "ollama/gemma3:12b",
     providerId: "ollama",
-    modelName: "llama3.2",
-    isAvailable: true,
-    reason: "prefer-local",
+    modelName: "gemma3:12b",
+    isLocal: true,
+    available: false,
+    reason: "model_absent",
   },
-  summarisation: {
-    providerId: "ollama",
-    modelName: "llama3.2",
-    isAvailable: true,
-    reason: "prefer-local",
-  },
-  agent_step: undefined,
-};
+];
 
 describe("runLlmStatusImpl", () => {
   beforeEach(() => {
     out.reset();
   });
 
-  it("prints table with provider, model, availability, and reason", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
+  it("prints one row per route with provider, model, and availability", async () => {
+    const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
     await runLlmStatusImpl(ipc.client, { json: false });
     expect(ipc.calls[0]).toEqual({ method: "llm.status", params: {} });
-    expect(out.stdout).toContain("classification");
+    expect(out.stdout).toContain("ollama/llama3.2");
     expect(out.stdout).toContain("ollama");
     expect(out.stdout).toContain("llama3.2");
     expect(out.stdout).toContain("yes");
-    expect(out.stdout).toContain("prefer-local");
+    expect(out.stdout).toContain("128000");
   });
 
-  it("shows — and unavailable for undefined task decisions", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
-    await runLlmStatusImpl(ipc.client, { json: false });
-    expect(out.stdout).toContain("agent_step");
-    expect(out.stdout).toContain("unavailable");
-  });
-
-  it("notes the fallback provider when the preferred provider is unavailable", async () => {
+  it("distinguishes model_absent from provider_unreachable, never collapsing to bare 'unavailable'", async () => {
     const ipc = createMockIpcClient([
       {
-        decisions: {
-          ...MOCK_DECISIONS,
-          classification: {
-            providerId: "ollama",
-            modelName: "llama3.2",
-            isAvailable: false,
-            reason: "prefer-local",
-            fallback: { providerId: "remote", modelName: "claude-sonnet-4-6" },
+        routes: [
+          ...MOCK_ROUTES,
+          {
+            routeId: "llamacpp/model.gguf",
+            providerId: "llamacpp",
+            modelName: "model.gguf",
+            isLocal: true,
+            available: false,
+            reason: "provider_unreachable",
           },
-        },
+        ],
       },
     ]);
     await runLlmStatusImpl(ipc.client, { json: false });
-    expect(out.stdout).toContain("falls back to remote/claude-sonnet-4-6");
+    expect(out.stdout).toContain("no (model not pulled)");
+    expect(out.stdout).toContain("no (provider unreachable)");
+    expect(out.stdout).not.toMatch(/\bunavailable\b/);
   });
 
-  it("emits JSON when --json flag is set", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
+  it("renders — for an undefined contextWindow, never a fabricated number", async () => {
+    const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
+    await runLlmStatusImpl(ipc.client, { json: false });
+    const lines = out.stdout.split("\n");
+    const gemmaLine = lines.find((l) => l.includes("ollama/gemma3:12b"));
+    expect(gemmaLine).toBeDefined();
+    // Ends with the context column: "—" for the absent-contextWindow route, never a
+    // fabricated number (e.g. the OTHER route's real 128000 leaking in, or a made-up default).
+    expect(gemmaLine?.trimEnd().endsWith("—")).toBe(true);
+    expect(gemmaLine).not.toContain("128000");
+  });
+
+  it("shows a placeholder row when no routes are registered", async () => {
+    const ipc = createMockIpcClient([{ routes: [] }]);
+    await runLlmStatusImpl(ipc.client, { json: false });
+    expect(out.stdout).toContain("no routes registered");
+  });
+
+  it("emits the route list faithfully as JSON, contextWindow omitted when absent", async () => {
+    const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
     await runLlmStatusImpl(ipc.client, { json: true });
-    const parsed = JSON.parse(out.stdout) as Record<string, unknown>;
-    expect(parsed["classification"]).toMatchObject({
+    const parsed = JSON.parse(out.stdout) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toMatchObject({
+      routeId: "ollama/llama3.2",
       providerId: "ollama",
       modelName: "llama3.2",
-      isAvailable: true,
-      reason: "prefer-local",
+      isLocal: true,
+      available: true,
+      reason: "ok",
+      contextWindow: 128000,
     });
-  });
-
-  it("JSON output always includes all four task types, using null for unavailable", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
-    await runLlmStatusImpl(ipc.client, { json: true });
-    const parsed = JSON.parse(out.stdout) as Record<string, unknown>;
-    expect(Object.keys(parsed).sort((a, b) => a.localeCompare(b))).toEqual([
-      "agent_step",
-      "classification",
-      "reasoning",
-      "summarisation",
-    ]);
-    expect(parsed["agent_step"]).toBeNull();
+    expect(parsed[1]).not.toHaveProperty("contextWindow");
+    expect(parsed[1]).toMatchObject({ available: false, reason: "model_absent" });
   });
 });
 
@@ -128,14 +133,14 @@ describe("runLlm (dispatcher)", () => {
   });
 
   it("runs status when gateway is running", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
+    const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
     setFixture({
       gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 42 },
       ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
     });
     await runLlm(["status"]);
     expect(ipc.calls[0]?.method).toBe("llm.status");
-    expect(out.stdout).toContain("classification");
+    expect(out.stdout).toContain("ollama/llama3.2");
   });
 
   it("throws when gateway is not running", async () => {
@@ -144,13 +149,13 @@ describe("runLlm (dispatcher)", () => {
   });
 
   it("passes --json to status", async () => {
-    const ipc = createMockIpcClient([{ decisions: MOCK_DECISIONS }]);
+    const ipc = createMockIpcClient([{ routes: MOCK_ROUTES }]);
     setFixture({
       gatewayState: { socketPath: FAKE_SOCKET_PATH, pid: 1 },
       ipcClient: { call: ipc.client.call, connect: () => {}, disconnect: () => {} },
     });
     await runLlm(["status", "--json"]);
-    const parsed = JSON.parse(out.stdout) as Record<string, unknown>;
-    expect(parsed["classification"]).toBeDefined();
+    const parsed = JSON.parse(out.stdout) as Array<Record<string, unknown>>;
+    expect(parsed[0]).toBeDefined();
   });
 });

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -17,10 +17,6 @@ type RouteStatus = {
   contextWindow?: number;
 };
 
-type LlmStatusResponse = {
-  routes: RouteStatus[];
-};
-
 const COL_WIDTHS = {
   routeId: 22,
   provider: 10,
@@ -74,15 +70,64 @@ function printRouteTable(routes: RouteStatus[]): void {
   }
 }
 
+/**
+ * Narrows the `llm.status` payload's envelope. Unguarded, a payload without a `routes` array
+ * threw a raw `TypeError` on `.length` deep inside the table renderer — a stack trace where the
+ * actual fact ("the gateway answered with something this build does not understand") is what the
+ * user needs. Returns the rows still UNVALIDATED, so `--json` can emit exactly what the gateway
+ * sent; the table path narrows each row itself, below.
+ */
+function requireRoutesArray(res: unknown): unknown[] {
+  const routes = (res as { routes?: unknown } | null | undefined)?.routes;
+  if (!Array.isArray(routes)) {
+    throw new Error(
+      "llm.status returned an unexpected payload: no `routes` array. " +
+        "The gateway is likely a different version than this CLI.",
+    );
+  }
+  return routes;
+}
+
+/**
+ * Narrows one row for the TABLE renderer, which indexes fields: `pad()` calls `.length` on
+ * `routeId`, so one malformed row is the same crash as a malformed envelope. Deliberately narrow
+ * — the fields this renderer reads and nothing more; an unknown extra field is not an error, and
+ * an absent `contextWindow` is normal (it renders as "—", never as a fabricated number).
+ */
+function toRouteStatus(row: unknown, i: number): RouteStatus {
+  const r = row as Partial<RouteStatus> | null;
+  if (
+    r === null ||
+    typeof r !== "object" ||
+    typeof r.routeId !== "string" ||
+    typeof r.providerId !== "string" ||
+    typeof r.modelName !== "string"
+  ) {
+    throw new Error(
+      `llm.status returned an unexpected payload: route ${i} is missing routeId/providerId/modelName.`,
+    );
+  }
+  return {
+    routeId: r.routeId,
+    providerId: r.providerId,
+    modelName: r.modelName,
+    isLocal: r.isLocal === true,
+    available: r.available === true,
+    reason: typeof r.reason === "string" ? r.reason : "unknown",
+    ...(typeof r.contextWindow === "number" ? { contextWindow: r.contextWindow } : {}),
+  };
+}
+
 export async function runLlmStatusImpl(client: IPCClient, opts: { json: boolean }): Promise<void> {
-  const res = await client.call<LlmStatusResponse>("llm.status", {});
+  const routes = requireRoutesArray(await client.call<unknown>("llm.status", {}));
   if (opts.json) {
     // Emitted faithfully: whatever the gateway reported, verbatim — including a missing
     // contextWindow staying absent from the JSON rather than becoming a fabricated number.
-    console.log(JSON.stringify(res.routes, null, 2));
+    // Hence the raw rows here, never the table renderer's narrowed copies.
+    console.log(JSON.stringify(routes, null, 2));
     return;
   }
-  printRouteTable(res.routes);
+  printRouteTable(routes.map(toRouteStatus));
 }
 
 export async function runLlm(args: string[]): Promise<void> {

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -127,7 +127,11 @@ export async function runLlmStatusImpl(client: IPCClient, opts: { json: boolean 
     console.log(JSON.stringify(routes, null, 2));
     return;
   }
-  printRouteTable(routes.map(toRouteStatus));
+  // Explicit arity rather than `map(toRouteStatus)`: `.map` supplies
+  // (element, index, array), so passing the function bare would hand it a third
+  // argument the day anyone adds a parameter. The index is wanted — it names the
+  // offending row in the validation error — but only the two.
+  printRouteTable(routes.map((row, i) => toRouteStatus(row, i)));
 }
 
 export async function runLlm(args: string[]): Promise<void> {

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -1,82 +1,88 @@
 import type { IPCClient } from "../ipc-client/index.ts";
 import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 
-type LlmTaskType = "classification" | "reasoning" | "summarisation" | "agent_step";
+// Mirrors gateway `llm/route-availability.ts`'s `RouteAvailability["reason"]` — kept as an
+// open string here (not re-imported: cli has no source dependency on gateway, IPC-only) so a
+// future reason value degrades to its raw text rather than a type error.
+type RouteReason = "ok" | "provider_unreachable" | "model_absent" | string;
 
-type TaskDecision = {
+type RouteStatus = {
+  routeId: string;
   providerId: string;
   modelName: string;
-  isAvailable: boolean;
-  reason: string;
-  fallback?: { providerId: string; modelName: string };
+  isLocal: boolean;
+  available: boolean;
+  reason: RouteReason;
+  // Frequently absent — never fabricate a value here, render "—" instead.
+  contextWindow?: number;
 };
 
-type RouterStatusResponse = {
-  decisions: Record<LlmTaskType, TaskDecision | undefined>;
+type LlmStatusResponse = {
+  routes: RouteStatus[];
 };
-
-const TASK_TYPES: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
 
 const COL_WIDTHS = {
-  task: 14,
+  routeId: 22,
   provider: 10,
-  model: 24,
-  available: 9,
-  reason: 14,
+  model: 20,
+  local: 7,
+  available: 26,
+  context: 8,
 };
 
 function pad(s: string, width: number): string {
   return s.length >= width ? s : s + " ".repeat(width - s.length);
 }
 
-function printStatusTable(decisions: Record<LlmTaskType, TaskDecision | undefined>): void {
+// The two failure reasons have different fixes (start the daemon vs. pull the model) and must
+// stay distinguishable in the rendered text — never collapsed to a bare "unavailable".
+function availabilityText(route: RouteStatus): string {
+  if (route.available) return "yes";
+  if (route.reason === "provider_unreachable") return "no (provider unreachable)";
+  if (route.reason === "model_absent") return "no (model not pulled)";
+  return `no (${route.reason})`;
+}
+
+function contextText(route: RouteStatus): string {
+  return route.contextWindow === undefined ? "—" : String(route.contextWindow);
+}
+
+function printRouteTable(routes: RouteStatus[]): void {
   const header =
-    pad("Task type", COL_WIDTHS.task) +
+    pad("Route", COL_WIDTHS.routeId) +
     pad("Provider", COL_WIDTHS.provider) +
     pad("Model", COL_WIDTHS.model) +
+    pad("Local", COL_WIDTHS.local) +
     pad("Available", COL_WIDTHS.available) +
-    "Reason";
+    "Context";
   const divider = "-".repeat(header.length);
   console.log(header);
   console.log(divider);
-  for (const task of TASK_TYPES) {
-    const d = decisions[task];
-    if (d === undefined) {
-      console.log(
-        pad(task, COL_WIDTHS.task) +
-          pad("—", COL_WIDTHS.provider) +
-          pad("—", COL_WIDTHS.model) +
-          pad("no", COL_WIDTHS.available) +
-          "unavailable",
-      );
-    } else {
-      const reason = d.fallback
-        ? `${d.reason} (falls back to ${d.fallback.providerId}/${d.fallback.modelName})`
-        : d.reason;
-      console.log(
-        pad(task, COL_WIDTHS.task) +
-          pad(d.providerId, COL_WIDTHS.provider) +
-          pad(d.modelName || "—", COL_WIDTHS.model) +
-          pad(d.isAvailable ? "yes" : "no", COL_WIDTHS.available) +
-          reason,
-      );
-    }
+  if (routes.length === 0) {
+    console.log("(no routes registered)");
+    return;
+  }
+  for (const route of routes) {
+    console.log(
+      pad(route.routeId, COL_WIDTHS.routeId) +
+        pad(route.providerId, COL_WIDTHS.provider) +
+        pad(route.modelName || "—", COL_WIDTHS.model) +
+        pad(route.isLocal ? "yes" : "no", COL_WIDTHS.local) +
+        pad(availabilityText(route), COL_WIDTHS.available) +
+        contextText(route),
+    );
   }
 }
 
 export async function runLlmStatusImpl(client: IPCClient, opts: { json: boolean }): Promise<void> {
-  const res = await client.call<RouterStatusResponse>("llm.status", {});
+  const res = await client.call<LlmStatusResponse>("llm.status", {});
   if (opts.json) {
-    const normalized: Record<LlmTaskType, TaskDecision | null> = {
-      classification: res.decisions.classification ?? null,
-      reasoning: res.decisions.reasoning ?? null,
-      summarisation: res.decisions.summarisation ?? null,
-      agent_step: res.decisions.agent_step ?? null,
-    };
-    console.log(JSON.stringify(normalized, null, 2));
+    // Emitted faithfully: whatever the gateway reported, verbatim — including a missing
+    // contextWindow staying absent from the JSON rather than becoming a fabricated number.
+    console.log(JSON.stringify(res.routes, null, 2));
     return;
   }
-  printStatusTable(res.decisions);
+  printRouteTable(res.routes);
 }
 
 export async function runLlm(args: string[]): Promise<void> {
@@ -86,7 +92,7 @@ export async function runLlm(args: string[]): Promise<void> {
     console.log("Usage: nimbus llm <subcommand>");
     console.log("");
     console.log("Subcommands:");
-    console.log("  status    Show selected LLM provider/model per task type");
+    console.log("  status    Show every registered LLM route and its availability");
     console.log("");
     console.log("Flags:");
     console.log("  --json    Emit machine-readable JSON");

--- a/packages/gateway/src/agents/_lib/synthesis-llm.ts
+++ b/packages/gateway/src/agents/_lib/synthesis-llm.ts
@@ -211,7 +211,7 @@ export function buildSynthesisRunner(deps: SynthesisLlmDeps): SynthesisRunner | 
 
       // Deliberately `generateMarkdown(prompt, resolved)` — the EXACT provider `resolveForSynthesis`
       // already resolved and classified above — never `LlmRouter.generate()`. `generate()` routes
-      // through `fitPromptOrFallback`, whose private `tryRemoteFallback` method (`llm/router.ts` —
+      // through `fitPromptOrFallback`, whose private `findFallbackRoute` method (`llm/router.ts` —
       // cited by name, not a line number, since this exact comment's own line-number citation
       // already drifted once) can reach a REMOTE provider on context overflow with NO egress row
       // appended and NO `[agents] synthesis` mode check — exactly the two guarantees this function

--- a/packages/gateway/src/agents/_lib/synthesis-llm.ts
+++ b/packages/gateway/src/agents/_lib/synthesis-llm.ts
@@ -6,6 +6,7 @@ import type { NimbusAgentsToml } from "../../config/nimbus-toml.ts";
 import type { NimbusPersonaToml } from "../../config/persona.ts";
 import { recordSynthesisEgress } from "../../egress/synthesis-egress.ts";
 import type { ResolvedSynthesisProvider } from "../../llm/router.ts";
+import type { ProviderId } from "../../llm/types.ts";
 
 export type SynthesisAttempt =
   | { ok: true; markdown: string; model: string; remote: boolean }
@@ -51,7 +52,11 @@ export type SynthesisEgressRecorder = (
   db: Database,
   args: {
     readonly briefKind: string;
-    readonly provider: { readonly modelName: string; readonly isLocal: boolean };
+    readonly provider: {
+      readonly providerId: ProviderId;
+      readonly modelName: string;
+      readonly isLocal: boolean;
+    };
     readonly now: number;
   },
 ) => void;

--- a/packages/gateway/src/briefs/brief-llm-adapter.test.ts
+++ b/packages/gateway/src/briefs/brief-llm-adapter.test.ts
@@ -17,6 +17,7 @@ function router(provider?: LlmProvider): LlmRouter {
 
 const stub: LlmProvider = {
   providerId: "ollama",
+  isLocal: true,
   isAvailable: async () => true,
   listModels: async () => [],
   generate: async () => ({

--- a/packages/gateway/src/briefs/brief-llm-adapter.test.ts
+++ b/packages/gateway/src/briefs/brief-llm-adapter.test.ts
@@ -11,7 +11,8 @@ function router(provider?: LlmProvider): LlmRouter {
     minReasoningParams: 0,
     enforceAirGap: false,
   });
-  if (provider !== undefined) r.registerProvider(provider);
+  if (provider !== undefined)
+    r.registerRoute(provider, provider.isLocal ? "llama3.1:8b" : "gpt-4o");
   return r;
 }
 
@@ -19,11 +20,10 @@ const stub: LlmProvider = {
   providerId: "ollama",
   isLocal: true,
   isAvailable: async () => true,
-  // Must report the model it registers under (`registerProvider` derives it from
-  // `config.localModel`, "llama3.1:8b", for an `isLocal` provider) — route availability
-  // (Task 5) requires the daemon reachable AND the route's own modelName among the models it
-  // reports, so an empty listing here makes every route `model_absent` regardless of
-  // `isAvailable()`.
+  // Must report the model it registers under ("llama3.1:8b", matching the `registerRoute`
+  // call above/below for an `isLocal` provider) — route availability (Task 5) requires the
+  // daemon reachable AND the route's own modelName among the models it reports, so an empty
+  // listing here makes every route `model_absent` regardless of `isAvailable()`.
   listModels: async () => [{ provider: "ollama", modelName: "llama3.1:8b" }],
   generate: async () => ({
     text: "{}",
@@ -82,8 +82,8 @@ describe("createBriefLlm", () => {
       minReasoningParams: 0,
       enforceAirGap: false,
     });
-    r.registerProvider(stub);
-    r.registerProvider(makeRemoteStub());
+    r.registerRoute(stub, "llama3.1:8b");
+    r.registerRoute(makeRemoteStub(), "gpt-4o");
     const out = await createBriefLlm(r, true).generateJson("p");
     expect(out).toEqual({ text: "{}", model: "llama3.1:8b", remote: false });
   });
@@ -96,8 +96,8 @@ describe("createBriefLlm", () => {
       minReasoningParams: 0,
       enforceAirGap: false,
     });
-    r.registerProvider(stub);
-    r.registerProvider(makeRemoteStub());
+    r.registerRoute(stub, "llama3.1:8b");
+    r.registerRoute(makeRemoteStub(), "gpt-4o");
     const out = await createBriefLlm(r, false).generateJson("p");
     expect(out).toEqual({ text: "{}", model: "gpt-4o", remote: true });
   });

--- a/packages/gateway/src/briefs/brief-llm-adapter.test.ts
+++ b/packages/gateway/src/briefs/brief-llm-adapter.test.ts
@@ -19,7 +19,12 @@ const stub: LlmProvider = {
   providerId: "ollama",
   isLocal: true,
   isAvailable: async () => true,
-  listModels: async () => [],
+  // Must report the model it registers under (`registerProvider` derives it from
+  // `config.localModel`, "llama3.1:8b", for an `isLocal` provider) — route availability
+  // (Task 5) requires the daemon reachable AND the route's own modelName among the models it
+  // reports, so an empty listing here makes every route `model_absent` regardless of
+  // `isAvailable()`.
+  listModels: async () => [{ provider: "ollama", modelName: "llama3.1:8b" }],
   generate: async () => ({
     text: "{}",
     tokensIn: 1,
@@ -29,6 +34,28 @@ const stub: LlmProvider = {
     provider: "ollama",
   }),
 };
+
+// A non-local double. `isLocal: false` is set explicitly here (not inherited via a `{ ...stub }`
+// spread, which would silently keep `isLocal: true` from `stub` and make this register as a
+// LOCAL route under `config.localModel` instead of `config.remoteModel` — a second, latent
+// fixture bug this fix also closes) and `listModels` reports `config.remoteModel`
+// ("gpt-4o"), the model this provider actually registers under once `isLocal` is correct.
+function makeRemoteStub(): LlmProvider {
+  return {
+    providerId: "remote",
+    isLocal: false,
+    isAvailable: async () => true,
+    listModels: async () => [{ provider: "remote", modelName: "gpt-4o" }],
+    generate: async () => ({
+      text: "{}",
+      tokensIn: 1,
+      tokensOut: 1,
+      modelUsed: "gpt-4o",
+      isLocal: false,
+      provider: "remote",
+    }),
+  };
+}
 
 describe("createBriefLlm", () => {
   test("returns null when no provider is available", async () => {
@@ -41,18 +68,7 @@ describe("createBriefLlm", () => {
   });
 
   test("marks a non-local provider as remote", async () => {
-    const remote: LlmProvider = {
-      ...stub,
-      providerId: "remote",
-      generate: async () => ({
-        text: "{}",
-        tokensIn: 1,
-        tokensOut: 1,
-        modelUsed: "gpt-4o",
-        isLocal: false,
-        provider: "remote",
-      }),
-    };
+    const remote = makeRemoteStub();
     const out = await createBriefLlm(router(remote), true).generateJson("p");
     expect(out?.remote).toBe(true);
     expect(out?.model).toBe("gpt-4o");
@@ -67,19 +83,7 @@ describe("createBriefLlm", () => {
       enforceAirGap: false,
     });
     r.registerProvider(stub);
-    const remote: LlmProvider = {
-      ...stub,
-      providerId: "remote",
-      generate: async () => ({
-        text: "{}",
-        tokensIn: 1,
-        tokensOut: 1,
-        modelUsed: "gpt-4o",
-        isLocal: false,
-        provider: "remote",
-      }),
-    };
-    r.registerProvider(remote);
+    r.registerProvider(makeRemoteStub());
     const out = await createBriefLlm(r, true).generateJson("p");
     expect(out).toEqual({ text: "{}", model: "llama3.1:8b", remote: false });
   });
@@ -93,19 +97,7 @@ describe("createBriefLlm", () => {
       enforceAirGap: false,
     });
     r.registerProvider(stub);
-    const remote: LlmProvider = {
-      ...stub,
-      providerId: "remote",
-      generate: async () => ({
-        text: "{}",
-        tokensIn: 1,
-        tokensOut: 1,
-        modelUsed: "gpt-4o",
-        isLocal: false,
-        provider: "remote",
-      }),
-    };
-    r.registerProvider(remote);
+    r.registerProvider(makeRemoteStub());
     const out = await createBriefLlm(r, false).generateJson("p");
     expect(out).toEqual({ text: "{}", model: "gpt-4o", remote: true });
   });

--- a/packages/gateway/src/config/nimbus-toml.test.ts
+++ b/packages/gateway/src/config/nimbus-toml.test.ts
@@ -682,6 +682,45 @@ model = "b.gguf"
     // membership, same as the other tests in this block.
     expect((cfg.localRoutes ?? new Map()).has("")).toBe(false);
   });
+
+  test("an unterminated sub-table header ends the previous route, never mutates it", () => {
+    // `isTableHeader` requires BOTH brackets, so `[llm.local.bad` was not recognised as a
+    // header at all and `currentId` stayed on `good` — every key under the malformed header
+    // was written into `good`'s bucket. The result was not a dropped route but a SILENTLY
+    // WRONG one: `good` came back carrying `bad`'s runtime and model, so the user got a
+    // route they never configured under a name they did configure.
+    const cfg = parseNimbusTomlLlmSection(
+      `[llm]
+enforce_air_gap = true
+
+[llm.local.good]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.bad
+runtime = "llamacpp"
+model = "evil.gguf"
+`,
+    );
+    expect(cfg.enforceAirGap).toBe(true);
+    // `good` keeps EXACTLY what its own block declared.
+    expect(cfg.localRoutes?.get("good")).toEqual({ runtime: "ollama", model: "qwen3:8b" });
+    // and the malformed block yields no route of its own.
+    expect([...(cfg.localRoutes ?? new Map()).keys()]).toEqual(["good"]);
+  });
+
+  test("a header-like line with no id resets the block rather than extending the previous one", () => {
+    const cfg = parseNimbusTomlLlmSection(
+      `[llm.local.good]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.]
+model = "hijacked"
+`,
+    );
+    expect(cfg.localRoutes?.get("good")).toEqual({ runtime: "ollama", model: "qwen3:8b" });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/config/nimbus-toml.test.ts
+++ b/packages/gateway/src/config/nimbus-toml.test.ts
@@ -655,6 +655,20 @@ model = "b.gguf"
     expect(cfg.routePriority).toEqual(["ollama", "ollama/qwen3"]);
   });
 
+  test("a non-array route_priority is swallowed without discarding the section", () => {
+    // Same hazard as the malformed-sub-table test below, one key over: `parseStringArray`
+    // THROWS on a non-bracket-delimited value. Unguarded, that throw would escape
+    // `parseNimbusTomlLlmSection` into `loadTomlSection`'s bare catch and revert the
+    // WHOLE [llm] section to DEFAULT_NIMBUS_LLM_TOML — including enforce_air_gap, whose
+    // default is false. Assert the SECURITY-relevant key specifically survives, not
+    // merely that "some key" survived.
+    const cfg = parseNimbusTomlLlmSection(
+      `[llm]\nenforce_air_gap = true\nroute_priority = "ollama"\n`,
+    );
+    expect(cfg.enforceAirGap).toBe(true); // the security-relevant key SURVIVES
+    expect(cfg.routePriority).toBeUndefined();
+  });
+
   test("a malformed sub-table is skipped without discarding the section", () => {
     // Mirrors the [ownership]/[hitl.quorum] precedent: one bad block must not
     // zero the section. Assert the SECURITY-relevant key specifically survives,
@@ -663,7 +677,10 @@ model = "b.gguf"
       `[llm]\nenforce_air_gap = true\n\n[llm.local.]\nmodel = "x"\n`,
     );
     expect(cfg.enforceAirGap).toBe(true); // the security-relevant key SURVIVES
-    expect(cfg.localRoutes ?? new Map()).not.toHaveProperty("");
+    // The malformed block never yields a route, so localRoutes stays unset here
+    // (Partial<>: no non-empty map to attach) — fall back to empty before checking
+    // membership, same as the other tests in this block.
+    expect((cfg.localRoutes ?? new Map()).has("")).toBe(false);
   });
 });
 

--- a/packages/gateway/src/config/nimbus-toml.test.ts
+++ b/packages/gateway/src/config/nimbus-toml.test.ts
@@ -581,6 +581,90 @@ describe("loadNimbusLlmFromConfigDir", () => {
     const result = loadNimbusLlmFromConfigDir(dir);
     expect(result.maxAgentDepth).toBe(7);
   });
+
+  test("defaults-merged load exposes an empty route map, not undefined", () => {
+    writeToml(dir, `[llm]\nlocal_model = "llama3.2"\n`);
+    const cfg = loadNimbusLlmFromConfigDir(dir);
+    expect(cfg.localRoutes.size).toBe(0);
+    expect(cfg.routePriority).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNimbusTomlLlmSection — [llm.local.<name>] sub-tables + route_priority
+// ---------------------------------------------------------------------------
+
+describe("parseNimbusTomlLlmSection — [llm.local.<name>] and route_priority", () => {
+  test("parses [llm.local.<name>] sub-tables", () => {
+    const toml = `
+[llm]
+prefer_local = true
+
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.gemma]
+runtime = "ollama"
+model = "gemma3:12b"
+`;
+    const cfg = parseNimbusTomlLlmSection(toml);
+    expect([...(cfg.localRoutes ?? new Map()).keys()].sort()).toEqual(["gemma", "qwen3"]);
+    expect(cfg.localRoutes?.get("qwen3")?.model).toBe("qwen3:8b");
+  });
+
+  test("legacy local_model still parses and defines no sub-table route", () => {
+    const cfg = parseNimbusTomlLlmSection(`[llm]\nlocal_model = "llama3.2"\n`);
+    expect(cfg.localModel).toBe("llama3.2");
+    // Partial<>: absent, not an empty map. assemble.ts synthesises the route (Task 9).
+    expect(cfg.localRoutes).toBeUndefined();
+  });
+
+  test("route_priority with a model name containing slashes round-trips", () => {
+    const cfg = parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama/hf.co/user/model"]\n`);
+    expect(cfg.routePriority).toEqual(["ollama/hf.co/user/model"]);
+  });
+
+  test("both llamacpp sub-tables are parsed; collision is Task 9's to catch", () => {
+    // The collision check moved to assemble.ts with the rest of validation. Compare
+    // RESOLVED base URLs there: two routes that both OMIT base_url resolve to the
+    // same default and collide, which a raw-string comparison would miss entirely.
+    const toml = `
+[llm.local.a]
+runtime = "llamacpp"
+model = "a.gguf"
+
+[llm.local.b]
+runtime = "llamacpp"
+model = "b.gguf"
+`;
+    const cfg = parseNimbusTomlLlmSection(toml);
+    expect([...(cfg.localRoutes ?? new Map()).keys()].sort()).toEqual(["a", "b"]);
+    expect(cfg.localRoutes?.get("a")?.baseUrl).toBeUndefined();
+  });
+
+  // Superseded (per the task-8 brief banner): a malformed route_priority entry and a
+  // base_url collision do NOT throw here. `loadTomlSection`'s bare catch (nimbus-toml.ts
+  // ~line 23) swallows any throw from this parser and reverts the WHOLE [llm] section to
+  // DEFAULT_NIMBUS_LLM_TOML — including enforce_air_gap, whose default is false. A typo
+  // in one route_priority entry would then silently disable air-gap. Validation (resolving
+  // route refs, catching base_url collisions) moves to assemble.ts (Task 9), which can log
+  // the offending entry and drop only that entry.
+  test("route_priority entries are collected verbatim, without validation", () => {
+    const cfg = parseNimbusTomlLlmSection(`[llm]\nroute_priority = ["ollama", "ollama/qwen3"]\n`);
+    expect(cfg.routePriority).toEqual(["ollama", "ollama/qwen3"]);
+  });
+
+  test("a malformed sub-table is skipped without discarding the section", () => {
+    // Mirrors the [ownership]/[hitl.quorum] precedent: one bad block must not
+    // zero the section. Assert the SECURITY-relevant key specifically survives,
+    // not merely that "some key" survived.
+    const cfg = parseNimbusTomlLlmSection(
+      `[llm]\nenforce_air_gap = true\n\n[llm.local.]\nmodel = "x"\n`,
+    );
+    expect(cfg.enforceAirGap).toBe(true); // the security-relevant key SURVIVES
+    expect(cfg.localRoutes ?? new Map()).not.toHaveProperty("");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -353,8 +353,15 @@ function collectLlmLocalKvSections(source: string): Map<string, Record<string, s
     const trimmed = stripComment(line).trim();
     if (hasUnterminatedString(line)) continue;
     if (trimmed === "") continue;
-    if (isTableHeader(trimmed)) {
-      currentId = beginLlmLocalTable(accum, trimmed);
+    // Header-LIKE, not header-VALID: a line that opens with `[` is a table header the writer
+    // meant, whether or not it closes. Ending the current block on the OPENING bracket — before
+    // `isTableHeader` gets to reject `[llm.local.bad` for its missing `]` — is what makes a
+    // malformed header end the previous route instead of leaking into it. Without the reset,
+    // `currentId` stayed on the last VALID id, so every `runtime`/`model` line under the
+    // malformed header was written into the PREVIOUS route's bucket: `[llm.local.good]` followed
+    // by `[llm.local.bad` silently became `good` carrying `bad`'s runtime and model.
+    if (trimmed.startsWith("[")) {
+      currentId = isTableHeader(trimmed) ? beginLlmLocalTable(accum, trimmed) : undefined;
       continue;
     }
     if (currentId === undefined) continue;

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -4,7 +4,11 @@ import { DEFAULT_LOCAL_CONTEXT_TOKENS } from "../llm/ollama-provider.ts";
 
 import type { ServiceConfig } from "../metrics/dora-config.ts";
 import { processEnvGet } from "../platform/env-access.ts";
-import { parseNimbusCiServiceToml, parseNimbusDoraToml } from "./service-config-toml.ts";
+import {
+  parseNimbusCiServiceToml,
+  parseNimbusDoraToml,
+  resolveServiceTableId,
+} from "./service-config-toml.ts";
 import {
   hasUnterminatedString,
   isTableHeader,
@@ -194,6 +198,13 @@ export function loadNimbusEmbeddingFromConfigDir(configDir: string): NimbusEmbed
   return loadNimbusEmbeddingFromPath(join(configDir, "nimbus.toml"));
 }
 
+/** One `[llm.local.<name>]` sub-table: a named local model route. Spec §3.6. */
+export type NimbusLlmLocalRoute = {
+  runtime: string;
+  model: string;
+  baseUrl?: string;
+};
+
 export type NimbusLlmToml = {
   preferLocal: boolean;
   remoteModel: string;
@@ -210,6 +221,22 @@ export type NimbusLlmToml = {
   enforceAirGap: boolean;
   maxAgentDepth: number;
   maxToolCallsPerSession: number;
+  /**
+   * Named `[llm.local.<name>]` sub-tables, keyed by name. Collected verbatim here —
+   * NO validation (resolving `route_priority` references, `base_url` collision
+   * checks) happens at this layer. See the module doc above `parseNimbusTomlLlmSection`
+   * for why: validation throws would be swallowed by `loadTomlSection`'s bare catch and
+   * silently revert the whole `[llm]` section to defaults. Validation lives in
+   * `platform/assemble.ts` (Task 9), against the loaded config, where a bad entry can be
+   * logged and dropped without discarding anything else.
+   */
+  localRoutes: ReadonlyMap<string, NimbusLlmLocalRoute>;
+  /**
+   * Verbatim `route_priority` entries — un-resolved route references, in file order.
+   * See `localRoutes` doc: resolving each entry against a registered route (built-in or
+   * `[llm.local.*]`) is Task 9's job, not this parser's.
+   */
+  routePriority: readonly string[];
 };
 
 export const DEFAULT_NIMBUS_LLM_TOML: NimbusLlmToml = {
@@ -223,6 +250,8 @@ export const DEFAULT_NIMBUS_LLM_TOML: NimbusLlmToml = {
   enforceAirGap: false,
   maxAgentDepth: 3,
   maxToolCallsPerSession: 20,
+  localRoutes: new Map(),
+  routePriority: [],
 };
 
 function applyNimbusLlmKey(out: Partial<NimbusLlmToml>, key: string, valRaw: string): void {
@@ -264,10 +293,108 @@ function applyNimbusLlmKey(out: Partial<NimbusLlmToml>, key: string, valRaw: str
       if (n !== undefined && n >= 1 && n <= 200) out.maxToolCallsPerSession = n;
       break;
     }
+    case "route_priority": {
+      // `parseStringArray` THROWS on a non-bracket-delimited value. Unguarded, that
+      // escapes into `loadTomlSection`'s catch and reverts the WHOLE [llm] section —
+      // see the doc above `NimbusLlmToml.routePriority`. Swallow it here instead:
+      // `routePriority` stays unset, every other key in the section survives. This is
+      // ALSO where the two superseded-by-the-brief "malformed entry throws" tests would
+      // have lived — they don't, on purpose: validating each entry (e.g. via
+      // `parseRouteRef`) is Task 9's job against the loaded config, not this parser's.
+      try {
+        out.routePriority = parseStringArray(valRaw);
+      } catch {
+        /* malformed: leave routePriority unset, fall back to the default (empty) */
+      }
+      break;
+    }
     default:
       applyNimbusLlmNumericKey(out, key, valRaw);
       break;
   }
+}
+
+const LLM_LOCAL_TABLE_PREFIX = "[llm.local.";
+
+/** Records a `key = value` line into the current `[llm.local.<name>]` bucket, if any. */
+function applyLlmLocalTableLine(bucket: Record<string, string> | undefined, trimmed: string): void {
+  if (bucket === undefined) return;
+  const kv = splitKeyValue(trimmed);
+  if (kv !== undefined) bucket[kv.key] = kv.valRaw;
+}
+
+/**
+ * If `trimmed` is a `[llm.local.<name>]` header, resolves its id via the shared
+ * `resolveServiceTableId` helper (reused from `service-config-toml.ts` rather than a
+ * second copy of the same prefix-match-and-slice logic). That helper THROWS on an
+ * empty id (`[llm.local.]`) — correct for its own `[metrics.dora.*]`/`[ci.service.*]`
+ * callers, wrong here: this parser must never throw (see the doc above
+ * `NimbusLlmToml.localRoutes`). Catch it locally and treat it as "skip this one
+ * malformed block" — matching the `[ownership]`/`[hitl.quorum]` precedent elsewhere in
+ * this file, where one bad entry is dropped rather than discarding the section.
+ */
+function beginLlmLocalTable(
+  accum: Map<string, Record<string, string>>,
+  trimmed: string,
+): string | undefined {
+  try {
+    return resolveServiceTableId(trimmed, LLM_LOCAL_TABLE_PREFIX, "llm.local", accum);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Accumulates raw kv strings per `[llm.local.<name>]` sub-table. */
+function collectLlmLocalKvSections(source: string): Map<string, Record<string, string>> {
+  const accum = new Map<string, Record<string, string>>();
+  let currentId: string | undefined;
+
+  for (const line of source.split(/\r?\n/)) {
+    const trimmed = stripComment(line).trim();
+    if (hasUnterminatedString(line)) continue;
+    if (trimmed === "") continue;
+    if (isTableHeader(trimmed)) {
+      currentId = beginLlmLocalTable(accum, trimmed);
+      continue;
+    }
+    if (currentId === undefined) continue;
+    applyLlmLocalTableLine(accum.get(currentId), trimmed);
+  }
+
+  return accum;
+}
+
+/**
+ * Validates one `[llm.local.<name>]` sub-table's raw kv strings into a route, or
+ * `undefined` when structurally unusable (missing `runtime`/`model`). No OTHER
+ * validation happens here — a runtime/model value that doesn't name a real thing, or
+ * a `base_url` that collides with another route, is Task 9's problem against the
+ * loaded config, not this parser's.
+ */
+function toLlmLocalRoute(kv: Record<string, string>): NimbusLlmLocalRoute | undefined {
+  const runtimeRaw = kv["runtime"];
+  const modelRaw = kv["model"];
+  if (runtimeRaw === undefined || modelRaw === undefined) return undefined;
+  const runtime = parseString(runtimeRaw);
+  const model = parseString(modelRaw);
+  if (runtime.length === 0 || model.length === 0) return undefined;
+  const route: NimbusLlmLocalRoute = { runtime, model };
+  const baseUrlRaw = kv["base_url"];
+  if (baseUrlRaw !== undefined) {
+    const baseUrl = parseString(baseUrlRaw);
+    if (baseUrl.length > 0) route.baseUrl = baseUrl;
+  }
+  return route;
+}
+
+/** Parses every `[llm.local.<name>]` sub-table into a name → route map. Never throws. */
+function parseLlmLocalRoutes(source: string): Map<string, NimbusLlmLocalRoute> {
+  const out = new Map<string, NimbusLlmLocalRoute>();
+  for (const [id, kv] of collectLlmLocalKvSections(source).entries()) {
+    const route = toLlmLocalRoute(kv);
+    if (route !== undefined) out.set(id, route);
+  }
+  return out;
 }
 
 /**
@@ -290,6 +417,12 @@ export function parseNimbusTomlLlmSection(source: string): Partial<NimbusLlmToml
   forEachSectionEntry(source, "[llm]", (key, valRaw) => {
     applyNimbusLlmKey(out, key, valRaw);
   });
+  // `forEachSectionEntry` matches `[llm]` by EXACT string equality, so it cannot see
+  // `[llm.local.*]` sub-tables — this is a second, independent scan over the same
+  // source. `Partial<>`: an absent `[llm.local.*]` block leaves `localRoutes` unset
+  // (not an empty map), matching every other optional field here.
+  const localRoutes = parseLlmLocalRoutes(source);
+  if (localRoutes.size > 0) out.localRoutes = localRoutes;
   return out;
 }
 

--- a/packages/gateway/src/config/service-config-toml.ts
+++ b/packages/gateway/src/config/service-config-toml.ts
@@ -125,7 +125,23 @@ function materializeServiceConfigs(
   return out;
 }
 
-function resolveServiceTableId(
+/**
+ * Resolves a `[<tablePrefix><id>]` table-header line to its `id`, registering an
+ * (initially empty) bucket for it in `accum`. Returns `undefined` when `trimmed`
+ * does not start with `tablePrefix` at all (a different section's header).
+ *
+ * Throws on an empty `id` (`[<tablePrefix>]`) — deliberately, for THIS module's two
+ * callers (`[metrics.dora.*]` / `[ci.service.*]`), which is why `platform/assemble.ts`
+ * wraps `loadNimbusServiceConfigsFromConfigDir` in a try/catch and degrades rather than
+ * aborting startup. Exported (pure, already covered by this module's own tests) so
+ * `nimbus-toml.ts`'s `[llm.local.<name>]` scan can reuse the same id-resolution logic
+ * for its OWN table prefix; that caller has a stricter "never throw" contract (a throw
+ * would be swallowed by `loadTomlSection`'s bare catch and silently revert the whole
+ * `[llm]` section to defaults, including `enforce_air_gap`), so it wraps this call in
+ * its own local try/catch and treats the throw as "skip this one malformed block"
+ * rather than letting it propagate.
+ */
+export function resolveServiceTableId(
   trimmed: string,
   tablePrefix: string,
   blockLabel: string,

--- a/packages/gateway/src/decisions/decision-llm-adapter.test.ts
+++ b/packages/gateway/src/decisions/decision-llm-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 
 import { LlmRouter } from "../llm/router.ts";
-import type { LlmProvider, LlmProviderKind } from "../llm/types.ts";
+import type { LlmProvider, ProviderId } from "../llm/types.ts";
 import {
   buildExtractionPrompt,
   createDecisionLlm,
@@ -14,12 +14,9 @@ function fakeLlm(reply: string): DecisionLlm {
   return { complete: async () => reply };
 }
 
-function fakeProvider(
-  id: LlmProviderKind,
-  opts: { available: boolean; text?: string },
-): LlmProvider {
-  // The model this route registers under — `registerProvider` derives it from
-  // `config.localModel`/`config.remoteModel` based on `isLocal`, matching `routerWith` below.
+function fakeProvider(id: ProviderId, opts: { available: boolean; text?: string }): LlmProvider {
+  // The model this route registers under — `routerWith` below registers each provider
+  // under `local-model`/`remote-model` based on `isLocal`, matching this listing.
   const modelName = id === "remote" ? "remote-model" : "local-model";
   return {
     providerId: id,
@@ -51,7 +48,7 @@ function routerWith(...providers: LlmProvider[]): LlmRouter {
     minReasoningParams: 0,
     enforceAirGap: false,
   });
-  for (const p of providers) r.registerProvider(p);
+  for (const p of providers) r.registerRoute(p, p.isLocal ? "local-model" : "remote-model");
   return r;
 }
 

--- a/packages/gateway/src/decisions/decision-llm-adapter.test.ts
+++ b/packages/gateway/src/decisions/decision-llm-adapter.test.ts
@@ -20,6 +20,7 @@ function fakeProvider(
 ): LlmProvider {
   return {
     providerId: id,
+    isLocal: id !== "remote",
     isAvailable: () => Promise.resolve(opts.available),
     listModels: () => Promise.resolve([]),
     generate: () =>

--- a/packages/gateway/src/decisions/decision-llm-adapter.test.ts
+++ b/packages/gateway/src/decisions/decision-llm-adapter.test.ts
@@ -18,11 +18,19 @@ function fakeProvider(
   id: LlmProviderKind,
   opts: { available: boolean; text?: string },
 ): LlmProvider {
+  // The model this route registers under — `registerProvider` derives it from
+  // `config.localModel`/`config.remoteModel` based on `isLocal`, matching `routerWith` below.
+  const modelName = id === "remote" ? "remote-model" : "local-model";
   return {
     providerId: id,
     isLocal: id !== "remote",
     isAvailable: () => Promise.resolve(opts.available),
-    listModels: () => Promise.resolve([]),
+    // Must report the model it registers under — route availability (Task 5) requires the
+    // daemon reachable AND the route's own modelName among the reported models; an empty
+    // listing here makes the route model_absent regardless of isAvailable(). Harmless when
+    // `opts.available` is false: `probeProvider` short-circuits on an unreachable daemon
+    // before ever consulting the model list.
+    listModels: () => Promise.resolve([{ provider: id, modelName }]),
     generate: () =>
       Promise.resolve({
         text: opts.text ?? "{}",

--- a/packages/gateway/src/decisions/decision-llm-adapter.ts
+++ b/packages/gateway/src/decisions/decision-llm-adapter.ts
@@ -1,4 +1,4 @@
-import { isLocalProviderKind, type LlmRouter } from "../llm/router.ts";
+import type { LlmRouter } from "../llm/router.ts";
 
 export type DecisionLlm = {
   complete(prompt: string): Promise<string | null>;
@@ -156,7 +156,7 @@ export function createDecisionLlm(router: LlmRouter): DecisionLlm {
     async complete(prompt: string): Promise<string | null> {
       const provider = await router.selectProvider("summarisation", { preferLocal: true });
       if (provider === undefined) return null;
-      if (!isLocalProviderKind(provider.providerId)) return null;
+      if (!provider.isLocal) return null;
       const result = await provider.generate({
         task: "summarisation",
         prompt,

--- a/packages/gateway/src/egress/synthesis-egress.test.ts
+++ b/packages/gateway/src/egress/synthesis-egress.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
 afterEach(() => db.close());
 
 /** A resolved REMOTE provider, in the `ResolvedSynthesisProvider` shape the appender reads. */
-const REMOTE = { modelName: "gpt-5", isLocal: false } as const;
+const REMOTE = { providerId: "openai", modelName: "gpt-5", isLocal: false } as const;
 
 describe("recordSynthesisEgress", () => {
   test("appends one authorized `model` row for a remote-provider brief synthesis", () => {
@@ -32,7 +32,7 @@ describe("recordSynthesisEgress", () => {
     expect(rows[0]).toMatchObject({
       sourceType: "model",
       sourceId: "gpt-5",
-      destination: "model",
+      destination: "openai",
       method: "agents.catchup.synthesis",
       hitlStatus: "not_required",
       resultStatus: "authorized",
@@ -45,20 +45,43 @@ describe("recordSynthesisEgress", () => {
     );
   });
 
+  test("destination is the vendor, not the literal 'model'", () => {
+    recordSynthesisEgress(db, {
+      briefKind: "why",
+      provider: { providerId: "gemini", modelName: "gemini-2.5-pro", isLocal: false },
+      now: 1_700_000_000_000,
+    });
+    const row = db.query("SELECT destination, source_type FROM egress_ledger").get() as {
+      destination: string;
+      source_type: string;
+    };
+    expect(row.destination).toBe("gemini");
+    expect(row.source_type).toBe("model"); // the CLASS stays "model"; the DESTINATION is the vendor
+  });
+
   test("a local-provider synthesis (`isLocal: true`) appends NOTHING — not even a blocked row", () => {
     recordSynthesisEgress(db, {
       briefKind: "catchup",
-      provider: { modelName: "local-test-model:latest", isLocal: true },
+      provider: { providerId: "ollama", modelName: "local-test-model:latest", isLocal: true },
       now: 1_000,
     });
     expect(listEgress(db, {})).toHaveLength(0);
+  });
+
+  test("a local provider still appends nothing", () => {
+    recordSynthesisEgress(db, {
+      briefKind: "why",
+      provider: { providerId: "ollama", modelName: "qwen3:8b", isLocal: true },
+      now: 1,
+    });
+    expect(db.query("SELECT COUNT(*) AS n FROM egress_ledger").get()).toEqual({ n: 0 });
   });
 
   test("two remote appends chain correctly (BLAKE3, I10-verifiable)", () => {
     recordSynthesisEgress(db, { briefKind: "catchup", provider: REMOTE, now: 1_000 });
     recordSynthesisEgress(db, {
       briefKind: "expert",
-      provider: { modelName: "claude-opus", isLocal: false },
+      provider: { providerId: "anthropic", modelName: "claude-opus", isLocal: false },
       now: 2_000,
     });
     const result = verifyEgressChain(db);

--- a/packages/gateway/src/egress/synthesis-egress.ts
+++ b/packages/gateway/src/egress/synthesis-egress.ts
@@ -1,6 +1,7 @@
 // packages/gateway/src/egress/synthesis-egress.ts
 
 import type { Database } from "bun:sqlite";
+import type { ProviderId } from "../llm/types.ts";
 import { appendEgressEntry } from "./egress-ledger.ts";
 import { redactEgressSummary } from "./egress-record.ts";
 
@@ -35,7 +36,11 @@ export function recordSynthesisEgress(
   db: Database,
   args: {
     readonly briefKind: string;
-    readonly provider: { readonly modelName: string; readonly isLocal: boolean };
+    readonly provider: {
+      readonly providerId: ProviderId;
+      readonly modelName: string;
+      readonly isLocal: boolean;
+    };
     readonly now: number;
   },
 ): void {
@@ -47,7 +52,7 @@ export function recordSynthesisEgress(
     timestamp: args.now,
     sourceType: "model",
     sourceId: model,
-    destination: "model",
+    destination: args.provider.providerId,
     method: `agents.${args.briefKind}.synthesis`,
     payloadSummary: redactEgressSummary({ briefKind: args.briefKind, model }),
     hitlStatus: "not_required",

--- a/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
+++ b/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "bun:test";
 
 import { LlmRouter } from "../llm/router.ts";
-import type { LlmProvider, LlmProviderKind } from "../llm/types.ts";
+import type { LlmProvider, ProviderId } from "../llm/types.ts";
 import { createGlossaryLlm } from "./glossary-llm-adapter.ts";
 
-function fakeProvider(
-  id: LlmProviderKind,
-  opts: { available: boolean; text?: string },
-): LlmProvider {
-  // The model this route registers under — `registerProvider` derives it from
-  // `config.localModel`/`config.remoteModel` based on `isLocal`, matching `routerWith` below.
+function fakeProvider(id: ProviderId, opts: { available: boolean; text?: string }): LlmProvider {
+  // The model this route registers under — `routerWith` below registers each provider
+  // under `local-model`/`remote-model` based on `isLocal`, matching this listing.
   const modelName = id === "remote" ? "remote-model" : "local-model";
   return {
     providerId: id,
@@ -41,7 +38,7 @@ function routerWith(...providers: LlmProvider[]): LlmRouter {
     minReasoningParams: 0,
     enforceAirGap: false,
   });
-  for (const p of providers) r.registerProvider(p);
+  for (const p of providers) r.registerRoute(p, p.isLocal ? "local-model" : "remote-model");
   return r;
 }
 

--- a/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
+++ b/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
@@ -10,6 +10,7 @@ function fakeProvider(
 ): LlmProvider {
   return {
     providerId: id,
+    isLocal: id !== "remote",
     isAvailable: () => Promise.resolve(opts.available),
     listModels: () => Promise.resolve([]),
     generate: () =>

--- a/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
+++ b/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
@@ -8,11 +8,19 @@ function fakeProvider(
   id: LlmProviderKind,
   opts: { available: boolean; text?: string },
 ): LlmProvider {
+  // The model this route registers under — `registerProvider` derives it from
+  // `config.localModel`/`config.remoteModel` based on `isLocal`, matching `routerWith` below.
+  const modelName = id === "remote" ? "remote-model" : "local-model";
   return {
     providerId: id,
     isLocal: id !== "remote",
     isAvailable: () => Promise.resolve(opts.available),
-    listModels: () => Promise.resolve([]),
+    // Must report the model it registers under — route availability (Task 5) requires the
+    // daemon reachable AND the route's own modelName among the reported models; an empty
+    // listing here makes the route model_absent regardless of isAvailable(). Harmless when
+    // `opts.available` is false: `probeProvider` short-circuits on an unreachable daemon
+    // before ever consulting the model list.
+    listModels: () => Promise.resolve([{ provider: id, modelName }]),
     generate: () =>
       Promise.resolve({
         text: opts.text ?? "{}",

--- a/packages/gateway/src/glossary/glossary-llm-adapter.ts
+++ b/packages/gateway/src/glossary/glossary-llm-adapter.ts
@@ -1,4 +1,4 @@
-import { isLocalProviderKind, type LlmRouter } from "../llm/router.ts";
+import type { LlmRouter } from "../llm/router.ts";
 import type { ConsolidatorLlm } from "./glossary-consolidate.ts";
 
 /**
@@ -41,7 +41,7 @@ export function createGlossaryLlm(router: LlmRouter): ConsolidatorLlm {
       if (signal?.aborted === true) return null;
       const provider = await router.selectProvider("summarisation", { preferLocal: true });
       if (provider === undefined) return null;
-      if (!isLocalProviderKind(provider.providerId)) return null;
+      if (!provider.isLocal) return null;
       const result = await provider.generate({
         task: "summarisation",
         prompt,

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -306,6 +306,76 @@ describe("llm.status", () => {
     expect(r.kind).toBe("hit");
     expect((r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value.routes).toEqual([]);
   });
+
+  // `packages/cli` cannot import gateway types — the dependency rule is IPC-only, no source
+  // imports (see CLAUDE.md "Dependency rules") — so `packages/cli/src/commands/llm.ts`'s
+  // `RouteStatus` is a HAND-MAINTAINED copy of this shape, and its own tests mock the IPC
+  // client wholesale rather than talking to a real dispatcher. Nothing on the CLI side would
+  // notice a gateway-side reshape. This already happened once in this branch — a caller went
+  // on reading `res.decisions.classification` after `llm.status` became a route list, and the
+  // whole suite stayed green (see Task 10). Pinning the EXACT key set here (not `toMatchObject`,
+  // which tolerates extra fields) is the gateway half of the fix; the CLI half stays a
+  // documented bound — see docs/CHANGELOG.md's 2026-08-27 entry.
+  test("pins the exact route object key set (available route: contextWindow present)", async () => {
+    const provider = makeFakeLlmProvider({
+      providerId: "ollama",
+      isLocal: true,
+      reachable: true,
+      reportedModels: ["qwen3:8b"],
+    });
+    const routes = [
+      {
+        routeId: "ollama/qwen3:8b",
+        provider,
+        modelName: "qwen3:8b",
+        meta: { contextWindow: 8192 },
+      },
+    ];
+    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
+    expect(r.kind).toBe("hit");
+    const value = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
+    // Top level: exactly `{ routes }` — no sibling key the CLI's `LlmStatusResponse` doesn't
+    // also declare.
+    expect(Object.keys(value).sort()).toEqual(["routes"]);
+    const route = value.routes[0];
+    expect(route).toBeDefined();
+    expect(Object.keys(route as object).sort()).toEqual([
+      "available",
+      "contextWindow",
+      "isLocal",
+      "modelName",
+      "providerId",
+      "reason",
+      "routeId",
+    ]);
+  });
+
+  test("pins the exact route object key set (contextWindow ABSENT — never a fabricated key)", async () => {
+    const provider = makeFakeLlmProvider({
+      providerId: "ollama",
+      isLocal: true,
+      reachable: true,
+      reportedModels: ["qwen3:8b"],
+    });
+    // No `meta.contextWindow` at all — the route object must OMIT the key entirely (matching
+    // the CLI's "render — for a missing contextWindow" contract), not carry it as `undefined`.
+    const routes = [{ routeId: "ollama/qwen3:8b", provider, modelName: "qwen3:8b", meta: {} }];
+    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
+    const value = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
+    const route = value.routes[0];
+    expect(route).toBeDefined();
+    expect(Object.keys(route as object).sort()).toEqual([
+      "available",
+      "isLocal",
+      "modelName",
+      "providerId",
+      "reason",
+      "routeId",
+    ]);
+    expect("contextWindow" in (route as object)).toBe(false);
+  });
 });
 
 describe("llm.setDefault", () => {

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { LlmRegistry } from "../llm/registry.ts";
-import type { LlmModelInfo } from "../llm/types.ts";
+import { RouteAvailabilityProbe } from "../llm/route-availability.ts";
+import type { LlmModelInfo, ModelRoute } from "../llm/types.ts";
 import type { LlmRouteStatus, LlmRpcContext } from "./llm-rpc.ts";
-import { dispatchLlmRpc } from "./llm-rpc.ts";
+import { dispatchLlmRpc, LlmRpcError } from "./llm-rpc.ts";
 
 function makeFakeRegistry(models: LlmModelInfo[] = []): LlmRpcContext["registry"] {
   return {
@@ -136,7 +137,8 @@ describe("llm.loadModel / llm.unloadModel", () => {
     );
     expect(r.kind).toBe("hit");
     expect((r as { kind: "hit"; value: { isLoaded: boolean } }).value.isLoaded).toBe(true);
-    expect(loadModel).toHaveBeenCalledWith("ollama", "gemma:2b");
+    // Third argument is the lifecycle discriminator: `{}` when the caller named no routeId.
+    expect(loadModel).toHaveBeenCalledWith("ollama", "gemma:2b", {});
   });
 
   test("unloadModel returns isLoaded: false", async () => {
@@ -148,7 +150,7 @@ describe("llm.loadModel / llm.unloadModel", () => {
       { registry, notify: () => {} },
     );
     expect((r as { kind: "hit"; value: { isLoaded: boolean } }).value.isLoaded).toBe(false);
-    expect(unloadModel).toHaveBeenCalledWith("ollama", "gemma:2b");
+    expect(unloadModel).toHaveBeenCalledWith("ollama", "gemma:2b", {});
   });
 
   // Deferred finding (Task 6/10): `loadModel`/`unloadModel` take `ProviderId` (any string) —
@@ -167,7 +169,7 @@ describe("llm.loadModel / llm.unloadModel", () => {
         { registry, notify: () => {} },
       ),
     ).rejects.toThrow("Provider not registered: remote");
-    expect(loadModel).toHaveBeenCalledWith("remote", "x");
+    expect(loadModel).toHaveBeenCalledWith("remote", "x", {});
   });
 
   test("loadModel rejects empty provider with -32602 before reaching the registry", async () => {
@@ -207,6 +209,21 @@ describe("llm.getRouterStatus", () => {
 
 // A minimal `LlmProvider`-shaped fake — enough for `RouteAvailabilityProbe.check()` to exercise
 // its real reachable/model-listing logic against, rather than mocking the probe's own verdict.
+/**
+ * A fake registry that mirrors the real one's OWNERSHIP of the availability probe: one
+ * `RouteAvailabilityProbe` per registry, reached only through `checkRoute`. `llm.status` used to
+ * construct a probe of its own per request — a cache no other caller shared, so it could report a
+ * route available that the router had already routed past. The fake still exercises the probe's
+ * REAL reachable/model-listing logic; only its owner changed.
+ */
+function makeFakeRouteRegistry(routes: unknown[]): LlmRegistry {
+  const probe = new RouteAvailabilityProbe();
+  return {
+    llmRouter: { routes: () => routes },
+    checkRoute: (route: ModelRoute) => probe.check(route),
+  } as unknown as LlmRegistry;
+}
+
 function makeFakeLlmProvider(opts: {
   providerId: string;
   isLocal: boolean;
@@ -252,7 +269,7 @@ describe("llm.status", () => {
         meta: {},
       },
     ];
-    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const registry = makeFakeRouteRegistry(routes);
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     expect(r.kind).toBe("hit");
     const val = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
@@ -294,14 +311,14 @@ describe("llm.status", () => {
     const routes = [
       { routeId: "llamacpp/model.gguf", provider, modelName: "model.gguf", meta: {} },
     ];
-    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const registry = makeFakeRouteRegistry(routes);
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     const val = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
     expect(val.routes[0]).toMatchObject({ available: false, reason: "provider_unreachable" });
   });
 
   test("returns an empty route list when no routes are registered", async () => {
-    const registry = { llmRouter: { routes: () => [] } } as unknown as LlmRegistry;
+    const registry = makeFakeRouteRegistry([]);
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     expect(r.kind).toBe("hit");
     expect((r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value.routes).toEqual([]);
@@ -331,7 +348,7 @@ describe("llm.status", () => {
         meta: { contextWindow: 8192 },
       },
     ];
-    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const registry = makeFakeRouteRegistry(routes);
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     expect(r.kind).toBe("hit");
     const value = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
@@ -361,7 +378,7 @@ describe("llm.status", () => {
     // No `meta.contextWindow` at all — the route object must OMIT the key entirely (matching
     // the CLI's "render — for a missing contextWindow" contract), not carry it as `undefined`.
     const routes = [{ routeId: "ollama/qwen3:8b", provider, modelName: "qwen3:8b", meta: {} }];
-    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const registry = makeFakeRouteRegistry(routes);
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     const value = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
     const route = value.routes[0];
@@ -428,5 +445,109 @@ describe("llm.setDefault", () => {
     );
     expect(r.kind).toBe("hit");
     expect(setDefault).toHaveBeenCalledWith("reasoning", "gemini", "gemini-pro");
+  });
+});
+
+describe("missing params map to -32602, never a raw TypeError (Fix D)", () => {
+  // JSON-RPC allows `params` to be omitted entirely. The cast this replaces left `p`
+  // `undefined` and the next line read `p.modelName`, throwing a raw `TypeError` — and only
+  // `LlmRpcError` is mapped to `-32602 Invalid params`, so "you forgot the arguments" surfaced
+  // to the client as an internal error.
+  const registry = {
+    pullModel: mock(async () => {}),
+    loadModel: mock(async () => {}),
+    unloadModel: mock(async () => {}),
+    setDefault: mock(async () => {}),
+  } as unknown as LlmRegistry;
+
+  for (const method of [
+    "llm.pullModel",
+    "llm.loadModel",
+    "llm.unloadModel",
+    "llm.setDefault",
+    "llm.cancelPull",
+  ]) {
+    for (const [label, params] of [
+      ["undefined", undefined],
+      ["null", null],
+      ["a string", "modelName"],
+      ["an array", ["gemma:2b"]],
+    ] as Array<[string, unknown]>) {
+      test(`${method} with ${label} params rejects as LlmRpcError(-32602)`, async () => {
+        let thrown: unknown;
+        try {
+          await dispatchLlmRpc(method, params, { registry, notify: () => {} });
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(LlmRpcError);
+        expect((thrown as LlmRpcError).rpcCode).toBe(-32602);
+        // Specifically NOT a bare TypeError — the shape that produced the wrong RPC code.
+        expect(thrown).not.toBeInstanceOf(TypeError);
+      });
+    }
+  }
+
+  test("a well-formed request still succeeds — the guard rejects shape, not content", async () => {
+    const pullModel = mock(async () => {});
+    const r = await dispatchLlmRpc(
+      "llm.pullModel",
+      { provider: "ollama", modelName: "gemma:2b" },
+      { registry: { pullModel } as unknown as LlmRegistry, notify: () => {} },
+    );
+    expect(r.kind).toBe("hit");
+    expect(pullModel).toHaveBeenCalledTimes(1);
+  });
+
+  test("a non-string routeId is rejected rather than silently dropped", async () => {
+    const pullModel = mock(async () => {});
+    await expect(
+      dispatchLlmRpc(
+        "llm.pullModel",
+        { provider: "ollama", modelName: "gemma:2b", routeId: 7 },
+        { registry: { pullModel } as unknown as LlmRegistry, notify: () => {} },
+      ),
+    ).rejects.toThrow("routeId must be a non-empty string");
+    expect(pullModel).not.toHaveBeenCalled();
+  });
+
+  test("routeId is forwarded to the registry when supplied", async () => {
+    const pullModel = mock(async () => {});
+    await dispatchLlmRpc(
+      "llm.pullModel",
+      { provider: "ollama", modelName: "gemma:2b", routeId: "ollama/qwen3:8b" },
+      { registry: { pullModel } as unknown as LlmRegistry, notify: () => {} },
+    );
+    expect(pullModel).toHaveBeenCalledWith(
+      "ollama",
+      "gemma:2b",
+      expect.objectContaining({ routeId: "ollama/qwen3:8b" }),
+    );
+  });
+});
+
+describe("llm.status reads the registry-owned probe (Fix E)", () => {
+  test("availability comes from registry.checkRoute, not a probe llm.status builds", async () => {
+    // The provider itself is UNREACHABLE. A probe constructed inside `getRouteStatuses` would
+    // answer `provider_unreachable` from its own private cache; the registry-owned probe is
+    // the authority route selection also consults, and here it says `ok`. Only the delegating
+    // implementation can produce this result — which is the whole point: the two snapshots
+    // must not be able to disagree.
+    const provider = makeFakeLlmProvider({
+      providerId: "ollama",
+      isLocal: true,
+      reachable: false,
+      reportedModels: [],
+    });
+    const routes = [{ routeId: "ollama/qwen3:8b", provider, modelName: "qwen3:8b", meta: {} }];
+    const checkRoute = mock(async () => ({ available: true, reason: "ok" as const }));
+    const registry = {
+      llmRouter: { routes: () => routes },
+      checkRoute,
+    } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
+    const val = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
+    expect(checkRoute).toHaveBeenCalledTimes(1);
+    expect(val.routes[0]).toMatchObject({ available: true, reason: "ok" });
   });
 });

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { LlmRegistry } from "../llm/registry.ts";
 import type { LlmModelInfo } from "../llm/types.ts";
-import type { LlmRpcContext } from "./llm-rpc.ts";
+import type { LlmRouteStatus, LlmRpcContext } from "./llm-rpc.ts";
 import { dispatchLlmRpc } from "./llm-rpc.ts";
 
 function makeFakeRegistry(models: LlmModelInfo[] = []): LlmRpcContext["registry"] {
@@ -65,15 +65,42 @@ describe("llm.pullModel", () => {
     expect(pullModel).toHaveBeenCalledTimes(1);
   });
 
-  test("rejects unknown provider with -32602", async () => {
+  test("rejects empty provider with -32602", async () => {
     const registry = { pullModel: mock(async () => {}) } as unknown as LlmRegistry;
     await expect(
       dispatchLlmRpc(
         "llm.pullModel",
-        { provider: "remote", modelName: "x" },
+        { provider: "", modelName: "x" },
         { registry, notify: () => {} },
       ),
     ).rejects.toThrow();
+  });
+
+  // Deferred finding (Task 6/10): validity of a provider string is no longer decided by an
+  // RPC-level closed set — `requireModelParams` accepts any non-empty string, so an
+  // unregistered provider reaches `registry.pullModel` (the widened `ProviderId` signature),
+  // and its rejection surfaces the same way any other pull failure does: via `llm.pullFailed`,
+  // not an RPC-level throw (pullModel returns { pullId } immediately, fire-and-forget).
+  test("an unregistered provider is rejected by the registry, not by RPC-level validation", async () => {
+    const registryError = new Error("Provider not registered: remote");
+    const pullModel = mock(async () => {
+      throw registryError;
+    });
+    const registry = { pullModel } as unknown as LlmRegistry;
+    const notify = mock((_m: string, _p: unknown) => {});
+    const result = await dispatchLlmRpc(
+      "llm.pullModel",
+      { provider: "remote", modelName: "x" },
+      { registry, notify },
+    );
+    expect(result.kind).toBe("hit");
+    expect(pullModel).toHaveBeenCalledWith("remote", "x", expect.anything());
+    // Let the fire-and-forget .then()/.catch() chain settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(notify).toHaveBeenCalledWith(
+      "llm.pullFailed",
+      expect.objectContaining({ provider: "remote", error: "Provider not registered: remote" }),
+    );
   });
 });
 
@@ -124,15 +151,36 @@ describe("llm.loadModel / llm.unloadModel", () => {
     expect(unloadModel).toHaveBeenCalledWith("ollama", "gemma:2b");
   });
 
-  test("loadModel rejects unsupported provider", async () => {
-    const registry = { loadModel: mock(async () => {}) } as unknown as LlmRegistry;
+  // Deferred finding (Task 6/10): `loadModel`/`unloadModel` take `ProviderId` (any string) —
+  // previously `requireLocalProvider` narrowed to a closed two-member union and rejected
+  // "remote" before the registry was ever called, making the widened signature unreachable
+  // from IPC. Now the call reaches the registry, and the registry decides validity.
+  test("loadModel rejects an unregistered provider via the registry, not RPC-level validation", async () => {
+    const loadModel = mock(async () => {
+      throw new Error("Provider not registered: remote");
+    });
+    const registry = { loadModel } as unknown as LlmRegistry;
     await expect(
       dispatchLlmRpc(
         "llm.loadModel",
         { provider: "remote", modelName: "x" },
         { registry, notify: () => {} },
       ),
+    ).rejects.toThrow("Provider not registered: remote");
+    expect(loadModel).toHaveBeenCalledWith("remote", "x");
+  });
+
+  test("loadModel rejects empty provider with -32602 before reaching the registry", async () => {
+    const loadModel = mock(async () => {});
+    const registry = { loadModel } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.loadModel",
+        { provider: "", modelName: "x" },
+        { registry, notify: () => {} },
+      ),
     ).rejects.toThrow();
+    expect(loadModel).not.toHaveBeenCalled();
   });
 });
 
@@ -157,44 +205,106 @@ describe("llm.getRouterStatus", () => {
   });
 });
 
+// A minimal `LlmProvider`-shaped fake — enough for `RouteAvailabilityProbe.check()` to exercise
+// its real reachable/model-listing logic against, rather than mocking the probe's own verdict.
+function makeFakeLlmProvider(opts: {
+  providerId: string;
+  isLocal: boolean;
+  reachable: boolean;
+  reportedModels: string[];
+}) {
+  return {
+    providerId: opts.providerId,
+    isLocal: opts.isLocal,
+    isAvailable: async () => opts.reachable,
+    listModels: async () =>
+      opts.reportedModels.map((modelName) => ({ provider: opts.providerId, modelName })),
+    generate: async () => {
+      throw new Error("generate() not used by this test");
+    },
+  };
+}
+
 describe("llm.status", () => {
-  test("returns per-task decisions with modelName, isAvailable, and reason", async () => {
-    const getRouterStatus = mock(async () => ({
-      classification: {
-        providerId: "ollama",
-        modelName: "llama3.2",
-        isAvailable: true,
-        reason: "prefer-local",
+  test("lists every route (routeId, providerId, modelName, isLocal, available, reason, contextWindow)", async () => {
+    const provider = makeFakeLlmProvider({
+      providerId: "ollama",
+      isLocal: true,
+      reachable: true,
+      reportedModels: ["qwen3:8b"],
+    });
+    // Two routes sharing one provider instance/daemon: this is the headline case (deferred
+    // finding, Task 3/10) — a same-provider, different-model fallback must be expressible.
+    // Listing every route separately (rather than the old one-decision-per-task-type shape)
+    // makes "ollama/qwen3:8b is up, ollama/gemma3:12b is down" visible without any fallback
+    // field at all.
+    const routes = [
+      {
+        routeId: "ollama/qwen3:8b",
+        provider,
+        modelName: "qwen3:8b",
+        meta: { contextWindow: 8192 },
       },
-      reasoning: {
-        providerId: "ollama",
-        modelName: "llama3.2",
-        isAvailable: true,
-        reason: "prefer-local",
+      {
+        routeId: "ollama/gemma3:12b",
+        provider,
+        modelName: "gemma3:12b",
+        meta: {},
       },
-      summarisation: {
-        providerId: "ollama",
-        modelName: "llama3.2",
-        isAvailable: true,
-        reason: "prefer-local",
-      },
-      agent_step: {
-        providerId: "ollama",
-        modelName: "llama3.2",
-        isAvailable: true,
-        reason: "prefer-local",
-      },
-    }));
-    const registry = { getRouterStatus } as unknown as LlmRegistry;
+    ];
+    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
     const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
     expect(r.kind).toBe("hit");
-    const val = (r as { kind: "hit"; value: { decisions: Record<string, unknown> } }).value;
-    expect(val.decisions["classification"]).toMatchObject({
-      modelName: "llama3.2",
-      isAvailable: true,
-      reason: "prefer-local",
+    const val = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
+    expect(val.routes).toHaveLength(2);
+
+    const qwen = val.routes.find((x) => x.routeId === "ollama/qwen3:8b");
+    expect(qwen).toMatchObject({
+      routeId: "ollama/qwen3:8b",
+      providerId: "ollama",
+      modelName: "qwen3:8b",
+      isLocal: true,
+      available: true,
+      reason: "ok",
+      contextWindow: 8192,
     });
-    expect(getRouterStatus).toHaveBeenCalledTimes(1);
+
+    // The absent-model route: same provider/daemon (so provider_unreachable cannot explain
+    // it), but its own modelName was never pulled — must report `model_absent`, distinct from
+    // `provider_unreachable`, and its contextWindow must stay undefined (never fabricated).
+    const gemma = val.routes.find((x) => x.routeId === "ollama/gemma3:12b");
+    expect(gemma).toMatchObject({
+      routeId: "ollama/gemma3:12b",
+      providerId: "ollama",
+      modelName: "gemma3:12b",
+      isLocal: true,
+      available: false,
+      reason: "model_absent",
+    });
+    expect(gemma?.contextWindow).toBeUndefined();
+  });
+
+  test("reports provider_unreachable (not model_absent) when the daemon itself is down", async () => {
+    const provider = makeFakeLlmProvider({
+      providerId: "llamacpp",
+      isLocal: true,
+      reachable: false,
+      reportedModels: [],
+    });
+    const routes = [
+      { routeId: "llamacpp/model.gguf", provider, modelName: "model.gguf", meta: {} },
+    ];
+    const registry = { llmRouter: { routes: () => routes } } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
+    const val = (r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value;
+    expect(val.routes[0]).toMatchObject({ available: false, reason: "provider_unreachable" });
+  });
+
+  test("returns an empty route list when no routes are registered", async () => {
+    const registry = { llmRouter: { routes: () => [] } } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc("llm.status", null, { registry, notify: () => {} });
+    expect(r.kind).toBe("hit");
+    expect((r as { kind: "hit"; value: { routes: LlmRouteStatus[] } }).value.routes).toEqual([]);
   });
 });
 
@@ -223,5 +333,30 @@ describe("llm.setDefault", () => {
         { registry, notify: () => {} },
       ),
     ).rejects.toThrow();
+  });
+
+  test("rejects empty provider", async () => {
+    const registry = { setDefault: mock(async () => {}) } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.setDefault",
+        { taskType: "classification", provider: "", modelName: "x" },
+        { registry, notify: () => {} },
+      ),
+    ).rejects.toThrow();
+  });
+
+  // Deleted symbol (Task 10): `VALID_LLM_PROVIDERS` used to reject any provider outside
+  // {"ollama", "llamacpp", "remote"}. Validity is now the registry's answer alone.
+  test("accepts a provider string outside the old closed set", async () => {
+    const setDefault = mock(async () => {});
+    const registry = { setDefault } as unknown as LlmRegistry;
+    const r = await dispatchLlmRpc(
+      "llm.setDefault",
+      { taskType: "reasoning", provider: "gemini", modelName: "gemini-pro" },
+      { registry, notify: () => {} },
+    );
+    expect(r.kind).toBe("hit");
+    expect(setDefault).toHaveBeenCalledWith("reasoning", "gemini", "gemini-pro");
   });
 });

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -1,6 +1,5 @@
 import type { LlmRegistry } from "../llm/registry.ts";
 import type { RouteAvailability } from "../llm/route-availability.ts";
-import { RouteAvailabilityProbe } from "../llm/route-availability.ts";
 import { dispatchByMethod, type RpcMissOrHit } from "./_lib/dispatch-by-method.ts";
 
 export class LlmRpcError extends Error {
@@ -21,22 +20,50 @@ const activePulls = new Map<string, AbortController>();
 
 const VALID_LLM_TASKS = new Set(["classification", "reasoning", "summarisation", "agent_step"]);
 
+/**
+ * Narrows `params` to a plain object BEFORE any field is read.
+ *
+ * The cast this replaces (`params as { … } | null`) was a lie for exactly one input: an OMITTED
+ * `params` member. JSON-RPC allows it, `p` was then `undefined`, and the very next line —
+ * `typeof p.modelName` — threw a raw `TypeError`. Only `LlmRpcError` is mapped to the intended
+ * `-32602 Invalid params`, so a request that merely forgot its arguments surfaced as an internal
+ * error. `typeof null === "object"`, hence the explicit null check; arrays are rejected too,
+ * since none of these handlers takes positional params.
+ */
+function requireParamsObject(params: unknown, message: string): Record<string, unknown> {
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new LlmRpcError(-32602, message);
+  }
+  return params as Record<string, unknown>;
+}
+
 // Validity of a provider string is the registry's answer (`Provider not registered: …`), not a
 // hardcoded set here — see `llm/router.ts` / `llm/registry.ts`, the one-definition-of-local-ness
 // sites. This function only enforces shape: non-empty, defaulting to "ollama" when omitted.
+// `routeId` is the OPTIONAL discriminator `LlmRegistry`'s lifecycle calls use when one vendor id
+// has several daemons behind it; omitted (the normal case) the registry resolves the single
+// instance, and throws naming the candidates rather than guessing when there is more than one.
 function requireModelParams(
   params: unknown,
   action: string,
-): { provider: string; modelName: string } {
-  const p = params as { provider?: string; modelName?: string } | null;
-  if (p === null || typeof p.modelName !== "string") {
+): { provider: string; modelName: string; routeId?: string } {
+  const p = requireParamsObject(params, `${action} requires modelName`);
+  if (typeof p["modelName"] !== "string") {
     throw new LlmRpcError(-32602, `${action} requires modelName`);
   }
-  const provider = p.provider ?? "ollama";
+  const provider = p["provider"] ?? "ollama";
   if (typeof provider !== "string" || provider === "") {
     throw new LlmRpcError(-32602, `${action} requires a non-empty provider`);
   }
-  return { provider, modelName: p.modelName };
+  const routeIdRaw = p["routeId"];
+  if (routeIdRaw !== undefined && (typeof routeIdRaw !== "string" || routeIdRaw === "")) {
+    throw new LlmRpcError(-32602, `${action} routeId must be a non-empty string when present`);
+  }
+  return {
+    provider,
+    modelName: p["modelName"],
+    ...(routeIdRaw === undefined ? {} : { routeId: routeIdRaw }),
+  };
 }
 
 export type LlmRouteStatus = {
@@ -51,15 +78,16 @@ export type LlmRouteStatus = {
   contextWindow?: number;
 };
 
-// One probe per call, not module-level: a status query should reflect current reality rather
-// than a cache shared with unrelated callers (and, incidentally, with any other status query),
-// and route lists are typically small enough that this costs little.
+// Availability comes from the REGISTRY-owned probe (`registry.checkRoute`), never one
+// constructed here. A fresh probe per call sounded like "current reality" but was the opposite:
+// it answered from a cache no other caller shares, so `llm.status` could report a route
+// available while the router — walking its own shared probe — had already routed past it, and
+// nothing could reconcile the two snapshots. One probe, one answer.
 async function getRouteStatuses(ctx: LlmRpcContext): Promise<{ routes: LlmRouteStatus[] }> {
-  const probe = new RouteAvailabilityProbe();
   const routes = ctx.registry.llmRouter.routes();
   const statuses = await Promise.all(
     routes.map(async (route): Promise<LlmRouteStatus> => {
-      const { available, reason } = await probe.check(route);
+      const { available, reason } = await ctx.registry.checkRoute(route);
       return {
         routeId: route.routeId,
         providerId: route.provider.providerId,
@@ -77,7 +105,7 @@ async function getRouteStatuses(ctx: LlmRpcContext): Promise<{ routes: LlmRouteS
 }
 
 async function handlePullModel(params: unknown, ctx: LlmRpcContext): Promise<{ pullId: string }> {
-  const { provider, modelName } = requireModelParams(params, "pullModel");
+  const { provider, modelName, routeId } = requireModelParams(params, "pullModel");
   const pullId = `pull_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
   const controller = new AbortController();
   activePulls.set(pullId, controller);
@@ -85,6 +113,7 @@ async function handlePullModel(params: unknown, ctx: LlmRpcContext): Promise<{ p
     .pullModel(provider, modelName, {
       signal: controller.signal,
       onProgress: (c) => ctx.notify("llm.pullProgress", { pullId, provider, modelName, ...c }),
+      ...(routeId === undefined ? {} : { routeId }),
     })
     .then(() => ctx.notify("llm.pullCompleted", { pullId, provider, modelName }))
     .catch((err: unknown) =>
@@ -104,13 +133,14 @@ async function handleLoadOrUnload(
   params: unknown,
   ctx: LlmRpcContext,
 ): Promise<{ isLoaded: boolean }> {
-  const { provider, modelName } = requireModelParams(params, `${action}Model`);
+  const { provider, modelName, routeId } = requireModelParams(params, `${action}Model`);
+  const target = routeId === undefined ? {} : { routeId };
   if (action === "load") {
-    await ctx.registry.loadModel(provider, modelName);
+    await ctx.registry.loadModel(provider, modelName, target);
     ctx.notify("llm.modelLoaded", { provider, modelName });
     return { isLoaded: true };
   }
-  await ctx.registry.unloadModel(provider, modelName);
+  await ctx.registry.unloadModel(provider, modelName, target);
   ctx.notify("llm.modelUnloaded", { provider, modelName });
   return { isLoaded: false };
 }
@@ -119,31 +149,35 @@ async function handleSetDefault(
   params: unknown,
   ctx: LlmRpcContext,
 ): Promise<{ taskType: string; provider: string; modelName: string }> {
-  const p = params as { taskType?: string; provider?: string; modelName?: string } | null;
+  const message = "setDefault requires valid taskType, provider, modelName";
+  const p = requireParamsObject(params, message);
+  const taskType = p["taskType"];
+  const provider = p["provider"];
+  const modelName = p["modelName"];
   if (
-    p === null ||
-    typeof p.taskType !== "string" ||
-    !VALID_LLM_TASKS.has(p.taskType) ||
-    typeof p.provider !== "string" ||
-    p.provider === "" ||
-    typeof p.modelName !== "string"
+    typeof taskType !== "string" ||
+    !VALID_LLM_TASKS.has(taskType) ||
+    typeof provider !== "string" ||
+    provider === "" ||
+    typeof modelName !== "string"
   ) {
-    throw new LlmRpcError(-32602, "setDefault requires valid taskType, provider, modelName");
+    throw new LlmRpcError(-32602, message);
   }
   await ctx.registry.setDefault(
-    p.taskType as "classification" | "reasoning" | "summarisation" | "agent_step",
-    p.provider,
-    p.modelName,
+    taskType as "classification" | "reasoning" | "summarisation" | "agent_step",
+    provider,
+    modelName,
   );
-  return { taskType: p.taskType, provider: p.provider, modelName: p.modelName };
+  return { taskType, provider, modelName };
 }
 
 function handleCancelPull(params: unknown): { cancelled: boolean } {
-  const p = params as { pullId?: string } | null;
-  if (p === null || typeof p.pullId !== "string") {
+  const p = requireParamsObject(params, "cancelPull requires pullId");
+  const pullId = p["pullId"];
+  if (typeof pullId !== "string") {
     throw new LlmRpcError(-32602, "cancelPull requires pullId");
   }
-  const controller = activePulls.get(p.pullId);
+  const controller = activePulls.get(pullId);
   const cancelled = controller !== undefined;
   controller?.abort();
   return { cancelled };

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -1,4 +1,6 @@
 import type { LlmRegistry } from "../llm/registry.ts";
+import type { RouteAvailability } from "../llm/route-availability.ts";
+import { RouteAvailabilityProbe } from "../llm/route-availability.ts";
 import { dispatchByMethod, type RpcMissOrHit } from "./_lib/dispatch-by-method.ts";
 
 export class LlmRpcError extends Error {
@@ -18,26 +20,60 @@ export type LlmRpcContext = {
 const activePulls = new Map<string, AbortController>();
 
 const VALID_LLM_TASKS = new Set(["classification", "reasoning", "summarisation", "agent_step"]);
-const VALID_LLM_PROVIDERS = new Set(["ollama", "llamacpp", "remote"]);
-const LOCAL_PROVIDERS = ["ollama", "llamacpp"] as const;
-type LocalProvider = (typeof LOCAL_PROVIDERS)[number];
 
-function requireLocalProvider(provider: string): LocalProvider {
-  if (provider !== "ollama" && provider !== "llamacpp") {
-    throw new LlmRpcError(-32602, `Unsupported provider: ${provider}`);
-  }
-  return provider;
-}
-
+// Validity of a provider string is the registry's answer (`Provider not registered: …`), not a
+// hardcoded set here — see `llm/router.ts` / `llm/registry.ts`, the one-definition-of-local-ness
+// sites. This function only enforces shape: non-empty, defaulting to "ollama" when omitted.
 function requireModelParams(
   params: unknown,
   action: string,
-): { provider: LocalProvider; modelName: string } {
+): { provider: string; modelName: string } {
   const p = params as { provider?: string; modelName?: string } | null;
   if (p === null || typeof p.modelName !== "string") {
     throw new LlmRpcError(-32602, `${action} requires modelName`);
   }
-  return { provider: requireLocalProvider(p.provider ?? "ollama"), modelName: p.modelName };
+  const provider = p.provider ?? "ollama";
+  if (typeof provider !== "string" || provider === "") {
+    throw new LlmRpcError(-32602, `${action} requires a non-empty provider`);
+  }
+  return { provider, modelName: p.modelName };
+}
+
+export type LlmRouteStatus = {
+  routeId: string;
+  providerId: string;
+  modelName: string;
+  isLocal: boolean;
+  available: boolean;
+  reason: RouteAvailability["reason"];
+  // Frequently undefined — the router's `meetsCapabilityFloor` fail-opens on exactly this gap.
+  // Passed through as-is; never substitute a fabricated default.
+  contextWindow?: number;
+};
+
+// One probe per call, not module-level: a status query should reflect current reality rather
+// than a cache shared with unrelated callers (and, incidentally, with any other status query),
+// and route lists are typically small enough that this costs little.
+async function getRouteStatuses(ctx: LlmRpcContext): Promise<{ routes: LlmRouteStatus[] }> {
+  const probe = new RouteAvailabilityProbe();
+  const routes = ctx.registry.llmRouter.routes();
+  const statuses = await Promise.all(
+    routes.map(async (route): Promise<LlmRouteStatus> => {
+      const { available, reason } = await probe.check(route);
+      return {
+        routeId: route.routeId,
+        providerId: route.provider.providerId,
+        modelName: route.modelName,
+        isLocal: route.provider.isLocal,
+        available,
+        reason,
+        ...(route.meta.contextWindow !== undefined
+          ? { contextWindow: route.meta.contextWindow }
+          : {}),
+      };
+    }),
+  );
+  return { routes: statuses };
 }
 
 async function handlePullModel(params: unknown, ctx: LlmRpcContext): Promise<{ pullId: string }> {
@@ -89,14 +125,14 @@ async function handleSetDefault(
     typeof p.taskType !== "string" ||
     !VALID_LLM_TASKS.has(p.taskType) ||
     typeof p.provider !== "string" ||
-    !VALID_LLM_PROVIDERS.has(p.provider) ||
+    p.provider === "" ||
     typeof p.modelName !== "string"
   ) {
     throw new LlmRpcError(-32602, "setDefault requires valid taskType, provider, modelName");
   }
   await ctx.registry.setDefault(
     p.taskType as "classification" | "reasoning" | "summarisation" | "agent_step",
-    p.provider as "ollama" | "llamacpp" | "remote",
+    p.provider,
     p.modelName,
   );
   return { taskType: p.taskType, provider: p.provider, modelName: p.modelName };
@@ -121,13 +157,15 @@ export async function dispatchLlmRpc(
   return dispatchByMethod<LlmRpcContext>(method, params, ctx, {
     "llm.listModels": async (_p, c) => ({ models: await c.registry.listAllModels() }),
     "llm.getStatus": async (_p, c) => ({ available: await c.registry.checkAvailability() }),
-    "llm.status": async (_p, c) => ({ decisions: await c.registry.getRouterStatus() }),
+    "llm.status": (_p, c) => getRouteStatuses(c),
     "llm.pullModel": handlePullModel,
     "llm.cancelPull": (p) => handleCancelPull(p),
     "llm.loadModel": (p, c) => handleLoadOrUnload("load", p, c),
     "llm.unloadModel": (p, c) => handleLoadOrUnload("unload", p, c),
-    // llm.getRouterStatus is superseded by llm.status (same payload, richer model data).
-    // Kept for backwards compatibility with existing clients; prefer llm.status for new callers.
+    // llm.getRouterStatus is the pre-route-list per-task-decision payload, kept for
+    // backwards compatibility with existing clients. llm.status now lists every registered
+    // route with its own availability (see getRouteStatuses) — no longer "the same payload,
+    // richer model data" as this comment used to claim; the two shapes have diverged.
     "llm.getRouterStatus": async (_p, c) => ({ decisions: await c.registry.getRouterStatus() }),
     "llm.setDefault": handleSetDefault,
   });

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -195,6 +195,7 @@ const FAKE_LLM_ROUTER_CONFIG = {
 function fakeLocalOllamaProvider(markdown: string): LlmProvider {
   return {
     providerId: "ollama",
+    isLocal: true,
     isAvailable: async () => true,
     listModels: async () => [],
     generate: async () => ({
@@ -212,6 +213,7 @@ function fakeLocalOllamaProvider(markdown: string): LlmProvider {
 function fakeRemoteProvider(): LlmProvider {
   return {
     providerId: "remote",
+    isLocal: false,
     isAvailable: async () => true,
     listModels: async () => [],
     generate: async () => ({

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -197,7 +197,12 @@ function fakeLocalOllamaProvider(markdown: string): LlmProvider {
     providerId: "ollama",
     isLocal: true,
     isAvailable: async () => true,
-    listModels: async () => [],
+    // Must report the model it is registered under (`FAKE_LLM_ROUTER_CONFIG.localModel`,
+    // "local-model" — `registerProvider`/`addProvider` derives the route's modelName from
+    // config, not from the provider) — route availability (Task 5) is reachable AND the
+    // route's own modelName among the models the daemon reports, so an empty listing here
+    // makes every route `model_absent` regardless of `isAvailable()`.
+    listModels: async () => [{ provider: "ollama", modelName: "local-model" }],
     generate: async () => ({
       text: markdown,
       tokensIn: 0,

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -198,10 +198,10 @@ function fakeLocalOllamaProvider(markdown: string): LlmProvider {
     isLocal: true,
     isAvailable: async () => true,
     // Must report the model it is registered under (`FAKE_LLM_ROUTER_CONFIG.localModel`,
-    // "local-model" — `registerProvider`/`addProvider` derives the route's modelName from
-    // config, not from the provider) — route availability (Task 5) is reachable AND the
-    // route's own modelName among the models the daemon reports, so an empty listing here
-    // makes every route `model_absent` regardless of `isAvailable()`.
+    // "local-model", matching the `addRoute` call in `makeLlmRegistry` below) — route
+    // availability (Task 5) requires the daemon reachable AND the route's own modelName
+    // among the models it reports, so an empty listing here makes every route
+    // `model_absent` regardless of `isAvailable()`.
     listModels: async () => [{ provider: "ollama", modelName: "local-model" }],
     generate: async () => ({
       text: markdown,
@@ -239,7 +239,10 @@ function fakeRemoteProvider(): LlmProvider {
 
 function makeLlmRegistry(provider: LlmProvider): LlmRegistry {
   const registry = new LlmRegistry({ config: FAKE_LLM_ROUTER_CONFIG });
-  registry.addProvider(provider);
+  registry.addRoute(
+    provider,
+    provider.isLocal ? FAKE_LLM_ROUTER_CONFIG.localModel : FAKE_LLM_ROUTER_CONFIG.remoteModel,
+  );
   return registry;
 }
 

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -220,7 +220,12 @@ function fakeRemoteProvider(): LlmProvider {
     providerId: "remote",
     isLocal: false,
     isAvailable: async () => true,
-    listModels: async () => [],
+    // Must report the model it registers under (FAKE_LLM_ROUTER_CONFIG.remoteModel,
+    // "remote-model") so the route genuinely RESOLVES as available — otherwise it reads
+    // model_absent, resolveForSynthesis() returns undefined, and the test below passes via
+    // no_eligible_provider from the EARLY branch rather than exercising the "local"-mode
+    // refusal (synthesis-llm.ts) it exists to guard.
+    listModels: async () => [{ provider: "remote", modelName: "remote-model" }],
     generate: async () => ({
       text: "SHOULD-NEVER-BE-USED",
       tokensIn: 0,

--- a/packages/gateway/src/llm/base-url-locality.test.ts
+++ b/packages/gateway/src/llm/base-url-locality.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { isLoopbackBaseUrl } from "./base-url-locality.ts";
+import { LlamaCppProvider } from "./llamacpp-provider.ts";
+import { OllamaProvider } from "./ollama-provider.ts";
+import { LlmRouter, type LlmRouterConfig } from "./router.ts";
+
+describe("isLoopbackBaseUrl", () => {
+  test("accepts the loopback forms a user would actually write", () => {
+    for (const url of [
+      "http://127.0.0.1:11434",
+      "http://127.0.0.1:8080/",
+      "http://127.1.2.3:8080", // the whole of 127.0.0.0/8, not just .0.0.1
+      "http://localhost:11434",
+      "http://LOCALHOST:11434",
+      // `URL` normalises IPv6: the expanded form compresses to `::1`, and the IPv4-mapped
+      // form is re-spelled in hex as `::ffff:7f00:1`.
+      "http://[::1]:8080",
+      "http://[0:0:0:0:0:0:0:1]:8080",
+      "http://[::ffff:127.0.0.1]:8080",
+      "http://[::ffff:127.255.0.1]:8080",
+      "https://127.0.0.1:8443",
+    ]) {
+      expect(isLoopbackBaseUrl(url)).toBe(true);
+    }
+  });
+
+  test("rejects every off-machine host", () => {
+    for (const url of [
+      "http://192.168.1.50:8080", // the LAN box from the finding
+      "http://10.0.0.4:11434",
+      "http://ollama.internal:11434",
+      "https://api.example.com",
+      "http://0.0.0.0:11434", // binds everywhere; is not loopback
+      "http://[fe80::1]:8080",
+      "http://[::ffff:10.0.0.1]:8080",
+      "http://127.0.0.999:8080", // not a valid IPv4 at all — `URL` itself rejects it
+    ]) {
+      expect(isLoopbackBaseUrl(url)).toBe(false);
+    }
+  });
+
+  test("fails CLOSED on an unparseable URL", () => {
+    // We cannot prove the traffic stays here, so it does not count as local.
+    for (const url of ["", "not a url", "127.0.0.1:11434", "://127.0.0.1"]) {
+      expect(isLoopbackBaseUrl(url)).toBe(false);
+    }
+  });
+});
+
+describe("provider isLocal is derived from the base URL, not hardcoded", () => {
+  test("a loopback provider is local", () => {
+    expect(new OllamaProvider("http://127.0.0.1:11434").isLocal).toBe(true);
+    expect(new LlamaCppProvider("http://127.0.0.1:8080").isLocal).toBe(true);
+    // The zero-argument defaults both point at loopback.
+    expect(new OllamaProvider().isLocal).toBe(true);
+    expect(new LlamaCppProvider().isLocal).toBe(true);
+  });
+
+  test("a LAN provider is NOT local, whatever its runtime is called", () => {
+    expect(new OllamaProvider("http://192.168.1.50:11434").isLocal).toBe(false);
+    expect(new LlamaCppProvider("http://192.168.1.50:8080").isLocal).toBe(false);
+  });
+});
+
+const AIR_GAPPED: LlmRouterConfig = {
+  preferLocal: true,
+  remoteModel: "claude-sonnet-4-6",
+  localModel: "m.gguf",
+  minReasoningParams: 0,
+  enforceAirGap: true,
+};
+
+describe("enforce_air_gap refuses a non-loopback [llm.local.*] route", () => {
+  const realFetch = globalThis.fetch;
+  let urls: string[] = [];
+
+  beforeEach(() => {
+    urls = [];
+    // Every request SUCCEEDS. If the route is skipped it is because of air-gap and nothing
+    // else — a failing daemon would make this test pass for the wrong reason.
+    globalThis.fetch = mock(async (input: unknown) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/health")) return new Response("ok");
+      if (url.endsWith("/api/tags")) {
+        return Response.json({ models: [{ name: "m.gguf" }] });
+      }
+      return Response.json({ content: "LEAKED", timings: { prompt_n: 1, predicted_n: 1 } });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("a LAN llama.cpp route is never selected, and NO byte of the prompt reaches it", async () => {
+    const router = new LlmRouter(AIR_GAPPED);
+    router.registerRoute(new LlamaCppProvider("http://192.168.1.50:8080", "m.gguf"), "m.gguf");
+
+    expect(await router.selectRoute("reasoning")).toBeUndefined();
+    await expect(
+      router.generate({ task: "reasoning", prompt: "a secret from the private index" }),
+    ).rejects.toThrow("No LLM provider available");
+
+    // The assertion that actually matters. `rejects.toThrow` alone would stay green if the
+    // route had been probed, or generated, and then thrown for some later reason: air-gap is
+    // a REFUSAL, so the host must see zero requests of any kind.
+    expect(urls.filter((u) => u.includes("192.168.1.50"))).toEqual([]);
+  });
+
+  test("a LAN Ollama route is refused the same way — the vendor id is irrelevant", async () => {
+    const router = new LlmRouter(AIR_GAPPED);
+    router.registerRoute(new OllamaProvider("http://192.168.1.50:11434", "m.gguf"), "m.gguf");
+    expect(await router.selectRoute("reasoning")).toBeUndefined();
+    expect(urls.filter((u) => u.includes("192.168.1.50"))).toEqual([]);
+  });
+
+  test("a loopback route on the SAME runtime is still selected under air-gap", async () => {
+    // The other half: the fix must refuse the LAN host without breaking local llama.cpp.
+    const router = new LlmRouter(AIR_GAPPED);
+    router.registerRoute(new LlamaCppProvider("http://127.0.0.1:8080", "m.gguf"), "m.gguf");
+    const route = await router.selectRoute("reasoning");
+    expect(route?.routeId).toBe("llamacpp/m.gguf");
+  });
+
+  test("with air-gap OFF the LAN route is usable — reclassified, not disabled", async () => {
+    const router = new LlmRouter({ ...AIR_GAPPED, enforceAirGap: false });
+    router.registerRoute(new LlamaCppProvider("http://192.168.1.50:8080", "m.gguf"), "m.gguf");
+    const route = await router.selectRoute("reasoning");
+    expect(route?.routeId).toBe("llamacpp/m.gguf");
+    // ...and it reports itself as REMOTE, which is what makes `egress/synthesis-egress.ts`
+    // ledger it (I29) and `[agents] synthesis = "local"` refuse it.
+    expect(route?.provider.isLocal).toBe(false);
+  });
+
+  test("a LAN route's generate() result declares itself remote", async () => {
+    const provider = new LlamaCppProvider("http://192.168.1.50:8080", "m.gguf");
+    const result = await provider.generate({ task: "reasoning", prompt: "x" });
+    expect(result.isLocal).toBe(false);
+  });
+});

--- a/packages/gateway/src/llm/base-url-locality.ts
+++ b/packages/gateway/src/llm/base-url-locality.ts
@@ -1,0 +1,72 @@
+// packages/gateway/src/llm/base-url-locality.ts
+
+/**
+ * The ONE definition of "this provider runs on this machine", derived from the base URL a
+ * provider was actually constructed with.
+ *
+ * Why it exists: `LlamaCppProvider.isLocal` and `OllamaProvider.isLocal` used to be the
+ * hardcoded literal `true`, while `base_url` is user-configurable and `[llm.local.<name>]`
+ * explicitly accepts a remote host. A route configured as
+ *
+ * ```toml
+ * [llm.local.ws]
+ * runtime = "llamacpp"
+ * base_url = "http://192.168.1.50:8080"
+ * ```
+ *
+ * therefore declared `isLocal: true`, so `LlmRouter.firstAvailableRoute`'s air-gap skip
+ * (`if (enforceAirGap && !route.provider.isLocal) continue`) did not exclude it and
+ * `generate()` sent prompts to that host. `[llm] enforce_air_gap` is a REFUSAL setting, not
+ * a preference — a runtime that only *looks* local defeats it entirely. The same hardcoded
+ * `true` also fed `egress/synthesis-egress.ts`, which derives "was this remote?" from
+ * `provider.isLocal`: a LAN llama.cpp server appended no `egress_ledger` row (I29).
+ *
+ * Locality is a property of the endpoint, so it is answered here and read off the provider
+ * INSTANCE everywhere else — never re-derived from a vendor id (see `local-definition.test.ts`).
+ *
+ * FAIL-CLOSED in both directions that matter: an unparseable URL is NOT local (we cannot
+ * prove the traffic stays here), and a hostname that merely resolves to loopback at DNS time
+ * is NOT local either — only the literal loopback forms below are. That is deliberately
+ * stricter than reality: air-gap should refuse a route it cannot prove, and the cost of a
+ * false negative is one warned-about reclassification, while the cost of a false positive is
+ * a prompt leaving the machine under a setting that promised it would not.
+ */
+export function isLoopbackBaseUrl(baseUrl: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(baseUrl).hostname;
+  } catch {
+    return false;
+  }
+  return isLoopbackHost(hostname);
+}
+
+/**
+ * The forms `URL.hostname` can actually hand back — it has already NORMALISED the host, which
+ * removes most of the spelling variety a matcher would otherwise have to chase:
+ *
+ * - case is folded (`LOCALHOST` → `localhost`);
+ * - an IPv6 literal keeps its brackets (`"[::1]"`), so they are stripped here;
+ * - IPv6 is compressed (`[0:0:0:0:0:0:0:1]` → `[::1]`) and an IPv4-mapped address is re-spelled
+ *   in HEX (`[::ffff:127.0.0.1]` → `[::ffff:7f00:1]`), which is why the mapped branch matches
+ *   `7f` — the high byte of the embedded IPv4 address, i.e. 127 — rather than a dotted quad;
+ * - a syntactically invalid IPv4 (`127.0.0.999`) makes the `URL` constructor THROW, and the
+ *   caller's catch already answers `false` for it.
+ *
+ * Matching only what the normaliser emits keeps every branch here reachable; a branch for
+ * `0:0:0:0:0:0:0:1` would be dead code that looks like coverage.
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[/, "").replace(/\]$/, "");
+  if (host === "localhost") return true;
+  if (host === "::1") return true;
+  if (/^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(host)) return true;
+  return isLoopbackIpv4(host);
+}
+
+/** The whole of `127.0.0.0/8`, not just `127.0.0.1` — the entire block is loopback. */
+function isLoopbackIpv4(host: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (m === null) return false;
+  return Number.parseInt(m[1] ?? "", 10) === 127;
+}

--- a/packages/gateway/src/llm/llamacpp-provider.ts
+++ b/packages/gateway/src/llm/llamacpp-provider.ts
@@ -7,6 +7,7 @@ type LlamaCppCompletionResponse = {
 
 export class LlamaCppProvider implements LlmProvider {
   readonly providerId = "llamacpp" as const;
+  readonly isLocal = true;
   private readonly baseUrl: string;
   private readonly modelName: string;
 

--- a/packages/gateway/src/llm/llamacpp-provider.ts
+++ b/packages/gateway/src/llm/llamacpp-provider.ts
@@ -1,3 +1,4 @@
+import { isLoopbackBaseUrl } from "./base-url-locality.ts";
 import type { LlmGenerateOptions, LlmGenerateResult, LlmModelInfo, LlmProvider } from "./types.ts";
 
 type LlamaCppCompletionResponse = {
@@ -7,13 +8,21 @@ type LlamaCppCompletionResponse = {
 
 export class LlamaCppProvider implements LlmProvider {
   readonly providerId = "llamacpp" as const;
-  readonly isLocal = true;
+  /**
+   * DERIVED from the resolved base URL, never hardcoded. `llamacpp` is a local RUNTIME, but a
+   * llama.cpp server is reachable over the network and `[llm.local.<name>] base_url` accepts a
+   * remote host — so "the runtime is local" and "this instance is local" are different claims.
+   * Hardcoding `true` here made `[llm] enforce_air_gap` skip its own exclusion for a LAN server
+   * and let prompts leave the machine. See `base-url-locality.ts`.
+   */
+  readonly isLocal: boolean;
   private readonly baseUrl: string;
   private readonly modelName: string;
 
   constructor(baseUrl = "http://127.0.0.1:8080", modelName = "model.gguf") {
     this.baseUrl = baseUrl.replace(/\/$/, "");
     this.modelName = modelName;
+    this.isLocal = isLoopbackBaseUrl(this.baseUrl);
   }
 
   async isAvailable(): Promise<boolean> {
@@ -57,7 +66,7 @@ export class LlamaCppProvider implements LlmProvider {
       tokensIn: data.timings?.prompt_n ?? 0,
       tokensOut: data.timings?.predicted_n ?? 0,
       modelUsed: this.modelName,
-      isLocal: true,
+      isLocal: this.isLocal,
       provider: "llamacpp",
     };
   }

--- a/packages/gateway/src/llm/local-definition.test.ts
+++ b/packages/gateway/src/llm/local-definition.test.ts
@@ -4,21 +4,72 @@ const FILES = [
   "packages/gateway/src/llm/router.ts",
   "packages/gateway/src/llm/registry.ts",
   "packages/gateway/src/ipc/llm-rpc.ts",
+  // Added after the whole-branch review: this file holds a FOURTH literal pair the
+  // original three-file scan could not see (`KNOWN_LOCAL_RUNTIMES`). That one is
+  // allow-listed below — it is the registry of runtimes this build knows how to
+  // CONSTRUCT a provider for, not a copy of the locality definition — but it must be
+  // allow-listed by name rather than by being invisible to the scan.
+  "packages/gateway/src/platform/assemble.ts",
 ];
+
+// The one literal pair that is NOT a locality copy. `KNOWN_LOCAL_RUNTIMES` gates
+// `[llm.local.<name>].runtime` before `buildLlmRegistryFromToml` picks a provider class:
+// a runtime it does not name (`"vllm"`) is dropped rather than silently constructed as
+// Ollama. Nothing reads it to decide whether a provider is local — that is
+// `provider.isLocal`, asserted positively below — and deleting it would not change any
+// locality answer, only re-open the silent-misconstruction hole.
+const ALLOWED_RUNTIME_REGISTRY = 'const KNOWN_LOCAL_RUNTIMES = new Set(["ollama", "llamacpp"]);';
+
+const LOCAL_ID_PAIR = /\["ollama",\s*"llamacpp"\]/;
+// A quoted vendor id. Locality must never be decided by comparing against one of these.
+const VENDOR_ID_LITERAL = /"(ollama|llamacpp|remote)"/;
 
 describe("local-ness has exactly one definition", () => {
   test("no file re-derives the local provider set from literals", async () => {
     const offenders: string[] = [];
     for (const f of FILES) {
       const src = await Bun.file(f).text();
-      // The three copies this refactor collapsed: a literal pair of local ids.
-      if (/\["ollama",\s*"llamacpp"\]/.test(src)) offenders.push(f);
+      // The three copies this refactor collapsed: a literal pair of local ids. The
+      // runtime registry is removed first, so allowing it cannot also blind the scan to
+      // a SECOND pair added later in the same file.
+      const scanned = src.replaceAll(ALLOWED_RUNTIME_REGISTRY, "");
+      if (LOCAL_ID_PAIR.test(scanned)) offenders.push(f);
     }
     expect(offenders).toEqual([]);
   });
 
+  test("the allow-listed literal pair is still exactly the runtime registry", async () => {
+    // Guards the allowance above: if `KNOWN_LOCAL_RUNTIMES` is renamed or reshaped, the
+    // `replaceAll` silently stops matching and the scan quietly widens instead of failing.
+    const src = await Bun.file("packages/gateway/src/platform/assemble.ts").text();
+    expect(src).toContain(ALLOWED_RUNTIME_REGISTRY);
+  });
+
   test("isLocal is read from the provider, never inferred from an id", async () => {
-    const src = await Bun.file("packages/gateway/src/llm/router.ts").text();
-    expect(src).not.toContain("LOCAL_PROVIDER_IDS");
+    // Positive property, not a missing-symbol check: every site that consults locality
+    // reads it off a provider INSTANCE, and no locality decision anywhere in the scanned
+    // set is made by comparing against a vendor-id literal.
+    const readSites: string[] = [];
+    const idDerived: string[] = [];
+    for (const f of FILES) {
+      const src = await Bun.file(f).text();
+      for (const line of src.split("\n")) {
+        // Comments describe the rule; only code can break it.
+        const code = line.replace(/\/\/.*$/, "").replace(/^\s*\*.*$/, "");
+        if (!code.includes("isLocal")) continue;
+        if (/(?:provider|p|r)\.isLocal\b/.test(code)) readSites.push(`${f}: ${code.trim()}`);
+        if (VENDOR_ID_LITERAL.test(code)) idDerived.push(`${f}: ${code.trim()}`);
+      }
+    }
+    // Locality is derived from a vendor id NOWHERE.
+    expect(idDerived).toEqual([]);
+    // And it is actually read off the provider — in the router (the resolution path), the
+    // registry (the capability-floor walk) and the IPC surface (what the CLI renders).
+    const files = new Set(readSites.map((s) => s.split(":")[0]));
+    expect([...files].sort()).toEqual([
+      "packages/gateway/src/ipc/llm-rpc.ts",
+      "packages/gateway/src/llm/registry.ts",
+      "packages/gateway/src/llm/router.ts",
+    ]);
   });
 });

--- a/packages/gateway/src/llm/local-definition.test.ts
+++ b/packages/gateway/src/llm/local-definition.test.ts
@@ -126,17 +126,31 @@ describe("local-ness has exactly one definition", () => {
     ]);
   });
 
-  test("no provider-id comparison or membership check, on ANY line", async () => {
+  test("no provider-id comparison or membership check, on any line OR ACROSS lines", async () => {
     // The independent half (see PROVIDER_ID_COMPARISON): a locality branch keyed on a vendor
     // id is forbidden whether or not the word `isLocal` appears beside it.
+    //
+    // Scanned BOTH per line and over the whole stripped file. A per-line scan alone is
+    // evadable: a formatter splits a long condition across lines, so
+    //   route.provider.providerId ===
+    //     "ollama"
+    // matches nothing on either line while re-deriving locality from a vendor id. The
+    // detectors separate their tokens with `\s*`, which spans newlines, so the joined pass
+    // catches the split form for free. Comments are stripped per line FIRST and the result
+    // re-joined, so prose describing the rule still cannot trip the rule.
     const offenders: string[] = [];
     for (const f of FILES) {
       const src = await readTarget(f.label);
-      for (const line of src.split("\n")) {
-        const code = codeOf(line);
+      const lines = src.split("\n").map(codeOf);
+      lines.forEach((code, i) => {
         if (PROVIDER_ID_COMPARISON.test(code) || PROVIDER_ID_MEMBERSHIP.test(code)) {
-          offenders.push(`${f.label}: ${code.trim()}`);
+          offenders.push(`${f.label}:${i + 1}: ${code.trim()}`);
         }
+      });
+      const joined = lines.join("\n");
+      const spansLines = PROVIDER_ID_COMPARISON.test(joined) || PROVIDER_ID_MEMBERSHIP.test(joined);
+      if (spansLines && !offenders.some((o) => o.startsWith(`${f.label}:`))) {
+        offenders.push(`${f.label}: provider-id check split across lines`);
       }
     }
     expect(offenders).toEqual([]);
@@ -151,12 +165,16 @@ describe("local-ness has exactly one definition", () => {
       'if (route.provider.providerId === "ollama") return true;',
       'const local = p.providerId !== "remote";',
       'if ("llamacpp" === provider.providerId) { }',
+      // Split across lines, the shape a formatter produces for a long condition — the
+      // evasion a per-line scan cannot see. `\s*` in the detector spans the newline.
+      ["if (", "  route.provider.providerId ===", '  "ollama"', ") return true;"].join("\n"),
     ]) {
       expect(PROVIDER_ID_COMPARISON.test(shape)).toBe(true);
     }
     for (const shape of [
       "if (LOCAL_IDS.has(route.provider.providerId)) return true;",
       "const local = LOCAL_IDS.includes(providerId);",
+      ["if (LOCAL_IDS.has(", "  route.provider.providerId,", ")) return true;"].join("\n"),
     ]) {
       expect(PROVIDER_ID_MEMBERSHIP.test(shape)).toBe(true);
     }

--- a/packages/gateway/src/llm/local-definition.test.ts
+++ b/packages/gateway/src/llm/local-definition.test.ts
@@ -1,16 +1,44 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 
-const FILES = [
-  "packages/gateway/src/llm/router.ts",
-  "packages/gateway/src/llm/registry.ts",
-  "packages/gateway/src/ipc/llm-rpc.ts",
+/**
+ * Scan targets, resolved relative to THIS FILE — never to the process working directory.
+ *
+ * The CWD-relative form (`Bun.file("packages/gateway/src/llm/router.ts")`) that shipped here
+ * only resolved when `bun test` happened to be invoked from the repo root. On CI it threw
+ * `ENOENT` and all three tests failed — but the failure mode this guards against is worse than
+ * a red test: a structural scan whose targets silently do not resolve reports an empty offender
+ * list and passes, which is exactly what a file-not-found returning empty text would have
+ * produced. `label` stays repo-relative POSIX so failure output and the file-set assertion below
+ * read the same on every OS (and so splitting on `":"` cannot hit a Windows drive letter).
+ */
+const HERE = import.meta.dir;
+const FILES: ReadonlyArray<{ label: string; path: string }> = [
+  { label: "packages/gateway/src/llm/router.ts", path: join(HERE, "router.ts") },
+  { label: "packages/gateway/src/llm/registry.ts", path: join(HERE, "registry.ts") },
+  { label: "packages/gateway/src/ipc/llm-rpc.ts", path: join(HERE, "..", "ipc", "llm-rpc.ts") },
   // Added after the whole-branch review: this file holds a FOURTH literal pair the
   // original three-file scan could not see (`KNOWN_LOCAL_RUNTIMES`). That one is
   // allow-listed below — it is the registry of runtimes this build knows how to
   // CONSTRUCT a provider for, not a copy of the locality definition — but it must be
   // allow-listed by name rather than by being invisible to the scan.
-  "packages/gateway/src/platform/assemble.ts",
+  {
+    label: "packages/gateway/src/platform/assemble.ts",
+    path: join(HERE, "..", "platform", "assemble.ts"),
+  },
 ];
+
+const ASSEMBLE = "packages/gateway/src/platform/assemble.ts";
+
+async function readTarget(label: string): Promise<string> {
+  const target = FILES.find((f) => f.label === label);
+  if (target === undefined) throw new Error(`not a scan target: ${label}`);
+  const src = await Bun.file(target.path).text();
+  // A scan over an empty string finds nothing and passes. Fail loudly instead: this guard's
+  // whole value is that it actually read the file it claims to have read.
+  if (src.trim() === "") throw new Error(`scan target is empty or unreadable: ${target.path}`);
+  return src;
+}
 
 // The one literal pair that is NOT a locality copy. `KNOWN_LOCAL_RUNTIMES` gates
 // `[llm.local.<name>].runtime` before `buildLlmRegistryFromToml` picks a provider class:
@@ -24,16 +52,41 @@ const LOCAL_ID_PAIR = /\["ollama",\s*"llamacpp"\]/;
 // A quoted vendor id. Locality must never be decided by comparing against one of these.
 const VENDOR_ID_LITERAL = /"(ollama|llamacpp|remote)"/;
 
+/**
+ * A provider-id comparison against a vendor literal, in either operand order —
+ * `route.provider.providerId === "ollama"`, `"llamacpp" !== p.providerId`.
+ *
+ * Checked INDEPENDENTLY of whether the line also mentions `isLocal`, which is the gap the
+ * previous version left wide open: it only recorded a vendor literal when the SAME line read
+ * `isLocal`, so an added `if (route.provider.providerId === "ollama") …` locality branch —
+ * precisely the re-derivation this whole file exists to forbid — evaded the guard entirely by
+ * not spelling the word.
+ *
+ * Keyed on the `providerId` token rather than on any vendor literal, so the legitimate
+ * RUNTIME dispatch in `assemble.ts` (`route.runtime === "llamacpp" ? … : …`, which chooses a
+ * provider CLASS and a default port, not a locality) is not a false positive.
+ */
+const PROVIDER_ID_COMPARISON =
+  /(?:providerId\s*[=!]==?\s*"(?:ollama|llamacpp|remote)")|(?:"(?:ollama|llamacpp|remote)"\s*[=!]==?\s*(?:[\w$.]*\.)?providerId\b)/;
+
+/** A membership check over a provider id: `SET.has(x.providerId)`, `[…].includes(providerId)`. */
+const PROVIDER_ID_MEMBERSHIP = /\.(?:has|includes)\(\s*(?:[\w$.]*\.)?providerId\b/;
+
+/** Strips line comments so prose describing the rule cannot trip the checks that enforce it. */
+function codeOf(line: string): string {
+  return line.replace(/\/\/.*$/, "").replace(/^\s*\*.*$/, "");
+}
+
 describe("local-ness has exactly one definition", () => {
   test("no file re-derives the local provider set from literals", async () => {
     const offenders: string[] = [];
     for (const f of FILES) {
-      const src = await Bun.file(f).text();
+      const src = await readTarget(f.label);
       // The three copies this refactor collapsed: a literal pair of local ids. The
       // runtime registry is removed first, so allowing it cannot also blind the scan to
       // a SECOND pair added later in the same file.
       const scanned = src.replaceAll(ALLOWED_RUNTIME_REGISTRY, "");
-      if (LOCAL_ID_PAIR.test(scanned)) offenders.push(f);
+      if (LOCAL_ID_PAIR.test(scanned)) offenders.push(f.label);
     }
     expect(offenders).toEqual([]);
   });
@@ -41,7 +94,7 @@ describe("local-ness has exactly one definition", () => {
   test("the allow-listed literal pair is still exactly the runtime registry", async () => {
     // Guards the allowance above: if `KNOWN_LOCAL_RUNTIMES` is renamed or reshaped, the
     // `replaceAll` silently stops matching and the scan quietly widens instead of failing.
-    const src = await Bun.file("packages/gateway/src/platform/assemble.ts").text();
+    const src = await readTarget(ASSEMBLE);
     expect(src).toContain(ALLOWED_RUNTIME_REGISTRY);
   });
 
@@ -52,13 +105,13 @@ describe("local-ness has exactly one definition", () => {
     const readSites: string[] = [];
     const idDerived: string[] = [];
     for (const f of FILES) {
-      const src = await Bun.file(f).text();
+      const src = await readTarget(f.label);
       for (const line of src.split("\n")) {
         // Comments describe the rule; only code can break it.
-        const code = line.replace(/\/\/.*$/, "").replace(/^\s*\*.*$/, "");
+        const code = codeOf(line);
         if (!code.includes("isLocal")) continue;
-        if (/(?:provider|p|r)\.isLocal\b/.test(code)) readSites.push(`${f}: ${code.trim()}`);
-        if (VENDOR_ID_LITERAL.test(code)) idDerived.push(`${f}: ${code.trim()}`);
+        if (/(?:provider|p|r)\.isLocal\b/.test(code)) readSites.push(`${f.label}: ${code.trim()}`);
+        if (VENDOR_ID_LITERAL.test(code)) idDerived.push(`${f.label}: ${code.trim()}`);
       }
     }
     // Locality is derived from a vendor id NOWHERE.
@@ -71,5 +124,49 @@ describe("local-ness has exactly one definition", () => {
       "packages/gateway/src/llm/registry.ts",
       "packages/gateway/src/llm/router.ts",
     ]);
+  });
+
+  test("no provider-id comparison or membership check, on ANY line", async () => {
+    // The independent half (see PROVIDER_ID_COMPARISON): a locality branch keyed on a vendor
+    // id is forbidden whether or not the word `isLocal` appears beside it.
+    const offenders: string[] = [];
+    for (const f of FILES) {
+      const src = await readTarget(f.label);
+      for (const line of src.split("\n")) {
+        const code = codeOf(line);
+        if (PROVIDER_ID_COMPARISON.test(code) || PROVIDER_ID_MEMBERSHIP.test(code)) {
+          offenders.push(`${f.label}: ${code.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("the vendor-id detectors actually match the shapes they forbid", async () => {
+    // Red-proves the guard above without editing production source: the detectors must fire
+    // on every re-derivation shape, including the ones with no `isLocal` on the line. A
+    // structural test whose regex silently matches nothing is the failure this file already
+    // shipped once (CWD-relative paths) — assert the detectors, not just their verdict.
+    for (const shape of [
+      'if (route.provider.providerId === "ollama") return true;',
+      'const local = p.providerId !== "remote";',
+      'if ("llamacpp" === provider.providerId) { }',
+    ]) {
+      expect(PROVIDER_ID_COMPARISON.test(shape)).toBe(true);
+    }
+    for (const shape of [
+      "if (LOCAL_IDS.has(route.provider.providerId)) return true;",
+      "const local = LOCAL_IDS.includes(providerId);",
+    ]) {
+      expect(PROVIDER_ID_MEMBERSHIP.test(shape)).toBe(true);
+    }
+    // And must NOT fire on the legitimate runtime dispatch in assemble.ts, or the guard
+    // becomes noise someone loosens.
+    expect(
+      PROVIDER_ID_COMPARISON.test('route.runtime === "llamacpp" ? "llamacpp" : "ollama"'),
+    ).toBe(false);
+    expect(PROVIDER_ID_MEMBERSHIP.test("KNOWN_LOCAL_RUNTIMES.has(route.runtime)")).toBe(false);
+    // The scan targets resolve: a path typo must fail, not scan an empty string.
+    await expect(readTarget(ASSEMBLE)).resolves.toContain("buildLlmRegistryFromToml");
   });
 });

--- a/packages/gateway/src/llm/local-definition.test.ts
+++ b/packages/gateway/src/llm/local-definition.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+const FILES = [
+  "packages/gateway/src/llm/router.ts",
+  "packages/gateway/src/llm/registry.ts",
+  "packages/gateway/src/ipc/llm-rpc.ts",
+];
+
+describe("local-ness has exactly one definition", () => {
+  test("no file re-derives the local provider set from literals", async () => {
+    const offenders: string[] = [];
+    for (const f of FILES) {
+      const src = await Bun.file(f).text();
+      // The three copies this refactor collapsed: a literal pair of local ids.
+      if (/\["ollama",\s*"llamacpp"\]/.test(src)) offenders.push(f);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("isLocal is read from the provider, never inferred from an id", async () => {
+    const src = await Bun.file("packages/gateway/src/llm/router.ts").text();
+    expect(src).not.toContain("LOCAL_PROVIDER_IDS");
+  });
+});

--- a/packages/gateway/src/llm/ollama-provider.ts
+++ b/packages/gateway/src/llm/ollama-provider.ts
@@ -97,6 +97,7 @@ export const DEFAULT_LOCAL_CONTEXT_TOKENS = 8192;
 
 export class OllamaProvider implements LlmProvider {
   readonly providerId = "ollama" as const;
+  readonly isLocal = true;
   private readonly baseUrl: string;
   private readonly modelName: string;
   private readonly contextTokens: number;

--- a/packages/gateway/src/llm/ollama-provider.ts
+++ b/packages/gateway/src/llm/ollama-provider.ts
@@ -1,3 +1,4 @@
+import { isLoopbackBaseUrl } from "./base-url-locality.ts";
 import type {
   LlmGenerateOptions,
   LlmGenerateResult,
@@ -97,7 +98,13 @@ export const DEFAULT_LOCAL_CONTEXT_TOKENS = 8192;
 
 export class OllamaProvider implements LlmProvider {
   readonly providerId = "ollama" as const;
-  readonly isLocal = true;
+  /**
+   * DERIVED from the resolved base URL, never hardcoded. An Ollama daemon is reachable over the
+   * network and `[llm.local.<name>] base_url` accepts a remote host, so "ollama" says nothing
+   * about where the weights run. Hardcoding `true` made `[llm] enforce_air_gap` skip its own
+   * exclusion for a LAN daemon. See `base-url-locality.ts`.
+   */
+  readonly isLocal: boolean;
   private readonly baseUrl: string;
   private readonly modelName: string;
   private readonly contextTokens: number;
@@ -110,6 +117,7 @@ export class OllamaProvider implements LlmProvider {
     this.baseUrl = baseUrl.replace(/\/$/, "");
     this.modelName = modelName;
     this.contextTokens = contextTokens;
+    this.isLocal = isLoopbackBaseUrl(this.baseUrl);
   }
 
   async isAvailable(): Promise<boolean> {
@@ -172,7 +180,7 @@ export class OllamaProvider implements LlmProvider {
       tokensIn: data.prompt_eval_count ?? 0,
       tokensOut: data.eval_count ?? 0,
       modelUsed: this.modelName,
-      isLocal: true,
+      isLocal: this.isLocal,
       provider: "ollama",
     };
   }
@@ -219,7 +227,7 @@ export class OllamaProvider implements LlmProvider {
       tokensIn: state.tokensIn,
       tokensOut: state.tokensOut,
       modelUsed: this.modelName,
-      isLocal: true,
+      isLocal: this.isLocal,
       provider: "ollama",
     };
   }

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -34,6 +34,7 @@ type ProviderOpts = {
 function makeProvider(id: LlmProviderKind, opts: ProviderOpts): LlmProvider {
   const base = {
     providerId: id,
+    isLocal: id !== "remote",
     isAvailable: async () => {
       if (opts.throwOnAvailable === true) throw new Error("availability check failed");
       return opts.available;

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -625,3 +625,153 @@ describe("min_reasoning_params can actually fire (F8)", () => {
     await expect(registry.refreshProviderMeta("llama3.2")).resolves.toBeUndefined();
   });
 });
+
+describe("LlmRegistry lifecycle — two daemons behind one vendor id (Fix I)", () => {
+  test("an unambiguous vendor id still resolves with no discriminator", async () => {
+    // The constraint that shapes this whole design: pulling a model that has NO route yet
+    // must keep working, so lifecycle cannot key on routeId. One instance → no ambiguity.
+    const pulled: string[] = [];
+    const provider = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        pulled.push(m);
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    // Two ROUTES, one provider INSTANCE — the ordinary two-models-on-one-daemon setup.
+    registry.addRoute(provider, "qwen3:8b");
+    registry.addRoute(provider, "gemma3:12b");
+    await registry.pullModel("ollama", "a-model-with-no-route");
+    expect(pulled).toEqual(["a-model-with-no-route"]);
+  });
+
+  test("two distinct daemons under one vendor id REFUSE to guess, and name the candidates", async () => {
+    // The bug: `.find(...)` on providerId sent the pull to whichever daemon was configured
+    // FIRST — a multi-gigabyte download onto the wrong machine, reported as success.
+    const laptopPulls: string[] = [];
+    const workstationPulls: string[] = [];
+    const laptop = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        laptopPulls.push(m);
+      },
+    });
+    const workstation = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        workstationPulls.push(m);
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(laptop, "qwen3:8b");
+    registry.addRoute(workstation, "gemma3:12b");
+
+    await expect(registry.pullModel("ollama", "new-model")).rejects.toThrow(/2 distinct endpoints/);
+    // Naming the candidates is the point — an error the user cannot act on is barely better
+    // than the silent wrong answer it replaced.
+    await expect(registry.pullModel("ollama", "new-model")).rejects.toThrow(/ollama\/qwen3:8b/);
+    await expect(registry.pullModel("ollama", "new-model")).rejects.toThrow(/ollama\/gemma3:12b/);
+    // And NOTHING was downloaded anywhere: refusing means refusing, not "tried the first one".
+    expect(laptopPulls).toEqual([]);
+    expect(workstationPulls).toEqual([]);
+  });
+
+  test("routeId names which daemon the operation reaches", async () => {
+    const laptopPulls: string[] = [];
+    const workstationPulls: string[] = [];
+    const laptop = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        laptopPulls.push(m);
+      },
+    });
+    const workstation = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        workstationPulls.push(m);
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(laptop, "qwen3:8b");
+    registry.addRoute(workstation, "gemma3:12b");
+
+    await registry.pullModel("ollama", "new-model", { routeId: "ollama/gemma3:12b" });
+    expect(workstationPulls).toEqual(["new-model"]);
+    expect(laptopPulls).toEqual([]);
+  });
+
+  test("loadModel/unloadModel resolve through the same rule", async () => {
+    const loaded: string[] = [];
+    const unloaded: string[] = [];
+    const laptop = makeProvider("ollama", { available: true, loadModel: async () => {} });
+    const workstation = makeProvider("ollama", {
+      available: true,
+      loadModel: async (m) => {
+        loaded.push(m);
+      },
+      unloadModel: async (m) => {
+        unloaded.push(m);
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(laptop, "qwen3:8b");
+    registry.addRoute(workstation, "gemma3:12b");
+
+    await expect(registry.loadModel("ollama", "x")).rejects.toThrow(/2 distinct endpoints/);
+    await registry.loadModel("ollama", "x", { routeId: "ollama/gemma3:12b" });
+    expect(loaded).toEqual(["x"]);
+    await registry.unloadModel("ollama", "x", { routeId: "ollama/gemma3:12b" });
+    expect(unloaded).toEqual(["x"]);
+  });
+
+  test("an unregistered routeId is rejected rather than silently ignored", async () => {
+    const provider = makeProvider("ollama", { available: true, pullModel: async () => {} });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(provider, "qwen3:8b");
+    await expect(
+      registry.pullModel("ollama", "x", { routeId: "ollama/not-registered" }),
+    ).rejects.toThrow("Route not registered: ollama/not-registered");
+  });
+
+  test("a routeId belonging to a DIFFERENT provider is rejected, never used as an override", async () => {
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(makeProvider("ollama", { available: true }), "qwen3:8b");
+    registry.addRoute(makeProvider("llamacpp", { available: true }), "a.gguf");
+    await expect(registry.loadModel("ollama", "x", { routeId: "llamacpp/a.gguf" })).rejects.toThrow(
+      /belongs to provider "llamacpp", not "ollama"/,
+    );
+  });
+});
+
+describe("LlmRegistry.checkRoute — the registry owns the probe (Fix E)", () => {
+  test("checkRoute answers from the SAME probe route selection consults", async () => {
+    // The property `llm.status` needs: one probe, one answer. A `RouteAvailabilityProbe`
+    // constructed at the IPC layer had its own cache, so status could report a route
+    // available while the router had already routed past it.
+    let listCalls = 0;
+    let reportedModels: string[] = [];
+    const provider = makeProvider("ollama", { available: true, models: [] });
+    (provider as unknown as { listModels: () => Promise<LlmModelInfo[]> }).listModels =
+      async () => {
+        listCalls += 1;
+        return reportedModels.map((m) => ({ provider: "ollama", modelName: m }));
+      };
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(provider, "fresh-model");
+    const route = registry.llmRouter.routes()[0];
+    expect(route).toBeDefined();
+
+    // Prime the shared cache through the ROUTER.
+    expect(await registry.llmRouter.selectProvider("agent_step")).toBeUndefined();
+    const callsAfterRouting = listCalls;
+    // The daemon now reports the model — but the shared cache has not expired, so a probe
+    // reading the same cache must still say `model_absent`. A freshly-constructed probe
+    // would re-list and answer `ok`, which is exactly the divergence this closes.
+    reportedModels = ["fresh-model"];
+    expect(await registry.checkRoute(route as NonNullable<typeof route>)).toEqual({
+      available: false,
+      reason: "model_absent",
+    });
+    expect(listCalls).toBe(callsAfterRouting);
+  });
+});

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -8,7 +8,7 @@ import { LLM_MODELS_V16_SQL } from "../index/llm-models-v16-sql.ts";
 import { LLM_TASK_DEFAULTS_V20_SQL } from "../index/llm-task-defaults-v20-sql.ts";
 import { LlmRegistry } from "./registry.ts";
 import type { LlmRouterConfig } from "./router.ts";
-import type { LlmModelInfo, LlmProvider, LlmProviderKind, PullProgressChunk } from "./types.ts";
+import type { LlmModelInfo, LlmProvider, ProviderId, PullProgressChunk } from "./types.ts";
 
 const DEFAULT_CONFIG: LlmRouterConfig = {
   preferLocal: true,
@@ -31,7 +31,7 @@ type ProviderOpts = {
   throwOnList?: boolean;
 };
 
-function makeProvider(id: LlmProviderKind, opts: ProviderOpts): LlmProvider {
+function makeProvider(id: ProviderId, opts: ProviderOpts): LlmProvider {
   const base = {
     providerId: id,
     isLocal: id !== "remote",
@@ -81,15 +81,16 @@ describe("LlmRegistry — construction + provider registration", () => {
     expect(typeof reg.llmRouter.selectProvider).toBe("function");
   });
 
-  test("addProvider forwards to LlmRouter.registerProvider", () => {
+  test("addRoute registers a provider that selectProvider can then resolve", () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    // The model-aware availability probe (Task 5) needs the fake to report the model
-    // `registerProvider` assigns it (`config.localModel`), or it reads as unavailable.
-    reg.addProvider(
+    // The model-aware availability probe (Task 5) needs the fake to report the model it is
+    // registered under, or it reads as unavailable.
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         models: [{ provider: "ollama", modelName: DEFAULT_CONFIG.localModel }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
     return reg.llmRouter.selectProvider("agent_step").then((p) => {
       expect(p?.providerId).toBe("ollama");
@@ -115,23 +116,26 @@ describe("LlmRegistry.listAllModels", () => {
   test("returns models from all registered + available providers", async () => {
     env = makeDbWithSchema();
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         models: [{ provider: "ollama", modelName: "llama3.2", parameterCount: 3 }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("llamacpp", {
         available: true,
         models: [{ provider: "llamacpp", modelName: "qwen", contextWindow: 8192 }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("remote", {
         available: true,
         models: [{ provider: "remote", modelName: "claude-sonnet-4-6" }],
       }),
+      DEFAULT_CONFIG.remoteModel,
     );
     const models = await reg.listAllModels();
     expect(models).toHaveLength(3);
@@ -145,17 +149,19 @@ describe("LlmRegistry.listAllModels", () => {
   test("skips a provider when isAvailable returns false", async () => {
     env = makeDbWithSchema();
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         models: [{ provider: "ollama", modelName: "m1" }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("llamacpp", {
         available: false,
         models: [{ provider: "llamacpp", modelName: "m2" }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
     const models = await reg.listAllModels();
     expect(models).toHaveLength(1);
@@ -165,12 +171,16 @@ describe("LlmRegistry.listAllModels", () => {
   test("a thrown provider error is swallowed (skip silently)", async () => {
     env = makeDbWithSchema();
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    reg.addProvider(makeProvider("ollama", { available: true, throwOnList: true }));
-    reg.addProvider(
+    reg.addRoute(
+      makeProvider("ollama", { available: true, throwOnList: true }),
+      DEFAULT_CONFIG.localModel,
+    );
+    reg.addRoute(
       makeProvider("remote", {
         available: true,
         models: [{ provider: "remote", modelName: "good" }],
       }),
+      DEFAULT_CONFIG.remoteModel,
     );
     const models = await reg.listAllModels();
     expect(models).toHaveLength(1);
@@ -180,7 +190,7 @@ describe("LlmRegistry.listAllModels", () => {
   test("syncs models to llm_models table on each listAllModels call", async () => {
     env = makeDbWithSchema();
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         models: [
@@ -194,6 +204,7 @@ describe("LlmRegistry.listAllModels", () => {
           },
         ],
       }),
+      DEFAULT_CONFIG.localModel,
     );
     await reg.listAllModels();
     const row = env.db
@@ -219,11 +230,12 @@ describe("LlmRegistry.listAllModels", () => {
 
   test("no-DB mode skips sync without throwing", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         models: [{ provider: "ollama", modelName: "x" }],
       }),
+      DEFAULT_CONFIG.localModel,
     );
     await expect(reg.listAllModels()).resolves.toBeDefined();
   });
@@ -232,8 +244,8 @@ describe("LlmRegistry.listAllModels", () => {
 describe("LlmRegistry.checkAvailability", () => {
   test("returns per-provider booleans for registered providers", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("ollama", { available: true }));
-    reg.addProvider(makeProvider("remote", { available: false }));
+    reg.addRoute(makeProvider("ollama", { available: true }), DEFAULT_CONFIG.localModel);
+    reg.addRoute(makeProvider("remote", { available: false }), DEFAULT_CONFIG.remoteModel);
     const out = await reg.checkAvailability();
     expect(out["ollama"]).toBe(true);
     expect(out["remote"]).toBe(false);
@@ -242,7 +254,10 @@ describe("LlmRegistry.checkAvailability", () => {
 
   test("isAvailable throw → false for that provider", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("ollama", { available: false, throwOnAvailable: true }));
+    reg.addRoute(
+      makeProvider("ollama", { available: false, throwOnAvailable: true }),
+      DEFAULT_CONFIG.localModel,
+    );
     const out = await reg.checkAvailability();
     expect(out["ollama"]).toBe(false);
   });
@@ -252,13 +267,14 @@ describe("LlmRegistry.loadModel / unloadModel", () => {
   test("loadModel invokes the provider's loadModel when defined", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
     let captured = "";
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("llamacpp", {
         available: true,
         loadModel: async (m) => {
           captured = m;
         },
       }),
+      DEFAULT_CONFIG.localModel,
     );
     await reg.loadModel("llamacpp", "qwen.gguf");
     expect(captured).toBe("qwen.gguf");
@@ -266,7 +282,7 @@ describe("LlmRegistry.loadModel / unloadModel", () => {
 
   test("loadModel is a no-op when the provider does not implement it", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("ollama", { available: true }));
+    reg.addRoute(makeProvider("ollama", { available: true }), DEFAULT_CONFIG.localModel);
     await expect(reg.loadModel("ollama", "any-model")).resolves.toBeUndefined();
   });
 
@@ -278,13 +294,14 @@ describe("LlmRegistry.loadModel / unloadModel", () => {
   test("unloadModel invokes the provider's unloadModel when defined", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
     let captured = "";
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("llamacpp", {
         available: true,
         unloadModel: async (m) => {
           captured = m;
         },
       }),
+      DEFAULT_CONFIG.localModel,
     );
     await reg.unloadModel("llamacpp", "qwen.gguf");
     expect(captured).toBe("qwen.gguf");
@@ -302,13 +319,14 @@ describe("LlmRegistry.pullModel", () => {
   test("dispatches to provider.pullModel when supported", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
     let captured = "";
-    reg.addProvider(
+    reg.addRoute(
       makeProvider("ollama", {
         available: true,
         pullModel: async (m) => {
           captured = m;
         },
       }),
+      DEFAULT_CONFIG.localModel,
     );
     await reg.pullModel("ollama", "llama3.2");
     expect(captured).toBe("llama3.2");
@@ -316,7 +334,7 @@ describe("LlmRegistry.pullModel", () => {
 
   test("rejects with TypeError when provider lacks pullModel", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("llamacpp", { available: true }));
+    reg.addRoute(makeProvider("llamacpp", { available: true }), DEFAULT_CONFIG.localModel);
     await expect(reg.pullModel("llamacpp", "x")).rejects.toThrow(
       "Provider llamacpp does not support pullModel",
     );
@@ -526,7 +544,7 @@ describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
 describe("LlmRegistry.getRouterStatus", () => {
   test("delegates to LlmRouter.getStatus and returns a shape with the four task types", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("ollama", { available: true }));
+    reg.addRoute(makeProvider("ollama", { available: true }), DEFAULT_CONFIG.localModel);
     const status = await reg.getRouterStatus();
     expect(status).toBeDefined();
     // The exact shape lives in LlmRouter; just confirm the call doesn't throw
@@ -548,6 +566,12 @@ describe("min_reasoning_params can actually fire (F8)", () => {
   function providerReporting(parameterCount: number | undefined): LlmProvider {
     return {
       providerId: "ollama",
+      // Required so `refreshProviderMeta`'s `if (!route.provider.isLocal) continue` does not
+      // skip this route — without it, parameterCount is never propagated to route.meta at
+      // all, and the test below passed for the wrong reason (the route read as unavailable
+      // via a route-id/modelName mismatch in the now-deleted `registerProvider` shim, not
+      // because the capability floor actually rejected the reported parameter count).
+      isLocal: true,
       isAvailable: async () => true,
       listModels: async () => [
         {
@@ -571,7 +595,7 @@ describe("min_reasoning_params can actually fire (F8)", () => {
     const registry = new LlmRegistry({
       config: { preferLocal: true, localModel: "llama3.2", minReasoningParams: 7 } as never,
     });
-    registry.addProvider(providerReporting(3.2));
+    registry.addRoute(providerReporting(3.2), DEFAULT_CONFIG.localModel);
     await registry.refreshProviderMeta("llama3.2");
 
     // 3.2B against a floor of 7 — the floor must now see the number it never used to get, so the
@@ -586,13 +610,17 @@ describe("min_reasoning_params can actually fire (F8)", () => {
     const registry = new LlmRegistry({
       config: { preferLocal: true, localModel: "llama3.2", minReasoningParams: 7 } as never,
     });
-    registry.addProvider({
-      providerId: "ollama",
-      isAvailable: async () => false,
-      listModels: async () => {
-        throw new Error("connection refused");
-      },
-    } as unknown as LlmProvider);
+    registry.addRoute(
+      {
+        providerId: "ollama",
+        isLocal: true,
+        isAvailable: async () => false,
+        listModels: async () => {
+          throw new Error("connection refused");
+        },
+      } as unknown as LlmProvider,
+      DEFAULT_CONFIG.localModel,
+    );
 
     await expect(registry.refreshProviderMeta("llama3.2")).resolves.toBeUndefined();
   });

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -83,7 +83,14 @@ describe("LlmRegistry — construction + provider registration", () => {
 
   test("addProvider forwards to LlmRouter.registerProvider", () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });
-    reg.addProvider(makeProvider("ollama", { available: true }));
+    // The model-aware availability probe (Task 5) needs the fake to report the model
+    // `registerProvider` assigns it (`config.localModel`), or it reads as unavailable.
+    reg.addProvider(
+      makeProvider("ollama", {
+        available: true,
+        models: [{ provider: "ollama", modelName: DEFAULT_CONFIG.localModel }],
+      }),
+    );
     return reg.llmRouter.selectProvider("agent_step").then((p) => {
       expect(p?.providerId).toBe("ollama");
     });

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -376,6 +376,96 @@ describe("LlmRegistry.setDefault / getDefault", () => {
   });
 });
 
+describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
+  test("pullModel works for a model that has NO route", async () => {
+    // The primary use of pull: fetch a model BEFORE configuring a route for it. Keying
+    // lifecycle on routeId would make this impossible — see Task 6 brief.
+    const pulled: string[] = [];
+    const provider = makeProvider("ollama", {
+      available: true,
+      pullModel: async (m) => {
+        pulled.push(m);
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(provider, "qwen3:8b");
+    await registry.pullModel("ollama", "a-model-with-no-route");
+    expect(pulled).toEqual(["a-model-with-no-route"]);
+  });
+
+  test("listAllModels covers a vendor id the registry has never heard of", async () => {
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(
+      makeProvider("gemini", {
+        available: true,
+        models: [{ provider: "gemini", modelName: "gemini-2.5-pro" }],
+      }),
+      "gemini-2.5-pro",
+    );
+    const models = await registry.listAllModels();
+    expect(models.some((m) => m.provider === "gemini")).toBe(true);
+  });
+
+  test("a successful pullModel invalidates the route-availability cache for that providerId", async () => {
+    // Without invalidate(), a freshly-pulled model reports model_absent for up to the
+    // positive TTL — indistinguishable from the pull having failed.
+    let reportedModels: string[] = [];
+    const provider = makeProvider("ollama", {
+      available: true,
+      models: [],
+      pullModel: async (m) => {
+        reportedModels = [m];
+      },
+    });
+    (provider as unknown as { listModels: () => Promise<LlmModelInfo[]> }).listModels = async () =>
+      reportedModels.map((m) => ({ provider: "ollama", modelName: m }));
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(provider, "fresh-model");
+    // Prime the negative cache: at this point the daemon does not yet report the model.
+    const before = await registry.llmRouter.selectProvider("agent_step");
+    expect(before).toBeUndefined();
+    await registry.pullModel("ollama", "fresh-model");
+    const after = await registry.llmRouter.selectProvider("agent_step");
+    expect(after?.providerId).toBe("ollama");
+  });
+
+  test("a FAILED pullModel does not invalidate the cache", async () => {
+    const provider = makeProvider("ollama", {
+      available: true,
+      models: [],
+      pullModel: async () => {
+        throw new Error("pull failed");
+      },
+    });
+    const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+    registry.addRoute(provider, "fresh-model");
+    await expect(registry.pullModel("ollama", "fresh-model")).rejects.toThrow("pull failed");
+    // No assertion beyond "did not throw during invalidate" — the cache-clear must be
+    // gated on success, proven directly in the invariant test above.
+  });
+
+  test(
+    "refreshProviderMeta does not mint a spurious route from config.localModel " +
+      "(Task 3 predicted bug)",
+    async () => {
+      const provider = makeProvider("ollama", {
+        available: true,
+        models: [{ provider: "ollama", modelName: "qwen3:8b", parameterCount: 8 }],
+      });
+      // DEFAULT_CONFIG.localModel is "llama3.2" — distinct from the route's own model,
+      // so the old registerProvider-shim re-registration would mint a second route
+      // "ollama/llama3.2" alongside "ollama/qwen3:8b".
+      const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+      registry.addRoute(provider, "qwen3:8b");
+      await registry.refreshProviderMeta("qwen3:8b");
+      const routes = registry.llmRouter.routes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0]?.modelName).toBe("qwen3:8b");
+      expect(routes[0]?.meta.parameterCount).toBe(8);
+    },
+  );
+});
+
 describe("LlmRegistry.getRouterStatus", () => {
   test("delegates to LlmRouter.getStatus and returns a shape with the four task types", async () => {
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG });

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -430,6 +430,14 @@ describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
   });
 
   test("a FAILED pullModel does not invalidate the cache", async () => {
+    // Same technique as the success test above, but the pull rejects: prime the
+    // negative cache, fail the pull, THEN flip listModels() to report the model, and
+    // assert the route STILL reads as unavailable — because a failed pull must not
+    // have cleared the cache, and the stale (positive-TTL) entry should still be in
+    // effect. This assertion is what actually distinguishes "invalidate was correctly
+    // skipped" from "invalidate ran anyway" — a bare `rejects.toThrow` on the pull
+    // call cannot: it stays green whether or not invalidate() runs on failure.
+    let reportedModels: string[] = [];
     const provider = makeProvider("ollama", {
       available: true,
       models: [],
@@ -437,11 +445,20 @@ describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
         throw new Error("pull failed");
       },
     });
+    (provider as unknown as { listModels: () => Promise<LlmModelInfo[]> }).listModels = async () =>
+      reportedModels.map((m) => ({ provider: "ollama", modelName: m }));
     const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
     registry.addRoute(provider, "fresh-model");
+    // Prime the negative cache: at this point the daemon does not report the model.
+    const before = await registry.llmRouter.selectProvider("agent_step");
+    expect(before).toBeUndefined();
     await expect(registry.pullModel("ollama", "fresh-model")).rejects.toThrow("pull failed");
-    // No assertion beyond "did not throw during invalidate" — the cache-clear must be
-    // gated on success, proven directly in the invariant test above.
+    // The daemon now DOES report the model (as if it landed some other way) — but the
+    // cache must still be serving its stale, pre-pull answer, because invalidate()
+    // must not have run on this failed pull.
+    reportedModels = ["fresh-model"];
+    const after = await registry.llmRouter.selectProvider("agent_step");
+    expect(after).toBeUndefined();
   });
 
   test(

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -481,6 +481,46 @@ describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
       expect(routes[0]?.meta.parameterCount).toBe(8);
     },
   );
+
+  test(
+    "refreshProviderMeta does not cross-assign parameterCount between routes sharing a " +
+      "daemon (Task 9 review, finding 1)",
+    async () => {
+      // Two DISTINCT provider instances (as `buildLlmRegistryFromToml` constructs, one per
+      // [llm.local.*] entry) both pointed at the same shared Ollama daemon — so both report
+      // the daemon's FULL model list, exactly as a real shared daemon would.
+      const sharedDaemonListing: LlmModelInfo[] = [
+        { provider: "ollama", modelName: "qwen3:8b", parameterCount: 8 },
+        { provider: "ollama", modelName: "gemma3:12b", parameterCount: 12 },
+      ];
+      const qwenProvider = makeProvider("ollama", {
+        available: true,
+        models: sharedDaemonListing,
+      });
+      const gemmaProvider = makeProvider("ollama", {
+        available: true,
+        models: sharedDaemonListing,
+      });
+      const registry = new LlmRegistry({ config: DEFAULT_CONFIG });
+      registry.addRoute(qwenProvider, "qwen3:8b");
+      registry.addRoute(gemmaProvider, "gemma3:12b");
+
+      // Mirrors the ACTUAL pre-fix production call pattern in assemble.ts: one call per
+      // distinct registered model name, looped across every route.
+      await registry.refreshProviderMeta("qwen3:8b");
+      await registry.refreshProviderMeta("gemma3:12b");
+
+      const routes = registry.llmRouter.routes();
+      const qwenRoute = routes.find((r) => r.modelName === "qwen3:8b");
+      const gemmaRoute = routes.find((r) => r.modelName === "gemma3:12b");
+      // Each route must get its OWN parameterCount — never the other route's, which is
+      // exactly what a caller-supplied `modelName` search applied indiscriminately to every
+      // route (rather than matched against that route's own modelName) produced: whichever
+      // name was refreshed LAST won for every route on the shared daemon.
+      expect(qwenRoute?.meta.parameterCount).toBe(8);
+      expect(gemmaRoute?.meta.parameterCount).toBe(12);
+    },
+  );
 });
 
 describe("LlmRegistry.getRouterStatus", () => {

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -1,13 +1,30 @@
 import type { Database } from "bun:sqlite";
 import { dbRun } from "../db/write.ts";
+import type { RouteAvailability } from "./route-availability.ts";
 import { RouteAvailabilityProbe } from "./route-availability.ts";
 import { LlmRouter, type LlmRouterConfig, type ProviderMeta } from "./router.ts";
-import type { LlmModelInfo, LlmProvider, ProviderId, PullProgressChunk } from "./types.ts";
+import type {
+  LlmModelInfo,
+  LlmProvider,
+  ModelRoute,
+  ProviderId,
+  PullProgressChunk,
+} from "./types.ts";
 
 export type LlmRegistryOptions = {
   config: LlmRouterConfig;
   db?: Database;
 };
+
+/**
+ * Optional discriminator for the providerId-keyed lifecycle calls (`pullModel`/`loadModel`/
+ * `unloadModel`). Names the exact registered route — and therefore the exact daemon — the
+ * operation must reach, for the case where one vendor id has several distinct provider
+ * INSTANCES behind it (two Ollama daemons at different base URLs). Omitted, the vendor id must
+ * resolve unambiguously or the call throws naming the candidates; see
+ * `resolveLifecycleProvider`.
+ */
+export type LlmLifecycleTarget = { routeId?: string };
 
 export class LlmRegistry {
   private readonly router: LlmRouter;
@@ -133,24 +150,105 @@ export class LlmRegistry {
     return result;
   }
 
+  /**
+   * Availability of one registered route, answered through the probe THIS registry owns — the
+   * same instance `LlmRouter` was constructed with, and therefore the same cache route selection
+   * consults.
+   *
+   * Exists because `ipc/llm-rpc.ts`'s `llm.status` used to construct a `RouteAvailabilityProbe`
+   * of its own per request. That bypassed the shared cache entirely and could report a DIFFERENT
+   * availability snapshot than the one the router had just routed on — "ollama/qwen3:8b:
+   * available" in `nimbus llm status` while `nimbus ask` was answering from the fallback,
+   * with nothing to reconcile the two. Threading it through the registry (which already holds
+   * the reference, for `pullModel`'s `invalidate()`) rather than adding a public probe accessor
+   * to `LlmRouter` keeps the reach-into-router-internals shape out of the IPC layer.
+   */
+  async checkRoute(route: ModelRoute): Promise<RouteAvailability> {
+    return await this.probe.check(route);
+  }
+
+  /**
+   * Resolves which provider INSTANCE a lifecycle call (`pullModel`/`loadModel`/`unloadModel`)
+   * must reach.
+   *
+   * The constraint that shaped this: pulling a model that has NO route yet is the PRIMARY use of
+   * pull, so lifecycle cannot key on `routeId` — the model being pulled has no route by
+   * definition. Keying on `providerId` alone was the previous answer, resolved with a
+   * first-match `.find(...)`; with two Ollama daemons registered at different base URLs that
+   * silently sent the pull to whichever was configured FIRST, downloading gigabytes onto the
+   * wrong machine with a success message.
+   *
+   * The resolution keeps vendor-id addressing (so route-less pulls still work) and closes the
+   * silent-wrong-target hole by refusing to guess:
+   *
+   * - one provider instance carries the vendor id → use it (the overwhelmingly common case, and
+   *   the one every existing caller is in);
+   * - several distinct instances carry it → THROW, naming every candidate route, rather than
+   *   picking one. An ambiguous pull has no safe default: both answers are a multi-gigabyte
+   *   download against a daemon the user may not have meant;
+   * - `target.routeId` supplied → that route's provider, after checking the route exists and
+   *   actually belongs to `providerId` (a mismatch is a caller bug, not a silent override).
+   */
+  private resolveLifecycleProvider(
+    providerId: ProviderId,
+    target: LlmLifecycleTarget,
+  ): LlmProvider {
+    const routeId = target.routeId;
+    if (routeId !== undefined) {
+      const route = this.router.routeFor(routeId);
+      if (route === undefined) throw new Error(`Route not registered: ${routeId}`);
+      if (route.provider.providerId !== providerId) {
+        throw new Error(
+          `Route "${routeId}" belongs to provider "${route.provider.providerId}", not "${providerId}"`,
+        );
+      }
+      return route.provider;
+    }
+    const instances: Array<{ provider: LlmProvider; routeIds: string[] }> = [];
+    for (const route of this.router.routes()) {
+      if (route.provider.providerId !== providerId) continue;
+      const existing = instances.find((e) => e.provider === route.provider);
+      if (existing === undefined) {
+        instances.push({ provider: route.provider, routeIds: [route.routeId] });
+      } else {
+        existing.routeIds.push(route.routeId);
+      }
+    }
+    const first = instances[0];
+    if (first === undefined) throw new Error(`Provider not registered: ${providerId}`);
+    if (instances.length === 1) return first.provider;
+    const candidates = instances.map((e) => e.routeIds.join(" + ")).join("; ");
+    throw new Error(
+      `Provider "${providerId}" is registered on ${instances.length} distinct endpoints — ` +
+        `pass routeId to name which one. Candidates: ${candidates}`,
+    );
+  }
+
   // Lifecycle methods key on `providerId`, and the model stays an argument — never the
   // route id. `OllamaProvider.pullModel(modelName)` posts its argument to the shared
   // daemon, so any registered instance of a providerId can pull/load/unload any model;
   // requiring a matching route would make it impossible to pull a model that has no
-  // route yet, which is the primary use of pull. Resolution is "any registered route
-  // whose provider.providerId matches" — exactly what `LlmRouter.providerFor` does.
-  async loadModel(provider: ProviderId, modelName: string): Promise<void> {
-    const p = this.router.providerFor(provider);
-    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+  // route yet, which is the primary use of pull. `target.routeId` is the optional
+  // tie-breaker for when one vendor id has several daemons — see
+  // `resolveLifecycleProvider`, which refuses to guess rather than taking the first.
+  async loadModel(
+    provider: ProviderId,
+    modelName: string,
+    target: LlmLifecycleTarget = {},
+  ): Promise<void> {
+    const p = this.resolveLifecycleProvider(provider, target);
     if (typeof (p as unknown as { loadModel?: unknown }).loadModel === "function") {
       await (p as unknown as { loadModel: (m: string) => Promise<void> }).loadModel(modelName);
     }
     // Ollama auto-loads on first generate; this is a no-op for Ollama.
   }
 
-  async unloadModel(provider: ProviderId, modelName: string): Promise<void> {
-    const p = this.router.providerFor(provider);
-    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+  async unloadModel(
+    provider: ProviderId,
+    modelName: string,
+    target: LlmLifecycleTarget = {},
+  ): Promise<void> {
+    const p = this.resolveLifecycleProvider(provider, target);
     if (typeof (p as unknown as { unloadModel?: unknown }).unloadModel === "function") {
       await (p as unknown as { unloadModel: (m: string) => Promise<void> }).unloadModel(modelName);
     }
@@ -159,14 +257,22 @@ export class LlmRegistry {
   async pullModel(
     provider: ProviderId,
     modelName: string,
-    opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void } = {},
+    opts: {
+      signal?: AbortSignal;
+      onProgress?: (p: PullProgressChunk) => void;
+      routeId?: string;
+    } = {},
   ): Promise<void> {
-    const p = this.router.providerFor(provider);
-    if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
+    const { routeId, ...providerOpts } = opts;
+    // Spread-conditional rather than `{ routeId }`: under `exactOptionalPropertyTypes`, an
+    // explicit `routeId: undefined` is a different type from an absent key.
+    const p = this.resolveLifecycleProvider(provider, routeId === undefined ? {} : { routeId });
     if (typeof p.pullModel !== "function") {
       throw new TypeError(`Provider ${provider} does not support pullModel`);
     }
-    await p.pullModel(modelName, opts);
+    // `routeId` is a REGISTRY-side discriminator; it is destructured off above rather than
+    // forwarded, so no provider ever receives a key its own `pullModel` contract does not name.
+    await p.pullModel(modelName, providerOpts);
     // Only on success: a failed pull must not clear the cache. Without this, a freshly
     // pulled model keeps reporting `model_absent` for up to
     // ROUTE_AVAILABILITY_POSITIVE_TTL_MS, which looks exactly like the pull having failed.

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -53,7 +53,7 @@ export class LlmRegistry {
    * whenever the information exists.
    */
   async refreshProviderMeta(modelName?: string): Promise<void> {
-    // Iterates registered routes rather than a fixed ["ollama", "llamacpp"] id set, and
+    // Iterates registered routes rather than a fixed ollama/llamacpp id pair, and
     // re-registers each matching route through `registerRoute(route.provider,
     // route.modelName, ...)` rather than the deprecated `registerProvider` shim.
     //

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -1,7 +1,8 @@
 import type { Database } from "bun:sqlite";
 import { dbRun } from "../db/write.ts";
+import { RouteAvailabilityProbe } from "./route-availability.ts";
 import { LlmRouter, type LlmRouterConfig, type ProviderMeta } from "./router.ts";
-import type { LlmModelInfo, LlmProvider, PullProgressChunk } from "./types.ts";
+import type { LlmModelInfo, LlmProvider, ProviderId, PullProgressChunk } from "./types.ts";
 
 export type LlmRegistryOptions = {
   config: LlmRouterConfig;
@@ -11,14 +12,25 @@ export type LlmRegistryOptions = {
 export class LlmRegistry {
   private readonly router: LlmRouter;
   private readonly db: Database | undefined;
+  // Constructed here (not by LlmRouter) so the registry keeps its own reference to call
+  // `invalidate()` on a successful pullModel — see pullModel below. No public accessor is
+  // exposed on LlmRouter for this: that would recreate the reach-into-router-internals
+  // shape Task 3 just deleted from this file.
+  private readonly probe = new RouteAvailabilityProbe();
 
   constructor(opts: LlmRegistryOptions) {
-    this.router = new LlmRouter(opts.config);
+    this.router = new LlmRouter(opts.config, this.probe);
     this.db = opts.db;
   }
 
   addProvider(provider: LlmProvider, meta?: ProviderMeta): void {
     this.router.registerProvider(provider, meta ?? {});
+  }
+
+  /** Registers a route with its own model name — the non-deprecated counterpart to
+   *  `addProvider`, which derives the model name from `config.localModel`/`config.remoteModel`. */
+  addRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void {
+    this.router.registerRoute(provider, modelName, meta ?? {});
   }
 
   /**
@@ -41,16 +53,28 @@ export class LlmRegistry {
    * whenever the information exists.
    */
   async refreshProviderMeta(modelName: string): Promise<void> {
-    for (const id of ["ollama", "llamacpp"] as const) {
-      const provider = this.router.providerFor(id);
-      if (provider === undefined) continue;
+    // Iterates registered routes rather than a fixed ["ollama", "llamacpp"] id set, and
+    // re-registers each matching route through `registerRoute(route.provider,
+    // route.modelName, ...)` rather than the deprecated `registerProvider` shim.
+    //
+    // The shim derives the model name it registers under from `config.localModel` /
+    // `config.remoteModel` — fine while every provider had exactly one config-derived
+    // route, but once a route is registered with its OWN model name (`addRoute`, Task 9),
+    // calling `registerProvider` here would re-register under `config.localModel` instead,
+    // MINTING A SPURIOUS second route (`<provider>/<config.localModel>`) alongside the
+    // real one on every refresh. Using `route.modelName` targets the exact existing route
+    // every time, so re-registration only ever updates that route's meta.
+    for (const route of this.router.routes()) {
+      if (!route.provider.isLocal) continue;
       try {
-        const models = await provider.listModels();
+        const models = await route.provider.listModels();
         const match = models.find(
           (m) => m.modelName === modelName || m.modelName.startsWith(`${modelName}:`),
         );
         if (match?.parameterCount !== undefined) {
-          this.router.registerProvider(provider, { parameterCount: match.parameterCount });
+          this.router.registerRoute(route.provider, route.modelName, {
+            parameterCount: match.parameterCount,
+          });
         }
       } catch {
         // Provider unreachable. Leaving meta empty keeps the documented fail-open.
@@ -64,11 +88,16 @@ export class LlmRegistry {
 
   async listAllModels(): Promise<LlmModelInfo[]> {
     const results: LlmModelInfo[] = [];
-    const providerIds = ["ollama", "llamacpp", "remote"] as const;
-    for (const id of providerIds) {
+    // Dedup by provider INSTANCE (not providerId): a future multi-route provider id
+    // (several distinct Ollama daemons, say) must still be listed once per instance, but
+    // two routes sharing the same instance must not trigger the same listModels() call
+    // twice.
+    const seen = new Set<LlmProvider>();
+    for (const route of this.router.routes()) {
+      const provider = route.provider;
+      if (seen.has(provider)) continue;
+      seen.add(provider);
       try {
-        const provider = this.router.providerFor(id);
-        if (provider === undefined) continue;
         if (!(await provider.isAvailable())) continue;
         const models = await provider.listModels();
         results.push(...models);
@@ -82,12 +111,13 @@ export class LlmRegistry {
 
   async checkAvailability(): Promise<Record<string, boolean>> {
     const result: Record<string, boolean> = {};
-    const providerIds = ["ollama", "llamacpp", "remote"] as const;
-    for (const id of providerIds) {
+    const seen = new Set<ProviderId>();
+    for (const route of this.router.routes()) {
+      const id = route.provider.providerId;
+      if (seen.has(id)) continue;
+      seen.add(id);
       try {
-        const provider = this.router.providerFor(id);
-        if (provider === undefined) continue;
-        result[id] = await provider.isAvailable();
+        result[id] = await route.provider.isAvailable();
       } catch {
         result[id] = false;
       }
@@ -95,7 +125,13 @@ export class LlmRegistry {
     return result;
   }
 
-  async loadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
+  // Lifecycle methods key on `providerId`, and the model stays an argument — never the
+  // route id. `OllamaProvider.pullModel(modelName)` posts its argument to the shared
+  // daemon, so any registered instance of a providerId can pull/load/unload any model;
+  // requiring a matching route would make it impossible to pull a model that has no
+  // route yet, which is the primary use of pull. Resolution is "any registered route
+  // whose provider.providerId matches" — exactly what `LlmRouter.providerFor` does.
+  async loadModel(provider: ProviderId, modelName: string): Promise<void> {
     const p = this.router.providerFor(provider);
     if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
     if (typeof (p as unknown as { loadModel?: unknown }).loadModel === "function") {
@@ -104,7 +140,7 @@ export class LlmRegistry {
     // Ollama auto-loads on first generate; this is a no-op for Ollama.
   }
 
-  async unloadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
+  async unloadModel(provider: ProviderId, modelName: string): Promise<void> {
     const p = this.router.providerFor(provider);
     if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
     if (typeof (p as unknown as { unloadModel?: unknown }).unloadModel === "function") {
@@ -113,7 +149,7 @@ export class LlmRegistry {
   }
 
   async pullModel(
-    provider: "ollama" | "llamacpp",
+    provider: ProviderId,
     modelName: string,
     opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void } = {},
   ): Promise<void> {
@@ -123,11 +159,15 @@ export class LlmRegistry {
       throw new TypeError(`Provider ${provider} does not support pullModel`);
     }
     await p.pullModel(modelName, opts);
+    // Only on success: a failed pull must not clear the cache. Without this, a freshly
+    // pulled model keeps reporting `model_absent` for up to
+    // ROUTE_AVAILABILITY_POSITIVE_TTL_MS, which looks exactly like the pull having failed.
+    this.probe.invalidate(provider);
   }
 
   async setDefault(
     taskType: "classification" | "reasoning" | "summarisation" | "agent_step",
-    provider: "ollama" | "llamacpp" | "remote",
+    provider: ProviderId,
     modelName: string,
   ): Promise<void> {
     if (this.db === undefined) return;

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -67,9 +67,7 @@ export class LlmRegistry {
     const providerIds = ["ollama", "llamacpp", "remote"] as const;
     for (const id of providerIds) {
       try {
-        const provider = (
-          this.router as unknown as { providers: Map<string, LlmProvider> }
-        ).providers?.get(id);
+        const provider = this.router.providerFor(id);
         if (provider === undefined) continue;
         if (!(await provider.isAvailable())) continue;
         const models = await provider.listModels();
@@ -87,9 +85,7 @@ export class LlmRegistry {
     const providerIds = ["ollama", "llamacpp", "remote"] as const;
     for (const id of providerIds) {
       try {
-        const provider = (
-          this.router as unknown as { providers: Map<string, LlmProvider> }
-        ).providers?.get(id);
+        const provider = this.router.providerFor(id);
         if (provider === undefined) continue;
         result[id] = await provider.isAvailable();
       } catch {
@@ -100,9 +96,7 @@ export class LlmRegistry {
   }
 
   async loadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
-    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
-      provider,
-    );
+    const p = this.router.providerFor(provider);
     if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
     if (typeof (p as unknown as { loadModel?: unknown }).loadModel === "function") {
       await (p as unknown as { loadModel: (m: string) => Promise<void> }).loadModel(modelName);
@@ -111,9 +105,7 @@ export class LlmRegistry {
   }
 
   async unloadModel(provider: "ollama" | "llamacpp", modelName: string): Promise<void> {
-    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
-      provider,
-    );
+    const p = this.router.providerFor(provider);
     if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
     if (typeof (p as unknown as { unloadModel?: unknown }).unloadModel === "function") {
       await (p as unknown as { unloadModel: (m: string) => Promise<void> }).unloadModel(modelName);
@@ -125,9 +117,7 @@ export class LlmRegistry {
     modelName: string,
     opts: { signal?: AbortSignal; onProgress?: (p: PullProgressChunk) => void } = {},
   ): Promise<void> {
-    const p = (this.router as unknown as { providers: Map<string, LlmProvider> }).providers?.get(
-      provider,
-    );
+    const p = this.router.providerFor(provider);
     if (p === undefined) throw new Error(`Provider not registered: ${provider}`);
     if (typeof p.pullModel !== "function") {
       throw new TypeError(`Provider ${provider} does not support pullModel`);

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -52,7 +52,7 @@ export class LlmRegistry {
    * capability preference into an outage. The difference from before is that the floor now fires
    * whenever the information exists.
    */
-  async refreshProviderMeta(modelName: string): Promise<void> {
+  async refreshProviderMeta(modelName?: string): Promise<void> {
     // Iterates registered routes rather than a fixed ["ollama", "llamacpp"] id set, and
     // re-registers each matching route through `registerRoute(route.provider,
     // route.modelName, ...)` rather than the deprecated `registerProvider` shim.
@@ -64,12 +64,25 @@ export class LlmRegistry {
     // MINTING A SPURIOUS second route (`<provider>/<config.localModel>`) alongside the
     // real one on every refresh. Using `route.modelName` targets the exact existing route
     // every time, so re-registration only ever updates that route's meta.
+    //
+    // `modelName`, when supplied, is a FILTER — refresh only the route(s) whose own
+    // `modelName` matches it — never a shared search target applied across every route. The
+    // bug this guards against (Task 9 review, finding 1): the previous version searched
+    // EVERY local route's provider listing for one caller-supplied `modelName` and stamped
+    // whatever it found onto whichever route the loop happened to be on. With two Ollama
+    // routes sharing one daemon (`qwen3:8b` and `gemma3:12b`), refreshing "qwen3:8b" also
+    // matched while examining the unrelated gemma route and wrote qwen3's parameter count
+    // onto gemma's meta — last name processed wins for every route. Matching each route
+    // only against ITS OWN `modelName` (never a caller-supplied one) makes that impossible
+    // by construction, and lets every local route refresh in one pass with no argument at
+    // all — one `listModels()` call per LOCAL ROUTE, not per route × distinct model name.
     for (const route of this.router.routes()) {
       if (!route.provider.isLocal) continue;
+      if (modelName !== undefined && route.modelName !== modelName) continue;
       try {
         const models = await route.provider.listModels();
         const match = models.find(
-          (m) => m.modelName === modelName || m.modelName.startsWith(`${modelName}:`),
+          (m) => m.modelName === route.modelName || m.modelName.startsWith(`${route.modelName}:`),
         );
         if (match?.parameterCount !== undefined) {
           this.router.registerRoute(route.provider, route.modelName, {

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -23,12 +23,7 @@ export class LlmRegistry {
     this.db = opts.db;
   }
 
-  addProvider(provider: LlmProvider, meta?: ProviderMeta): void {
-    this.router.registerProvider(provider, meta ?? {});
-  }
-
-  /** Registers a route with its own model name — the non-deprecated counterpart to
-   *  `addProvider`, which derives the model name from `config.localModel`/`config.remoteModel`. */
+  /** Registers a route under an explicit model name. */
   addRoute(provider: LlmProvider, modelName: string, meta?: ProviderMeta): void {
     this.router.registerRoute(provider, modelName, meta ?? {});
   }

--- a/packages/gateway/src/llm/route-availability.test.ts
+++ b/packages/gateway/src/llm/route-availability.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { RouteAvailabilityProbe } from "./route-availability.ts";
 import type { LlmModelInfo, LlmProvider, ModelRoute } from "./types.ts";
 
-function route(
-  modelName: string,
-  opts: { reachable: boolean; models: string[]; onList?: () => void },
-): ModelRoute {
-  const provider: LlmProvider = {
+function makeProvider(opts: {
+  reachable: boolean;
+  models: string[];
+  onList?: () => void;
+}): LlmProvider {
+  return {
     providerId: "ollama",
     isLocal: true,
     isAvailable: async () => opts.reachable,
@@ -18,7 +19,20 @@ function route(
       throw new Error("not called");
     },
   };
-  return { routeId: `ollama/${modelName}`, provider, modelName, meta: {} };
+}
+
+/** A route on a specific provider INSTANCE. Which instance a route carries is load-bearing
+ *  now that the cache keys on the instance: two routes sharing one daemon must be built
+ *  from ONE `makeProvider(...)` call, and two routes on two daemons from two. */
+function routeOn(p: LlmProvider, modelName: string): ModelRoute {
+  return { routeId: `ollama/${modelName}`, provider: p, modelName, meta: {} };
+}
+
+function route(
+  modelName: string,
+  opts: { reachable: boolean; models: string[]; onList?: () => void },
+): ModelRoute {
+  return routeOn(makeProvider(opts), modelName);
 }
 
 describe("RouteAvailabilityProbe", () => {
@@ -51,16 +65,39 @@ describe("RouteAvailabilityProbe", () => {
   test("listModels is called ONCE for two routes on the same provider within the TTL", async () => {
     let calls = 0;
     const probe = new RouteAvailabilityProbe(60_000);
-    const opts = {
+    // ONE provider instance, two routes on it — the shared-daemon case. Built from a single
+    // `makeProvider(...)` call deliberately: two separate calls would be two instances, which is
+    // a different scenario entirely (see the independence test below) and would make this
+    // amortization claim untestable.
+    const shared = makeProvider({
       reachable: true,
       models: ["a", "b"],
       onList: () => {
         calls += 1;
       },
-    };
-    await probe.check(route("a", opts));
-    await probe.check(route("b", opts));
+    });
+    await probe.check(routeOn(shared, "a"));
+    await probe.check(routeOn(shared, "b"));
     expect(calls).toBe(1);
+  });
+
+  test("two routes on DIFFERENT instances sharing a providerId are probed independently", async () => {
+    // `assemble.ts` builds a new `OllamaProvider` per `[llm.local.*]` entry, and ollama is
+    // exempt from the base-url collision rule — so two ollama routes on two DIFFERENT
+    // daemons is legitimate config. Keyed on `providerId`, the second route is answered from
+    // the FIRST daemon's model list: `laptop` lists gemma3:12b, so the `ws` route (on a
+    // daemon that has no such model, and here is not even reachable) reads as available, the
+    // priority walk stops there, and generate() fails at the network call.
+    const probe = new RouteAvailabilityProbe(60_000);
+    const laptop = makeProvider({ reachable: true, models: ["qwen3:8b", "gemma3:12b"] });
+    const workstation = makeProvider({ reachable: false, models: [] });
+
+    const laptopRoute = await probe.check(routeOn(laptop, "qwen3:8b"));
+    expect(laptopRoute).toEqual({ available: true, reason: "ok" });
+
+    // The assertion that fails under an id-keyed cache: this must consult the WORKSTATION.
+    const wsRoute = await probe.check(routeOn(workstation, "gemma3:12b"));
+    expect(wsRoute).toEqual({ available: false, reason: "provider_unreachable" });
   });
 
   test("a listModels rejection is unavailable, not a thrown probe", async () => {
@@ -83,17 +120,47 @@ describe("RouteAvailabilityProbe", () => {
   test("invalidate() forces the next check to re-list", async () => {
     let calls = 0;
     const probe = new RouteAvailabilityProbe(60_000);
-    const opts = {
+    // The SAME instance either side of invalidate() — otherwise the second check would miss
+    // the cache anyway (different key) and the test would pass whether or not invalidate did
+    // anything, which is the shape this repo calls a test that cannot fail.
+    const p = makeProvider({
       reachable: true,
       models: ["a"],
       onList: () => {
         calls += 1;
       },
-    };
-    await probe.check(route("a", opts));
+    });
+    await probe.check(routeOn(p, "a"));
     probe.invalidate("ollama");
-    await probe.check(route("a", opts));
+    await probe.check(routeOn(p, "a"));
     expect(calls).toBe(2);
+  });
+
+  test("invalidate(providerId) clears EVERY instance carrying that vendor id", async () => {
+    let laptopCalls = 0;
+    let wsCalls = 0;
+    const probe = new RouteAvailabilityProbe(60_000);
+    const laptop = makeProvider({
+      reachable: true,
+      models: ["a"],
+      onList: () => {
+        laptopCalls += 1;
+      },
+    });
+    const workstation = makeProvider({
+      reachable: true,
+      models: ["a"],
+      onList: () => {
+        wsCalls += 1;
+      },
+    });
+    await probe.check(routeOn(laptop, "a"));
+    await probe.check(routeOn(workstation, "a"));
+    probe.invalidate("ollama");
+    await probe.check(routeOn(laptop, "a"));
+    await probe.check(routeOn(workstation, "a"));
+    expect(laptopCalls).toBe(2);
+    expect(wsCalls).toBe(2);
   });
 
   test("an unreachable provider is re-probed sooner than a reachable one (split TTL)", async () => {

--- a/packages/gateway/src/llm/route-availability.test.ts
+++ b/packages/gateway/src/llm/route-availability.test.ts
@@ -95,4 +95,65 @@ describe("RouteAvailabilityProbe", () => {
     await probe.check(route("a", opts));
     expect(calls).toBe(2);
   });
+
+  test("an unreachable provider is re-probed sooner than a reachable one (split TTL)", async () => {
+    // Positive TTL long enough that the sleep below can't cross it; negative TTL short
+    // enough that the SAME sleep does. If both reasons shared one TTL this would either
+    // fail to re-probe the down provider (TTL too long) or needlessly re-probe the
+    // healthy one (TTL too short) — this test can only pass if the two are different.
+    const probe = new RouteAvailabilityProbe(10_000, 5);
+
+    let unreachableCalls = 0;
+    const unreachable: LlmProvider = {
+      providerId: "down",
+      isLocal: true,
+      isAvailable: async () => {
+        unreachableCalls += 1;
+        return false;
+      },
+      listModels: async () => [],
+      generate: async () => {
+        throw new Error("not called");
+      },
+    };
+    const downRoute: ModelRoute = {
+      routeId: "down/x",
+      provider: unreachable,
+      modelName: "x",
+      meta: {},
+    };
+
+    let reachableCalls = 0;
+    const reachable: LlmProvider = {
+      providerId: "up",
+      isLocal: true,
+      isAvailable: async () => true,
+      listModels: async (): Promise<LlmModelInfo[]> => {
+        reachableCalls += 1;
+        return [{ provider: "up", modelName: "other" }]; // "wanted" stays model_absent
+      },
+      generate: async () => {
+        throw new Error("not called");
+      },
+    };
+    const upRoute: ModelRoute = {
+      routeId: "up/wanted",
+      provider: reachable,
+      modelName: "wanted",
+      meta: {},
+    };
+
+    await probe.check(downRoute);
+    await probe.check(upRoute);
+    expect(unreachableCalls).toBe(1);
+    expect(reachableCalls).toBe(1);
+
+    // Longer than the negative TTL (5ms), shorter than the positive TTL (10_000ms).
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    await probe.check(downRoute);
+    await probe.check(upRoute);
+    expect(unreachableCalls).toBe(2); // negative TTL expired — re-probed
+    expect(reachableCalls).toBe(1); // positive TTL still holds — NOT re-probed
+  });
 });

--- a/packages/gateway/src/llm/route-availability.test.ts
+++ b/packages/gateway/src/llm/route-availability.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { RouteAvailabilityProbe } from "./route-availability.ts";
+import type { LlmModelInfo, LlmProvider, ModelRoute } from "./types.ts";
+
+function route(
+  modelName: string,
+  opts: { reachable: boolean; models: string[]; onList?: () => void },
+): ModelRoute {
+  const provider: LlmProvider = {
+    providerId: "ollama",
+    isLocal: true,
+    isAvailable: async () => opts.reachable,
+    listModels: async (): Promise<LlmModelInfo[]> => {
+      opts.onList?.();
+      return opts.models.map((m) => ({ provider: "ollama", modelName: m }));
+    },
+    generate: async () => {
+      throw new Error("not called");
+    },
+  };
+  return { routeId: `ollama/${modelName}`, provider, modelName, meta: {} };
+}
+
+describe("RouteAvailabilityProbe", () => {
+  test("a reachable daemon WITHOUT the model is unavailable", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("gemma3:12b", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r).toEqual({ available: false, reason: "model_absent" });
+  });
+
+  test("a reachable daemon WITH the model is available", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3:8b", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r).toEqual({ available: true, reason: "ok" });
+  });
+
+  test("an unreachable provider is distinguished from an absent model", async () => {
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3:8b", { reachable: false, models: [] }));
+    expect(r).toEqual({ available: false, reason: "provider_unreachable" });
+  });
+
+  test("a tag matches when the route omits the :tag suffix", async () => {
+    // `local_model = "qwen3"` against a daemon reporting "qwen3:8b" must match, or
+    // every existing config breaks on upgrade.
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check(route("qwen3", { reachable: true, models: ["qwen3:8b"] }));
+    expect(r.available).toBe(true);
+  });
+
+  test("listModels is called ONCE for two routes on the same provider within the TTL", async () => {
+    let calls = 0;
+    const probe = new RouteAvailabilityProbe(60_000);
+    const opts = {
+      reachable: true,
+      models: ["a", "b"],
+      onList: () => {
+        calls += 1;
+      },
+    };
+    await probe.check(route("a", opts));
+    await probe.check(route("b", opts));
+    expect(calls).toBe(1);
+  });
+
+  test("a listModels rejection is unavailable, not a thrown probe", async () => {
+    const provider: LlmProvider = {
+      providerId: "ollama",
+      isLocal: true,
+      isAvailable: async () => true,
+      listModels: async () => {
+        throw new Error("boom");
+      },
+      generate: async () => {
+        throw new Error("not called");
+      },
+    };
+    const probe = new RouteAvailabilityProbe();
+    const r = await probe.check({ routeId: "ollama/a", provider, modelName: "a", meta: {} });
+    expect(r.available).toBe(false);
+  });
+
+  test("invalidate() forces the next check to re-list", async () => {
+    let calls = 0;
+    const probe = new RouteAvailabilityProbe(60_000);
+    const opts = {
+      reachable: true,
+      models: ["a"],
+      onList: () => {
+        calls += 1;
+      },
+    };
+    await probe.check(route("a", opts));
+    probe.invalidate("ollama");
+    await probe.check(route("a", opts));
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/gateway/src/llm/route-availability.ts
+++ b/packages/gateway/src/llm/route-availability.ts
@@ -1,0 +1,108 @@
+import type { LlmProvider, ModelRoute, ProviderId } from "./types.ts";
+
+/**
+ * Why a route is or isn't usable, kept as two distinct failure reasons rather than a
+ * single "unavailable" boolean — they have different fixes. `provider_unreachable`
+ * means the daemon is down (start Ollama / llama.cpp). `model_absent` means the
+ * daemon is up but the configured model was never pulled (`nimbus llm pull`).
+ * Collapsing the two sends the user to the wrong remedy.
+ */
+export type RouteAvailability = {
+  available: boolean;
+  reason: "ok" | "provider_unreachable" | "model_absent";
+};
+
+/** Default TTL for a cached provider probe result — see `RouteAvailabilityProbe`. */
+export const ROUTE_AVAILABILITY_TTL_MS = 30_000;
+
+// What a single `/api/tags`-shaped probe of a provider daemon establishes: whether it
+// answered at all, and — only if it did — what models it currently reports. Cached
+// per `providerId`, not per route: the model list is a property of the daemon a route's
+// provider talks to, not of any one route, so four routes sharing one Ollama daemon
+// must cost one round trip, not four.
+type ProviderProbeResult = {
+  reachable: boolean;
+  modelNames: readonly string[];
+};
+
+/**
+ * Answers "is this route actually usable right now?" — the daemon is reachable AND the
+ * route's `modelName` is among the models that daemon currently reports. Deliberately
+ * does NOT pull a missing model: falling through to the next configured route is
+ * correct; silently starting a multi-gigabyte download because a config entry named a
+ * model is not.
+ *
+ * Caches the per-provider probe (reachability + model list) for `ttlMs`, keyed on
+ * `providerId` — long enough that resolving a several-route table over one daemon costs
+ * one `/api/tags` call, short enough that a model removed out-of-band (`ollama rm`) is
+ * noticed without a restart. `invalidate(providerId)` exists so a successful
+ * `LlmRegistry.pullModel` can drop the cache immediately rather than making the caller
+ * wait out the TTL to see a model it just pulled.
+ */
+export class RouteAvailabilityProbe {
+  private readonly ttlMs: number;
+  private readonly cache = new Map<
+    ProviderId,
+    { result: Promise<ProviderProbeResult>; expiresAt: number }
+  >();
+
+  constructor(ttlMs: number = ROUTE_AVAILABILITY_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  async check(route: ModelRoute): Promise<RouteAvailability> {
+    const probe = await this.probeProvider(route.provider);
+    if (!probe.reachable) {
+      return { available: false, reason: "provider_unreachable" };
+    }
+    if (matchesModel(probe.modelNames, route.modelName)) {
+      return { available: true, reason: "ok" };
+    }
+    return { available: false, reason: "model_absent" };
+  }
+
+  /** Drops the cached probe for `providerId`, so the next `check()` re-lists. */
+  invalidate(providerId: ProviderId): void {
+    this.cache.delete(providerId);
+  }
+
+  private probeProvider(provider: LlmProvider): Promise<ProviderProbeResult> {
+    const now = Date.now();
+    const cached = this.cache.get(provider.providerId);
+    if (cached !== undefined && cached.expiresAt > now) {
+      return cached.result;
+    }
+    const result = fetchProviderProbe(provider);
+    this.cache.set(provider.providerId, { result, expiresAt: now + this.ttlMs });
+    return result;
+  }
+}
+
+async function fetchProviderProbe(provider: LlmProvider): Promise<ProviderProbeResult> {
+  let reachable: boolean;
+  try {
+    reachable = await provider.isAvailable();
+  } catch {
+    reachable = false;
+  }
+  if (!reachable) {
+    return { reachable: false, modelNames: [] };
+  }
+  try {
+    const models = await provider.listModels();
+    return { reachable: true, modelNames: models.map((m) => m.modelName) };
+  } catch {
+    // The daemon answered `isAvailable()` but failed to list its models — treat this
+    // the same as unreachable rather than as "model absent", since we could not
+    // actually determine which models it holds. Reporting `model_absent` here would
+    // send the user to `nimbus llm pull`, which is the wrong fix for a flaky daemon.
+    return { reachable: false, modelNames: [] };
+  }
+}
+
+// Exact match first, then tag-tolerant: `name.startsWith(`${modelName}:`)`. Mirrors the
+// existing match in `registry.refreshProviderMeta` — a `local_model = "qwen3"` config
+// must match a daemon reporting `qwen3:8b`, or every existing config breaks on upgrade.
+function matchesModel(modelNames: readonly string[], modelName: string): boolean {
+  return modelNames.some((m) => m === modelName || m.startsWith(`${modelName}:`));
+}

--- a/packages/gateway/src/llm/route-availability.ts
+++ b/packages/gateway/src/llm/route-availability.ts
@@ -12,8 +12,29 @@ export type RouteAvailability = {
   reason: "ok" | "provider_unreachable" | "model_absent";
 };
 
-/** Default TTL for a cached provider probe result — see `RouteAvailabilityProbe`. */
-export const ROUTE_AVAILABILITY_TTL_MS = 30_000;
+/**
+ * TTL for a cached probe result when the daemon WAS reachable — covers both `ok` and
+ * `model_absent`. Long: a model list only changes when someone pulls a model (which
+ * `invalidate()` handles immediately, without waiting out this TTL) or removes one
+ * out-of-band, so resolving a several-route table over one daemon can safely cost one
+ * `/api/tags` call per 30s rather than one per route per resolution.
+ */
+export const ROUTE_AVAILABILITY_POSITIVE_TTL_MS = 30_000;
+
+/**
+ * TTL for a cached probe result when the daemon was UNREACHABLE. Deliberately much
+ * shorter than the positive TTL, not the same value and not zero:
+ *
+ * - Short, not the 30s positive TTL: a down daemon is a fast-changing state a user is
+ *   actively waiting on (`ollama serve` then immediately `nimbus llm status`) — caching
+ *   "unreachable" for 30s would make a freshly-started daemon read as broken for up to
+ *   30 seconds, which is indistinguishable from an actual outage from the user's seat.
+ * - Not zero: with the daemon actually down, an UNcached probe costs one failed HTTP
+ *   attempt per route per resolution (each Ollama/llama.cpp `isAvailable()` call pays
+ *   its own connection-refused/timeout latency) — some negative caching is still
+ *   worth having, just far less of it than the positive case.
+ */
+export const ROUTE_AVAILABILITY_NEGATIVE_TTL_MS = 2_000;
 
 // What a single `/api/tags`-shaped probe of a provider daemon establishes: whether it
 // answered at all, and — only if it did — what models it currently reports. Cached
@@ -25,6 +46,15 @@ type ProviderProbeResult = {
   modelNames: readonly string[];
 };
 
+type CacheEntry = {
+  result: Promise<ProviderProbeResult>;
+  // Mutable: set to a provisional (positive-TTL) value when the entry is created so a
+  // burst of concurrent `check()` calls for the same provider shares one in-flight
+  // fetch, then corrected once the result resolves — a rejected daemon gets the much
+  // shorter negative TTL (Finding B), which cannot be known until the fetch settles.
+  expiresAt: number;
+};
+
 /**
  * Answers "is this route actually usable right now?" — the daemon is reachable AND the
  * route's `modelName` is among the models that daemon currently reports. Deliberately
@@ -32,23 +62,19 @@ type ProviderProbeResult = {
  * correct; silently starting a multi-gigabyte download because a config entry named a
  * model is not.
  *
- * Caches the per-provider probe (reachability + model list) for `ttlMs`, keyed on
- * `providerId` — long enough that resolving a several-route table over one daemon costs
- * one `/api/tags` call, short enough that a model removed out-of-band (`ollama rm`) is
- * noticed without a restart. `invalidate(providerId)` exists so a successful
- * `LlmRegistry.pullModel` can drop the cache immediately rather than making the caller
- * wait out the TTL to see a model it just pulled.
+ * Caches the per-provider probe (reachability + model list) keyed on `providerId`, for
+ * `positiveTtlMs` when the daemon answered or `negativeTtlMs` when it didn't — see the
+ * two constants above for why they differ. `invalidate(providerId)` exists so a
+ * successful `LlmRegistry.pullModel` can drop the cache immediately rather than making
+ * the caller wait out the TTL to see a model it just pulled.
  */
 export class RouteAvailabilityProbe {
-  private readonly ttlMs: number;
-  private readonly cache = new Map<
-    ProviderId,
-    { result: Promise<ProviderProbeResult>; expiresAt: number }
-  >();
+  private readonly cache = new Map<ProviderId, CacheEntry>();
 
-  constructor(ttlMs: number = ROUTE_AVAILABILITY_TTL_MS) {
-    this.ttlMs = ttlMs;
-  }
+  constructor(
+    private readonly positiveTtlMs: number = ROUTE_AVAILABILITY_POSITIVE_TTL_MS,
+    private readonly negativeTtlMs: number = ROUTE_AVAILABILITY_NEGATIVE_TTL_MS,
+  ) {}
 
   async check(route: ModelRoute): Promise<RouteAvailability> {
     const probe = await this.probeProvider(route.provider);
@@ -73,7 +99,16 @@ export class RouteAvailabilityProbe {
       return cached.result;
     }
     const result = fetchProviderProbe(provider);
-    this.cache.set(provider.providerId, { result, expiresAt: now + this.ttlMs });
+    // Provisional entry, cached under the positive TTL so concurrent callers share
+    // this fetch; `entry` is the SAME object stored in the map, so mutating its
+    // `expiresAt` below is visible to every future `probeProvider` lookup once the
+    // fetch settles. `fetchProviderProbe` never rejects (it catches both awaits
+    // internally), so no `.catch()` is needed here.
+    const entry: CacheEntry = { result, expiresAt: now + this.positiveTtlMs };
+    this.cache.set(provider.providerId, entry);
+    void result.then((r) => {
+      entry.expiresAt = Date.now() + (r.reachable ? this.positiveTtlMs : this.negativeTtlMs);
+    });
     return result;
   }
 }

--- a/packages/gateway/src/llm/route-availability.ts
+++ b/packages/gateway/src/llm/route-availability.ts
@@ -37,10 +37,15 @@ export const ROUTE_AVAILABILITY_POSITIVE_TTL_MS = 30_000;
 export const ROUTE_AVAILABILITY_NEGATIVE_TTL_MS = 2_000;
 
 // What a single `/api/tags`-shaped probe of a provider daemon establishes: whether it
-// answered at all, and — only if it did — what models it currently reports. Cached
-// per `providerId`, not per route: the model list is a property of the daemon a route's
-// provider talks to, not of any one route, so four routes sharing one Ollama daemon
-// must cost one round trip, not four.
+// answered at all, and — only if it did — what models it currently reports. Cached per
+// provider INSTANCE, not per route and NOT per `providerId`: the model list is a property
+// of the one daemon a route's provider talks to, so four routes sharing one Ollama
+// provider instance must cost one round trip, not four — while two `[llm.local.*]` entries
+// pointed at DIFFERENT Ollama daemons (`assemble.ts` constructs one `OllamaProvider` per
+// entry, and ollama is exempt from the base-url collision rule) must each be probed
+// against their own daemon. Keying on `providerId` would answer the second daemon's route
+// from the first daemon's model list, reopening exactly the fail-open §3.4 exists to close.
+// Mirrors `registry.ts` `listAllModels`, which dedups by instance for the same reason.
 type ProviderProbeResult = {
   reachable: boolean;
   modelNames: readonly string[];
@@ -62,14 +67,15 @@ type CacheEntry = {
  * correct; silently starting a multi-gigabyte download because a config entry named a
  * model is not.
  *
- * Caches the per-provider probe (reachability + model list) keyed on `providerId`, for
+ * Caches the probe (reachability + model list) keyed on the provider INSTANCE, for
  * `positiveTtlMs` when the daemon answered or `negativeTtlMs` when it didn't — see the
  * two constants above for why they differ. `invalidate(providerId)` exists so a
  * successful `LlmRegistry.pullModel` can drop the cache immediately rather than making
- * the caller wait out the TTL to see a model it just pulled.
+ * the caller wait out the TTL to see a model it just pulled; it still takes a vendor id
+ * (that is all `pullModel` has) and clears every cached instance carrying that id.
  */
 export class RouteAvailabilityProbe {
-  private readonly cache = new Map<ProviderId, CacheEntry>();
+  private readonly cache = new Map<LlmProvider, CacheEntry>();
 
   constructor(
     private readonly positiveTtlMs: number = ROUTE_AVAILABILITY_POSITIVE_TTL_MS,
@@ -87,14 +93,23 @@ export class RouteAvailabilityProbe {
     return { available: false, reason: "model_absent" };
   }
 
-  /** Drops the cached probe for `providerId`, so the next `check()` re-lists. */
+  /**
+   * Drops every cached probe belonging to a provider whose vendor id is `providerId`, so
+   * the next `check()` on any of them re-lists. Iterates rather than deleting one key
+   * because the cache is keyed on the provider INSTANCE: one vendor id can have several
+   * instances (several Ollama daemons), and a pull against that vendor invalidates what
+   * we believe about all of them — dropping too much only costs a re-list, whereas
+   * dropping too little leaves a just-pulled model reading as absent.
+   */
   invalidate(providerId: ProviderId): void {
-    this.cache.delete(providerId);
+    for (const provider of [...this.cache.keys()]) {
+      if (provider.providerId === providerId) this.cache.delete(provider);
+    }
   }
 
   private probeProvider(provider: LlmProvider): Promise<ProviderProbeResult> {
     const now = Date.now();
-    const cached = this.cache.get(provider.providerId);
+    const cached = this.cache.get(provider);
     if (cached !== undefined && cached.expiresAt > now) {
       return cached.result;
     }
@@ -105,7 +120,7 @@ export class RouteAvailabilityProbe {
     // fetch settles. `fetchProviderProbe` never rejects (it catches both awaits
     // internally), so no `.catch()` is needed here.
     const entry: CacheEntry = { result, expiresAt: now + this.positiveTtlMs };
-    this.cache.set(provider.providerId, entry);
+    this.cache.set(provider, entry);
     void result.then((r) => {
       entry.expiresAt = Date.now() + (r.reachable ? this.positiveTtlMs : this.negativeTtlMs);
     });

--- a/packages/gateway/src/llm/route-id.test.ts
+++ b/packages/gateway/src/llm/route-id.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { makeRouteId, parseRouteRef } from "./route-id.ts";
+
+describe("makeRouteId", () => {
+  test("joins provider and model on a slash", () => {
+    expect(makeRouteId("ollama", "qwen3:8b")).toBe("ollama/qwen3:8b");
+  });
+
+  test("rejects a providerId containing a slash", () => {
+    // The delimiter is only unambiguous because the LEFT side cannot contain it.
+    expect(() => makeRouteId("bad/vendor", "m")).toThrow(/providerId/);
+  });
+});
+
+describe("parseRouteRef", () => {
+  test("splits on the FIRST slash, leaving the rest to the model name", () => {
+    expect(parseRouteRef("ollama/hf.co/user/model")).toEqual({
+      providerId: "ollama",
+      modelName: "hf.co/user/model",
+    });
+  });
+
+  test("keeps a Windows path intact as a model name", () => {
+    expect(parseRouteRef("llamacpp/C:\\models\\Llama-3-8B.gguf")).toEqual({
+      providerId: "llamacpp",
+      modelName: "C:\\models\\Llama-3-8B.gguf",
+    });
+  });
+
+  test("keeps a POSIX path intact as a model name", () => {
+    expect(parseRouteRef("llamacpp//models/meta-llama/Llama-3-8B.gguf")).toEqual({
+      providerId: "llamacpp",
+      modelName: "/models/meta-llama/Llama-3-8B.gguf",
+    });
+  });
+
+  test("throws on a ref with no slash", () => {
+    expect(() => parseRouteRef("ollama")).toThrow(/expected "<provider>\/<model>"/);
+  });
+
+  test("throws on an empty provider or model half", () => {
+    expect(() => parseRouteRef("/qwen3")).toThrow(/provider/);
+    expect(() => parseRouteRef("ollama/")).toThrow(/model/);
+  });
+
+  test("round-trips a model name containing slashes", () => {
+    const id = makeRouteId("ollama", "hf.co/user/model");
+    expect(parseRouteRef(id)).toEqual({ providerId: "ollama", modelName: "hf.co/user/model" });
+  });
+});

--- a/packages/gateway/src/llm/route-id.ts
+++ b/packages/gateway/src/llm/route-id.ts
@@ -1,0 +1,45 @@
+// packages/gateway/src/llm/route-id.ts
+
+import type { ProviderId } from "./types.ts";
+
+/**
+ * The ONLY place a route reference string is built or split.
+ *
+ * `routeId` is opaque INSIDE the router — `ModelRoute` already carries `providerId`
+ * and `modelName` as separate fields, so parsing the key there would re-derive data
+ * the struct holds. Parsing belongs only where a human typed a string:
+ * `[llm] route_priority` entries and (slice 4) `nimbus llm use <ref>`.
+ *
+ * The split is on the FIRST slash and that is load-bearing: model names legitimately
+ * contain slashes. `LlamaCppProvider`'s model name defaults to `"model.gguf"` and is
+ * realistically a path (`/models/meta-llama/Llama-3-8B.gguf`, or a Windows path with
+ * backslashes and a drive colon), and Ollama accepts namespaced tags like
+ * `hf.co/user/model`. The delimiter is unambiguous only because the LEFT half cannot
+ * contain it, which `makeRouteId` enforces.
+ */
+export function makeRouteId(providerId: ProviderId, modelName: string): string {
+  if (providerId.includes("/")) {
+    throw new Error(`providerId must not contain "/": ${providerId}`);
+  }
+  if (providerId === "") throw new Error("providerId must not be empty");
+  if (modelName === "") throw new Error("modelName must not be empty");
+  return `${providerId}/${modelName}`;
+}
+
+/**
+ * Parse a human-supplied route reference. THROWS on anything malformed rather than
+ * returning `undefined`: a `route_priority` entry that silently vanished would
+ * degrade the router to default ordering with no signal, which is the "a supplied
+ * flag decaying into an omitted filter" shape — invisible from the outside.
+ */
+export function parseRouteRef(raw: string): { providerId: ProviderId; modelName: string } {
+  const i = raw.indexOf("/");
+  if (i === -1) {
+    throw new Error(`malformed route reference "${raw}": expected "<provider>/<model>"`);
+  }
+  const providerId = raw.slice(0, i);
+  const modelName = raw.slice(i + 1); // may itself contain slashes — deliberate
+  if (providerId === "") throw new Error(`malformed route reference "${raw}": empty provider`);
+  if (modelName === "") throw new Error(`malformed route reference "${raw}": empty model`);
+  return { providerId, modelName };
+}

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -8,7 +8,7 @@ function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boole
     providerId: id,
     isLocal: id !== "remote",
     isAvailable: async () => available,
-    // Matches the model `registerProvider` will assign this fake (localModel for a
+    // Matches the model callers register this fake under below (localModel for a
     // local id, remoteModel for "remote"), so the model-aware availability probe
     // wired in Task 5 does not fail these route-selection-focused fakes on a model
     // mismatch they were never testing for.
@@ -40,23 +40,23 @@ const DEFAULT_CONFIG: LlmRouterConfig = {
 describe("LlmRouter.selectProvider", () => {
   test("returns ollama when preferLocal=true and ollama is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("ollama");
   });
 
   test("falls back to remote when local unavailable and enforceAirGap=false", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("remote");
   });
 
   test("returns undefined when all providers unavailable", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
     const provider = await router.selectProvider("classification");
     expect(provider).toBeUndefined();
   });
@@ -64,8 +64,8 @@ describe("LlmRouter.selectProvider", () => {
   test("enforceAirGap=true never returns remote provider", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", false));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("reasoning");
     expect(provider).toBeUndefined();
   });
@@ -73,7 +73,7 @@ describe("LlmRouter.selectProvider", () => {
   test("enforceAirGap=true returns local when available", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("llamacpp", true));
+    router.registerRoute(makeFakeProvider("llamacpp", true), DEFAULT_CONFIG.localModel);
     const provider = await router.selectProvider("reasoning");
     expect(provider?.providerId).toBe("llamacpp");
   });
@@ -81,8 +81,8 @@ describe("LlmRouter.selectProvider", () => {
   test("preferLocal=false prefers remote over local", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("classification");
     expect(provider?.providerId).toBe("remote");
   });
@@ -90,8 +90,8 @@ describe("LlmRouter.selectProvider", () => {
   test("per-call preferLocal override prefers local even when config prefers remote", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const overridden = await router.selectProvider("reasoning", { preferLocal: true });
     expect(overridden?.providerId).toBe("ollama");
     // No override: falls back to config, which prefers remote — proves the override is per-call.
@@ -102,7 +102,7 @@ describe("LlmRouter.selectProvider", () => {
   test("per-call preferLocal override falls back to remote when no local provider is available", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("reasoning", { preferLocal: true });
     expect(provider?.providerId).toBe("remote");
   });
@@ -111,7 +111,7 @@ describe("LlmRouter.selectProvider", () => {
 describe("LlmRouter.generate", () => {
   test("delegates to selected provider and returns result", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const result = await router.generate({ task: "agent_step", prompt: "hello" });
     expect(result.provider).toBe("ollama");
     expect(result.text).toBe("response from ollama");
@@ -128,30 +128,38 @@ describe("LlmRouter.generate", () => {
 describe("LlmRouter capability floor", () => {
   test("skips provider below minReasoningParams for reasoning task", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 3 });
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 3,
+    });
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("reasoning");
     expect(provider?.providerId).toBe("remote");
   });
 
   test("selects provider at or above minReasoningParams for reasoning task", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 13 });
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 13,
+    });
     const provider = await router.selectProvider("reasoning");
     expect(provider?.providerId).toBe("ollama");
   });
 
   test("does not apply capability floor to classification task", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 1 });
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 1,
+    });
     const provider = await router.selectProvider("classification");
     expect(provider?.providerId).toBe("ollama");
   });
 
   test("skips small provider for agent_step, falls back to remote", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 3 });
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 3,
+    });
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("remote");
   });
@@ -161,9 +169,10 @@ function makeCaptureProvider(
   id: "ollama" | "llamacpp" | "remote",
   available: boolean,
   captured: { prompt: string },
-  // Defaults to the model `registerProvider` would assign this id; a caller using
-  // `registerRoute` with an explicit model name (e.g. "small"/"big" below) passes it
-  // here too, so the model-aware availability probe matches what was registered.
+  // Defaults to the model callers register this id under via `registerRoute` below
+  // (localModel/remoteModel); a caller using an explicit model name (e.g. "small"/"big"
+  // below) passes it here too, so the model-aware availability probe matches what was
+  // registered.
   models: string[] = [id === "remote" ? DEFAULT_CONFIG.remoteModel : DEFAULT_CONFIG.localModel],
 ): LlmProvider {
   return {
@@ -189,7 +198,9 @@ describe("LlmRouter context window overflow", () => {
   test("mid-truncates prompt for summarisation when it exceeds context window", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     const captured = { prompt: "" };
-    router.registerProvider(makeCaptureProvider("ollama", true, captured), { contextWindow: 100 });
+    router.registerRoute(makeCaptureProvider("ollama", true, captured), DEFAULT_CONFIG.localModel, {
+      contextWindow: 100,
+    });
     const longPrompt = "x".repeat(500);
     await router.generate({ task: "summarisation", prompt: longPrompt });
     expect(captured.prompt).toContain("[...truncated...]");
@@ -199,10 +210,14 @@ describe("LlmRouter context window overflow", () => {
   test("falls back to remote for reasoning when local context window overflows", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     const captured = { prompt: "" };
-    router.registerProvider(makeCaptureProvider("ollama", true, { prompt: "" }), {
-      contextWindow: 100,
-    });
-    router.registerProvider(makeCaptureProvider("remote", true, captured));
+    router.registerRoute(
+      makeCaptureProvider("ollama", true, { prompt: "" }),
+      DEFAULT_CONFIG.localModel,
+      {
+        contextWindow: 100,
+      },
+    );
+    router.registerRoute(makeCaptureProvider("remote", true, captured), DEFAULT_CONFIG.remoteModel);
     const longPrompt = "x".repeat(500);
     await router.generate({ task: "reasoning", prompt: longPrompt });
     expect(captured.prompt).toBe(longPrompt);
@@ -216,7 +231,9 @@ describe("LlmRouter context window overflow", () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
     const captured = { prompt: "" };
-    router.registerProvider(makeCaptureProvider("ollama", true, captured), { contextWindow: 100 });
+    router.registerRoute(makeCaptureProvider("ollama", true, captured), DEFAULT_CONFIG.localModel, {
+      contextWindow: 100,
+    });
     const longPrompt = "x".repeat(500);
     const result = await router.generate({ task: "reasoning", prompt: longPrompt });
     expect(captured.prompt).toContain("[...truncated...]");
@@ -267,7 +284,7 @@ describe("LlmRouter context window overflow", () => {
   test("short prompt within context window is not truncated", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     const captured = { prompt: "" };
-    router.registerProvider(makeCaptureProvider("ollama", true, captured), {
+    router.registerRoute(makeCaptureProvider("ollama", true, captured), DEFAULT_CONFIG.localModel, {
       contextWindow: 1000,
     });
     const shortPrompt = "hello world";
@@ -279,7 +296,7 @@ describe("LlmRouter context window overflow", () => {
 describe("LlmRouter.getStatus", () => {
   test("populates modelName from localModel for ollama", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.modelName).toBe(DEFAULT_CONFIG.localModel);
   });
@@ -287,21 +304,21 @@ describe("LlmRouter.getStatus", () => {
   test("populates modelName from remoteModel for remote", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     expect(status.classification?.modelName).toBe(DEFAULT_CONFIG.remoteModel);
   });
 
   test("isAvailable is true when provider is reachable", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.agent_step?.isAvailable).toBe(true);
   });
 
   test("isAvailable is false when preferred provider is registered but unreachable", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.isAvailable).toBe(false);
     expect(status.classification?.providerId).toBe("ollama");
@@ -315,7 +332,7 @@ describe("LlmRouter.getStatus", () => {
 
   test("reason is prefer-local when preferLocal=true and local provider selected", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("prefer-local");
   });
@@ -323,7 +340,7 @@ describe("LlmRouter.getStatus", () => {
   test("reason is prefer-remote when preferLocal=false and remote provider selected", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("prefer-remote");
   });
@@ -335,14 +352,14 @@ describe("LlmRouter.getStatus", () => {
       preferLocal: true,
     };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("air-gap");
   });
 
   test("reason is no-local-provider when preferLocal=true but only remote is registered", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("no-local-provider");
   });
@@ -350,14 +367,14 @@ describe("LlmRouter.getStatus", () => {
   test("reason is no-remote-provider when preferLocal=false but only local is registered", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("no-remote-provider");
   });
 
   test("returns all four task types", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(Object.keys(status).sort((a, b) => a.localeCompare(b))).toEqual([
       "agent_step",
@@ -369,8 +386,8 @@ describe("LlmRouter.getStatus", () => {
 
   test("reports the fallback generate() would use when the preferred provider is down", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     expect(status.classification?.providerId).toBe("ollama");
     expect(status.classification?.isAvailable).toBe(false);
@@ -382,8 +399,8 @@ describe("LlmRouter.getStatus", () => {
 
   test("no fallback when the preferred provider is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     expect(status.classification?.isAvailable).toBe(true);
     expect(status.classification?.fallback).toBeUndefined();
@@ -391,7 +408,7 @@ describe("LlmRouter.getStatus", () => {
 
   test("no fallback when the preferred is down and nothing else is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
     const status = await router.getStatus();
     expect(status.classification?.isAvailable).toBe(false);
     expect(status.classification?.fallback).toBeUndefined();
@@ -399,8 +416,10 @@ describe("LlmRouter.getStatus", () => {
 
   test("reason is local-below-reasoning-floor when local exists but misses the floor", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 1 });
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 1,
+    });
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const status = await router.getStatus();
     // reasoning carries a capability floor; ollama (1B < minReasoningParams) is skipped → remote.
     expect(status.reasoning?.providerId).toBe("remote");
@@ -420,7 +439,7 @@ describe("LlmRouter.getStatus", () => {
       },
     };
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(ollama);
+    router.registerRoute(ollama, DEFAULT_CONFIG.localModel);
     await router.getStatus();
     expect(ollamaProbes).toBe(1);
   });
@@ -448,7 +467,7 @@ describe("midTruncate", () => {
 describe("LlmRouter.resolveForSynthesis", () => {
   test("a LOCAL provider kind resolves isLocal: true — via the REAL provider.isLocal, not a stub", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     // This is the security-relevant assertion: `isLocal` comes from the resolved route's
     // REAL `provider.isLocal`, never from a caller-supplied flag — a caller deciding
@@ -463,7 +482,7 @@ describe("LlmRouter.resolveForSynthesis", () => {
   test("a REMOTE provider kind resolves isLocal: false", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const resolved = await router.resolveForSynthesis();
     expect(resolved).toEqual({
       providerId: "remote",
@@ -475,22 +494,24 @@ describe("LlmRouter.resolveForSynthesis", () => {
   test("llamacpp (the second local provider kind) also resolves isLocal: true", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("llamacpp", true));
+    router.registerRoute(makeFakeProvider("llamacpp", true), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     expect(resolved?.isLocal).toBe(true);
   });
 
   test("returns undefined when no provider is available, exactly like selectProvider", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", false));
+    router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     expect(resolved).toBeUndefined();
   });
 
   test("honors the reasoning capability floor, same as selectProvider('reasoning')", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true), { parameterCount: 1 });
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
+      parameterCount: 1,
+    });
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
     const resolved = await router.resolveForSynthesis();
     expect(resolved?.providerId).toBe("remote");
   });
@@ -504,8 +525,8 @@ describe("LlmRouter.resolveForSynthesis", () => {
     // is picked.
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true));
-    router.registerProvider(makeFakeProvider("remote", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
+    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
 
     const viaConfigDefault = await router.resolveForSynthesis();
     expect(viaConfigDefault).toEqual({
@@ -526,7 +547,7 @@ describe("LlmRouter.resolveForSynthesis", () => {
 describe("LlmRouter.generateMarkdown", () => {
   test("invokes the EXACT resolved provider and returns its generated text", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     if (resolved === undefined) throw new Error("expected a resolved provider");
     const markdown = await router.generateMarkdown("write a brief", resolved);
@@ -535,7 +556,7 @@ describe("LlmRouter.generateMarkdown", () => {
 
   test("throws when the resolved provider is no longer registered", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerProvider(makeFakeProvider("ollama", true));
+    router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     if (resolved === undefined) throw new Error("expected a resolved provider");
     // The provider that answered resolveForSynthesis() is no longer registered by the time
@@ -549,7 +570,7 @@ describe("LlmRouter.generateMarkdown", () => {
   test("passes the prompt through to the underlying provider's generate() call", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     const captured = { prompt: "" };
-    router.registerProvider(makeCaptureProvider("ollama", true, captured));
+    router.registerRoute(makeCaptureProvider("ollama", true, captured), DEFAULT_CONFIG.localModel);
     const resolved = await router.resolveForSynthesis();
     if (resolved === undefined) throw new Error("expected a resolved provider");
     await router.generateMarkdown("the exact prompt text", resolved);

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { RouteAvailabilityProbe } from "./route-availability.ts";
 import { LlmRouter, type LlmRouterConfig, midTruncate } from "./router.ts";
 import type { LlmProvider } from "./types.ts";
 
@@ -246,14 +245,11 @@ describe("LlmRouter context window overflow", () => {
     // keyed on provider id, so with two same-id routes it cannot tell "walked to the fitting
     // route" apart from "truncated on the original" — only asserting on what each instance
     // actually received can.
-    // Both routes share providerId "ollama", and the availability probe caches by
-    // providerId — a zero TTL forces each check to re-list rather than reuse the OTHER
-    // instance's cached model list (which would report "big" unavailable, since the
-    // cached list would still say ["small"]).
-    const router = new LlmRouter(
-      { ...DEFAULT_CONFIG, preferLocal: true },
-      new RouteAvailabilityProbe(0),
-    );
+    // Both routes share providerId "ollama" but are DISTINCT provider instances, which is
+    // what `RouteAvailabilityProbe` keys its cache on — so each is probed against its own
+    // model list and the default (production) TTLs are what run here. No zero-TTL probe is
+    // injected: a guarantee verified only under a TTL production never uses is not verified.
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, preferLocal: true });
     const smallCaptured = { prompt: "" };
     const bigCaptured = { prompt: "" };
     router.registerRoute(makeCaptureProvider("ollama", true, smallCaptured, ["small"]), "small", {
@@ -693,16 +689,16 @@ describe("LlmRouter route registration", () => {
     // returns it, because the daemon is up even though the configured model was never
     // pulled. That is the whole defect this task fixes.
     //
-    // Both routes share providerId "ollama" — the availability probe caches by
-    // providerId, so a zero TTL is used (rather than a distinct vendor id) to force
-    // each check to re-list against its OWN fake instance, which is what a real daemon
-    // would do too.
+    // Both routes share providerId "ollama" but are DISTINCT provider instances — which is
+    // what the availability probe keys its cache on — so each check re-lists against its
+    // OWN fake, exactly as two real daemons would answer. Deliberately runs on the default
+    // (production) TTLs rather than an injected zero-TTL probe.
     const absent = makeFakeRouteProvider("ollama", true, true, ["other"]);
     const present = makeFakeRouteProvider("ollama", true, true, ["present"]);
-    const router = new LlmRouter(
-      { ...DEFAULT_CONFIG, routePriority: ["ollama/missing", "ollama/present"] },
-      new RouteAvailabilityProbe(0),
-    );
+    const router = new LlmRouter({
+      ...DEFAULT_CONFIG,
+      routePriority: ["ollama/missing", "ollama/present"],
+    });
     router.registerRoute(absent, "missing");
     router.registerRoute(present, "present");
     const chosen = await router.selectRoute("reasoning");

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isLocalProviderKind, LlmRouter, type LlmRouterConfig, midTruncate } from "./router.ts";
+import { LlmRouter, type LlmRouterConfig, midTruncate } from "./router.ts";
 import type { LlmProvider } from "./types.ts";
 
 function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boolean): LlmProvider {
@@ -385,22 +385,14 @@ describe("midTruncate", () => {
   });
 });
 
-describe("isLocalProviderKind", () => {
-  test("classifies ollama and llamacpp as local, remote as not", () => {
-    expect(isLocalProviderKind("ollama")).toBe(true);
-    expect(isLocalProviderKind("llamacpp")).toBe(true);
-    expect(isLocalProviderKind("remote")).toBe(false);
-  });
-});
-
 describe("LlmRouter.resolveForSynthesis", () => {
-  test("a LOCAL provider kind resolves isLocal: true — via the REAL LOCAL_PROVIDER_IDS membership, not a stub", async () => {
+  test("a LOCAL provider kind resolves isLocal: true — via the REAL provider.isLocal, not a stub", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerProvider(makeFakeProvider("ollama", true));
     const resolved = await router.resolveForSynthesis();
-    // This is the security-relevant assertion: `isLocal` comes from `isLocalProviderKind`
-    // classifying the REAL resolved `providerId` ("ollama"), never from a caller-supplied flag —
-    // a caller deciding `[agents].synthesis = "local"` vs egress-ledgering trusts THIS value.
+    // This is the security-relevant assertion: `isLocal` comes from the resolved route's
+    // REAL `provider.isLocal`, never from a caller-supplied flag — a caller deciding
+    // `[agents].synthesis = "local"` vs egress-ledgering trusts THIS value.
     expect(resolved).toEqual({
       providerId: "ollama",
       modelName: DEFAULT_CONFIG.localModel,
@@ -502,5 +494,98 @@ describe("LlmRouter.generateMarkdown", () => {
     if (resolved === undefined) throw new Error("expected a resolved provider");
     await router.generateMarkdown("the exact prompt text", resolved);
     expect(captured.prompt).toBe("the exact prompt text");
+  });
+});
+
+function makeFakeRouteProvider(id: string, isLocal: boolean, available: boolean): LlmProvider {
+  return {
+    providerId: id,
+    isLocal,
+    isAvailable: async () => available,
+    listModels: async () => [],
+    generate: async () => ({
+      text: `response from ${id}`,
+      tokensIn: 1,
+      tokensOut: 1,
+      modelUsed: id,
+      isLocal,
+      provider: id,
+    }),
+  };
+}
+
+describe("LlmRouter route registration", () => {
+  test("two models on ONE runtime both survive registration", async () => {
+    // RED-PROVE: on the pre-refactor Map<LlmProviderKind, LlmProvider> the second
+    // register overwrote the first, so this asserted 1 where it should assert 2.
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "gemma3:12b");
+
+    const ids = router
+      .routes()
+      .map((r) => r.routeId)
+      .sort();
+    expect(ids).toEqual(["ollama/gemma3:12b", "ollama/qwen3:8b"]);
+  });
+
+  test("a route is addressable by its id", () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    expect(router.routeFor("ollama/qwen3:8b")?.modelName).toBe("qwen3:8b");
+    expect(router.routeFor("ollama/nope")).toBeUndefined();
+  });
+
+  test("re-registering the SAME routeId replaces it rather than duplicating", () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b", {
+      parameterCount: 8,
+    });
+    expect(router.routes()).toHaveLength(1);
+    expect(router.routes()[0]?.meta.parameterCount).toBe(8);
+  });
+
+  test("selectProvider prefers a local route when preferLocal=true", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    const provider = await router.selectProvider("agent_step");
+    expect(provider?.providerId).toBe("ollama");
+  });
+
+  test("enforceAirGap skips every non-local route, whatever its id", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    // A vendor id this code has never seen must still be refused, because isLocal
+    // is declared false — not because "gemini" is on a list somewhere.
+    const provider = await router.selectProvider("agent_step");
+    expect(provider).toBeUndefined();
+  });
+
+  test("the unnamed tail after route_priority still honours preferLocal", async () => {
+    const router = new LlmRouter({
+      ...DEFAULT_CONFIG,
+      preferLocal: true,
+      routePriority: ["gemini/gemini-2.5-pro"], // an explicit remote FIRST choice
+    });
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    router.registerRoute(makeFakeRouteProvider("xai", false, true), "grok-4");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    // Registration order puts xai (remote) before ollama (local); preferLocal must
+    // reorder the tail so the local route is tried before the unranked remote one.
+    const ids = (router as unknown as { orderedRoutes(p?: boolean): { routeId: string }[] })
+      .orderedRoutes(true)
+      .map((r) => r.routeId);
+    expect(ids).toEqual(["gemini/gemini-2.5-pro", "ollama/qwen3:8b", "xai/grok-4"]);
+  });
+
+  test("selectRoute returns the full ModelRoute, not just the provider", async () => {
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    const route = await router.selectRoute("reasoning");
+    expect(route?.modelName).toBe("qwen3:8b");
+    expect(route?.routeId).toBe("ollama/qwen3:8b");
+    expect(route?.provider.providerId).toBe("ollama");
   });
 });

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -194,14 +194,47 @@ describe("LlmRouter context window overflow", () => {
     expect(captured.prompt).toBe(longPrompt);
   });
 
-  test("throws for reasoning overflow when air-gap is enforced", async () => {
+  test("truncates onto the local route for reasoning overflow when air-gap is enforced and no fallback route fits", async () => {
+    // Old behavior (pre-route-walk) threw unconditionally here, even though there was no
+    // remote route registered to "prevent" reaching. The route walk correctly finds no
+    // fitting fallback (the only route IS the overflowing one) and truncates, same as the
+    // non-air-gapped case would with no other route registered.
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
-    router.registerProvider(makeFakeProvider("ollama", true), { contextWindow: 100 });
+    const captured = { prompt: "" };
+    router.registerProvider(makeCaptureProvider("ollama", true, captured), { contextWindow: 100 });
     const longPrompt = "x".repeat(500);
-    await expect(router.generate({ task: "reasoning", prompt: longPrompt })).rejects.toThrow(
-      "air-gap mode prevents remote fallback",
-    );
+    const result = await router.generate({ task: "reasoning", prompt: longPrompt });
+    expect(captured.prompt).toContain("[...truncated...]");
+    expect(result.provider).toBe("ollama");
+  });
+
+  test("falls through to a route whose context window fits", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, preferLocal: true });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+      contextWindow: 100,
+    });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "big", {
+      contextWindow: 100_000,
+    });
+    const result = await router.generate({
+      task: "reasoning",
+      prompt: "x".repeat(40_000), // ~10k tokens: overflows "small", fits "big"
+    });
+    expect(result.text).toContain("ollama");
+  });
+
+  test("air-gap still refuses a non-local route on overflow", async () => {
+    const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+      contextWindow: 100,
+    });
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "big", {
+      contextWindow: 100_000,
+    });
+    // Must truncate onto the local route, never reach the remote one.
+    const result = await router.generate({ task: "reasoning", prompt: "x".repeat(40_000) });
+    expect(result.provider).toBe("ollama");
   });
 
   test("short prompt within context window is not truncated", async () => {

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { RouteAvailabilityProbe } from "./route-availability.ts";
 import { LlmRouter, type LlmRouterConfig, midTruncate } from "./router.ts";
 import type { LlmProvider } from "./types.ts";
 
@@ -7,7 +8,16 @@ function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boole
     providerId: id,
     isLocal: id !== "remote",
     isAvailable: async () => available,
-    listModels: async () => [],
+    // Matches the model `registerProvider` will assign this fake (localModel for a
+    // local id, remoteModel for "remote"), so the model-aware availability probe
+    // wired in Task 5 does not fail these route-selection-focused fakes on a model
+    // mismatch they were never testing for.
+    listModels: async () => [
+      {
+        provider: id,
+        modelName: id === "remote" ? DEFAULT_CONFIG.remoteModel : DEFAULT_CONFIG.localModel,
+      },
+    ],
     generate: async (_opts) => ({
       text: `response from ${id}`,
       tokensIn: 1,
@@ -151,12 +161,16 @@ function makeCaptureProvider(
   id: "ollama" | "llamacpp" | "remote",
   available: boolean,
   captured: { prompt: string },
+  // Defaults to the model `registerProvider` would assign this id; a caller using
+  // `registerRoute` with an explicit model name (e.g. "small"/"big" below) passes it
+  // here too, so the model-aware availability probe matches what was registered.
+  models: string[] = [id === "remote" ? DEFAULT_CONFIG.remoteModel : DEFAULT_CONFIG.localModel],
 ): LlmProvider {
   return {
     providerId: id,
     isLocal: id !== "remote",
     isAvailable: async () => available,
-    listModels: async () => [],
+    listModels: async () => models.map((m) => ({ provider: id, modelName: m })),
     generate: async (opts) => {
       captured.prompt = opts.prompt;
       return {
@@ -215,13 +229,20 @@ describe("LlmRouter context window overflow", () => {
     // keyed on provider id, so with two same-id routes it cannot tell "walked to the fitting
     // route" apart from "truncated on the original" — only asserting on what each instance
     // actually received can.
-    const router = new LlmRouter({ ...DEFAULT_CONFIG, preferLocal: true });
+    // Both routes share providerId "ollama", and the availability probe caches by
+    // providerId — a zero TTL forces each check to re-list rather than reuse the OTHER
+    // instance's cached model list (which would report "big" unavailable, since the
+    // cached list would still say ["small"]).
+    const router = new LlmRouter(
+      { ...DEFAULT_CONFIG, preferLocal: true },
+      new RouteAvailabilityProbe(0),
+    );
     const smallCaptured = { prompt: "" };
     const bigCaptured = { prompt: "" };
-    router.registerRoute(makeCaptureProvider("ollama", true, smallCaptured), "small", {
+    router.registerRoute(makeCaptureProvider("ollama", true, smallCaptured, ["small"]), "small", {
       contextWindow: 100,
     });
-    router.registerRoute(makeCaptureProvider("ollama", true, bigCaptured), "big", {
+    router.registerRoute(makeCaptureProvider("ollama", true, bigCaptured, ["big"]), "big", {
       contextWindow: 100_000,
     });
     const longPrompt = "x".repeat(40_000); // ~10k tokens: overflows "small", fits "big"
@@ -232,10 +253,10 @@ describe("LlmRouter context window overflow", () => {
 
   test("air-gap still refuses a non-local route on overflow", async () => {
     const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
-    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true, ["small"]), "small", {
       contextWindow: 100,
     });
-    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "big", {
+    router.registerRoute(makeFakeRouteProvider("gemini", false, true, ["big"]), "big", {
       contextWindow: 100_000,
     });
     // Must truncate onto the local route, never reach the remote one.
@@ -536,12 +557,20 @@ describe("LlmRouter.generateMarkdown", () => {
   });
 });
 
-function makeFakeRouteProvider(id: string, isLocal: boolean, available: boolean): LlmProvider {
+function makeFakeRouteProvider(
+  id: string,
+  isLocal: boolean,
+  available: boolean,
+  // The models this fake's daemon reports — must include whatever model name the
+  // caller then registers this provider under, or the model-aware availability
+  // probe (Task 5) reports `model_absent` regardless of `available`.
+  models: string[] = [],
+): LlmProvider {
   return {
     providerId: id,
     isLocal,
     isAvailable: async () => available,
-    listModels: async () => [],
+    listModels: async () => models.map((m) => ({ provider: id, modelName: m })),
     generate: async () => ({
       text: `response from ${id}`,
       tokensIn: 1,
@@ -587,8 +616,11 @@ describe("LlmRouter route registration", () => {
 
   test("selectProvider prefers a local route when preferLocal=true", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
-    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(
+      makeFakeRouteProvider("gemini", false, true, ["gemini-2.5-pro"]),
+      "gemini-2.5-pro",
+    );
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true, ["qwen3:8b"]), "qwen3:8b");
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("ollama");
   });
@@ -621,10 +653,31 @@ describe("LlmRouter route registration", () => {
 
   test("selectRoute returns the full ModelRoute, not just the provider", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "qwen3:8b");
+    router.registerRoute(makeFakeRouteProvider("ollama", true, true, ["qwen3:8b"]), "qwen3:8b");
     const route = await router.selectRoute("reasoning");
     expect(route?.modelName).toBe("qwen3:8b");
     expect(route?.routeId).toBe("ollama/qwen3:8b");
     expect(route?.provider.providerId).toBe("ollama");
+  });
+
+  test("the walk falls THROUGH a route whose model is not pulled", async () => {
+    // Without per-route (model-aware) availability this stops at the first route and
+    // returns it, because the daemon is up even though the configured model was never
+    // pulled. That is the whole defect this task fixes.
+    //
+    // Both routes share providerId "ollama" — the availability probe caches by
+    // providerId, so a zero TTL is used (rather than a distinct vendor id) to force
+    // each check to re-list against its OWN fake instance, which is what a real daemon
+    // would do too.
+    const absent = makeFakeRouteProvider("ollama", true, true, ["other"]);
+    const present = makeFakeRouteProvider("ollama", true, true, ["present"]);
+    const router = new LlmRouter(
+      { ...DEFAULT_CONFIG, routePriority: ["ollama/missing", "ollama/present"] },
+      new RouteAvailabilityProbe(0),
+    );
+    router.registerRoute(absent, "missing");
+    router.registerRoute(present, "present");
+    const chosen = await router.selectRoute("reasoning");
+    expect(chosen?.modelName).toBe("present");
   });
 });

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -393,6 +393,41 @@ describe("LlmRouter.getStatus", () => {
     });
   });
 
+  test("reports a SAME-provider fallback — two routes on one provider is the normal case", async () => {
+    // The bug this pins: the fallback was suppressed whenever it shared a `providerId` with
+    // the preferred route. Once the key became `(provider, model)`, that describes the most
+    // ordinary setup there is — two models on one Ollama daemon — so `ollama/qwen3:8b` down
+    // and `ollama/gemma3:12b` answering in its place was never reported at all. The status
+    // said "unavailable" and stopped, while `generate()` was quietly succeeding elsewhere.
+    const daemon: LlmProvider = {
+      providerId: "ollama",
+      isLocal: true,
+      isAvailable: async () => true,
+      // The daemon is UP but has only ever pulled gemma3:12b, so `qwen3:8b` is
+      // `model_absent` — a same-provider, different-model failure, which is precisely the
+      // case a providerId comparison cannot express.
+      listModels: async () => [{ provider: "ollama", modelName: "gemma3:12b" }],
+      generate: async () => ({
+        text: "x",
+        tokensIn: 1,
+        tokensOut: 1,
+        modelUsed: "gemma3:12b",
+        isLocal: true,
+        provider: "ollama",
+      }),
+    };
+    const router = new LlmRouter(DEFAULT_CONFIG);
+    router.registerRoute(daemon, "qwen3:8b");
+    router.registerRoute(daemon, "gemma3:12b");
+    const status = await router.getStatus();
+    expect(status.classification?.modelName).toBe("qwen3:8b");
+    expect(status.classification?.isAvailable).toBe(false);
+    expect(status.classification?.fallback).toEqual({
+      providerId: "ollama",
+      modelName: "gemma3:12b",
+    });
+  });
+
   test("no fallback when the preferred provider is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -627,7 +627,14 @@ describe("LlmRouter route registration", () => {
 
   test("enforceAirGap skips every non-local route, whatever its id", async () => {
     const router = new LlmRouter({ ...DEFAULT_CONFIG, enforceAirGap: true });
-    router.registerRoute(makeFakeRouteProvider("gemini", false, true), "gemini-2.5-pro");
+    // The model list is supplied and matches, so the ONLY thing that can make this
+    // route unavailable is the air-gap skip itself — without this the route would
+    // read as model_absent regardless of enforceAirGap, and the test would pass for
+    // the wrong reason.
+    router.registerRoute(
+      makeFakeRouteProvider("gemini", false, true, ["gemini-2.5-pro"]),
+      "gemini-2.5-pro",
+    );
     // A vendor id this code has never seen must still be refused, because isLocal
     // is declared false — not because "gemini" is on a list somewhere.
     const provider = await router.selectProvider("agent_step");

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -210,18 +210,24 @@ describe("LlmRouter context window overflow", () => {
   });
 
   test("falls through to a route whose context window fits", async () => {
+    // Each route gets a DISTINCT provider instance with its own capture object.
+    // `makeFakeRouteProvider`'s generate() ignores its input and always returns fixed text
+    // keyed on provider id, so with two same-id routes it cannot tell "walked to the fitting
+    // route" apart from "truncated on the original" — only asserting on what each instance
+    // actually received can.
     const router = new LlmRouter({ ...DEFAULT_CONFIG, preferLocal: true });
-    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "small", {
+    const smallCaptured = { prompt: "" };
+    const bigCaptured = { prompt: "" };
+    router.registerRoute(makeCaptureProvider("ollama", true, smallCaptured), "small", {
       contextWindow: 100,
     });
-    router.registerRoute(makeFakeRouteProvider("ollama", true, true), "big", {
+    router.registerRoute(makeCaptureProvider("ollama", true, bigCaptured), "big", {
       contextWindow: 100_000,
     });
-    const result = await router.generate({
-      task: "reasoning",
-      prompt: "x".repeat(40_000), // ~10k tokens: overflows "small", fits "big"
-    });
-    expect(result.text).toContain("ollama");
+    const longPrompt = "x".repeat(40_000); // ~10k tokens: overflows "small", fits "big"
+    await router.generate({ task: "reasoning", prompt: longPrompt });
+    expect(bigCaptured.prompt).toBe(longPrompt); // walked to the fitting route, untruncated
+    expect(smallCaptured.prompt).toBe(""); // the small route was never invoked
   });
 
   test("air-gap still refuses a non-local route on overflow", async () => {

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -5,6 +5,7 @@ import type { LlmProvider } from "./types.ts";
 function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boolean): LlmProvider {
   return {
     providerId: id,
+    isLocal: id !== "remote",
     isAvailable: async () => available,
     listModels: async () => [],
     generate: async (_opts) => ({
@@ -153,6 +154,7 @@ function makeCaptureProvider(
 ): LlmProvider {
   return {
     providerId: id,
+    isLocal: id !== "remote",
     isAvailable: async () => available,
     listModels: async () => [],
     generate: async (opts) => {

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -4,7 +4,6 @@ import type {
   LlmGenerateOptions,
   LlmGenerateResult,
   LlmProvider,
-  LlmProviderKind,
   LlmTaskType,
   ModelRoute,
   ProviderId,
@@ -37,19 +36,19 @@ export type LlmRouterConfig = {
  * provider rather than trust config intent.
  */
 export type ResolvedSynthesisProvider = {
-  readonly providerId: LlmProviderKind;
+  readonly providerId: ProviderId;
   readonly modelName: string;
   readonly isLocal: boolean;
 };
 
 export type LlmTaskStatus = {
-  providerId: LlmProviderKind;
+  providerId: ProviderId;
   modelName: string;
   isAvailable: boolean;
   reason: string;
   // Populated only when the preferred provider is unavailable: the provider generate() would
   // actually fall back to, so the status reflects real routing rather than just config intent.
-  fallback?: { providerId: LlmProviderKind; modelName: string };
+  fallback?: { providerId: ProviderId; modelName: string };
 };
 
 const CONTEXT_OVERFLOW_THRESHOLD = 0.85;
@@ -112,12 +111,6 @@ export class LlmRouter {
 
   routeFor(routeId: string): ModelRoute | undefined {
     return this.routeMap.get(routeId);
-  }
-
-  /** @deprecated Migration shim for call sites not yet on `registerRoute`. */
-  registerProvider(provider: LlmProvider, meta: ProviderMeta = {}): void {
-    const modelName = provider.isLocal ? this.config.localModel : this.config.remoteModel;
-    this.registerRoute(provider, modelName, meta);
   }
 
   prefersLocal(): boolean {

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -1,3 +1,4 @@
+import { RouteAvailabilityProbe } from "./route-availability.ts";
 import { makeRouteId } from "./route-id.ts";
 import type {
   LlmGenerateOptions,
@@ -72,9 +73,19 @@ function byPreference(routes: readonly ModelRoute[], preferLocal: boolean): Mode
 export class LlmRouter {
   private readonly routeMap = new Map<string, ModelRoute>();
   private readonly config: LlmRouterConfig;
+  // A single long-lived probe shared across every walk this router performs, so its
+  // per-providerId cache (see `RouteAvailabilityProbe`) actually amortizes repeated
+  // checks within the TTL. Injected — not constructed here — so a caller needing a
+  // zero-TTL probe (tests with two distinct provider instances sharing one providerId)
+  // has a seam, rather than `mock.module`.
+  private readonly availability: RouteAvailabilityProbe;
 
-  constructor(config: LlmRouterConfig) {
+  constructor(
+    config: LlmRouterConfig,
+    probe: RouteAvailabilityProbe = new RouteAvailabilityProbe(),
+  ) {
     this.config = config;
+    this.availability = probe;
   }
 
   /**
@@ -133,11 +144,7 @@ export class LlmRouter {
     task: LlmTaskType,
     opts?: { preferLocal?: boolean },
   ): Promise<ModelRoute | undefined> {
-    return this.firstAvailableRoute(
-      task,
-      (r) => this.probeAvailable(r.provider),
-      opts?.preferLocal,
-    );
+    return this.firstAvailableRoute(task, (r) => this.probeAvailable(r), opts?.preferLocal);
   }
 
   async selectProvider(
@@ -241,9 +248,13 @@ export class LlmRouter {
     return byPreference(all, preferLocal);
   }
 
-  private async probeAvailable(provider: LlmProvider): Promise<boolean> {
+  // Route-level availability: the daemon is reachable AND `route.modelName` is among the
+  // models it currently reports (via the shared `RouteAvailabilityProbe`) — not just
+  // "the daemon answered". `RouteAvailabilityProbe.check` already catches internally,
+  // so this catch is defense-in-depth, preserving the pre-existing catch-to-false.
+  private async probeAvailable(route: ModelRoute): Promise<boolean> {
     try {
-      return await provider.isAvailable();
+      return (await this.availability.check(route)).available;
     } catch {
       return false; // treat availability check failure as unavailable
     }
@@ -323,7 +334,7 @@ export class LlmRouter {
         const limit = Math.floor(window * CONTEXT_OVERFLOW_THRESHOLD);
         if (estimatedTokens > limit) continue;
       }
-      if (await this.probeAvailable(candidate.provider)) return candidate;
+      if (await this.probeAvailable(candidate)) return candidate;
     }
     return undefined;
   }
@@ -375,33 +386,28 @@ export class LlmRouter {
   async getStatus(): Promise<Record<LlmTaskType, LlmTaskStatus | undefined>> {
     const tasks: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
     const out: Partial<Record<LlmTaskType, LlmTaskStatus | undefined>> = {};
-    // Probe each provider's availability at most once for the whole call.
-    const availabilityCache = new Map<string, Promise<boolean>>();
-    const cachedAvailable = (route: ModelRoute): Promise<boolean> => {
-      let probe = availabilityCache.get(route.provider.providerId);
-      if (probe === undefined) {
-        probe = this.probeAvailable(route.provider);
-        availabilityCache.set(route.provider.providerId, probe);
-      }
-      return probe;
-    };
+    // `probeAvailable` already goes through the shared `this.availability` probe, whose
+    // own per-providerId TTL cache amortizes repeated checks — a second, per-call cache
+    // here (as this used to have) is redundant, and two caching layers with different
+    // lifetimes over the same question is how they drift apart.
+    const isAvailable = (route: ModelRoute): Promise<boolean> => this.probeAvailable(route);
     for (const t of tasks) {
       const preferred = this.findPreferredRoute(t);
       if (preferred === undefined) {
         out[t] = undefined;
         continue;
       }
-      const isAvailable = await cachedAvailable(preferred);
+      const preferredAvailable = await isAvailable(preferred);
       const entry: LlmTaskStatus = {
         providerId: preferred.provider.providerId,
         modelName: preferred.modelName,
-        isAvailable,
+        isAvailable: preferredAvailable,
         reason: this.reasonFor(t, preferred),
       };
-      if (!isAvailable) {
+      if (!preferredAvailable) {
         // The preferred provider is down; report the route generate() would actually fall
         // back to (next available in priority order) so status matches real routing.
-        const actual = await this.firstAvailableRoute(t, cachedAvailable);
+        const actual = await this.firstAvailableRoute(t, isAvailable);
         if (actual !== undefined && actual.provider.providerId !== preferred.provider.providerId) {
           entry.fallback = {
             providerId: actual.provider.providerId,

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -21,9 +21,12 @@ export type LlmRouterConfig = {
   /**
    * An explicit, human-authored ordering of route ids (`"<provider>/<model>"`) to try
    * first, before the normal preferLocal-driven ordering. An entry that no longer
-   * resolves to a registered route is skipped (it either failed config-load validation
-   * in Task 8, or the route was unregistered at runtime). Routes not named here still
-   * follow, ordered by `preferLocal` — see `orderedRoutes`.
+   * resolves to a registered route is skipped. Nothing throws on the way here: config
+   * load never rejects a bad entry (a throw in the `[llm]` parser is swallowed by
+   * `loadTomlSection`'s bare catch, which would silently revert the WHOLE section,
+   * `enforce_air_gap` included), so `platform/assemble.ts` warn-logs and DROPS an
+   * unresolvable entry before this config is built, and boot continues. Routes not named
+   * here still follow, ordered by `preferLocal` — see `orderedRoutes`.
    */
   readonly routePriority?: readonly string[];
 };
@@ -73,10 +76,10 @@ export class LlmRouter {
   private readonly routeMap = new Map<string, ModelRoute>();
   private readonly config: LlmRouterConfig;
   // A single long-lived probe shared across every walk this router performs, so its
-  // per-providerId cache (see `RouteAvailabilityProbe`) actually amortizes repeated
-  // checks within the TTL. Injected — not constructed here — so a caller needing a
-  // zero-TTL probe (tests with two distinct provider instances sharing one providerId)
-  // has a seam, rather than `mock.module`.
+  // per-provider-INSTANCE cache (see `RouteAvailabilityProbe`) actually amortizes repeated
+  // checks within the TTL. Injected — not constructed here — so `LlmRegistry` can hold its
+  // own reference and `invalidate()` after a successful pull, and so a caller needing
+  // different TTLs has a seam rather than `mock.module`.
   private readonly availability: RouteAvailabilityProbe;
 
   constructor(
@@ -218,7 +221,8 @@ export class LlmRouter {
     const explicit = this.config.routePriority;
     if (explicit !== undefined && explicit.length > 0) {
       const byId = new Map(all.map((r) => [r.routeId, r]));
-      // An unresolvable entry threw at config load (Task 8); anything still missing
+      // Nothing throws for an unresolvable entry: `platform/assemble.ts` already warn-logged
+      // and dropped it (by name) before this router was constructed. Anything still missing
       // here was unregistered at runtime, so skipping is correct.
       const ordered = explicit
         .map((id) => byId.get(id))
@@ -380,8 +384,8 @@ export class LlmRouter {
     const tasks: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
     const out: Partial<Record<LlmTaskType, LlmTaskStatus | undefined>> = {};
     // `probeAvailable` already goes through the shared `this.availability` probe, whose
-    // own per-providerId TTL cache amortizes repeated checks — a second, per-call cache
-    // here (as this used to have) is redundant, and two caching layers with different
+    // own per-provider-instance TTL cache amortizes repeated checks — a second, per-call
+    // cache here (as this used to have) is redundant, and two caching layers with different
     // lifetimes over the same question is how they drift apart.
     const isAvailable = (route: ModelRoute): Promise<boolean> => this.probeAvailable(route);
     for (const t of tasks) {

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -4,7 +4,10 @@ import type {
   LlmProvider,
   LlmProviderKind,
   LlmTaskType,
+  ProviderMeta,
 } from "./types.ts";
+
+export type { ProviderMeta } from "./types.ts";
 
 export type LlmRouterConfig = {
   preferLocal: boolean;
@@ -12,11 +15,6 @@ export type LlmRouterConfig = {
   localModel: string;
   minReasoningParams: number;
   enforceAirGap: boolean;
-};
-
-export type ProviderMeta = {
-  parameterCount?: number;
-  contextWindow?: number;
 };
 
 /**

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -1,9 +1,12 @@
+import { makeRouteId } from "./route-id.ts";
 import type {
   LlmGenerateOptions,
   LlmGenerateResult,
   LlmProvider,
   LlmProviderKind,
   LlmTaskType,
+  ModelRoute,
+  ProviderId,
   ProviderMeta,
 } from "./types.ts";
 
@@ -15,14 +18,22 @@ export type LlmRouterConfig = {
   localModel: string;
   minReasoningParams: number;
   enforceAirGap: boolean;
+  /**
+   * An explicit, human-authored ordering of route ids (`"<provider>/<model>"`) to try
+   * first, before the normal preferLocal-driven ordering. An entry that no longer
+   * resolves to a registered route is skipped (it either failed config-load validation
+   * in Task 8, or the route was unregistered at runtime). Routes not named here still
+   * follow, ordered by `preferLocal` — see `orderedRoutes`.
+   */
+  readonly routePriority?: readonly string[];
 };
 
 /**
  * The provider `resolveForSynthesis()` selected for an `[agents]` brief synthesis attempt, plus
- * whether it runs on this machine. `isLocal` is derived from `LOCAL_PROVIDER_IDS` — never from
- * `prefersLocal()`/`config.preferLocal`, which express only a preference (see `isLocalProviderKind`
- * doc comment) — so a caller enforcing `[agents].synthesis = "local"` can refuse a resolved
- * remote provider rather than trust config intent.
+ * whether it runs on this machine. `isLocal` is derived from the resolved route's
+ * `provider.isLocal` — never from `prefersLocal()`/`config.preferLocal`, which express only a
+ * preference — so a caller enforcing `[agents].synthesis = "local"` can refuse a resolved remote
+ * provider rather than trust config intent.
  */
 export type ResolvedSynthesisProvider = {
   readonly providerId: LlmProviderKind;
@@ -40,21 +51,6 @@ export type LlmTaskStatus = {
   fallback?: { providerId: LlmProviderKind; modelName: string };
 };
 
-const LOCAL_PROVIDER_IDS: ReadonlySet<LlmProviderKind> = new Set(["ollama", "llamacpp"]);
-
-/**
- * Whether a provider kind runs on this machine.
- *
- * Exported so a caller can enforce local-only routing BEFORE dispatching a
- * prompt. `selectProvider(_, { preferLocal: true })` only expresses a
- * preference — it falls through to `remote` when no local provider answers —
- * so a surface that promises no egress must check the kind itself. The set
- * stays module-private; only the predicate is exported.
- */
-export function isLocalProviderKind(id: LlmProviderKind): boolean {
-  return LOCAL_PROVIDER_IDS.has(id);
-}
-
 const CONTEXT_OVERFLOW_THRESHOLD = 0.85;
 const TOKENS_PER_CHAR = 4;
 
@@ -64,23 +60,53 @@ export function midTruncate(text: string, maxChars: number): string {
   return `${text.slice(0, keep)}\n[...truncated...]\n${text.slice(-keep)}`;
 }
 
+// Orders routes local-first or remote-first per `preferLocal`, preserving each half's
+// relative (registration) order. Module-level, mirroring `midTruncate` above — no
+// per-instance state is involved.
+function byPreference(routes: readonly ModelRoute[], preferLocal: boolean): ModelRoute[] {
+  const local = routes.filter((r) => r.provider.isLocal);
+  const remote = routes.filter((r) => !r.provider.isLocal);
+  return preferLocal ? [...local, ...remote] : [...remote, ...local];
+}
+
 export class LlmRouter {
-  private readonly providers = new Map<LlmProviderKind, LlmProvider>();
-  private readonly providerMeta = new Map<LlmProviderKind, ProviderMeta>();
+  private readonly routeMap = new Map<string, ModelRoute>();
   private readonly config: LlmRouterConfig;
 
   constructor(config: LlmRouterConfig) {
     this.config = config;
   }
 
-  /** The registered provider for a kind, or `undefined`. Used to re-register it with real meta. */
-  providerFor(id: LlmProviderKind): LlmProvider | undefined {
-    return this.providers.get(id);
+  /**
+   * The first registered provider matching this vendor id, or `undefined`. Used by callers
+   * that still address a provider by vendor id alone (`LlmRegistry`) rather than by full
+   * route. Ambiguous only when the same vendor id has multiple routes registered under it —
+   * returns the first found in registration order.
+   */
+  providerFor(id: ProviderId): LlmProvider | undefined {
+    for (const route of this.routeMap.values()) {
+      if (route.provider.providerId === id) return route.provider;
+    }
+    return undefined;
   }
 
+  registerRoute(provider: LlmProvider, modelName: string, meta: ProviderMeta = {}): void {
+    const routeId = makeRouteId(provider.providerId, modelName);
+    this.routeMap.set(routeId, { routeId, provider, modelName, meta });
+  }
+
+  routes(): readonly ModelRoute[] {
+    return [...this.routeMap.values()];
+  }
+
+  routeFor(routeId: string): ModelRoute | undefined {
+    return this.routeMap.get(routeId);
+  }
+
+  /** @deprecated Migration shim for call sites not yet on `registerRoute`. */
   registerProvider(provider: LlmProvider, meta: ProviderMeta = {}): void {
-    this.providers.set(provider.providerId, provider);
-    this.providerMeta.set(provider.providerId, meta);
+    const modelName = provider.isLocal ? this.config.localModel : this.config.remoteModel;
+    this.registerRoute(provider, modelName, meta);
   }
 
   prefersLocal(): boolean {
@@ -103,20 +129,32 @@ export class LlmRouter {
   // `opts.preferLocal` overrides `config.preferLocal` for this call only (e.g. research briefs
   // honoring `[briefs].prefer_local` independently of `[llm].prefer_local` — source text is
   // privacy-sensitive enough to warrant its own knob). Omitted, behavior is unchanged.
+  async selectRoute(
+    task: LlmTaskType,
+    opts?: { preferLocal?: boolean },
+  ): Promise<ModelRoute | undefined> {
+    return this.firstAvailableRoute(
+      task,
+      (r) => this.probeAvailable(r.provider),
+      opts?.preferLocal,
+    );
+  }
+
   async selectProvider(
     task: LlmTaskType,
     opts?: { preferLocal?: boolean },
   ): Promise<LlmProvider | undefined> {
-    return this.firstAvailable(task, (p) => this.probeAvailable(p), opts?.preferLocal);
+    const route = await this.selectRoute(task, opts);
+    return route?.provider;
   }
 
   /**
    * Resolve the provider a `[agents]` brief synthesis attempt would use, right now, for the
-   * `"reasoning"` task — plus an `isLocal` flag derived from `LOCAL_PROVIDER_IDS` rather than
-   * duplicating the priority walk at the call site. Reuses `selectProvider`, so air-gap and the
-   * reasoning capability floor are honored the same way they are for every other caller. Callers
-   * that must not trust a bare `remote: true`/`false` re-derive it from `providerId` here, not
-   * from `config.preferLocal`.
+   * `"reasoning"` task — plus an `isLocal` flag read directly off the resolved route's provider
+   * instance rather than duplicating the priority walk at the call site. Reuses `selectRoute`, so
+   * air-gap and the reasoning capability floor are honored the same way they are for every other
+   * caller. Callers that must not trust a bare `remote: true`/`false` re-derive it from
+   * `providerId` here, not from `config.preferLocal`.
    *
    * `preferLocal` defaults to `config.preferLocal` — an omitted argument behaves exactly as
    * before this parameter existed. A caller with its own local-preference precedent (mirroring
@@ -130,48 +168,77 @@ export class LlmRouter {
   async resolveForSynthesis(
     preferLocal: boolean = this.config.preferLocal,
   ): Promise<ResolvedSynthesisProvider | undefined> {
-    const provider = await this.selectProvider("reasoning", { preferLocal });
-    if (provider === undefined) {
+    const route = await this.selectRoute("reasoning", { preferLocal });
+    if (route === undefined) {
       return undefined;
     }
     return {
-      providerId: provider.providerId,
-      modelName: this.modelNameFor(provider.providerId),
-      isLocal: isLocalProviderKind(provider.providerId),
+      providerId: route.provider.providerId,
+      modelName: route.modelName,
+      isLocal: route.provider.isLocal,
     };
   }
 
   /**
-   * Generates markdown from the EXACT provider `resolveForSynthesis()` resolved — never
+   * Generates markdown from the EXACT route `resolveForSynthesis()` resolved — never
    * re-selects — so the provider actually invoked always matches the one a caller classified as
    * local/remote and (if applicable) ledgered.
    */
   async generateMarkdown(prompt: string, resolved: ResolvedSynthesisProvider): Promise<string> {
-    const provider = this.providers.get(resolved.providerId);
-    if (provider === undefined) {
+    const route = this.routeFor(makeRouteId(resolved.providerId, resolved.modelName));
+    if (route === undefined) {
       throw new Error(`LLM provider "${resolved.providerId}" is no longer registered`);
     }
-    const result = await provider.generate({ task: "reasoning", prompt });
+    const result = await route.provider.generate({ task: "reasoning", prompt });
     return result.text;
   }
 
-  // Walks the task's provider priority order (respecting air-gap and the capability floor) and
-  // returns the first provider whose availability check resolves true. The check is injected so
-  // callers can share a memoized probe across many tasks (see getStatus). `preferLocal`, when
-  // provided, overrides `config.preferLocal` for this call only.
-  private async firstAvailable(
+  // Walks the task's route priority order (respecting air-gap and the capability floor) and
+  // returns the first route whose provider's availability check resolves true. The check is
+  // injected so callers can share a memoized probe across many tasks (see getStatus).
+  // `preferLocal`, when provided, overrides `config.preferLocal` for this call only.
+  private async firstAvailableRoute(
     task: LlmTaskType,
-    isAvailable: (provider: LlmProvider) => Promise<boolean>,
+    isAvailable: (route: ModelRoute) => Promise<boolean>,
     preferLocal?: boolean,
-  ): Promise<LlmProvider | undefined> {
-    for (const id of this.providerPriority(task, preferLocal)) {
-      if (this.config.enforceAirGap && !LOCAL_PROVIDER_IDS.has(id)) continue;
-      if (!this.meetsCapabilityFloor(id, task)) continue;
-      const provider = this.providers.get(id);
-      if (provider === undefined) continue;
-      if (await isAvailable(provider)) return provider;
+  ): Promise<ModelRoute | undefined> {
+    for (const route of this.orderedRoutes(preferLocal)) {
+      if (this.config.enforceAirGap && !route.provider.isLocal) continue;
+      if (!this.meetsCapabilityFloor(route, task)) continue;
+      if (await isAvailable(route)) return route;
     }
     return undefined;
+  }
+
+  // Orders every registered route: `config.routePriority` entries first (in the order given,
+  // skipping any that no longer resolve to a registered route), then everything else ordered by
+  // `preferLocal`.
+  private orderedRoutes(preferLocal: boolean = this.config.preferLocal): ModelRoute[] {
+    const all = this.routes();
+    const explicit = this.config.routePriority;
+    if (explicit !== undefined && explicit.length > 0) {
+      const byId = new Map(all.map((r) => [r.routeId, r]));
+      // An unresolvable entry threw at config load (Task 8); anything still missing
+      // here was unregistered at runtime, so skipping is correct.
+      const ordered = explicit
+        .map((id) => byId.get(id))
+        .filter((r): r is ModelRoute => r !== undefined);
+      const named = new Set(ordered.map((r) => r.routeId));
+      // The unnamed tail still honours preferLocal. Leaving it in registration order
+      // would make the fallback order depend on config-file ordering, which is
+      // arbitrary — and would quietly ignore prefer_local for exactly the routes the
+      // user did not think to rank. Appending them at all (rather than dropping) is
+      // deliberate: a route added to [llm.local.*] but forgotten in route_priority
+      // should still be reachable, not invisible.
+      return [
+        ...ordered,
+        ...byPreference(
+          all.filter((r) => !named.has(r.routeId)),
+          preferLocal,
+        ),
+      ];
+    }
+    return byPreference(all, preferLocal);
   }
 
   private async probeAvailable(provider: LlmProvider): Promise<boolean> {
@@ -183,30 +250,30 @@ export class LlmRouter {
   }
 
   async generate(opts: LlmGenerateOptions): Promise<LlmGenerateResult> {
-    const provider = await this.selectProvider(opts.task);
-    if (provider === undefined) {
+    const route = await this.selectRoute(opts.task);
+    if (route === undefined) {
       throw new Error(`No LLM provider available for task: ${opts.task}`);
     }
-    const adjusted = await this.fitPromptOrFallback(opts, provider.providerId);
+    const adjusted = await this.fitPromptOrFallback(opts, route);
     if (adjusted.kind === "remote-result") {
       return adjusted.result;
     }
-    return provider.generate(adjusted.opts);
+    return route.provider.generate(adjusted.opts);
   }
 
   private async fitPromptOrFallback(
     opts: LlmGenerateOptions,
-    providerId: LlmProviderKind,
+    route: ModelRoute,
   ): Promise<
     | { kind: "opts"; opts: LlmGenerateOptions }
     | { kind: "remote-result"; result: LlmGenerateResult }
   > {
-    const meta = this.providerMeta.get(providerId);
-    if (meta?.contextWindow === undefined) {
+    const contextWindow = route.meta.contextWindow;
+    if (contextWindow === undefined) {
       return { kind: "opts", opts };
     }
     const estimatedTokens = Math.ceil(opts.prompt.length / TOKENS_PER_CHAR);
-    const tokenLimit = Math.floor(meta.contextWindow * CONTEXT_OVERFLOW_THRESHOLD);
+    const tokenLimit = Math.floor(contextWindow * CONTEXT_OVERFLOW_THRESHOLD);
     if (estimatedTokens <= tokenLimit) {
       return { kind: "opts", opts };
     }
@@ -232,7 +299,7 @@ export class LlmRouter {
   private async tryRemoteFallback(
     opts: LlmGenerateOptions,
   ): Promise<LlmGenerateResult | undefined> {
-    const remote = this.providers.get("remote");
+    const remote = this.providerFor("remote");
     if (remote === undefined) {
       return undefined;
     }
@@ -246,23 +313,14 @@ export class LlmRouter {
     return undefined;
   }
 
-  private meetsCapabilityFloor(id: LlmProviderKind, task: LlmTaskType): boolean {
+  private meetsCapabilityFloor(route: ModelRoute, task: LlmTaskType): boolean {
     if (task !== "reasoning" && task !== "agent_step") return true;
-    const meta = this.providerMeta.get(id);
-    if (meta?.parameterCount === undefined) return true;
-    return meta.parameterCount >= this.config.minReasoningParams;
+    if (route.meta.parameterCount === undefined) return true;
+    return route.meta.parameterCount >= this.config.minReasoningParams;
   }
 
-  private modelNameFor(providerId: LlmProviderKind): string {
-    // NOTE: this returns the global local/remote model from config. Per-task overrides set via
-    // llm.setDefault (stored in llm_task_defaults) are not consulted here because the router
-    // has no DB access. If per-task dispatch is wired to respect those overrides in the future,
-    // this method should be updated to accept a task argument and query the registry.
-    return LOCAL_PROVIDER_IDS.has(providerId) ? this.config.localModel : this.config.remoteModel;
-  }
-
-  private reasonFor(task: LlmTaskType, providerId: LlmProviderKind): string {
-    const isLocal = LOCAL_PROVIDER_IDS.has(providerId);
+  private reasonFor(task: LlmTaskType, route: ModelRoute): string {
+    const isLocal = route.provider.isLocal;
     if (this.config.enforceAirGap && isLocal) return "air-gap";
     if (this.config.preferLocal && isLocal) return "prefer-local";
     if (!this.config.preferLocal && !isLocal) return "prefer-remote";
@@ -277,26 +335,24 @@ export class LlmRouter {
     return "no-remote-provider";
   }
 
-  // True when a local provider is registered for this task but was excluded by the reasoning
+  // True when a local route is registered for this task but was excluded by the reasoning
   // capability floor (only reasoning/agent_step carry a floor).
   private localProviderBelowFloor(task: LlmTaskType): boolean {
-    for (const id of this.providers.keys()) {
-      if (!LOCAL_PROVIDER_IDS.has(id)) continue;
-      if (!this.meetsCapabilityFloor(id, task)) return true;
+    for (const route of this.routes()) {
+      if (!route.provider.isLocal) continue;
+      if (!this.meetsCapabilityFloor(route, task)) return true;
     }
     return false;
   }
 
-  // Finds the highest-priority provider for a task based on config (priority order, capability
+  // Finds the highest-priority route for a task based on config (priority order, capability
   // floor, air-gap) WITHOUT calling isAvailable(). Used by getStatus() so that the status entry
   // reflects config intent; isAvailable() is then probed separately.
-  private findPreferred(task: LlmTaskType): LlmProvider | undefined {
-    const orderedIds = this.providerPriority(task);
-    for (const id of orderedIds) {
-      if (this.config.enforceAirGap && !LOCAL_PROVIDER_IDS.has(id)) continue;
-      if (!this.meetsCapabilityFloor(id, task)) continue;
-      const provider = this.providers.get(id);
-      if (provider !== undefined) return provider;
+  private findPreferredRoute(task: LlmTaskType): ModelRoute | undefined {
+    for (const route of this.orderedRoutes()) {
+      if (this.config.enforceAirGap && !route.provider.isLocal) continue;
+      if (!this.meetsCapabilityFloor(route, task)) continue;
+      return route;
     }
     return undefined;
   }
@@ -305,51 +361,41 @@ export class LlmRouter {
     const tasks: LlmTaskType[] = ["classification", "reasoning", "summarisation", "agent_step"];
     const out: Partial<Record<LlmTaskType, LlmTaskStatus | undefined>> = {};
     // Probe each provider's availability at most once for the whole call.
-    const availabilityCache = new Map<LlmProviderKind, Promise<boolean>>();
-    const cachedAvailable = (provider: LlmProvider): Promise<boolean> => {
-      let probe = availabilityCache.get(provider.providerId);
+    const availabilityCache = new Map<string, Promise<boolean>>();
+    const cachedAvailable = (route: ModelRoute): Promise<boolean> => {
+      let probe = availabilityCache.get(route.provider.providerId);
       if (probe === undefined) {
-        probe = this.probeAvailable(provider);
-        availabilityCache.set(provider.providerId, probe);
+        probe = this.probeAvailable(route.provider);
+        availabilityCache.set(route.provider.providerId, probe);
       }
       return probe;
     };
     for (const t of tasks) {
-      const preferred = this.findPreferred(t);
+      const preferred = this.findPreferredRoute(t);
       if (preferred === undefined) {
         out[t] = undefined;
         continue;
       }
       const isAvailable = await cachedAvailable(preferred);
       const entry: LlmTaskStatus = {
-        providerId: preferred.providerId,
-        modelName: this.modelNameFor(preferred.providerId),
+        providerId: preferred.provider.providerId,
+        modelName: preferred.modelName,
         isAvailable,
-        reason: this.reasonFor(t, preferred.providerId),
+        reason: this.reasonFor(t, preferred),
       };
       if (!isAvailable) {
-        // The preferred provider is down; report the provider generate() would actually fall
+        // The preferred provider is down; report the route generate() would actually fall
         // back to (next available in priority order) so status matches real routing.
-        const actual = await this.firstAvailable(t, cachedAvailable);
-        if (actual !== undefined && actual.providerId !== preferred.providerId) {
+        const actual = await this.firstAvailableRoute(t, cachedAvailable);
+        if (actual !== undefined && actual.provider.providerId !== preferred.provider.providerId) {
           entry.fallback = {
-            providerId: actual.providerId,
-            modelName: this.modelNameFor(actual.providerId),
+            providerId: actual.provider.providerId,
+            modelName: actual.modelName,
           };
         }
       }
       out[t] = entry;
     }
     return out as Record<LlmTaskType, LlmTaskStatus | undefined>;
-  }
-
-  private providerPriority(
-    _task: LlmTaskType,
-    preferLocal: boolean = this.config.preferLocal,
-  ): LlmProviderKind[] {
-    if (preferLocal) {
-      return ["ollama", "llamacpp", "remote"];
-    }
-    return ["remote", "ollama", "llamacpp"];
   }
 }

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -90,19 +90,6 @@ export class LlmRouter {
     this.availability = probe;
   }
 
-  /**
-   * The first registered provider matching this vendor id, or `undefined`. Used by callers
-   * that still address a provider by vendor id alone (`LlmRegistry`) rather than by full
-   * route. Ambiguous only when the same vendor id has multiple routes registered under it —
-   * returns the first found in registration order.
-   */
-  providerFor(id: ProviderId): LlmProvider | undefined {
-    for (const route of this.routeMap.values()) {
-      if (route.provider.providerId === id) return route.provider;
-    }
-    return undefined;
-  }
-
   registerRoute(provider: LlmProvider, modelName: string, meta: ProviderMeta = {}): void {
     const routeId = makeRouteId(provider.providerId, modelName);
     this.routeMap.set(routeId, { routeId, provider, modelName, meta });
@@ -405,7 +392,13 @@ export class LlmRouter {
         // The preferred provider is down; report the route generate() would actually fall
         // back to (next available in priority order) so status matches real routing.
         const actual = await this.firstAvailableRoute(t, isAvailable);
-        if (actual !== undefined && actual.provider.providerId !== preferred.provider.providerId) {
+        // Compared by ROUTE id, not provider id. Two routes on one provider is the normal case
+        // now that `(provider, model)` is the key — `ollama/qwen3:8b` down and
+        // `ollama/gemma3:12b` answering in its place is precisely the fallback a user needs to
+        // see, and a providerId comparison suppressed it as "same provider, nothing to report".
+        // A route can only equal itself here, so the self-suppression this guard exists for
+        // still holds.
+        if (actual !== undefined && actual.routeId !== preferred.routeId) {
           entry.fallback = {
             providerId: actual.provider.providerId,
             modelName: actual.modelName,

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -255,8 +255,8 @@ export class LlmRouter {
       throw new Error(`No LLM provider available for task: ${opts.task}`);
     }
     const adjusted = await this.fitPromptOrFallback(opts, route);
-    if (adjusted.kind === "remote-result") {
-      return adjusted.result;
+    if (adjusted.kind === "route") {
+      return adjusted.route.provider.generate(adjusted.opts);
     }
     return route.provider.generate(adjusted.opts);
   }
@@ -266,7 +266,7 @@ export class LlmRouter {
     route: ModelRoute,
   ): Promise<
     | { kind: "opts"; opts: LlmGenerateOptions }
-    | { kind: "remote-result"; result: LlmGenerateResult }
+    | { kind: "route"; route: ModelRoute; opts: LlmGenerateOptions }
   > {
     const contextWindow = route.meta.contextWindow;
     if (contextWindow === undefined) {
@@ -284,31 +284,46 @@ export class LlmRouter {
     if (opts.task === "summarisation" || opts.task === "classification") {
       return { kind: "opts", opts: truncated };
     }
-    if (this.config.enforceAirGap) {
+    // Defensive, not reachable through the public `generate()` path today: `selectRoute`
+    // already excludes non-local routes when air-gap is enforced (I6-adjacent posture), so
+    // `route` here is always local under air-gap. Kept because truncating a NON-local route's
+    // prompt would not fix the actual problem — the prompt would still leave the machine — so
+    // truncation is not an acceptable substitute for refusal in that case. A local overflowing
+    // route with no fitting fallback truncates instead (below), which the "local" half of this
+    // condition permits.
+    if (this.config.enforceAirGap && !route.provider.isLocal) {
       throw new Error(
         `Prompt exceeds provider context window and air-gap mode prevents remote fallback`,
       );
     }
-    const remoteResult = await this.tryRemoteFallback(opts);
-    if (remoteResult !== undefined) {
-      return { kind: "remote-result", result: remoteResult };
+    const fallback = await this.findFallbackRoute(opts.task, estimatedTokens);
+    if (fallback !== undefined) {
+      return { kind: "route", route: fallback, opts };
     }
     return { kind: "opts", opts: truncated };
   }
 
-  private async tryRemoteFallback(
-    opts: LlmGenerateOptions,
-  ): Promise<LlmGenerateResult | undefined> {
-    const remote = this.providerFor("remote");
-    if (remote === undefined) {
-      return undefined;
-    }
-    try {
-      if (await remote.isAvailable()) {
-        return await remote.generate(opts);
+  // Walks routes in priority order looking for the next one the overflowing prompt actually
+  // fits in — replaces the old literal `providerFor("remote")` lookup. Applies the SAME gates
+  // as `firstAvailableRoute` (air-gap, capability floor, availability), evaluated per candidate
+  // rather than against a pre-filtered pool, plus a context-fit check using the same threshold
+  // math as the overflow check above. A route with no declared `contextWindow` is eligible
+  // (fail-open, matching `meetsCapabilityFloor`'s treatment of an undisclosed `parameterCount`).
+  // The originally overflowing route is never explicitly excluded — it fails its own fit check
+  // here for the same reason it overflowed above, since both use the same threshold formula.
+  private async findFallbackRoute(
+    task: LlmTaskType,
+    estimatedTokens: number,
+  ): Promise<ModelRoute | undefined> {
+    for (const candidate of this.orderedRoutes()) {
+      if (this.config.enforceAirGap && !candidate.provider.isLocal) continue;
+      if (!this.meetsCapabilityFloor(candidate, task)) continue;
+      const window = candidate.meta.contextWindow;
+      if (window !== undefined) {
+        const limit = Math.floor(window * CONTEXT_OVERFLOW_THRESHOLD);
+        if (estimatedTokens > limit) continue;
       }
-    } catch {
-      /* treat as unavailable */
+      if (await this.probeAvailable(candidate.provider)) return candidate;
     }
     return undefined;
   }

--- a/packages/gateway/src/llm/types.test.ts
+++ b/packages/gateway/src/llm/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { LlamaCppProvider } from "./llamacpp-provider.ts";
+import { OllamaProvider } from "./ollama-provider.ts";
+import type { LlmProvider } from "./types.ts";
+
+describe("LlmProvider.isLocal", () => {
+  test("both shipped providers declare themselves local", () => {
+    const providers: LlmProvider[] = [new OllamaProvider(), new LlamaCppProvider()];
+    for (const p of providers) {
+      expect(p.isLocal).toBe(true);
+    }
+  });
+
+  test("a provider that omits isLocal does not satisfy the interface", () => {
+    // Compile-time proof, asserted at runtime so the test is not vacuous: an object
+    // literal missing `isLocal` is not assignable to LlmProvider. If this ever
+    // compiles without the field, the interface has been weakened back to optional.
+    const withoutIsLocal = {
+      providerId: "fake",
+      isAvailable: async () => true,
+      listModels: async () => [],
+      generate: async () => ({
+        text: "",
+        tokensIn: 0,
+        tokensOut: 0,
+        modelUsed: "fake",
+        isLocal: false,
+        provider: "fake",
+      }),
+    };
+    // @ts-expect-error isLocal is required on LlmProvider
+    const bad: LlmProvider = withoutIsLocal;
+    expect(bad.isLocal).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/llm/types.ts
+++ b/packages/gateway/src/llm/types.ts
@@ -12,9 +12,6 @@ export type LlmTaskType = "classification" | "reasoning" | "summarisation" | "ag
  */
 export type ProviderId = string;
 
-/** @deprecated Alias kept so call sites migrate incrementally. Use `ProviderId`. */
-export type LlmProviderKind = ProviderId;
-
 export type ModelRoute = {
   readonly routeId: string;
   readonly provider: LlmProvider;
@@ -28,7 +25,7 @@ export type ProviderMeta = {
 };
 
 export type LlmModelInfo = {
-  provider: LlmProviderKind;
+  provider: ProviderId;
   modelName: string;
   parameterCount?: number;
   contextWindow?: number;
@@ -52,7 +49,7 @@ export type LlmGenerateResult = {
   tokensOut: number;
   modelUsed: string;
   isLocal: boolean;
-  provider: LlmProviderKind;
+  provider: ProviderId;
 };
 
 export type PullProgressChunk = {

--- a/packages/gateway/src/llm/types.ts
+++ b/packages/gateway/src/llm/types.ts
@@ -1,6 +1,31 @@
 export type LlmTaskType = "classification" | "reasoning" | "summarisation" | "agent_step";
 
-export type LlmProviderKind = "ollama" | "llamacpp" | "remote";
+/**
+ * A provider VENDOR id — `"ollama"`, `"llamacpp"`, and (slice 2) `"gemini"`,
+ * `"bedrock"`, ... Deliberately an open string, not a union: the closed union it
+ * replaced capped `LlmRouter.providers` at one provider per kind, so registering a
+ * second vendor silently evicted the first.
+ *
+ * NOT unique across routes — two Ollama routes share `"ollama"`. Route identity is
+ * `ModelRoute.routeId`. This is the value that reaches the egress ledger as
+ * `destination`, so it names a place data can go.
+ */
+export type ProviderId = string;
+
+/** @deprecated Alias kept so call sites migrate incrementally. Use `ProviderId`. */
+export type LlmProviderKind = ProviderId;
+
+export type ModelRoute = {
+  readonly routeId: string;
+  readonly provider: LlmProvider;
+  readonly modelName: string;
+  readonly meta: ProviderMeta;
+};
+
+export type ProviderMeta = {
+  parameterCount?: number;
+  contextWindow?: number;
+};
 
 export type LlmModelInfo = {
   provider: LlmProviderKind;
@@ -37,7 +62,17 @@ export type PullProgressChunk = {
 };
 
 export interface LlmProvider {
-  readonly providerId: LlmProviderKind;
+  readonly providerId: ProviderId;
+  /**
+   * Whether this provider runs on this machine. REQUIRED, so omitting it is a
+   * compile error rather than a silent `undefined`.
+   *
+   * Declared by the provider rather than looked up in a module-private set,
+   * because that set existed in three places that had to agree. Note the failure
+   * direction is safe either way: an unset value is falsy, i.e. REMOTE — which
+   * air-gap refuses and the egress appender ledgers.
+   */
+  readonly isLocal: boolean;
   isAvailable(): Promise<boolean>;
   listModels(): Promise<LlmModelInfo[]>;
   generate(opts: LlmGenerateOptions): Promise<LlmGenerateResult>;

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -56,6 +56,7 @@ import {
   loadNimbusTribalFromConfigDir,
   loadNimbusUpdaterFromConfigDir,
   type NimbusChatopsToml,
+  type NimbusLlmLocalRoute,
   type NimbusTribalToml,
   resolveNimbusTomlForProfile,
   type TeamCredentialConnector,
@@ -180,6 +181,7 @@ import type { TribalSubmitAction } from "../ipc/tribal-rpc.ts";
 import { LlamaCppProvider } from "../llm/llamacpp-provider.ts";
 import { OllamaProvider } from "../llm/ollama-provider.ts";
 import { LlmRegistry } from "../llm/registry.ts";
+import { makeRouteId, parseRouteRef } from "../llm/route-id.ts";
 import { SessionMemoryStore } from "../memory/session-memory-store.ts";
 import { buildServiceIdentityResolver } from "../metrics/service-identity.ts";
 import { runOwnershipPass } from "../ownership/ownership-pass.ts";
@@ -1272,9 +1274,122 @@ function bootPolicyGateWithConnectorAllowlist(
   return { policyStore, policyGate, isConnectorAllowed };
 }
 
+const OLLAMA_DEFAULT_BASE_URL = "http://127.0.0.1:11434";
+const LLAMACPP_DEFAULT_BASE_URL = "http://127.0.0.1:8080";
+
+/** A minimal logging seam so `buildLlmRegistryFromToml` stays independently callable (the
+ *  integration test constructs it with no logger at all) while production wiring passes the real
+ *  `syncLogger.warn`, matching the `log: (m) => syncLogger.warn(m)` adapter shape already used
+ *  elsewhere in this file. The default is a no-op — production always supplies `syncLogger`
+ *  explicitly (see the call in `assemblePlatformServices`), so a dropped-entry warning is never
+ *  actually silent at boot; this default only covers callers (e.g. tests) that don't need one. */
+type RouteValidationLogger = { warn: (msg: string) => void };
+const defaultRouteValidationLogger: RouteValidationLogger = { warn: () => {} };
+
+/** Resolves what base URL a `[llm.local.*]` entry actually talks to, applying the runtime's
+ *  default when `base_url` is omitted and stripping a trailing slash — the form two entries must
+ *  be compared in. Comparing the raw, unresolved field misses the case where BOTH entries omit
+ *  `base_url`: both fields are `undefined`, but both resolve to the SAME real endpoint. */
+function resolveBaseUrl(runtime: string, baseUrl: string | undefined): string {
+  const explicit = baseUrl?.trim() ?? "";
+  if (explicit !== "") return explicit.replace(/\/$/, "");
+  return runtime === "llamacpp" ? LLAMACPP_DEFAULT_BASE_URL : OLLAMA_DEFAULT_BASE_URL;
+}
+
+/**
+ * Task 9's validation stage — deliberately NOT in the Task 8 parser, because a throw there is
+ * swallowed by `loadTomlSection`'s bare catch and silently reverts the WHOLE `[llm]` section to
+ * defaults (including `enforce_air_gap`). Here a bad entry is logged and dropped; nothing else in
+ * `[llm]` is affected.
+ *
+ * Only a `llamacpp` base URL claimed twice is an error: `LlamaCppProvider.generate()` sends no
+ * model field, so the server answers with whatever weights it was launched with — two llama.cpp
+ * routes at one URL would report two different model names against IDENTICAL weights, a route
+ * table that lies. Ollama is exempt: `generate()` sends `this.modelName` per request to a shared
+ * daemon, so many routes at one base URL is the normal, correct case.
+ *
+ * First occurrence (file order — `localRoutes` preserves it) wins; every later collider is
+ * dropped and logged by name.
+ */
+function dropLlamacppBaseUrlCollisions(
+  localRoutes: ReadonlyMap<string, NimbusLlmLocalRoute>,
+  logger: RouteValidationLogger,
+): Map<string, NimbusLlmLocalRoute> {
+  const kept = new Map<string, NimbusLlmLocalRoute>();
+  const claimedBy = new Map<string, string>(); // resolved llamacpp base URL -> first entry name
+  for (const [name, route] of localRoutes) {
+    if (route.runtime === "llamacpp") {
+      const resolved = resolveBaseUrl(route.runtime, route.baseUrl);
+      const existing = claimedBy.get(resolved);
+      if (existing !== undefined) {
+        logger.warn(
+          `[llm] dropping [llm.local.${name}]: llamacpp base URL "${resolved}" is already ` +
+            `claimed by [llm.local.${existing}] — a llama.cpp server reports one model for the ` +
+            "whole process, so two routes at the same URL would report different model names " +
+            "against identical weights",
+        );
+        continue;
+      }
+      claimedBy.set(resolved, name);
+    }
+    kept.set(name, route);
+  }
+  return kept;
+}
+
+/**
+ * Resolves `[llm] route_priority` entries against the route ids that are ACTUALLY about to be
+ * registered, dropping (with a named log line) any entry that fails `parseRouteRef` or names no
+ * registered route. Silence is not acceptable here: a vanished priority entry changes which model
+ * answers with no outward sign.
+ *
+ * LIMITATION (stated, not papered over): a malformed `route_priority` VALUE — e.g.
+ * `route_priority = "ollama"`, a string rather than an array — is swallowed by
+ * `parseNimbusTomlLlmSection` (Task 8) with no diagnostic, and arrives here as simply unset. This
+ * function only ever sees entries that PARSED as an array of strings, so it cannot distinguish
+ * "not configured" from "malformed", and cannot name that entry — it validates only well-formed
+ * strings that fail `parseRouteRef` or resolve to no registered route.
+ */
+function dropUnresolvableRoutePriorityEntries(
+  routePriority: readonly string[],
+  registeredRouteIds: ReadonlySet<string>,
+  logger: RouteValidationLogger,
+): string[] {
+  const kept: string[] = [];
+  for (const entry of routePriority) {
+    let parsed: { providerId: string; modelName: string };
+    try {
+      parsed = parseRouteRef(entry);
+    } catch (err) {
+      logger.warn(
+        `[llm] dropping route_priority entry "${entry}": malformed — ${String(err instanceof Error ? err.message : err)}`,
+      );
+      continue;
+    }
+    const routeId = makeRouteId(parsed.providerId, parsed.modelName);
+    if (!registeredRouteIds.has(routeId)) {
+      logger.warn(
+        `[llm] dropping route_priority entry "${entry}": does not name a registered route`,
+      );
+      continue;
+    }
+    kept.push(routeId);
+  }
+  return kept;
+}
+
 /** Load the [llm] config from the active TOML, apply the model overrides, and build the provider
- *  registry (Ollama + llama.cpp local providers). */
-function buildLlmRegistryFromToml(db: Database, activeTomlPath: string): LlmRegistry {
+ *  registry — one route per `[llm.local.<name>]` entry when any are configured, else today's two
+ *  built-in Ollama + llama.cpp providers (unchanged behaviour). Also runs the validation Task 8
+ *  deliberately does not: dropping (never aborting boot on) a duplicate llamacpp base URL or an
+ *  unresolvable `route_priority` entry. `logger` defaults to a no-op so this stays independently
+ *  callable (e.g. from a test) without a real Gateway logger; production wiring always supplies
+ *  `syncLogger`, so a dropped-entry warning is never actually silent at boot. */
+export function buildLlmRegistryFromToml(
+  db: Database,
+  activeTomlPath: string,
+  logger: RouteValidationLogger = defaultRouteValidationLogger,
+): LlmRegistry {
   const llmToml = loadNimbusLlmFromPath(activeTomlPath);
   const llmTomlPartial = loadNimbusLlmPartialFromPath(activeTomlPath);
   const llmOverrides: { agentModel?: string; classifierModel?: string } = {};
@@ -1285,6 +1400,26 @@ function buildLlmRegistryFromToml(db: Database, activeTomlPath: string): LlmRegi
     llmOverrides.classifierModel = llmTomlPartial.classifierModel;
   }
   applyLlmTomlOverrides(llmOverrides);
+
+  const validatedLocalRoutes = dropLlamacppBaseUrlCollisions(llmToml.localRoutes, logger);
+
+  // The route ids that WILL be registered below — computed up front (without touching the
+  // registry) so route_priority can be validated against the real, post-collision-check set
+  // before the router is constructed, since `LlmRouterConfig.routePriority` is set at
+  // construction time.
+  const routeIdsToRegister: string[] =
+    validatedLocalRoutes.size > 0
+      ? [...validatedLocalRoutes.values()].map((route) =>
+          makeRouteId(route.runtime === "llamacpp" ? "llamacpp" : "ollama", route.model),
+        )
+      : [makeRouteId("ollama", llmToml.localModel), makeRouteId("llamacpp", llmToml.localModel)];
+
+  const validatedRoutePriority = dropUnresolvableRoutePriorityEntries(
+    llmToml.routePriority,
+    new Set(routeIdsToRegister),
+    logger,
+  );
+
   const llmRegistry = new LlmRegistry({
     db,
     config: {
@@ -1293,19 +1428,45 @@ function buildLlmRegistryFromToml(db: Database, activeTomlPath: string): LlmRegi
       localModel: llmToml.localModel,
       minReasoningParams: llmToml.minReasoningParams,
       enforceAirGap: llmToml.enforceAirGap,
+      routePriority: validatedRoutePriority,
     },
   });
-  llmRegistry.addProvider(
-    new OllamaProvider("http://127.0.0.1:11434", llmToml.localModel, llmToml.localContextTokens),
-  );
-  const llamacppBaseUrl = llmToml.llamacppServerPath.trim();
-  llmRegistry.addProvider(
-    new LlamaCppProvider(llamacppBaseUrl === "" ? undefined : llamacppBaseUrl, llmToml.localModel),
-  );
+
+  if (validatedLocalRoutes.size > 0) {
+    for (const route of validatedLocalRoutes.values()) {
+      const baseUrl = resolveBaseUrl(route.runtime, route.baseUrl);
+      if (route.runtime === "llamacpp") {
+        llmRegistry.addRoute(new LlamaCppProvider(baseUrl, route.model), route.model);
+      } else {
+        llmRegistry.addRoute(
+          new OllamaProvider(baseUrl, route.model, llmToml.localContextTokens),
+          route.model,
+        );
+      }
+    }
+  } else {
+    llmRegistry.addRoute(
+      new OllamaProvider(OLLAMA_DEFAULT_BASE_URL, llmToml.localModel, llmToml.localContextTokens),
+      llmToml.localModel,
+    );
+    const llamacppBaseUrl = llmToml.llamacppServerPath.trim();
+    llmRegistry.addRoute(
+      new LlamaCppProvider(
+        llamacppBaseUrl === "" ? undefined : llamacppBaseUrl,
+        llmToml.localModel,
+      ),
+      llmToml.localModel,
+    );
+  }
   // Fill in `parameterCount` so `[llm] min_reasoning_params` can fire at all (F8). Fire-and-
-  // forget: it is one `/api/tags` call, nothing downstream blocks on it, and a provider that is
-  // down simply leaves the floor fail-open exactly as it was.
-  void llmRegistry.refreshProviderMeta(llmToml.localModel);
+  // forget: it is one `/api/tags` call per distinct model name, nothing downstream blocks on it,
+  // and a provider that is down simply leaves the floor fail-open exactly as it was. Iterates the
+  // distinct model names actually registered, not just `llmToml.localModel`, so a
+  // `[llm.local.*]`-configured route with its own model name gets refreshed too.
+  const distinctModelNames = new Set(llmRegistry.llmRouter.routes().map((r) => r.modelName));
+  for (const modelName of distinctModelNames) {
+    void llmRegistry.refreshProviderMeta(modelName);
+  }
   return llmRegistry;
 }
 
@@ -2313,7 +2474,9 @@ export async function assemblePlatformServices(
   // design review raised (Q2).
   resolvePersona(paths.configDir, syncLogger);
   const sessionToml = loadNimbusSessionFromPath(activeTomlPath);
-  const llmRegistry = buildLlmRegistryFromToml(db, activeTomlPath);
+  const llmRegistry = buildLlmRegistryFromToml(db, activeTomlPath, {
+    warn: (m) => syncLogger.warn(m),
+  });
 
   const { localIndex, scheduleItemEmbedding, rt } = createLocalIndexWithEmbeddingRuntime(
     db,

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -30,6 +30,7 @@ import { PairingWindowController } from "../clips/pairing-window.ts";
 import { loadNimbusFilesystemRootsFromConfigDir } from "../config/filesystem-toml.ts";
 import {
   type ConnectorsConfig,
+  DEFAULT_NIMBUS_LLM_TOML,
   loadNimbusAuditFromConfigDir,
   loadNimbusAutomationFromConfigDir,
   loadNimbusBriefsFromPath,
@@ -178,6 +179,7 @@ import { startMetricsServer } from "../ipc/metrics-server.ts";
 import type { PolicyRpcCtx } from "../ipc/policy-rpc.ts";
 import { extractKbPageRef } from "../ipc/server/dispatchers.ts";
 import type { TribalSubmitAction } from "../ipc/tribal-rpc.ts";
+import { isLoopbackBaseUrl } from "../llm/base-url-locality.ts";
 import { LlamaCppProvider } from "../llm/llamacpp-provider.ts";
 import { OllamaProvider } from "../llm/ollama-provider.ts";
 import { LlmRegistry } from "../llm/registry.ts";
@@ -1403,6 +1405,36 @@ function dropDuplicateRouteIds(
 }
 
 /**
+ * Names — in the boot log, by entry name — every `[llm.local.*]` entry whose resolved base URL is
+ * NOT loopback, and is therefore registered as a REMOTE route.
+ *
+ * Nothing is dropped here. The reclassification itself happens in the provider constructors
+ * (`OllamaProvider`/`LlamaCppProvider` derive `isLocal` from the resolved base URL — see
+ * `llm/base-url-locality.ts`), which is what actually stops `[llm] enforce_air_gap` from treating
+ * a LAN daemon as air-gap-eligible. This stage exists so the reclassification is never SILENT: a
+ * route configured under a heading that reads `[llm.local.ws]` and then excluded by air-gap, or
+ * ledgered as egress, would otherwise be inexplicable from the user's seat.
+ *
+ * Dropping instead of warning was the other option and is wrong: a deliberately-configured LAN
+ * llama.cpp box is a legitimate setup, and it stays usable with air-gap off. What must not happen
+ * is it counting as local.
+ */
+function warnRemoteClassifiedLocalRoutes(
+  localRoutes: ReadonlyMap<string, NimbusLlmLocalRoute>,
+  logger: RouteValidationLogger,
+): void {
+  for (const [name, route] of localRoutes) {
+    const resolved = resolveBaseUrl(route.runtime, route.baseUrl);
+    if (isLoopbackBaseUrl(resolved)) continue;
+    logger.warn(
+      `[llm] [llm.local.${name}] base URL "${resolved}" is not loopback — registering it as a ` +
+        "REMOTE route: prompts sent to it leave this machine, so it is excluded when " +
+        "[llm] enforce_air_gap is set and its use is recorded in the egress ledger",
+    );
+  }
+}
+
+/**
  * Resolves `[llm] route_priority` entries against the route ids that are ACTUALLY about to be
  * registered, dropping (with a named log line) any entry that fails `parseRouteRef` or names no
  * registered route. Silence is not acceptable here: a vanished priority entry changes which model
@@ -1469,6 +1501,23 @@ export function buildLlmRegistryFromToml(
   const knownRuntimeLocalRoutes = dropUnknownRuntimeEntries(llmToml.localRoutes, logger);
   const uncollidedLocalRoutes = dropLlamacppBaseUrlCollisions(knownRuntimeLocalRoutes, logger);
   const validatedLocalRoutes = dropDuplicateRouteIds(uncollidedLocalRoutes, logger);
+  warnRemoteClassifiedLocalRoutes(validatedLocalRoutes, logger);
+
+  // `local_model = ""` parses to the empty string and survives `loadNimbusLlmFromPath` (the
+  // `[llm]` parser assigns `parseString(valRaw)` unconditionally). It then reaches
+  // `makeRouteId`, which THROWS on an empty model name — and this function is called from
+  // `assemblePlatformServices` with nothing between it and boot, so a one-character config typo
+  // took the whole Gateway down with `modelName must not be empty`. Nothing in assembly may
+  // abort boot: keep the shipped default and say so by name.
+  const localModel = llmToml.localModel.trim();
+  const effectiveLocalModel =
+    localModel === "" ? DEFAULT_NIMBUS_LLM_TOML.localModel : llmToml.localModel;
+  if (localModel === "") {
+    logger.warn(
+      `[llm] local_model is empty — keeping the default "${DEFAULT_NIMBUS_LLM_TOML.localModel}"; ` +
+        "an empty model name cannot name a route",
+    );
+  }
 
   // The route ids that WILL be registered below — computed up front (without touching the
   // registry) so route_priority can be validated against the real, post-collision-check set
@@ -1479,7 +1528,7 @@ export function buildLlmRegistryFromToml(
       ? [...validatedLocalRoutes.values()].map((route) =>
           makeRouteId(route.runtime === "llamacpp" ? "llamacpp" : "ollama", route.model),
         )
-      : [makeRouteId("ollama", llmToml.localModel), makeRouteId("llamacpp", llmToml.localModel)];
+      : [makeRouteId("ollama", effectiveLocalModel), makeRouteId("llamacpp", effectiveLocalModel)];
 
   const validatedRoutePriority = dropUnresolvableRoutePriorityEntries(
     llmToml.routePriority,
@@ -1492,7 +1541,7 @@ export function buildLlmRegistryFromToml(
     config: {
       preferLocal: llmToml.preferLocal,
       remoteModel: llmToml.remoteModel,
-      localModel: llmToml.localModel,
+      localModel: effectiveLocalModel,
       minReasoningParams: llmToml.minReasoningParams,
       enforceAirGap: llmToml.enforceAirGap,
       routePriority: validatedRoutePriority,
@@ -1513,16 +1562,25 @@ export function buildLlmRegistryFromToml(
     }
   } else {
     llmRegistry.addRoute(
-      new OllamaProvider(OLLAMA_DEFAULT_BASE_URL, llmToml.localModel, llmToml.localContextTokens),
-      llmToml.localModel,
+      new OllamaProvider(OLLAMA_DEFAULT_BASE_URL, effectiveLocalModel, llmToml.localContextTokens),
+      effectiveLocalModel,
     );
     const llamacppBaseUrl = llmToml.llamacppServerPath.trim();
+    // The legacy single-route path reaches the same hazard through a different key: an
+    // `[llm] llamacpp_server_path` pointed at a LAN box also produces a non-local provider now,
+    // and that must be as visible here as it is for a `[llm.local.*]` entry.
+    if (llamacppBaseUrl !== "" && !isLoopbackBaseUrl(llamacppBaseUrl)) {
+      logger.warn(
+        `[llm] llamacpp_server_path "${llamacppBaseUrl}" is not loopback — registering the ` +
+          "llama.cpp route as REMOTE: it is excluded when [llm] enforce_air_gap is set",
+      );
+    }
     llmRegistry.addRoute(
       new LlamaCppProvider(
         llamacppBaseUrl === "" ? undefined : llamacppBaseUrl,
-        llmToml.localModel,
+        effectiveLocalModel,
       ),
-      llmToml.localModel,
+      effectiveLocalModel,
     );
   }
   // Fill in `parameterCount` so `[llm] min_reasoning_params` can fire at all (F8). Fire-and-

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -1366,6 +1366,43 @@ function dropLlamacppBaseUrlCollisions(
 }
 
 /**
+ * Drops (and names) any `[llm.local.*]` entry whose derived route id — `<runtime>/<model>` — was
+ * already claimed by an earlier entry. `LlmRouter.registerRoute` keys on that id and uses
+ * `Map.set`, so without this stage a second entry naming the same runtime AND model at a
+ * different `base_url` (a plausible failover pairing: the same model on a laptop and on a
+ * workstation) silently REPLACES the first, and `nimbus llm status` shows one row pointing at the
+ * second URL with nothing to explain where the other went.
+ *
+ * FIRST occurrence wins, matching `dropLlamacppBaseUrlCollisions` above — the two drop rules must
+ * not disagree about which entry survives, or which one you get depends on which check fired.
+ * Every other drop path in this slice names the offending entry; a route that vanishes without a
+ * word is the exact shape `dropUnresolvableRoutePriorityEntries` refuses to allow.
+ */
+function dropDuplicateRouteIds(
+  localRoutes: ReadonlyMap<string, NimbusLlmLocalRoute>,
+  logger: RouteValidationLogger,
+): Map<string, NimbusLlmLocalRoute> {
+  const kept = new Map<string, NimbusLlmLocalRoute>();
+  const claimedBy = new Map<string, string>(); // route id -> first entry name
+  for (const [name, route] of localRoutes) {
+    const routeId = makeRouteId(route.runtime === "llamacpp" ? "llamacpp" : "ollama", route.model);
+    const existing = claimedBy.get(routeId);
+    if (existing !== undefined) {
+      logger.warn(
+        `[llm] dropping [llm.local.${name}]: route id "${routeId}" is already claimed by ` +
+          `[llm.local.${existing}] — a route is keyed on (runtime, model), so two entries ` +
+          "naming the same pair are one route; keeping the first, and the later entry's " +
+          "base_url is NOT used",
+      );
+      continue;
+    }
+    claimedBy.set(routeId, name);
+    kept.set(name, route);
+  }
+  return kept;
+}
+
+/**
  * Resolves `[llm] route_priority` entries against the route ids that are ACTUALLY about to be
  * registered, dropping (with a named log line) any entry that fails `parseRouteRef` or names no
  * registered route. Silence is not acceptable here: a vanished priority entry changes which model
@@ -1430,7 +1467,8 @@ export function buildLlmRegistryFromToml(
   applyLlmTomlOverrides(llmOverrides);
 
   const knownRuntimeLocalRoutes = dropUnknownRuntimeEntries(llmToml.localRoutes, logger);
-  const validatedLocalRoutes = dropLlamacppBaseUrlCollisions(knownRuntimeLocalRoutes, logger);
+  const uncollidedLocalRoutes = dropLlamacppBaseUrlCollisions(knownRuntimeLocalRoutes, logger);
+  const validatedLocalRoutes = dropDuplicateRouteIds(uncollidedLocalRoutes, logger);
 
   // The route ids that WILL be registered below — computed up front (without touching the
   // registry) so route_priority can be validated against the real, post-collision-check set

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -1296,6 +1296,34 @@ function resolveBaseUrl(runtime: string, baseUrl: string | undefined): string {
   return runtime === "llamacpp" ? LLAMACPP_DEFAULT_BASE_URL : OLLAMA_DEFAULT_BASE_URL;
 }
 
+const KNOWN_LOCAL_RUNTIMES = new Set(["ollama", "llamacpp"]);
+
+/**
+ * Drops (and names, via `logger.warn`) any `[llm.local.*]` entry whose `runtime` is neither
+ * `"ollama"` nor `"llamacpp"` — the only two runtimes this build knows how to construct a
+ * provider for. `NimbusLlmLocalRoute.runtime` is an intentionally open string at the parser layer
+ * (Task 8), so a typo or a not-yet-supported runtime (e.g. `"vllm"`) must not silently fall
+ * through to the `runtime === "llamacpp" ? llamacpp : ollama` branches below and get constructed
+ * as an Ollama route pointed at a port that entry never asked for.
+ */
+function dropUnknownRuntimeEntries(
+  localRoutes: ReadonlyMap<string, NimbusLlmLocalRoute>,
+  logger: RouteValidationLogger,
+): Map<string, NimbusLlmLocalRoute> {
+  const kept = new Map<string, NimbusLlmLocalRoute>();
+  for (const [name, route] of localRoutes) {
+    if (!KNOWN_LOCAL_RUNTIMES.has(route.runtime)) {
+      logger.warn(
+        `[llm] dropping [llm.local.${name}]: unknown runtime "${route.runtime}" — expected ` +
+          '"ollama" or "llamacpp"',
+      );
+      continue;
+    }
+    kept.set(name, route);
+  }
+  return kept;
+}
+
 /**
  * Task 9's validation stage — deliberately NOT in the Task 8 parser, because a throw there is
  * swallowed by `loadTomlSection`'s bare catch and silently reverts the WHOLE `[llm]` section to
@@ -1401,7 +1429,8 @@ export function buildLlmRegistryFromToml(
   }
   applyLlmTomlOverrides(llmOverrides);
 
-  const validatedLocalRoutes = dropLlamacppBaseUrlCollisions(llmToml.localRoutes, logger);
+  const knownRuntimeLocalRoutes = dropUnknownRuntimeEntries(llmToml.localRoutes, logger);
+  const validatedLocalRoutes = dropLlamacppBaseUrlCollisions(knownRuntimeLocalRoutes, logger);
 
   // The route ids that WILL be registered below — computed up front (without touching the
   // registry) so route_priority can be validated against the real, post-collision-check set
@@ -1459,14 +1488,13 @@ export function buildLlmRegistryFromToml(
     );
   }
   // Fill in `parameterCount` so `[llm] min_reasoning_params` can fire at all (F8). Fire-and-
-  // forget: it is one `/api/tags` call per distinct model name, nothing downstream blocks on it,
-  // and a provider that is down simply leaves the floor fail-open exactly as it was. Iterates the
-  // distinct model names actually registered, not just `llmToml.localModel`, so a
-  // `[llm.local.*]`-configured route with its own model name gets refreshed too.
-  const distinctModelNames = new Set(llmRegistry.llmRouter.routes().map((r) => r.modelName));
-  for (const modelName of distinctModelNames) {
-    void llmRegistry.refreshProviderMeta(modelName);
-  }
+  // forget: nothing downstream blocks on it, and a provider that is down simply leaves the floor
+  // fail-open exactly as it was. Called with NO argument — one pass over every registered local
+  // route, each matched against its OWN `route.modelName` inside `refreshProviderMeta` — never a
+  // single shared name looped across all routes (Task 9 review, finding 1: that shape cross-
+  // assigned one route's parameterCount onto another route sharing the same daemon). One
+  // `listModels()` call per local route, not per route × distinct model name.
+  void llmRegistry.refreshProviderMeta();
   return llmRegistry;
 }
 

--- a/packages/gateway/src/voice/push-to-talk.test.ts
+++ b/packages/gateway/src/voice/push-to-talk.test.ts
@@ -29,7 +29,11 @@ function makeFakeLlmProvider(): LlmProvider {
     providerId: "ollama",
     isLocal: true,
     isAvailable: async () => true,
-    listModels: async () => [],
+    // Must report the model it registers under (`ROUTER_CONFIG.localModel`, "llama3.2") — route
+    // availability (Task 5) requires the daemon reachable AND the route's own modelName among
+    // the reported models; an empty listing here makes the route model_absent regardless of
+    // isAvailable().
+    listModels: async () => [{ provider: "ollama", modelName: "llama3.2" }],
     generate: async (opts) => ({
       text: `LLM response to: ${opts.prompt}`,
       tokensIn: 1,

--- a/packages/gateway/src/voice/push-to-talk.test.ts
+++ b/packages/gateway/src/voice/push-to-talk.test.ts
@@ -27,6 +27,7 @@ function makeFakeSpokenLog(): { spoken: string[]; tts: TtsProvider } {
 function makeFakeLlmProvider(): LlmProvider {
   return {
     providerId: "ollama",
+    isLocal: true,
     isAvailable: async () => true,
     listModels: async () => [],
     generate: async (opts) => ({

--- a/packages/gateway/src/voice/push-to-talk.test.ts
+++ b/packages/gateway/src/voice/push-to-talk.test.ts
@@ -59,7 +59,7 @@ describe("Push-to-talk round-trip", () => {
     const { spoken, tts } = makeFakeSpokenLog();
 
     const router = new LlmRouter(ROUTER_CONFIG);
-    router.registerProvider(makeFakeLlmProvider());
+    router.registerRoute(makeFakeLlmProvider(), ROUTER_CONFIG.localModel);
 
     const voice = new VoiceService({ enabled: true, stt, tts });
 

--- a/packages/gateway/test/integration/llm-routes.integration.test.ts
+++ b/packages/gateway/test/integration/llm-routes.integration.test.ts
@@ -144,6 +144,34 @@ base_url = "http://127.0.0.1:8099"
     expect(llamacpp[0]?.modelName).toBe("a.gguf");
   });
 
+  test("two entries deriving the SAME route id keep the first and name the drop", () => {
+    // A plausible failover config: the same model on two daemons. The route id is
+    // (runtime, model), so both entries derive "ollama/qwen3:8b" — last-wins on the
+    // router's Map would keep the workstation and discard the laptop with no outward sign.
+    const { db, tomlPath } = writeConfig(`
+[llm.local.laptop]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.workstation]
+runtime = "ollama"
+model = "qwen3:8b"
+base_url = "http://192.168.1.50:11434"
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    const routes = registry.llmRouter.routes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.routeId).toBe("ollama/qwen3:8b");
+    // FIRST wins, matching the llamacpp base-URL rule — the two drop rules must not
+    // disagree about which entry survives.
+    const dropMessage = logger.messages.find((m) => m.includes("route id"));
+    expect(dropMessage).toBeDefined();
+    expect(dropMessage).toContain("llm.local.workstation");
+    expect(dropMessage).toContain("llm.local.laptop");
+    expect(dropMessage).toContain("ollama/qwen3:8b");
+  });
+
   test("an unknown runtime is dropped by name, never silently constructed as ollama", () => {
     const { db, tomlPath } = writeConfig(`
 [llm.local.mystery]

--- a/packages/gateway/test/integration/llm-routes.integration.test.ts
+++ b/packages/gateway/test/integration/llm-routes.integration.test.ts
@@ -193,4 +193,80 @@ model = "qwen3:8b"
     expect(dropMessage).toContain("llm.local.mystery");
     expect(dropMessage).toContain("vllm");
   });
+
+  test("a non-loopback [llm.local.*] entry is registered REMOTE, and named in the log", () => {
+    // The `[llm.local.<name>]` heading says local; the base URL says otherwise, and the base
+    // URL wins. Registering it as local made `[llm] enforce_air_gap` skip its own exclusion
+    // and sent prompts to that host — air-gap is a refusal, not a preference.
+    const { db, tomlPath } = writeConfig(`
+[llm.local.ws]
+runtime = "llamacpp"
+model = "big.gguf"
+base_url = "http://192.168.1.50:8080"
+
+[llm.local.here]
+runtime = "ollama"
+model = "qwen3:8b"
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    const routes = registry.llmRouter.routes();
+    // Reclassified, not dropped: a deliberately-configured LAN box stays usable with
+    // air-gap off.
+    expect(routes).toHaveLength(2);
+    expect(routes.find((r) => r.routeId === "llamacpp/big.gguf")?.provider.isLocal).toBe(false);
+    expect(routes.find((r) => r.routeId === "ollama/qwen3:8b")?.provider.isLocal).toBe(true);
+    // And it is never silent — the entry is named, so an air-gap exclusion is explicable.
+    const warning = logger.messages.find((m) => m.includes("not loopback"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("llm.local.ws");
+    expect(warning).toContain("192.168.1.50");
+    // The loopback entry earns no warning.
+    expect(logger.messages.filter((m) => m.includes("not loopback"))).toHaveLength(1);
+  });
+
+  test("a LAN llamacpp_server_path is reclassified remote on the legacy path too", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm]
+local_model = "llama3.2"
+llamacpp_server_path = "http://192.168.1.50:8080"
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    const routes = registry.llmRouter.routes();
+    expect(routes.find((r) => r.provider.providerId === "llamacpp")?.provider.isLocal).toBe(false);
+    expect(routes.find((r) => r.provider.providerId === "ollama")?.provider.isLocal).toBe(true);
+    const warning = logger.messages.find((m) => m.includes("llamacpp_server_path"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("192.168.1.50");
+  });
+
+  test('local_model = "" keeps the default instead of aborting boot', () => {
+    // `makeRouteId` THROWS on an empty model name, and nothing sits between this function and
+    // boot — so a one-character config typo took the whole Gateway down. Nothing in assembly
+    // may abort boot.
+    const { db, tomlPath } = writeConfig(`
+[llm]
+local_model = ""
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    const routes = registry.llmRouter.routes();
+    expect(routes).toHaveLength(2);
+    expect(routes.map((r) => r.routeId).sort()).toEqual(["llamacpp/llama3.2", "ollama/llama3.2"]);
+    const warning = logger.messages.find((m) => m.includes("local_model is empty"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("llama3.2");
+  });
+
+  test("a whitespace-only local_model is treated the same as empty", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm]
+local_model = "   "
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    expect(registry.llmRouter.routes()).toHaveLength(2);
+    expect(logger.messages.some((m) => m.includes("local_model is empty"))).toBe(true);
+  });
 });

--- a/packages/gateway/test/integration/llm-routes.integration.test.ts
+++ b/packages/gateway/test/integration/llm-routes.integration.test.ts
@@ -25,6 +25,11 @@ describe("buildLlmRegistryFromToml — route assembly from [llm.local.*]", () =>
     return { db, tomlPath };
   }
 
+  function capturingLogger(): { warn: (msg: string) => void; messages: string[] } {
+    const messages: string[] = [];
+    return { warn: (msg) => messages.push(msg), messages };
+  }
+
   test("two [llm.local.*] entries produce two routes", () => {
     const { db, tomlPath } = writeConfig(`
 [llm.local.qwen3]
@@ -66,11 +71,19 @@ model = "a.gguf"
 runtime = "llamacpp"
 model = "b.gguf"
 `);
-    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
     const llamacpp = registry.llmRouter
       .routes()
       .filter((r) => r.provider.providerId === "llamacpp");
     expect(llamacpp).toHaveLength(1);
+    // The drop must NAME the offending entry (never silent) — the dropped route "b", the
+    // route it collided with "a", and the resolved URL both entries share.
+    const dropMessage = logger.messages.find((m) => m.includes("dropping"));
+    expect(dropMessage).toBeDefined();
+    expect(dropMessage).toContain("llm.local.b");
+    expect(dropMessage).toContain("llm.local.a");
+    expect(dropMessage).toContain("http://127.0.0.1:8080");
   });
 
   test("many ollama routes on one base URL are all kept", () => {
@@ -98,11 +111,17 @@ route_priority = ["ollama/nope", "ollama/qwen3:8b"]
 runtime = "ollama"
 model = "qwen3:8b"
 `);
-    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
     // The security-relevant key MUST survive a bad neighbour — this is the regression
     // guard for loadTomlSection's swallow-and-revert behaviour.
     expect(registry.llmRouter.enforcesAirGap()).toBe(true);
     expect(registry.llmRouter.routes()).toHaveLength(1);
+    // The drop must NAME the offending entry — a vanished priority entry changes which
+    // model answers with no outward sign, so silence here is not acceptable.
+    const dropMessage = logger.messages.find((m) => m.includes("route_priority"));
+    expect(dropMessage).toBeDefined();
+    expect(dropMessage).toContain("ollama/nope");
   });
 
   test("two llamacpp routes at the SAME explicit base_url collide and one is dropped", () => {
@@ -123,5 +142,27 @@ base_url = "http://127.0.0.1:8099"
       .filter((r) => r.provider.providerId === "llamacpp");
     expect(llamacpp).toHaveLength(1);
     expect(llamacpp[0]?.modelName).toBe("a.gguf");
+  });
+
+  test("an unknown runtime is dropped by name, never silently constructed as ollama", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm.local.mystery]
+runtime = "vllm"
+model = "mystery.gguf"
+
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+`);
+    const logger = capturingLogger();
+    const registry = buildLlmRegistryFromToml(db, tomlPath, logger);
+    const routes = registry.llmRouter.routes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.provider.providerId).toBe("ollama");
+    expect(routes[0]?.modelName).toBe("qwen3:8b");
+    const dropMessage = logger.messages.find((m) => m.includes("unknown runtime"));
+    expect(dropMessage).toBeDefined();
+    expect(dropMessage).toContain("llm.local.mystery");
+    expect(dropMessage).toContain("vllm");
   });
 });

--- a/packages/gateway/test/integration/llm-routes.integration.test.ts
+++ b/packages/gateway/test/integration/llm-routes.integration.test.ts
@@ -1,0 +1,127 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildLlmRegistryFromToml } from "../../src/platform/assemble.ts";
+
+// This tree is NOT loaded by `bun test packages/gateway/src` — run the CI command
+// (`bun test packages/gateway packages/cli scripts`) to exercise it.
+
+describe("buildLlmRegistryFromToml — route assembly from [llm.local.*]", () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  function writeConfig(contents: string): { db: Database; tomlPath: string } {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-llm-routes-"));
+    const tomlPath = join(dir, "nimbus.toml");
+    writeFileSync(tomlPath, contents, "utf8");
+    const db = new Database(":memory:");
+    return { db, tomlPath };
+  }
+
+  test("two [llm.local.*] entries produce two routes", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.llamacpp1]
+runtime = "llamacpp"
+model = "a.gguf"
+base_url = "http://127.0.0.1:9090"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const routes = registry.llmRouter.routes();
+    expect(routes).toHaveLength(2);
+    const ids = routes.map((r) => r.routeId).sort();
+    expect(ids).toEqual(["llamacpp/a.gguf", "ollama/qwen3:8b"].sort());
+  });
+
+  test("only legacy local_model configured → exactly one ollama route plus the llama.cpp route", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm]
+local_model = "llama3.2"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const routes = registry.llmRouter.routes();
+    expect(routes).toHaveLength(2);
+    const providerIds = routes.map((r) => r.provider.providerId).sort();
+    expect(providerIds).toEqual(["llamacpp", "ollama"]);
+  });
+
+  test("two llamacpp routes that BOTH omit base_url collide and one is dropped", () => {
+    // The case a raw-string comparison misses: both values are `undefined`.
+    const { db, tomlPath } = writeConfig(`
+[llm.local.a]
+runtime = "llamacpp"
+model = "a.gguf"
+
+[llm.local.b]
+runtime = "llamacpp"
+model = "b.gguf"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const llamacpp = registry.llmRouter
+      .routes()
+      .filter((r) => r.provider.providerId === "llamacpp");
+    expect(llamacpp).toHaveLength(1);
+  });
+
+  test("many ollama routes on one base URL are all kept", () => {
+    // Ollama sends the model name per request, so sharing a daemon is correct.
+    const { db, tomlPath } = writeConfig(`
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+
+[llm.local.gemma]
+runtime = "ollama"
+model = "gemma3:12b"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    expect(registry.llmRouter.routes()).toHaveLength(2);
+  });
+
+  test("an unresolvable route_priority entry is dropped, and the rest of [llm] survives", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm]
+enforce_air_gap = true
+route_priority = ["ollama/nope", "ollama/qwen3:8b"]
+
+[llm.local.qwen3]
+runtime = "ollama"
+model = "qwen3:8b"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    // The security-relevant key MUST survive a bad neighbour — this is the regression
+    // guard for loadTomlSection's swallow-and-revert behaviour.
+    expect(registry.llmRouter.enforcesAirGap()).toBe(true);
+    expect(registry.llmRouter.routes()).toHaveLength(1);
+  });
+
+  test("two llamacpp routes at the SAME explicit base_url collide and one is dropped", () => {
+    const { db, tomlPath } = writeConfig(`
+[llm.local.a]
+runtime = "llamacpp"
+model = "a.gguf"
+base_url = "http://127.0.0.1:8099/"
+
+[llm.local.b]
+runtime = "llamacpp"
+model = "b.gguf"
+base_url = "http://127.0.0.1:8099"
+`);
+    const registry = buildLlmRegistryFromToml(db, tomlPath);
+    const llamacpp = registry.llmRouter
+      .routes()
+      .filter((r) => r.provider.providerId === "llamacpp");
+    expect(llamacpp).toHaveLength(1);
+    expect(llamacpp[0]?.modelName).toBe("a.gguf");
+  });
+});


### PR DESCRIPTION
## What this changes

`LlmRouter` kept its providers in a map keyed on a closed three-member union, so it had exactly **one seat per provider kind**. Registering a second provider of a kind silently evicted the first, because `Map.set` on the same key overwrites. That seat was never filled: only Ollama and llama.cpp were ever registered, and `[llm] remote_model` defaulted to a model name for a provider that does not exist.

The same limit applied one level down. `OllamaProvider` takes a model name and there is no allowlist, so `local_model = "qwen3"` already worked — but two local models at once was unrepresentable, because the seat is per runtime and the model was a single global config string.

This re-keys the router on **`(provider, model)` routes**. Provider implementations are unchanged: two models means two instances sharing a `providerId`, so only the map key moved.

## What ships

- Multiple local models at once, per task — `[llm.local.<name>]` sub-tables plus `route_priority`
- Availability that means **this model answers**, not **the daemon is up**
- Egress destination naming the vendor instead of the literal string `model`
- One definition of `isLocal`, declared by the provider, replacing three copies that had to agree

## What does NOT ship

**Zero cloud vendors.** No adapter for Anthropic, OpenAI, Gemini, xAI or Bedrock. This slice is the enabling refactor; vendors are slice 2.

Two fixes here are **unit-proven only**, because no remote route exists yet to exercise them: the vendor-named egress destination, and the route-aware context-overflow fallback.

## Breaking

- `llm.status` returns a route list. `nimbus llm status --json` therefore changes shape — anything scripting against it must be updated.
- The deprecated `LlmProviderKind` alias and `LlmRouter.registerProvider` shim are removed.

`ALLOWED_METHODS` is untouched — no new IPC method, so invariant I7 is unaffected.

## Known bounds, stated rather than papered over

- `packages/cli` keeps a private copy of the route-status type. A shared type is forbidden by the IPC-only dependency rule, and nothing pins the copy to the real payload. This break already happened once during development and the suite stayed green throughout. A gateway-side shape pin now catches the gateway half; the CLI half remains a documented gap.
- `LlmRouter.generate` still calls the route provider directly with no egress append. Previously only a route keyed `remote` could reach it — never. Now any registered non-local route can, once slice 2 adds one. **Named slice-2 blocker**: resolve `generate`'s I29 coverage before the first remote route registers.
- A malformed `route_priority` value, as opposed to an unresolvable entry, is swallowed during parsing with no diagnostic, so assembly cannot name it.
- Per-task pinning did not ship. Slice 4 is therefore a router change, not the surface-only change the spec originally claimed.

## Verification

- `bun test packages/gateway/src` — 12370 pass, 0 fail
- `bun test packages/cli/src` — 2470 pass, 0 fail
- `bun test scripts` — 1596 pass, 0 fail
- `bun run typecheck` — exit 0
- `bun run lint:markdown` — exit 0

**Not run locally:** the coverage floor, which is CI-Linux-authoritative and could not run without Docker here. Three new source files land in `llm/`, which is under the Engine gate. Please let CI settle before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and prioritizing multiple local LLM routes by provider and model.
  - Added route-specific availability reporting, including unreachable providers and missing models.
  - Improved context-overflow handling by falling back to the next suitable available route.
  - Added vendor-specific destinations for remote synthesis activity.
  - Added locality-aware routing and air-gap filtering.

- **Documentation**
  - Updated architecture, configuration, CLI, changelog, and implementation guidance for route-based LLM selection.

- **Bug Fixes**
  - Invalid or conflicting route configurations are now safely ignored with diagnostics instead of preventing startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->