### PR TITLE
fix(connectors): index a Confluence page under its browser URL

### DIFF
--- a/packages/gateway/src/connectors/confluence-sync.test.ts
+++ b/packages/gateway/src/connectors/confluence-sync.test.ts
@@ -837,4 +837,140 @@ describeWithFetchRestore("confluence-sync", () => {
       }),
     ).toBe("Note");
   });
+
+  // ---------------------------------------------------------------------------
+  // The indexed URL must be one a browser is actually on.
+  // ---------------------------------------------------------------------------
+
+  /** One CQL search result, with whatever `_links` the case under test needs. */
+  function pageResult(links?: unknown): unknown {
+    return {
+      type: "page",
+      id: "12345",
+      title: "Wiki Page",
+      ...(links === undefined ? {} : { _links: links }),
+      history: { lastUpdated: { when: "2026-04-01T12:00:00.000+0000" } },
+    };
+  }
+
+  /** The `url` column of the single indexed Confluence item. */
+  function indexedUrl(db: ReturnType<typeof createMemoryIndexDb>): string | null {
+    const row = db.prepare("SELECT url FROM item WHERE service = 'confluence' LIMIT 1").get() as
+      | { url: string | null }
+      | undefined;
+    return row?.url ?? null;
+  }
+
+  test("indexes a page under its browser URL when the API supplies _links.webui", async () => {
+    // `_links.webui` is site-relative and omits the `/wiki` context. It is the
+    // URL a browser is on, and therefore the only one the clipper's
+    // `GET /v1/items/resolve` can ever match: that ladder is resolve-key based
+    // (exact, query-stripped, up to three trimmed trailing segments) and cannot
+    // bridge to `viewpage.action?pageId=`.
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          results: [pageResult({ webui: "/spaces/ENG/pages/12345/Wiki+Page" })],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "tok",
+        "confluence.base_url": "https://example.atlassian.net",
+      }),
+      db,
+      ...silentSyncContextExtras(),
+      ...boundTestCapabilities(
+        db,
+        createStubVault({
+          "confluence.email": "u@example.com",
+          "confluence.api_token": "tok",
+          "confluence.base_url": "https://example.atlassian.net",
+        }),
+        "confluence",
+      ),
+    };
+    await sync.sync(ctx, null);
+
+    expect(indexedUrl(db)).toBe(
+      "https://example.atlassian.net/wiki/spaces/ENG/pages/12345/Wiki+Page",
+    );
+  });
+
+  test("falls back to the constructed viewpage URL when _links is absent", async () => {
+    // Server/DC and older Cloud responses may carry no `_links` at all. The
+    // fallback must be the previous behaviour, not `undefined` concatenated
+    // into a URL.
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ results: [pageResult()] }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "tok",
+        "confluence.base_url": "https://example.atlassian.net",
+      }),
+      db,
+      ...silentSyncContextExtras(),
+      ...boundTestCapabilities(
+        db,
+        createStubVault({
+          "confluence.email": "u@example.com",
+          "confluence.api_token": "tok",
+          "confluence.base_url": "https://example.atlassian.net",
+        }),
+        "confluence",
+      ),
+    };
+    await sync.sync(ctx, null);
+
+    expect(indexedUrl(db)).toBe(
+      "https://example.atlassian.net/wiki/pages/viewpage.action?pageId=12345",
+    );
+  });
+
+  test("falls back when webui is present but not a rooted path", async () => {
+    // A `webui` that does not start with "/" would concatenate into a URL on
+    // another host. The guard is not theoretical politeness: this value crosses
+    // JSON from a remote API.
+    const db = createMemoryIndexDb();
+    globalThis.fetch = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ results: [pageResult({ webui: "https://evil.example/x" })] }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
+    const sync = createConfluenceSyncable({ ensureConfluenceMcpRunning: async () => {} });
+    const ctx = {
+      vault: createStubVault({
+        "confluence.email": "u@example.com",
+        "confluence.api_token": "tok",
+        "confluence.base_url": "https://example.atlassian.net",
+      }),
+      db,
+      ...silentSyncContextExtras(),
+      ...boundTestCapabilities(
+        db,
+        createStubVault({
+          "confluence.email": "u@example.com",
+          "confluence.api_token": "tok",
+          "confluence.base_url": "https://example.atlassian.net",
+        }),
+        "confluence",
+      ),
+    };
+    await sync.sync(ctx, null);
+
+    expect(indexedUrl(db)).toBe(
+      "https://example.atlassian.net/wiki/pages/viewpage.action?pageId=12345",
+    );
+  });
 });

--- a/packages/gateway/src/connectors/confluence-sync.ts
+++ b/packages/gateway/src/connectors/confluence-sync.ts
@@ -139,7 +139,20 @@ function confluenceUpsertOneSearchHit(
     return true;
   }
   const site = normalizeAtlassianSiteBaseUrl(opts.baseRaw);
