### PR TITLE
fix(llm)!: remove the inert remote_model key and document the vendor tables

### DIFF
--- a/.claude/commands/nimbus-commands.md
+++ b/.claude/commands/nimbus-commands.md
@@ -540,7 +540,6 @@ Bare model ids work; the engine auto-prefixes for Mastra (`claude-*` → `anthro
 
 Local model ids are passed to the local router. With Ollama running on `http://127.0.0.1:11434`, set `[llm].local_model` to any pulled model name and `[llm].prefer_local = true`; `nimbus ask` can then answer open-ended questions from indexed context even when no remote classifier key is configured.
 ```
-NIMBUS_AGENT_MODEL=claude-sonnet-4-6                # overrides [llm].remote_model       (Mastra agent)
 ```
 
 ## Docs site

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,26 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   worse than no key. A stale entry in an existing `nimbus.toml` is ignored, as any unrecognised
   `[llm]` key is.
 
+  **`[llm] remote_model` and `NIMBUS_AGENT_MODEL` were inert and are removed too.** Found while
+  verifying the Gemini adapter against the live API. Slice 2b moved the engine agent onto
+  `[llm.remote.<vendor>] model` and left `getEffectiveAgentModel()` **without a production
+  caller** — so both keys changed nothing, while `nimbus config list` still listed
+  `llm.remote_model` as a live env-overridable key and `cli-reference.md` still documented
+  `nimbus config set llm.remote_model claude-sonnet-4-6` as THE way to choose a cloud model. A
+  comment in `engine/agent.ts` asserted they "still override the MODEL NAME within the enabled
+  vendor"; nothing wired that. With four vendors the key is no longer well defined anyway — a
+  bare `claude-sonnet-4-6` says nothing about which vendor is enabled — so it is removed rather
+  than rewired, and `[llm.remote.*]` gained the reference documentation it shipped without.
+
+  **A live-API check of the Gemini adapter.** The wire format is correct — URL-path model,
+  query-string key, `systemInstruction`, `generationConfig`, multi-part concatenation and
+  `usageMetadata` all verified against the real endpoint. What is NOT correct is the model id
+  every internal document had been using: `gemini-2.5-pro` and `gemini-2.5-flash` still appear in
+  Google's `GET /v1beta/models` listing but return `404 NOT_FOUND … no longer available to new
+  users` on `generateContent` for a key issued after their retirement, so anyone following our
+  examples got a hard 404 from a model the listing said existed. The new `[llm.remote.*]` docs say
+  to check the vendor's current list rather than copy an id, and give this as the worked example.
+
   **`route_priority` could not name a cloud vendor.** A defect introduced by slice 2b:
   `routeIdsToRegister` was computed from LOCAL routes only, so
   `dropUnresolvableRoutePriorityEntries` dropped every enabled vendor's route id as unresolvable

--- a/docs/README.md
+++ b/docs/README.md
@@ -465,8 +465,7 @@ Gateway binaries built with `bun build --compile` bundle JavaScript into a singl
 |---|---|---|
 | **Local LLM (Ollama)** | [Ollama](https://ollama.com/download) running on `localhost:11434`, plus at least one pulled model (e.g. `ollama pull llama3.2`) | Default endpoint: `http://127.0.0.1:11434`. Set the local model with `nimbus config set llm.local_model <model>` and prefer it with `nimbus config set llm.prefer_local true`. |
 | **Local LLM (llama.cpp)** | A `llama-server` HTTP endpoint reachable from the Gateway | Default endpoint: `http://127.0.0.1:8080`; override with `nimbus config set llm.llamacpp_server_path http://127.0.0.1:8080`. The key stores the HTTP base URL, not the binary path. |
-| **Cloud LLM (Anthropic)** | Anthropic API key | Export `ANTHROPIC_API_KEY=…` in the Gateway's environment, then `nimbus config set llm.remote_model claude-sonnet-4-6` (provider is inferred from the model id; `claude-*` → Anthropic). |
-| **Cloud LLM (OpenAI)** | OpenAI API key | Export `OPENAI_API_KEY=…`, then `nimbus config set llm.remote_model gpt-4o` (provider is inferred; `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI). |
+| **Cloud LLM (Anthropic / OpenAI / Gemini / xAI)** | That vendor's API key | Two independent halves, both required. Store the key in the Vault — `nimbus vault set anthropic.api_key` (or `openai` / `gemini` / `xai`) — and opt the vendor in with an `[llm.remote.<vendor>]` table carrying `enabled = true` and a `model`. **No environment variable enables a vendor**, so a key alone does nothing. See [`cli-reference.md`](./cli-reference.md#configuration-file). |
 | **Voice — STT (push-to-talk hotkey / wake-word loop)** | `whisper-cli` (whisper.cpp) on PATH, plus `ffmpeg` for audio capture | Build whisper.cpp from source or install via `brew install whisper-cpp`; `ffmpeg` via your distro/`brew`. Set `voice.whisper_path` if not on PATH. |
 | **Voice — TTS** | macOS: `say` (built-in). Windows: PowerShell SAPI (built-in). Linux: `espeak-ng` (preferred) or `spd-say` | `sudo apt install espeak-ng` / `brew install espeak-ng`. |
 | **Wake-word loop** | Same as STT, plus a microphone configured at the OS level | Verify with `nimbus doctor` — voice section appears when `[voice].enabled = true`. |
@@ -505,7 +504,7 @@ The first time the Gateway starts it creates a default `nimbus.toml` in the plat
 | macOS | `~/Library/Application Support/Nimbus/nimbus.toml` | `~/Library/Application Support/Nimbus` |
 | Linux | `~/.config/nimbus/nimbus.toml` | `~/.local/share/nimbus` |
 
-`NIMBUS_CONFIG_DIR` moves the config directory only — it deliberately does not move the data directory, and there is no data-directory override (on Linux the data root follows `XDG_DATA_HOME`). Most TOML keys also have a corresponding `NIMBUS_`-prefixed env var override that wins over the file (e.g. `NIMBUS_AGENT_MODEL`, `NIMBUS_TELEMETRY_ENABLED`) — see [`cli-reference.md`](./cli-reference.md#environment-variables).
+`NIMBUS_CONFIG_DIR` moves the config directory only — it deliberately does not move the data directory, and there is no data-directory override (on Linux the data root follows `XDG_DATA_HOME`). Most TOML keys also have a corresponding `NIMBUS_`-prefixed env var override that wins over the file (e.g. `NIMBUS_TELEMETRY_ENABLED`, `NIMBUS_ASK_MAX_STEPS`) — see [`cli-reference.md`](./cli-reference.md#environment-variables).
 
 `nimbus ask` needs an LLM; indexing, `nimbus why` and the deterministic briefs do not. Remote model ids are inferred: `claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI. Local model ids are passed to Ollama or llama.cpp through `[llm].local_model`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1515,7 +1515,7 @@ Read a single configuration value.
 
 ```bash
 nimbus config get telemetry.enabled
-nimbus config get llm.remote_model
+nimbus config get llm.local_model
 ```
 
 There is no TOML key for sync cadence — per-connector intervals are set with `nimbus connector set-interval <service> <duration>`, which writes to the index, not to `nimbus.toml`.
@@ -1528,18 +1528,17 @@ Set a configuration value. Changes take effect on the next Gateway restart for G
 
 ```bash
 nimbus config set telemetry.enabled false
-nimbus config set llm.remote_model      claude-sonnet-4-6
 nimbus config set llm.local_model       llama3.2
 nimbus config set llm.prefer_local      true
 ```
 
-The provider is inferred from the model id: `claude-*` → Anthropic, `gpt-*` / `o1-*` / `o3-*` / `o4-*` → OpenAI. Already-prefixed forms (`anthropic/...`, `openai/...`) are accepted as-is.
+Cloud vendors are **not** configured this way — they need a whole `[llm.remote.<vendor>]` table plus a Vault key, so use `nimbus config edit` and `nimbus vault set`. See [Configuration File](#configuration-file) below.
 
 ---
 
 ### `nimbus config list`
 
-Print the config file path, then a per-key line for whichever of the four env-overridable keys (`telemetry.enabled`, `telemetry.endpoint`, `telemetry.flush_interval_seconds`, `llm.remote_model`) currently has a value, followed by the raw `nimbus.toml` body. A key is listed as `env` when its environment variable is set to a non-empty value, otherwise as `file` when it is present in `nimbus.toml` — and is **omitted entirely** when it is neither. There is no `default` source and no line for an unset key. Every other key appears only in the raw dump; there is no per-key documentation column.
+Print the config file path, then a per-key line for whichever of the three env-overridable keys (`telemetry.enabled`, `telemetry.endpoint`, `telemetry.flush_interval_seconds`) currently has a value, followed by the raw `nimbus.toml` body. A key is listed as `env` when its environment variable is set to a non-empty value, otherwise as `file` when it is present in `nimbus.toml` — and is **omitted entirely** when it is neither. There is no `default` source and no line for an unset key. Every other key appears only in the raw dump; there is no per-key documentation column.
 
 ```bash
 nimbus config list
@@ -1594,10 +1593,7 @@ Key sections:
 
 ```toml
 [llm]
-# Conversational agent (Mastra). Provider is inferred from the model id:
-# claude-* → Anthropic; gpt-*/o1-*/o3-*/o4-* → OpenAI.
-remote_model       = "claude-sonnet-4-6"
-# Local-LLM routing (Phase 4 LLM router).
+# Local-LLM routing.
 prefer_local       = true
 local_model        = "llama3.2" # Any pulled Ollama model name
 # llama.cpp HTTP base URL; not the filesystem path to the llama-server binary.
@@ -1630,7 +1626,35 @@ endpoint = "https://telemetry.nimbus-agent.dev/v1/collect"
 # graph_conditions = true
 ```
 
-**Environment variable overrides:** Most TOML keys have a corresponding `NIMBUS_`-prefixed env var that wins over the file. Examples: `NIMBUS_AGENT_MODEL` (overrides `[llm].remote_model`), `NIMBUS_TELEMETRY_ENABLED`. See the [Environment Variables](#environment-variables) table at the end of this document for the full list.
+#### Cloud vendors — `[llm.remote.<vendor>]`
+
+Four vendors are supported: `anthropic`, `openai`, `gemini`, `xai`. Each is its own table, and each is **off by default**.
+
+```toml
+[llm.remote.anthropic]
+enabled = true                    # REQUIRED. Never inferred from the presence of a key.
+model   = "claude-sonnet-4-6"     # REQUIRED. An empty model drops the route (warn-logged by name).
+# base_url = "https://api.anthropic.com"   # optional; for a proxy
+```
+
+The API key is **never** read from the environment or from this file. Store it in the Vault:
+
+| Vendor | Vault key |
+|---|---|
+| `anthropic` | `anthropic.api_key` |
+| `openai` | `openai.api_key` — deliberately the SAME key the embedding runtime uses |
+| `gemini` | `gemini.api_key` |
+| `xai` | `xai.api_key` |
+
+```bash
+nimbus vault set gemini.api_key      # prompts for the value; never on the command line
+```
+
+Both halves are required and they are independent: a key with no `enabled = true` registers no route, and `enabled = true` with no key registers a route that reports `no (no api key)` in `nimbus llm status`. Each enabled vendor becomes one route named `<vendor>/<model>`, which is the name `[llm].route_priority` and `nimbus llm status` use.
+
+**Model ids are the vendor's, and vendors retire them.** Check the vendor's current list rather than copying an id from a document — a retired id fails with a 404 that names the replacement. As of 2026-08-28, for example, `gemini-2.5-pro` and `gemini-2.5-flash` still appear in Google's `GET /v1beta/models` listing but return `404 NOT_FOUND … no longer available to new users` on `generateContent` for a key issued after their retirement; `gemini-flash-lite-latest` and `gemini-3.5-flash` answer normally.
+
+**Environment variable overrides:** Most TOML keys have a corresponding `NIMBUS_`-prefixed env var that wins over the file — `NIMBUS_TELEMETRY_ENABLED`, `NIMBUS_ASK_MAX_STEPS`, and so on. **No vendor credential or vendor selection is env-overridable**, by design: a capability must not turn itself on because a credential happens to exist in the environment. See the [Environment Variables](#environment-variables) table at the end of this document for the full list.
 
 ---
 
@@ -3510,7 +3534,6 @@ nimbus lan remove abc123
 
 | Variable | Purpose |
 |---|---|
-| `NIMBUS_AGENT_MODEL` | Override `[llm].remote_model` — model id for the conversational agent (default: `claude-sonnet-4-6`). Bare ids work; provider is inferred from `claude-*` / `gpt-*` / `o1-*` / `o3-*` / `o4-*` prefix. |
 | `NIMBUS_TELEMETRY_ENABLED` | Override `[telemetry].enabled` |
 | `NIMBUS_TELEMETRY_ENDPOINT` | Override `[telemetry].endpoint` |
 | `NIMBUS_CONFIG_DIR` | Override the platform config directory — **config only**. There is no data-directory override: the data directory is not relocatable by any `NIMBUS_*` variable (on Linux it follows `XDG_DATA_HOME`). |

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -51,7 +51,7 @@ function printAdditionalEnvOverrideLegend(): void {
   console.log(
     "  NIMBUS_PROFILE, NIMBUS_HTTP_PORT, NIMBUS_METRICS_PORT, NIMBUS_LOG_LEVEL, NIMBUS_EMBEDDINGS,",
   );
-  console.log("  NIMBUS_EMBEDDING_MODEL_DIR, NIMBUS_AGENT_MODEL, NIMBUS_ASK_MAX_STEPS, …");
+  console.log("  NIMBUS_EMBEDDING_MODEL_DIR, NIMBUS_ASK_MAX_STEPS, …");
   console.log(
     "  (see packages/gateway/src/config.ts and packages/gateway/src/platform/assemble.ts)",
   );

--- a/packages/cli/src/lib/nimbus-toml-config.test.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.test.ts
@@ -13,6 +13,7 @@ const SAVED = {
   agent: process.env["NIMBUS_AGENT_MODEL"],
   classifier: process.env["NIMBUS_CLASSIFIER_MODEL"],
   telemetry: process.env["NIMBUS_TELEMETRY_ENABLED"],
+  endpoint: process.env["NIMBUS_TELEMETRY_ENDPOINT"],
 };
 
 let dir: string;
@@ -22,6 +23,7 @@ beforeEach(() => {
   delete process.env["NIMBUS_AGENT_MODEL"];
   delete process.env["NIMBUS_CLASSIFIER_MODEL"];
   delete process.env["NIMBUS_TELEMETRY_ENABLED"];
+  delete process.env["NIMBUS_TELEMETRY_ENDPOINT"];
   dir = mkdtempSync(join(tmpdir(), "nimbus-toml-cfg-"));
   tomlPath = join(dir, "nimbus.toml");
 });
@@ -34,71 +36,70 @@ afterEach(() => {
   else process.env["NIMBUS_CLASSIFIER_MODEL"] = SAVED.classifier;
   if (SAVED.telemetry === undefined) delete process.env["NIMBUS_TELEMETRY_ENABLED"];
   else process.env["NIMBUS_TELEMETRY_ENABLED"] = SAVED.telemetry;
+  if (SAVED.endpoint === undefined) delete process.env["NIMBUS_TELEMETRY_ENDPOINT"];
+  else process.env["NIMBUS_TELEMETRY_ENDPOINT"] = SAVED.endpoint;
 });
 
-describe("listTomlKeysWithEnv — llm.* entries", () => {
-  test("llm.remote_model surfaces from env when NIMBUS_AGENT_MODEL is set", () => {
-    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-8";
+describe("listTomlKeysWithEnv — env-overridable entries", () => {
+  // These exercised `llm.remote_model` until 2026-08-28, when it and `llm.classifier_model` were
+  // removed: the engine agent moved to `[llm.remote.<vendor>] model` and the intent classifier
+  // to `LlmRouter`, leaving nothing that read either key. `telemetry.endpoint` is the remaining
+  // string-valued env-overridable key and carries the same behaviours.
+  test("surfaces from env when the env var is set", () => {
+    process.env["NIMBUS_TELEMETRY_ENDPOINT"] = "https://otel.example/v1";
     const rows = listTomlKeysWithEnv(tomlPath);
-    const row = rows.find((r) => r.key === "llm.remote_model");
+    const row = rows.find((r) => r.key === "telemetry.endpoint");
     expect(row).toEqual({
-      key: "llm.remote_model",
-      value: "claude-opus-4-8",
+      key: "telemetry.endpoint",
+      value: "https://otel.example/v1",
       source: "env",
-      envVar: "NIMBUS_AGENT_MODEL",
+      envVar: "NIMBUS_TELEMETRY_ENDPOINT",
     });
   });
 
-  test("llm.classifier_model is NOT listed — the key was removed on 2026-08-28", () => {
-    // The intent classifier no longer owns an HTTP client that could take a model name: it asks
-    // `LlmRouter` for the `"classification"` task. Listing a key nothing reads would tell the
-    // owner they had configured something.
-    process.env["NIMBUS_CLASSIFIER_MODEL"] = "claude-haiku-4-5-20251001";
-    writeFileSync(
-      tomlPath,
-      `[llm]
-classifier_model = "claude-haiku-4-5-20251001"
-`,
-    );
+  test("surfaces from file when env is unset and the key is in the TOML", () => {
+    writeFileSync(tomlPath, `[telemetry]\nendpoint = "https://otel.example/v1"\n`);
     const rows = listTomlKeysWithEnv(tomlPath);
-    expect(rows.find((r) => r.key === "llm.classifier_model")).toBeUndefined();
-  });
-
-  test("llm.* surfaces from file when env is unset and the key is in the TOML", () => {
-    writeFileSync(
-      tomlPath,
-      `[llm]\nremote_model = "claude-sonnet-4-6"\nclassifier_model = "claude-haiku-4-5-20251001"\n`,
-    );
-    const rows = listTomlKeysWithEnv(tomlPath);
-    const remote = rows.find((r) => r.key === "llm.remote_model");
-    expect(remote).toEqual({
-      key: "llm.remote_model",
-      value: '"claude-sonnet-4-6"',
+    expect(rows.find((r) => r.key === "telemetry.endpoint")).toEqual({
+      key: "telemetry.endpoint",
+      value: '"https://otel.example/v1"',
       source: "file",
     });
   });
 
   test("env beats file when both are set", () => {
-    writeFileSync(tomlPath, `[llm]\nremote_model = "claude-sonnet-4-6"\n`);
-    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-8";
+    writeFileSync(tomlPath, `[telemetry]\nendpoint = "https://from-file"\n`);
+    process.env["NIMBUS_TELEMETRY_ENDPOINT"] = "https://from-env";
     const rows = listTomlKeysWithEnv(tomlPath);
-    const row = rows.find((r) => r.key === "llm.remote_model");
+    const row = rows.find((r) => r.key === "telemetry.endpoint");
     expect(row?.source).toBe("env");
-    expect(row?.value).toBe("claude-opus-4-8");
-  });
-
-  test("llm.* is omitted when both env and file are unset", () => {
-    const rows = listTomlKeysWithEnv(tomlPath);
-    expect(rows.find((r) => r.key === "llm.remote_model")).toBeUndefined();
-    expect(rows.find((r) => r.key === "llm.classifier_model")).toBeUndefined();
+    expect(row?.value).toBe("https://from-env");
   });
 
   test("trims whitespace-only env values to undefined and falls back to file", () => {
-    process.env["NIMBUS_AGENT_MODEL"] = "   ";
-    writeFileSync(tomlPath, `[llm]\nremote_model = "from-file"\n`);
+    process.env["NIMBUS_TELEMETRY_ENDPOINT"] = "   ";
+    writeFileSync(tomlPath, `[telemetry]\nendpoint = "https://from-file"\n`);
     const rows = listTomlKeysWithEnv(tomlPath);
-    const row = rows.find((r) => r.key === "llm.remote_model");
-    expect(row?.source).toBe("file");
+    expect(rows.find((r) => r.key === "telemetry.endpoint")?.source).toBe("file");
+  });
+
+  test("a key is omitted entirely when both env and file are unset", () => {
+    const rows = listTomlKeysWithEnv(tomlPath);
+    expect(rows.find((r) => r.key === "telemetry.endpoint")).toBeUndefined();
+  });
+
+  // The removed keys must not merely be absent from the map — they must not surface even when
+  // the owner still has them set both ways, because a listed key reads as "this is configured".
+  test("the removed llm.* keys are not listed, from env or from file", () => {
+    process.env["NIMBUS_AGENT_MODEL"] = "claude-opus-4-8";
+    process.env["NIMBUS_CLASSIFIER_MODEL"] = "claude-haiku-4-5-20251001";
+    writeFileSync(
+      tomlPath,
+      `[llm]\nremote_model = "claude-sonnet-4-6"\nclassifier_model = "haiku"\n`,
+    );
+    const rows = listTomlKeysWithEnv(tomlPath);
+    expect(rows.find((r) => r.key === "llm.remote_model")).toBeUndefined();
+    expect(rows.find((r) => r.key === "llm.classifier_model")).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/lib/nimbus-toml-config.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.ts
@@ -22,7 +22,6 @@ const ENV_BY_DOTTED: Readonly<Record<string, string>> = {
   "telemetry.enabled": "NIMBUS_TELEMETRY_ENABLED",
   "telemetry.endpoint": "NIMBUS_TELEMETRY_ENDPOINT",
   "telemetry.flush_interval_seconds": "NIMBUS_TELEMETRY_FLUSH_SECONDS",
-  "llm.remote_model": "NIMBUS_AGENT_MODEL",
 };
 
 function stripComment(line: string): string {

--- a/packages/gateway/src/briefs/brief-llm-adapter.test.ts
+++ b/packages/gateway/src/briefs/brief-llm-adapter.test.ts
@@ -6,7 +6,6 @@ import { createBriefLlm } from "./brief-llm-adapter.ts";
 function router(provider?: LlmProvider): LlmRouter {
   const r = new LlmRouter({
     preferLocal: true,
-    remoteModel: "gpt-4o",
     localModel: "llama3.1:8b",
     minReasoningParams: 0,
     enforceAirGap: false,
@@ -77,7 +76,6 @@ describe("createBriefLlm", () => {
   test("forwards preferLocal=true to the router, choosing local even when router config prefers remote", async () => {
     const r = new LlmRouter({
       preferLocal: false,
-      remoteModel: "gpt-4o",
       localModel: "llama3.1:8b",
       minReasoningParams: 0,
       enforceAirGap: false,
@@ -91,7 +89,6 @@ describe("createBriefLlm", () => {
   test("forwards preferLocal=false to the router, choosing remote even when local is registered first", async () => {
     const r = new LlmRouter({
       preferLocal: true,
-      remoteModel: "gpt-4o",
       localModel: "llama3.1:8b",
       minReasoningParams: 0,
       enforceAirGap: false,

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1,8 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import {
-  applyLlmTomlOverrides,
   Config,
-  getEffectiveAgentModel,
   parseConversationalAgentMaxSteps,
   parseEmbeddingsEnabled,
   parseEngineContextWindowItems,
@@ -25,54 +23,6 @@ afterAll(() => {
   if (SAVED_ENV.agent !== undefined) process.env["NIMBUS_AGENT_MODEL"] = SAVED_ENV.agent;
   if (SAVED_ENV.classifier !== undefined)
     process.env["NIMBUS_CLASSIFIER_MODEL"] = SAVED_ENV.classifier;
-});
-
-afterEach(() => {
-  applyLlmTomlOverrides({});
-});
-
-describe("getEffectiveAgentModel / getEffectiveClassifierModel", () => {
-  test("falls back to hardcoded defaults when no overrides applied", () => {
-    expect(getEffectiveAgentModel()).toBe("claude-sonnet-4-6");
-  });
-
-  test("TOML overrides win over hardcoded defaults", () => {
-    applyLlmTomlOverrides({
-      agentModel: "claude-opus-4-8",
-    });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
-  });
-
-  test("calling applyLlmTomlOverrides({}) resets to hardcoded defaults", () => {
-    applyLlmTomlOverrides({ agentModel: "claude-opus-4-8" });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
-    applyLlmTomlOverrides({});
-    expect(getEffectiveAgentModel()).toBe("claude-sonnet-4-6");
-  });
-
-  test("empty-string TOML value is treated as unset", () => {
-    applyLlmTomlOverrides({ agentModel: "" });
-    expect(getEffectiveAgentModel()).toBe("claude-sonnet-4-6");
-  });
-
-  test("partial overrides leave other field on default", () => {
-    applyLlmTomlOverrides({ agentModel: "claude-opus-4-8" });
-    expect(getEffectiveAgentModel()).toBe("claude-opus-4-8");
-  });
-
-  test("env var wins over TOML override", () => {
-    applyLlmTomlOverrides({
-      agentModel: "claude-opus-4-8",
-    });
-    process.env["NIMBUS_AGENT_MODEL"] = "claude-sonnet-from-env";
-    process.env["NIMBUS_CLASSIFIER_MODEL"] = "claude-haiku-from-env";
-    try {
-      expect(getEffectiveAgentModel()).toBe("claude-sonnet-from-env");
-    } finally {
-      delete process.env["NIMBUS_AGENT_MODEL"];
-      delete process.env["NIMBUS_CLASSIFIER_MODEL"];
-    }
-  });
 });
 
 describe("env-var parsers", () => {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -68,29 +68,13 @@ export function parseEmbeddingsEnabled(): boolean {
 
 const searchServicePriorityMap: ReadonlyMap<string, number> = parseSearchPriorityJson();
 
-const HARDCODED_AGENT_MODEL_DEFAULT = "claude-sonnet-4-6";
-
-let tomlAgentModel: string | undefined;
-
-export type LlmTomlOverrides = {
-  agentModel?: string;
-};
-
-export function applyLlmTomlOverrides(overrides: LlmTomlOverrides): void {
-  tomlAgentModel =
-    typeof overrides.agentModel === "string" && overrides.agentModel !== ""
-      ? overrides.agentModel
-      : undefined;
-}
-
-function envOrUndefined(name: string): string | undefined {
-  const v = processEnvGet(name);
-  return v !== undefined && v !== "" ? v : undefined;
-}
-
-export function getEffectiveAgentModel(): string {
-  return envOrUndefined("NIMBUS_AGENT_MODEL") ?? tomlAgentModel ?? HARDCODED_AGENT_MODEL_DEFAULT;
-}
+// `[llm] remote_model` / `NIMBUS_AGENT_MODEL` and their `getEffectiveAgentModel()` accessor were
+// REMOVED on 2026-08-28. Slice 2b moved the engine agent onto `[llm.remote.<vendor>] model` and
+// left this chain dead-ended: nothing called the accessor, so setting either key changed nothing
+// while `nimbus config list` still listed the key and `cli-reference.md` still documented
+// `nimbus config set llm.remote_model` as THE way to choose a cloud model. With four vendors the
+// key is also no longer well defined -- a bare `claude-sonnet-4-6` says nothing about which of
+// them is enabled -- which is why it is removed rather than rewired.
 
 export const Config = {
   oauthGoogleClientId: processEnvGet("NIMBUS_OAUTH_GOOGLE_CLIENT_ID") ?? "",

--- a/packages/gateway/src/config/nimbus-toml-llm.test.ts
+++ b/packages/gateway/src/config/nimbus-toml-llm.test.ts
@@ -24,14 +24,17 @@ describe("parseNimbusTomlLlmSection", () => {
     expect(parseNimbusTomlLlmSection(src)).toEqual({ preferLocal: false });
   });
 
-  test("parses remote_model string", () => {
-    const src = `[llm]\nremote_model = "claude-sonnet-4-6"\n`;
-    expect(parseNimbusTomlLlmSection(src)).toEqual({ remoteModel: "claude-sonnet-4-6" });
+  // Both keys were REMOVED on 2026-08-28. A stale one in an existing nimbus.toml must be
+  // IGNORED like any unrecognised [llm] key — never parsed into a field nothing reads, and
+  // never an error, which would revert the whole section and take the live keys with it.
+  test("remote_model and classifier_model are ignored, not parsed", () => {
+    const src = `[llm]\nremote_model = "claude-sonnet-4-6"\nclassifier_model = "haiku"\n`;
+    expect(parseNimbusTomlLlmSection(src)).toEqual({});
   });
 
-  test("parses classifier_model string", () => {
-    const src = `[llm]\nclassifier_model = "claude-haiku-4-5-20251001"\n`;
-    expect(parseNimbusTomlLlmSection(src)).toEqual({});
+  test("a stale key does not stop the rest of the section parsing", () => {
+    const src = `[llm]\nremote_model = "claude-sonnet-4-6"\nprefer_local = true\n`;
+    expect(parseNimbusTomlLlmSection(src)).toEqual({ preferLocal: true });
   });
 
   test("parses local_model string", () => {
@@ -126,8 +129,8 @@ describe("loadNimbusLlmPartialFromPath", () => {
   test("returns only explicitly-set keys (no defaults)", () => {
     const dir = mkdtempSync(join(tmpdir(), "nimbus-llm-partial-"));
     const tomlPath = join(dir, "nimbus.toml");
-    writeFileSync(tomlPath, `[llm]\nremote_model = "claude-opus-4-8"\n`);
-    expect(loadNimbusLlmPartialFromPath(tomlPath)).toEqual({ remoteModel: "claude-opus-4-8" });
+    writeFileSync(tomlPath, `[llm]\nlocal_model = "qwen3:8b"\n`);
+    expect(loadNimbusLlmPartialFromPath(tomlPath)).toEqual({ localModel: "qwen3:8b" });
   });
 
   test("returns empty object when [llm] section is absent", () => {

--- a/packages/gateway/src/config/nimbus-toml.ts
+++ b/packages/gateway/src/config/nimbus-toml.ts
@@ -224,7 +224,6 @@ export type NimbusLlmRemoteVendor = {
 
 export type NimbusLlmToml = {
   preferLocal: boolean;
-  remoteModel: string;
   localModel: string;
   /**
    * `num_ctx` for the local provider, in tokens. See `DEFAULT_LOCAL_CONTEXT_TOKENS`: unset is
@@ -265,7 +264,6 @@ export type NimbusLlmToml = {
 
 export const DEFAULT_NIMBUS_LLM_TOML: NimbusLlmToml = {
   preferLocal: true,
-  remoteModel: "claude-sonnet-4-6",
   localModel: "llama3.2",
   localContextTokens: DEFAULT_LOCAL_CONTEXT_TOKENS,
   llamacppServerPath: "",
@@ -285,9 +283,8 @@ function applyNimbusLlmKey(out: Partial<NimbusLlmToml>, key: string, valRaw: str
       if (b !== undefined) out.preferLocal = b;
       break;
     }
-    case "remote_model":
-      out.remoteModel = parseString(valRaw);
-      break;
+    // `remote_model` was removed on 2026-08-28 alongside `classifier_model`, for the same
+    // reason and with the same handling: a stale key in an existing nimbus.toml is ignored.
     // `classifier_model` was removed on 2026-08-28 and is deliberately NOT parsed here: the
     // intent classifier no longer owns an HTTP client that could take a model name, it asks
     // `LlmRouter` for the `"classification"` task and takes whatever route answers. A stale key

--- a/packages/gateway/src/decisions/decision-llm-adapter.test.ts
+++ b/packages/gateway/src/decisions/decision-llm-adapter.test.ts
@@ -43,7 +43,6 @@ function fakeProvider(id: ProviderId, opts: { available: boolean; text?: string 
 function routerWith(...providers: LlmProvider[]): LlmRouter {
   const r = new LlmRouter({
     preferLocal: true,
-    remoteModel: "remote-model",
     localModel: "local-model",
     minReasoningParams: 0,
     enforceAirGap: false,

--- a/packages/gateway/src/engine/agent.ts
+++ b/packages/gateway/src/engine/agent.ts
@@ -87,8 +87,8 @@ function clipToolString(s: string, max = MAX_TOOL_STRING_LEN): string {
  * Builds the `"<provider>/<model>"` router id Mastra resolves against.
  *
  * The `includes("/")` branch is load-bearing and replaces the old `toMastraModelId`: an operator
- * may set `NIMBUS_AGENT_MODEL` / `[llm] remote_model` to EITHER a bare model name
- * (`claude-sonnet-4-6`) or an already-qualified router id (`anthropic/claude-sonnet-4-6`).
+ * may set `[llm.remote.<vendor>] model` to EITHER a bare model name (`claude-sonnet-4-6`) or an
+ * already-qualified router id (`anthropic/claude-sonnet-4-6`).
  * Unconditionally prefixing the vendor would turn the second form into
  * `anthropic/anthropic/claude-sonnet-4-6`, which resolves to nothing.
  *
@@ -133,10 +133,13 @@ export function createNimbusEngineAgent(deps: NimbusEngineAgentDeps): {
   agent: Agent;
   agentsByName: { nimbus: Agent; devops: Agent; research: Agent };
 } {
-  // `NIMBUS_AGENT_MODEL` / `[llm] remote_model` still override the MODEL NAME within the enabled
-  // vendor, so no existing config breaks silently — but they can no longer SELECT a vendor, and
-  // they can no longer supply a credential. Both of those now come from `[llm.remote.<vendor>]`
-  // and the Vault.
+  // `deps.agentModel` is an INJECTION SEAM for tests, not a config path: nothing in production
+  // supplies it, so the model is `[llm.remote.<vendor>] model`. It is spelled out because the
+  // comment that stood here until 2026-08-28 claimed `NIMBUS_AGENT_MODEL` / `[llm] remote_model`
+  // "still override the MODEL NAME within the enabled vendor" — which was never wired. Slice 2b
+  // left `getEffectiveAgentModel()` without a caller, so both keys were inert while
+  // `cli-reference.md` still documented `nimbus config set llm.remote_model` as THE way to pick a
+  // cloud model; both are now removed rather than left claiming to work.
   const modelId = deps.agentModel ?? deps.vendor.modelId;
   // Wrapped at the AI-SDK seam: Mastra keeps its own client (which is what makes tool-calling
   // work), and the decorator ledgers every doGenerate/doStream before it runs. See

--- a/packages/gateway/src/engine/classifier-egress-wire.test.ts
+++ b/packages/gateway/src/engine/classifier-egress-wire.test.ts
@@ -57,7 +57,6 @@ describe("classifyIntent appends an I29 model row for a REMOTE route", () => {
         preferLocal: false,
         enforceAirGap: false,
         minReasoningParams: 0,
-        remoteModel: "claude-x",
         localModel: "",
       },
       db,

--- a/packages/gateway/src/engine/gateway-agent-error.ts
+++ b/packages/gateway/src/engine/gateway-agent-error.ts
@@ -104,7 +104,12 @@ function buildAgentErrorMessage(init: AgentUnavailableInit): string {
     case "rate_limited":
       return `${provider} rate limit hit. Wait a moment and retry, or upgrade your usage tier.`;
     case "model_not_found":
-      return `${provider} returned 404 for the configured model. Check the model name in your [llm.remote.*] block (or NIMBUS_AGENT_MODEL) and your access tier.`;
+      // Names no env var: `NIMBUS_AGENT_MODEL` / `NIMBUS_CLASSIFIER_MODEL` were removed, and
+      // sending someone to check a variable nothing reads is worse than saying nothing. The
+      // "vendors retire model ids" clause is there because that is the common cause in practice:
+      // `gemini-2.5-pro` still appears in `GET /v1beta/models` while `generateContent` on it
+      // 404s for keys issued after its retirement.
+      return `${provider} returned 404 for the configured model. Check the \`model\` in your [llm.remote.*] block against the vendor's current model list, and your access tier — vendors retire model ids.`;
     case "provider_error": {
       const detail = init.detail !== undefined && init.detail !== "" ? ` ${init.detail}` : "";
       return `${provider} request failed.${detail}`;

--- a/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
+++ b/packages/gateway/src/glossary/glossary-llm-adapter.test.ts
@@ -33,7 +33,6 @@ function fakeProvider(id: ProviderId, opts: { available: boolean; text?: string 
 function routerWith(...providers: LlmProvider[]): LlmRouter {
   const r = new LlmRouter({
     preferLocal: true,
-    remoteModel: "remote-model",
     localModel: "local-model",
     minReasoningParams: 0,
     enforceAirGap: false,

--- a/packages/gateway/src/ipc/server/dispatchers.test.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.test.ts
@@ -72,6 +72,10 @@ import {
 } from "./dispatchers.ts";
 import { RpcMethodError } from "./rpc-error.ts";
 
+// A stand-in remote model name. Was `LlmRouterConfig.remoteModel`, removed on 2026-08-28
+// along with `[llm] remote_model`; these tests only ever needed an arbitrary non-local id.
+const REMOTE_MODEL = "claude-sonnet-4-6";
+
 function makePolicyRpcCtx(overrides: Partial<PolicyRpcCtx> = {}): PolicyRpcCtx {
   return {
     showPolicy: () => ({
@@ -185,7 +189,6 @@ function trackedDb(): Database {
 
 const FAKE_LLM_ROUTER_CONFIG = {
   preferLocal: true,
-  remoteModel: "remote-model",
   localModel: "local-model",
   minReasoningParams: 0,
   enforceAirGap: false,
@@ -220,7 +223,7 @@ function fakeRemoteProvider(): LlmProvider {
     providerId: "remote",
     isLocal: false,
     isAvailable: async () => true,
-    // Must report the model it registers under (FAKE_LLM_ROUTER_CONFIG.remoteModel,
+    // Must report the model it registers under (REMOTE_MODEL,
     // "remote-model") so the route genuinely RESOLVES as available — otherwise it reads
     // model_absent, resolveForSynthesis() returns undefined, and the test below passes via
     // no_eligible_provider from the EARLY branch rather than exercising the "local"-mode
@@ -249,10 +252,7 @@ function makeLlmRegistry(provider: LlmProvider, db?: Database): LlmRegistry {
     config: FAKE_LLM_ROUTER_CONFIG,
     ...(db === undefined ? {} : { db }),
   });
-  registry.addRoute(
-    provider,
-    provider.isLocal ? FAKE_LLM_ROUTER_CONFIG.localModel : FAKE_LLM_ROUTER_CONFIG.remoteModel,
-  );
+  registry.addRoute(provider, provider.isLocal ? FAKE_LLM_ROUTER_CONFIG.localModel : REMOTE_MODEL);
   return registry;
 }
 

--- a/packages/gateway/src/llm/base-url-locality.test.ts
+++ b/packages/gateway/src/llm/base-url-locality.test.ts
@@ -64,7 +64,6 @@ describe("provider isLocal is derived from the base URL, not hardcoded", () => {
 
 const AIR_GAPPED: LlmRouterConfig = {
   preferLocal: true,
-  remoteModel: "claude-sonnet-4-6",
   localModel: "m.gguf",
   minReasoningParams: 0,
   enforceAirGap: true,

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -13,9 +13,12 @@ import { LlmRegistry } from "./registry.ts";
 import type { LlmRouterConfig } from "./router.ts";
 import type { LlmModelInfo, LlmProvider, ProviderId, PullProgressChunk } from "./types.ts";
 
+// A stand-in remote model name. Was `LlmRouterConfig.remoteModel`, removed on 2026-08-28
+// along with `[llm] remote_model`; these tests only ever needed an arbitrary non-local id.
+const REMOTE_MODEL = "claude-sonnet-4-6";
+
 const DEFAULT_CONFIG: LlmRouterConfig = {
   preferLocal: true,
-  remoteModel: "claude-sonnet-4-6",
   localModel: "llama3.2",
   minReasoningParams: 7,
   enforceAirGap: false,
@@ -138,7 +141,7 @@ describe("LlmRegistry.listAllModels", () => {
         available: true,
         models: [{ provider: "remote", modelName: "claude-sonnet-4-6" }],
       }),
-      DEFAULT_CONFIG.remoteModel,
+      REMOTE_MODEL,
     );
     const models = await reg.listAllModels();
     expect(models).toHaveLength(3);
@@ -183,7 +186,7 @@ describe("LlmRegistry.listAllModels", () => {
         available: true,
         models: [{ provider: "remote", modelName: "good" }],
       }),
-      DEFAULT_CONFIG.remoteModel,
+      REMOTE_MODEL,
     );
     const models = await reg.listAllModels();
     expect(models).toHaveLength(1);
@@ -251,7 +254,7 @@ describe("LlmRegistry.checkAvailability", () => {
     const db = freshLedgerDb();
     const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db });
     reg.addRoute(makeProvider("ollama", { available: true }), DEFAULT_CONFIG.localModel);
-    reg.addRoute(makeProvider("remote", { available: false }), DEFAULT_CONFIG.remoteModel);
+    reg.addRoute(makeProvider("remote", { available: false }), REMOTE_MODEL);
     const out = await reg.checkAvailability();
     expect(out["ollama"]).toBe(true);
     expect(out["remote"]).toBe(false);

--- a/packages/gateway/src/llm/router.test.ts
+++ b/packages/gateway/src/llm/router.test.ts
@@ -3,6 +3,10 @@ import { LlmProviderError } from "./provider-error.ts";
 import { LlmRouter, type LlmRouterConfig, midTruncate } from "./router.ts";
 import type { LlmProvider } from "./types.ts";
 
+// A stand-in remote model name. Was `LlmRouterConfig.remoteModel`, removed on 2026-08-28
+// along with `[llm] remote_model`; these tests only ever needed an arbitrary non-local id.
+const REMOTE_MODEL = "claude-sonnet-4-6";
+
 function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boolean): LlmProvider {
   return {
     providerId: id,
@@ -15,7 +19,7 @@ function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boole
     listModels: async () => [
       {
         provider: id,
-        modelName: id === "remote" ? DEFAULT_CONFIG.remoteModel : DEFAULT_CONFIG.localModel,
+        modelName: id === "remote" ? REMOTE_MODEL : DEFAULT_CONFIG.localModel,
       },
     ],
     generate: async (_opts) => ({
@@ -31,7 +35,6 @@ function makeFakeProvider(id: "ollama" | "llamacpp" | "remote", available: boole
 
 const DEFAULT_CONFIG: LlmRouterConfig = {
   preferLocal: true,
-  remoteModel: "claude-sonnet-4-6",
   localModel: "llama3.2",
   minReasoningParams: 7,
   enforceAirGap: false,
@@ -41,7 +44,7 @@ describe("LlmRouter.selectProvider", () => {
   test("returns ollama when preferLocal=true and ollama is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("ollama");
   });
@@ -49,7 +52,7 @@ describe("LlmRouter.selectProvider", () => {
   test("falls back to remote when local unavailable and enforceAirGap=false", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("remote");
   });
@@ -65,7 +68,7 @@ describe("LlmRouter.selectProvider", () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, enforceAirGap: true };
     const router = new LlmRouter(config);
     router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("reasoning");
     expect(provider).toBeUndefined();
   });
@@ -82,7 +85,7 @@ describe("LlmRouter.selectProvider", () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("classification");
     expect(provider?.providerId).toBe("remote");
   });
@@ -91,7 +94,7 @@ describe("LlmRouter.selectProvider", () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const overridden = await router.selectProvider("reasoning", { preferLocal: true });
     expect(overridden?.providerId).toBe("ollama");
     // No override: falls back to config, which prefers remote — proves the override is per-call.
@@ -102,7 +105,7 @@ describe("LlmRouter.selectProvider", () => {
   test("per-call preferLocal override falls back to remote when no local provider is available", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("reasoning", { preferLocal: true });
     expect(provider?.providerId).toBe("remote");
   });
@@ -131,7 +134,7 @@ describe("LlmRouter capability floor", () => {
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
       parameterCount: 3,
     });
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("reasoning");
     expect(provider?.providerId).toBe("remote");
   });
@@ -159,7 +162,7 @@ describe("LlmRouter capability floor", () => {
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
       parameterCount: 3,
     });
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const provider = await router.selectProvider("agent_step");
     expect(provider?.providerId).toBe("remote");
   });
@@ -173,7 +176,7 @@ function makeCaptureProvider(
   // (localModel/remoteModel); a caller using an explicit model name (e.g. "small"/"big"
   // below) passes it here too, so the model-aware availability probe matches what was
   // registered.
-  models: string[] = [id === "remote" ? DEFAULT_CONFIG.remoteModel : DEFAULT_CONFIG.localModel],
+  models: string[] = [id === "remote" ? REMOTE_MODEL : DEFAULT_CONFIG.localModel],
 ): LlmProvider {
   return {
     providerId: id,
@@ -217,7 +220,7 @@ describe("LlmRouter context window overflow", () => {
         contextWindow: 100,
       },
     );
-    router.registerRoute(makeCaptureProvider("remote", true, captured), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeCaptureProvider("remote", true, captured), REMOTE_MODEL);
     const longPrompt = "x".repeat(500);
     await router.generate({ task: "reasoning", prompt: longPrompt });
     expect(captured.prompt).toBe(longPrompt);
@@ -301,9 +304,9 @@ describe("LlmRouter.getStatus", () => {
   test("populates modelName from remoteModel for remote", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
-    expect(status.classification?.modelName).toBe(DEFAULT_CONFIG.remoteModel);
+    expect(status.classification?.modelName).toBe(REMOTE_MODEL);
   });
 
   test("isAvailable is true when provider is reachable", async () => {
@@ -337,7 +340,7 @@ describe("LlmRouter.getStatus", () => {
   test("reason is prefer-remote when preferLocal=false and remote provider selected", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("prefer-remote");
   });
@@ -356,7 +359,7 @@ describe("LlmRouter.getStatus", () => {
 
   test("reason is no-local-provider when preferLocal=true but only remote is registered", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
     expect(status.classification?.reason).toBe("no-local-provider");
   });
@@ -384,13 +387,13 @@ describe("LlmRouter.getStatus", () => {
   test("reports the fallback generate() would use when the preferred provider is down", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerRoute(makeFakeProvider("ollama", false), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
     expect(status.classification?.providerId).toBe("ollama");
     expect(status.classification?.isAvailable).toBe(false);
     expect(status.classification?.fallback).toEqual({
       providerId: "remote",
-      modelName: DEFAULT_CONFIG.remoteModel,
+      modelName: REMOTE_MODEL,
     });
   });
 
@@ -432,7 +435,7 @@ describe("LlmRouter.getStatus", () => {
   test("no fallback when the preferred provider is available", async () => {
     const router = new LlmRouter(DEFAULT_CONFIG);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
     expect(status.classification?.isAvailable).toBe(true);
     expect(status.classification?.fallback).toBeUndefined();
@@ -451,7 +454,7 @@ describe("LlmRouter.getStatus", () => {
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
       parameterCount: 1,
     });
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const status = await router.getStatus();
     // reasoning carries a capability floor; ollama (1B < minReasoningParams) is skipped → remote.
     expect(status.reasoning?.providerId).toBe("remote");
@@ -514,11 +517,11 @@ describe("LlmRouter.resolveForSynthesis", () => {
   test("a REMOTE provider kind resolves isLocal: false", async () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const resolved = await router.resolveForSynthesis();
     expect(resolved).toEqual({
       providerId: "remote",
-      modelName: DEFAULT_CONFIG.remoteModel,
+      modelName: REMOTE_MODEL,
       isLocal: false,
     });
   });
@@ -543,7 +546,7 @@ describe("LlmRouter.resolveForSynthesis", () => {
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel, {
       parameterCount: 1,
     });
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
     const resolved = await router.resolveForSynthesis();
     expect(resolved?.providerId).toBe("remote");
   });
@@ -558,12 +561,12 @@ describe("LlmRouter.resolveForSynthesis", () => {
     const config: LlmRouterConfig = { ...DEFAULT_CONFIG, preferLocal: false };
     const router = new LlmRouter(config);
     router.registerRoute(makeFakeProvider("ollama", true), DEFAULT_CONFIG.localModel);
-    router.registerRoute(makeFakeProvider("remote", true), DEFAULT_CONFIG.remoteModel);
+    router.registerRoute(makeFakeProvider("remote", true), REMOTE_MODEL);
 
     const viaConfigDefault = await router.resolveForSynthesis();
     expect(viaConfigDefault).toEqual({
       providerId: "remote",
-      modelName: DEFAULT_CONFIG.remoteModel,
+      modelName: REMOTE_MODEL,
       isLocal: false,
     });
 
@@ -749,7 +752,6 @@ describe("generate-time route fallback", () => {
   // the roadmap row this serves promises "with local fallback".
   const CFG: LlmRouterConfig = {
     preferLocal: false,
-    remoteModel: "remote-model",
     localModel: "local-model",
     minReasoningParams: 0,
     enforceAirGap: false,
@@ -875,7 +877,6 @@ describe("generate-time walk — no destination is invoked twice", () => {
     let remoteCalls = 0;
     const cfg: LlmRouterConfig = {
       preferLocal: true,
-      remoteModel: "remote-model",
       localModel: "local-model",
       minReasoningParams: 0,
       enforceAirGap: false,

--- a/packages/gateway/src/llm/router.ts
+++ b/packages/gateway/src/llm/router.ts
@@ -15,7 +15,6 @@ export type { ProviderMeta } from "./types.ts";
 
 export type LlmRouterConfig = {
   preferLocal: boolean;
-  remoteModel: string;
   localModel: string;
   minReasoningParams: number;
   enforceAirGap: boolean;

--- a/packages/gateway/src/platform/assemble.ts
+++ b/packages/gateway/src/platform/assemble.ts
@@ -45,7 +45,6 @@ import {
   loadNimbusIdentityFromConfigDir,
   loadNimbusLanFromConfigDir,
   loadNimbusLlmFromPath,
-  loadNimbusLlmPartialFromPath,
   loadNimbusOwnershipFromConfigDir,
   loadNimbusPagerdutyFromConfigDir,
   loadNimbusPreflightFromConfigDir,
@@ -68,7 +67,7 @@ import { loadNimbusWorkdayFromConfigDir } from "../config/nimbus-toml-workday.ts
 import { resolvePersona } from "../config/persona.ts";
 import { ProfileManager } from "../config/profiles.ts";
 import { loadNimbusSessionFromPath } from "../config/session-toml.ts";
-import { applyLlmTomlOverrides, Config } from "../config.ts";
+import { Config } from "../config.ts";
 import { bitbucketFetchOneUrlIsSupported } from "../connectors/bitbucket-sync.ts";
 import { createBlameIndexSyncable } from "../connectors/blame-index-sync.ts";
 import {
@@ -1624,13 +1623,6 @@ export async function buildLlmRegistryFromToml(
   logger: RouteValidationLogger = defaultRouteValidationLogger,
 ): Promise<LlmRegistry> {
   const llmToml = loadNimbusLlmFromPath(activeTomlPath);
-  const llmTomlPartial = loadNimbusLlmPartialFromPath(activeTomlPath);
-  const llmOverrides: { agentModel?: string } = {};
-  if (llmTomlPartial.remoteModel !== undefined) {
-    llmOverrides.agentModel = llmTomlPartial.remoteModel;
-  }
-  applyLlmTomlOverrides(llmOverrides);
-
   const knownRuntimeLocalRoutes = dropUnknownRuntimeEntries(llmToml.localRoutes, logger);
   const uncollidedLocalRoutes = dropLlamacppBaseUrlCollisions(knownRuntimeLocalRoutes, logger);
   const validatedLocalRoutes = dropDuplicateRouteIds(uncollidedLocalRoutes, logger);
@@ -1694,7 +1686,6 @@ export async function buildLlmRegistryFromToml(
     db,
     config: {
       preferLocal: llmToml.preferLocal,
-      remoteModel: llmToml.remoteModel,
       localModel: effectiveLocalModel,
       minReasoningParams: llmToml.minReasoningParams,
       enforceAirGap: llmToml.enforceAirGap,

--- a/packages/gateway/src/voice/push-to-talk.test.ts
+++ b/packages/gateway/src/voice/push-to-talk.test.ts
@@ -47,7 +47,6 @@ function makeFakeLlmProvider(): LlmProvider {
 
 const ROUTER_CONFIG: LlmRouterConfig = {
   preferLocal: true,
-  remoteModel: "claude-sonnet-4-6",
   localModel: "llama3.2",
   minReasoningParams: 7,
   enforceAirGap: false,


### PR DESCRIPTION
Follow-on to #1366, found while verifying the **Gemini adapter against the live API** — which was the one thing #1366 left open.

## What the live check found

The adapter itself is **correct**. Verified against the real endpoint with a key read straight from the Vault: URL-path model, query-string key, `systemInstruction`, `generationConfig`, multi-part concatenation and `usageMetadata` all work, and `?key=` and `x-goog-api-key` both authenticate.

```
gemini-3.5-flash          200  text="pong" in=8 out=1
gemini-flash-lite-latest  200  text="pong" in=8 out=1
```

What is **not** correct is the model id every internal document had been using:

```
gemini-2.5-pro    404  NOT_FOUND: This model models/gemini-2.5-pro is no longer available
                       to new users. Please update your code to use models/gemini-3.1-pro-preview
gemini-2.5-flash  404  NOT_FOUND: … no longer available to new users
```

Both still appear in Google's `GET /v1beta/models` listing, so "it's in the model list" is not evidence the model answers. Anyone following our examples got a hard 404 from a model we told them to use.

## The larger finding

Chasing where that default was documented turned up that **`[llm.remote.*]` has no user-facing reference documentation at all**, despite shipping in `v5.0.0` — and that what `docs/cli-reference.md` *does* document for cloud models is dead:

- `getEffectiveAgentModel()` has **no production caller**. Slice 2b moved the engine agent onto `[llm.remote.<vendor>] model` and left the whole `remote_model → tomlAgentModel → getEffectiveAgentModel()` chain dead-ended.
- So `[llm] remote_model` and `NIMBUS_AGENT_MODEL` changed nothing — while `nimbus config list` still surfaced `llm.remote_model` as a live env-overridable key, and `cli-reference.md` and `docs/README.md` both documented `nimbus config set llm.remote_model claude-sonnet-4-6` as **the** way to choose a cloud model.
- A comment in `engine/agent.ts` asserted the keys *"still override the MODEL NAME within the enabled vendor, so no existing config breaks silently"*. Nothing wired that. `deps.agentModel` is a test injection seam and no production call site passes it.

This is the same defect class as the `classifier_model` removal in #1366, found one file over.

## Removed, not rewired

With four vendors the key is no longer well defined — a bare `claude-sonnet-4-6` says nothing about which vendor is enabled, and that ambiguity is exactly why the per-vendor `model` key exists. So both keys go, the same way `classifier_model` did: a stale entry in an existing `nimbus.toml` is **ignored**, as any unrecognised `[llm]` key is, never an error that would revert the section and take the live keys with it.

## Documentation added

`docs/cli-reference.md` gains the `[llm.remote.<vendor>]` section it shipped without: the `enabled` + `model` pair (both required, `enabled` never inferred from a key), the four Vault key names, the note that `openai.api_key` is deliberately shared with the embedding runtime, the two independent failure modes (key without opt-in → no route; opt-in without key → `no (no api key)`), and that no vendor credential or selection is env-overridable by design.

It also says to check the vendor's current model list rather than copy an id from a document, with `gemini-2.5-pro` as the worked example — a retired id that still appears in the listing is the failure mode a reader will not predict.

`docs/README.md`'s prerequisites table replaces the two `export ANTHROPIC_API_KEY` / `nimbus config set llm.remote_model` rows with the real two-halves setup.

## Verification

- `bun run typecheck`, `bun run preflight:fast` — pass.
- The verbatim CI command `bun test packages/gateway packages/cli scripts` — 19,437 pass; the three `tui` failures are the known load-flake (they pass in isolation, on this branch and on `main`).
- **Both Linux-authoritative coverage gates** rebuilt through the `reseed-docker.sh` docker block against the committed baseline: `audit:coverage-floor` ok, `audit:coverage-scopes` ok across all 23 scopes.
- The `listTomlKeysWithEnv` suite was rebuilt on `telemetry.endpoint` rather than deleted — env-source, file-source, env-beats-file, whitespace-trim and omitted-when-unset all still covered — plus a new case asserting the two removed keys do **not** surface even when set in both the environment and the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