-  const webUi = `${site}/wiki/pages/viewpage.action?pageId=${encodeURIComponent(id)}`;
+  // The URL a browser is actually on. `_links.webui` is site-relative and omits
+  // the `/wiki` context (`/spaces/ENG/pages/123/Title`). The constructed
+  // viewpage.action URL below is a valid Confluence address but not one any
+  // browser shows, so indexing it made `resolveItemByUrl` miss every real page:
+  // its ladder is resolve-key based (exact, query-stripped, up to three trimmed
+  // trailing segments) and cannot bridge the two shapes.
+  //
+  // The leading-slash check is load-bearing: a `webui` that did not start with
+  // "/" would concatenate into a URL on another host.
+  const links = asRecord(row["_links"]);
+  const webui = links === undefined ? undefined : stringField(links, "webui");
+  const webUi = webui?.startsWith("/")
+    ? `${site}/wiki${webui}`
+    : `${site}/wiki/pages/viewpage.action?pageId=${encodeURIComponent(id)}`;
   const modified = when !== undefined && when !== "" ? isoMs(when) : opts.syncTime;
   acc.upserted += 1;
   const by = confluenceLastUpdatedBy(row);


### PR DESCRIPTION
## Summary

`confluence-sync` indexes every page under a URL it **constructs**:

```ts
const webUi = `${site}/wiki/pages/viewpage.action?pageId=${encodeURIComponent(id)}`;
```

That is a valid Confluence address, but not one a browser is ever on — Confluence Cloud serves pages at `/wiki/spaces/<KEY>/pages/<id>/<Title>`.

`GET /v1/items/resolve` resolves purely by URL. `resolveItemByUrl` computes a resolve key and tries exact, then query-stripped, then up to three trimmed trailing path segments — there is no title fallback. No rung of that ladder can bridge `?pageId=12345` to `/spaces/ENG/pages/12345/Title`, so **every browser resolve on a Confluence page misses an item the gateway is holding.**

The Confluence v1 content API already returns `_links.webui` on every content response (it is not gated by `expand`), and it is exactly the shape a browser shows — site-relative, without the `/wiki` context. This prefers it, and keeps the constructed URL as a fallback for Server/DC and older Cloud responses that carry no `_links`.

Found while adding Confluence page recognition to the browser extension (nimbus-agent/nimbus-web-clipper#88), where the symptom is a Confluence page reporting *not indexed* while indexed. That client deliberately does **not** work around this — canonicalisation is the gateway's job, and encoding `viewpage.action?pageId=` in a client would hard-code a gateway implementation detail.

Notes:
- `_links` / `webui` are narrowed with the file's own `asRecord` / `stringField` helpers — the value crosses JSON from a remote API, so no casts and no `any`.
- The leading-slash check is load-bearing: a `webui` not starting with `/` would concatenate into a URL naming a different host. Reviewed for the protocol-relative case (`//evil.example/x`) — not exploitable, because this is string concatenation onto an already-absolute site base, not `new URL(webui, base)` resolution, so the host cannot move. A test pins the rejection anyway.
- Nothing about `expand`, pagination, watermarks or authorship is touched. URL construction only.

## Related Issue

<!-- No existing issue; discovered while building the browser-side client. -->

Relates to nimbus-agent/nimbus-web-clipper#88

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactor (no behaviour change)
- [ ] Test improvement
- [ ] Documentation only
- [ ] CI / tooling

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`)
- [x] New behaviour is covered by tests
- [x] No `any` types introduced — `unknown` is used for external data
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction (no OS checks in business logic) — n/a, no platform-specific code
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] If this PR touches `docs/README.md`, a screenshot of the rendered page (light + dark) is attached — n/a, no docs touched

## Coverage (if engine/ or vault/ was changed)

Neither `engine/` nor `vault/` was modified.

## Testing

`bun test packages/gateway/src/connectors/confluence-sync.test.ts` → **36 pass, 0 fail** (33 before; 3 added).

Written test-first. Before the change, the `_links.webui` case failed and both fallback cases passed — confirming the new test actually distinguishes the new behaviour rather than passing against the old code.

The three cases:
1. `_links.webui` present → indexed as `<site>/wiki/spaces/ENG/pages/12345/Wiki+Page`.
2. `_links` absent → falls back to the constructed `viewpage.action?pageId=` URL, byte-identical to today's output.
3. `webui` present but not a rooted path (`https://evil.example/x`) → falls back, rather than concatenating.

## Notes for Reviewers

The fallback path is intentionally byte-identical to the pre-change behaviour, so an instance whose API omits `_links` sees no change at all. The interesting review question is whether preferring `_links.webui` could ever produce a *worse* key than the constructed one — I believe not, since `webui` is what Confluence itself links to and therefore what a user's address bar and any pasted link will carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
