### PR TITLE
fix(connectors): stop connector CLI spawns flashing console windows on Windows

### DIFF
--- a/packages/gateway/src/connectors/_lib/aws-cli.ts
+++ b/packages/gateway/src/connectors/_lib/aws-cli.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../../extensions/spawn-env.ts";
+import { spawnCapture } from "../../platform/spawn-capture.ts";
 import {
   syncPassCursorParseEmpty,
   syncPassCursorSuccess,
@@ -114,14 +115,14 @@ export async function awsCliJson(
   if (extra === null) {
     return { ok: false, text: "" };
   }
-  const proc = Bun.spawn(["aws", ...args, "--output", "json"], {
+  // `spawnCapture`, not `Bun.spawn`: the Gateway runs detached, so on Windows every
+  // console-subsystem child gets a NEW console and a visible window. `cloudwatch` and
+  // `sagemaker` spawn one of these PER INDEXED ITEM via `runAwsCliPaginatedWalk`, so the
+  // unhidden version flashed dozens of windows per sync tick. See `platform/spawn-capture.ts`.
+  const r = await spawnCapture(["aws", ...args, "--output", "json"], {
     env: extensionProcessEnv(extra),
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const code = await proc.exited;
-  const out = await new Response(proc.stdout).text();
-  return { ok: code === 0, text: out };
+  return { ok: r.ok, text: r.stdout };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
@@ -60,6 +60,8 @@ describe("runGcloudCommand", () => {
   });
 
   test("degrades to { ok:false, text:'' } when spawn throws (gcloud missing)", async () => {
+    // The handling lives in `spawnCapture` now, not in a local try/catch here — that catch was
+    // deleted as unreachable. This asserts the contract still holds through the seam.
     stubSpawn(() => {
       throw new Error("ENOENT: gcloud not found");
     });

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.test.ts
@@ -1,54 +1,58 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { spawnCaptureInternals } from "../../platform/spawn-capture.ts";
 
 import { runGcloudCommand } from "./gcloud-runner.ts";
 
-type SpawnArgs = Parameters<typeof Bun.spawn>;
-type BunWithSpawn = { spawn: typeof Bun.spawn };
+type CaptureSpawn = typeof spawnCaptureInternals.spawn;
 
-const realSpawn = Bun.spawn;
+const realSpawn = spawnCaptureInternals.spawn;
 afterEach(() => {
-  (Bun as unknown as BunWithSpawn).spawn = realSpawn;
+  spawnCaptureInternals.spawn = realSpawn;
 });
 
-/** Replace Bun.spawn with a fake; returns the captured argv + env. */
+/** Replace the spawn seam with a fake; returns the captured argv + env. */
 function stubSpawn(
   impl: (
     argv: string[],
     opts: { env: Record<string, string> },
   ) => {
-    exited: Promise<number>;
+    exitCode: number;
     stdout: string;
   },
 ): { calls: { argv: string[]; env: Record<string, string> }[] } {
   const calls: { argv: string[]; env: Record<string, string> }[] = [];
-  const fake = ((argv: SpawnArgs[0], opts?: SpawnArgs[1]) => {
-    const a = argv as string[];
-    const env = (opts?.env ?? {}) as Record<string, string>;
-    calls.push({ argv: a, env });
-    const r = impl(a, { env });
-    return { exited: r.exited, stdout: r.stdout } as unknown as ReturnType<typeof Bun.spawn>;
-  }) as unknown as typeof Bun.spawn;
-  (Bun as unknown as BunWithSpawn).spawn = fake;
+  spawnCaptureInternals.spawn = ((
+    cmd: string,
+    args: readonly string[],
+    opts?: { env?: Record<string, string> },
+  ) => {
+    const argv = [cmd, ...args];
+    const env = opts?.env ?? {};
+    calls.push({ argv, env });
+    const r = impl(argv, { env });
+    return fakeChild(r.exitCode, r.stdout);
+  }) as unknown as CaptureSpawn;
   return { calls };
 }
 
 describe("runGcloudCommand", () => {
   test("returns ok + stdout text on exit code 0", async () => {
-    stubSpawn(() => ({ exited: Promise.resolve(0), stdout: '[{"a":1}]' }));
+    stubSpawn(() => ({ exitCode: 0, stdout: '[{"a":1}]' }));
     const res = await runGcloudCommand(["gcloud", "logging", "sinks", "list"], "/creds.json");
     expect(res.ok).toBe(true);
     expect(res.text).toBe('[{"a":1}]');
   });
 
   test("returns ok:false on a non-zero exit code (text still captured)", async () => {
-    stubSpawn(() => ({ exited: Promise.resolve(1), stdout: "boom" }));
+    stubSpawn(() => ({ exitCode: 1, stdout: "boom" }));
     const res = await runGcloudCommand(["gcloud", "ai", "models", "list"], "/creds.json");
     expect(res.ok).toBe(false);
     expect(res.text).toBe("boom");
   });
 
   test("passes the argv through and scopes GOOGLE_APPLICATION_CREDENTIALS into the env (I1)", async () => {
-    const { calls } = stubSpawn(() => ({ exited: Promise.resolve(0), stdout: "[]" }));
+    const { calls } = stubSpawn(() => ({ exitCode: 0, stdout: "[]" }));
     await runGcloudCommand(["gcloud", "x"], "/path/to/creds.json");
     expect(calls).toHaveLength(1);
     expect(calls[0]!.argv).toEqual(["gcloud", "x"]);
@@ -63,3 +67,25 @@ describe("runGcloudCommand", () => {
     expect(res).toEqual({ ok: false, text: "" });
   });
 });
+
+/**
+ * A `node:child_process` stand-in. The connector CLI runners moved off `Bun.spawn` to
+ * `platform/spawn-capture.ts`, which spawns with `windowsHide` — the Gateway runs detached, so an
+ * unhidden child pops a console window on every sync tick. These tests stub the seam that module
+ * exports rather than `Bun.spawn`, which it no longer uses.
+ */
+function fakeChild(exitCode: number, stdout: string): unknown {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = (): void => {};
+  queueMicrotask(() => {
+    if (stdout !== "") proc.stdout.emit("data", Buffer.from(stdout));
+    proc.emit("close", exitCode);
+  });
+  return proc;
+}

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../../extensions/spawn-env.ts";
+import { spawnCapture } from "../../platform/spawn-capture.ts";
 
 /**
  * Spawn a `gcloud` CLI command with Application Default Credentials pointed at
@@ -15,14 +16,10 @@ export async function runGcloudCommand(
   credPath: string,
 ): Promise<{ ok: boolean; text: string }> {
   try {
-    const proc = Bun.spawn(argv, {
+    const r = await spawnCapture(argv, {
       env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-      stdout: "pipe",
-      stderr: "pipe",
     });
-    const code = await proc.exited;
-    const out = await new Response(proc.stdout).text();
-    return { ok: code === 0, text: out };
+    return { ok: r.ok, text: r.stdout };
   } catch {
     return { ok: false, text: "" };
   }

--- a/packages/gateway/src/connectors/_lib/gcloud-runner.ts
+++ b/packages/gateway/src/connectors/_lib/gcloud-runner.ts
@@ -4,23 +4,23 @@ import { spawnCapture } from "../../platform/spawn-capture.ts";
 /**
  * Spawn a `gcloud` CLI command with Application Default Credentials pointed at
  * `credPath` (via `GOOGLE_APPLICATION_CREDENTIALS`), capturing stdout. Returns
- * `{ ok: code === 0, text }`, or `{ ok: false, text: "" }` if the spawn throws
- * (gcloud missing, etc.) — never throws past this boundary, so a Syncable caller
- * degrades gracefully. The env is scoped through `extensionProcessEnv` (invariant
- * I1). Byte-equivalent to the per-connector `gcloud…List` spawn wrappers it
- * replaces in cloud-logging-sync and vertex-ai-sync; each connector keeps its own
- * argv builder + credential loader.
+ * `{ ok, text }`; a missing `gcloud`, a non-zero exit and a spawn failure all come back as
+ * `ok: false`, so a Syncable caller degrades gracefully. The env is scoped through
+ * `extensionProcessEnv` (invariant I1). Each connector keeps its own argv builder +
+ * credential loader.
+ *
+ * There is deliberately NO try/catch here. It had one while this spawned through `Bun.spawn`,
+ * which throws on a missing executable; `spawnCapture` never rejects — a synchronous throw, an
+ * `error` event and a non-zero exit all resolve to `ok: false`, and that is its documented
+ * contract with its own tests. Keeping the catch would leave a branch no test can reach, which
+ * is how dead code survives a coverage gate by being excluded rather than deleted.
  */
 export async function runGcloudCommand(
   argv: string[],
   credPath: string,
 ): Promise<{ ok: boolean; text: string }> {
-  try {
-    const r = await spawnCapture(argv, {
-      env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-    });
-    return { ok: r.ok, text: r.stdout };
-  } catch {
-    return { ok: false, text: "" };
-  }
+  const r = await spawnCapture(argv, {
+    env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
+  });
+  return { ok: r.ok, text: r.stdout };
 }

--- a/packages/gateway/src/connectors/azure-sync.ts
+++ b/packages/gateway/src/connectors/azure-sync.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../extensions/spawn-env.ts";
+import { spawnCapture } from "../platform/spawn-capture.ts";
 import {
   clampSyncTitle,
   syncPassCursorHttpEmpty,
@@ -32,17 +33,18 @@ async function azureCliJson(
   if (tenant === "" || clientId === "" || secret === "") {
     return { ok: false, text: "" };
   }
-  const proc = Bun.spawn(["az", ...args, "-o", "json"], {
+  // `spawnCapture`, not `Bun.spawn`: the Gateway runs detached, so on Windows an unhidden
+  // console-subsystem child pops a visible window on every sync tick. See
+  // `platform/spawn-capture.ts`.
+  const r = await spawnCapture(["az", ...args, "-o", "json"], {
     env: extensionProcessEnv({
       AZURE_TENANT_ID: tenant,
       AZURE_CLIENT_ID: clientId,
       AZURE_CLIENT_SECRET: secret,
     }),
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const code = await proc.exited;
-  const out = await new Response(proc.stdout).text();
+  const code = r.ok ? 0 : 1;
+  const out = r.stdout;
   return { ok: code === 0, text: out };
 }
 

--- a/packages/gateway/src/connectors/bigquery-sync.ts
+++ b/packages/gateway/src/connectors/bigquery-sync.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../extensions/spawn-env.ts";
+import { spawnCapture } from "../platform/spawn-capture.ts";
 import {
   syncPassCursorHttpEmpty,
   syncPassCursorParseEmpty,
@@ -37,16 +38,13 @@ function pass1Cursor(): string {
  */
 async function gcloudPrintAccessToken(credPath: string): Promise<string | null> {
   try {
-    const proc = Bun.spawn(["gcloud", "auth", "print-access-token"], {
+    const r = await spawnCapture(["gcloud", "auth", "print-access-token"], {
       env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-      stdout: "pipe",
-      stderr: "pipe",
     });
-    const code = await proc.exited;
-    if (code !== 0) {
+    if (!r.ok) {
       return null;
     }
-    const out = (await new Response(proc.stdout).text()).trim();
+    const out = r.stdout.trim();
     return out === "" ? null : out;
   } catch {
     return null;

--- a/packages/gateway/src/connectors/gcp-sync.ts
+++ b/packages/gateway/src/connectors/gcp-sync.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../extensions/spawn-env.ts";
+import { spawnCapture } from "../platform/spawn-capture.ts";
 import {
   clampSyncTitle,
   syncPassCursorHttpEmpty,
@@ -30,14 +31,13 @@ async function gcloudJson(
   if (credPath === "") {
     return { ok: false, text: "" };
   }
-  const proc = Bun.spawn(["gcloud", ...args, "--format", "json"], {
+  // `spawnCapture`, not `Bun.spawn`: the Gateway runs detached, so on Windows an unhidden
+  // console-subsystem child pops a visible window on every sync tick. See
+  // `platform/spawn-capture.ts`.
+  const r = await spawnCapture(["gcloud", ...args, "--format", "json"], {
     env: extensionProcessEnv({ GOOGLE_APPLICATION_CREDENTIALS: credPath }),
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const code = await proc.exited;
-  const out = await new Response(proc.stdout).text();
-  return { ok: code === 0, text: out };
+  return { ok: r.ok, text: r.stdout };
 }
 
 export type GcpSyncableOptions = {

--- a/packages/gateway/src/connectors/kubernetes-sync.ts
+++ b/packages/gateway/src/connectors/kubernetes-sync.ts
@@ -1,4 +1,5 @@
 import { extensionProcessEnv } from "../extensions/spawn-env.ts";
+import { spawnCapture } from "../platform/spawn-capture.ts";
 import { syncPassCursorParseEmpty } from "../sync/pass-cursor-sync-result.ts";
 import { type Syncable, type SyncContext, type SyncResult, syncNoopResult } from "../sync/types.ts";
 import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
@@ -108,14 +109,13 @@ async function kubectlDeploymentsJson(
     args.push("--context", context.trim());
   }
   args.push("get", "deployments", "-A", "-o", "json");
-  const proc = Bun.spawn(args, {
+  // `spawnCapture`, not `Bun.spawn`: the Gateway runs detached, so on Windows an unhidden
+  // console-subsystem child pops a visible window on every sync tick. See
+  // `platform/spawn-capture.ts`.
+  const r = await spawnCapture(args, {
     env: extensionProcessEnv({ KUBECONFIG: kubeconfig }),
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const code = await proc.exited;
-  const out = await new Response(proc.stdout).text();
-  return { ok: code === 0, text: out };
+  return { ok: r.ok, text: r.stdout };
 }
 
 export type KubernetesSyncableOptions = {

--- a/packages/gateway/src/platform/spawn-capture.test.ts
+++ b/packages/gateway/src/platform/spawn-capture.test.ts
@@ -126,4 +126,85 @@ describe("spawnCapture", () => {
     expect("env" in (bare ?? {})).toBe(false);
     expect("cwd" in (bare ?? {})).toBe(false);
   });
+
+  test("captures stderr alongside stdout", async () => {
+    const r = await withStub(
+      () => fakeChild(1, "out", "boom"),
+      () => spawnCapture(["aws", "x"]),
+    );
+    expect(r.stdout).toBe("out");
+    expect(r.stderr).toBe("boom");
+  });
+
+  test("an async 'error' event (ENOENT: CLI not installed) resolves ok:false", async () => {
+    // Distinct from the synchronous throw above: a missing executable is reported by node as an
+    // `error` EVENT after spawn returns, not as a throw. Without the listener the promise would
+    // never settle and the sync would hang forever rather than degrade.
+    const r = await withStub(
+      () => {
+        const proc = new EventEmitter() as EventEmitter & {
+          stdout: EventEmitter;
+          stderr: EventEmitter;
+          kill: () => void;
+        };
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = (): void => {};
+        queueMicrotask(() => proc.emit("error", new Error("spawn aws ENOENT")));
+        return proc;
+      },
+      () => spawnCapture(["aws"]),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.code).toBeNull();
+  });
+
+  test("timeoutMs kills a child that never closes, resolving ok:false", async () => {
+    // A vendor CLI hanging on a network read would otherwise pin the sync forever.
+    let killed = false;
+    const r = await withStub(
+      () => {
+        const proc = new EventEmitter() as EventEmitter & {
+          stdout: EventEmitter;
+          stderr: EventEmitter;
+          kill: () => void;
+        };
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = (): void => {
+          killed = true;
+        };
+        // Never emits `close` — the hang this option exists for.
+        return proc;
+      },
+      () => spawnCapture(["aws"], { timeoutMs: 20 }),
+    );
+    expect(killed).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBeNull();
+  });
+
+  test("a close that arrives AFTER the timeout does not overwrite the result", async () => {
+    // `done()` is idempotent by design: the timeout already resolved, and a late close must not
+    // flip a timed-out call to ok:true.
+    let emitClose: (() => void) | undefined;
+    const r = await withStub(
+      () => {
+        const proc = new EventEmitter() as EventEmitter & {
+          stdout: EventEmitter;
+          stderr: EventEmitter;
+          kill: () => void;
+        };
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = (): void => {};
+        emitClose = () => proc.emit("close", 0);
+        return proc;
+      },
+      () => spawnCapture(["aws"], { timeoutMs: 15 }),
+    );
+    expect(r.ok).toBe(false);
+    emitClose?.();
+    expect(r.ok).toBe(false);
+  });
 });

--- a/packages/gateway/src/platform/spawn-capture.test.ts
+++ b/packages/gateway/src/platform/spawn-capture.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
 
 import { spawnCapture, spawnCaptureInternals } from "./spawn-capture.ts";
 
@@ -104,16 +105,17 @@ describe("spawnCapture", () => {
   });
 
   test("passes cwd and env through when supplied, and omits them when not", async () => {
+    const cwd = tmpdir();
     let seen: Record<string, unknown> | undefined;
     await withStub(
       (_c, _a, opts) => {
         seen = opts;
         return fakeChild(0);
       },
-      () => spawnCapture(["aws"], { env: { A: "1" }, cwd: "/tmp" }),
+      () => spawnCapture(["aws"], { env: { A: "1" }, cwd }),
     );
     expect(seen?.["env"]).toEqual({ A: "1" });
-    expect(seen?.["cwd"]).toBe("/tmp");
+    expect(seen?.["cwd"]).toBe(cwd);
 
     let bare: Record<string, unknown> | undefined;
     await withStub(

--- a/packages/gateway/src/platform/spawn-capture.test.ts
+++ b/packages/gateway/src/platform/spawn-capture.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import { spawnCapture, spawnCaptureInternals } from "./spawn-capture.ts";
+
+/**
+ * The load-bearing assertion in this file is the FIRST one: `windowsHide: true` reaches the
+ * spawn call. Everything else here is ordinary capture behaviour.
+ *
+ * It is asserted at the option boundary rather than by observing a window, and that limit is
+ * worth stating plainly: proving no window appears needs a detached parent (the Gateway's own
+ * shape — a parent WITH a console shares it with the child, so no new window is created either
+ * way) plus a visible-window enumeration. A unit test cannot reproduce that, and a probe that
+ * tries produces results that look decisive and are not. What this test does prove is that the
+ * flag is passed on every call, which is the part the code owns.
+ */
+function withStub<T>(
+  impl: (cmd: string, args: readonly string[], opts: Record<string, unknown>) => unknown,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const real = spawnCaptureInternals.spawn;
+  spawnCaptureInternals.spawn = impl as never;
+  return fn().finally(() => {
+    spawnCaptureInternals.spawn = real;
+  });
+}
+
+function fakeChild(exitCode: number, stdout = "", stderr = ""): unknown {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = (): void => {};
+  queueMicrotask(() => {
+    if (stdout !== "") proc.stdout.emit("data", Buffer.from(stdout));
+    if (stderr !== "") proc.stderr.emit("data", Buffer.from(stderr));
+    proc.emit("close", exitCode);
+  });
+  return proc;
+}
+
+describe("spawnCapture", () => {
+  test("ALWAYS passes windowsHide — the reason this module exists", async () => {
+    // The Gateway runs detached, so an unhidden console-subsystem child gets a brand-new console
+    // and a visible window. `cloudwatch`/`sagemaker` spawn one CLI per indexed item, so a missing
+    // flag here is dozens of windows per sync tick.
+    let seen: Record<string, unknown> | undefined;
+    await withStub(
+      (_c, _a, opts) => {
+        seen = opts;
+        return fakeChild(0);
+      },
+      () => spawnCapture(["aws", "lambda", "list-functions"]),
+    );
+    expect(seen?.["windowsHide"]).toBe(true);
+  });
+
+  test("captures stdout and reports ok on exit 0", async () => {
+    const r = await withStub(
+      () => fakeChild(0, '{"Functions":[]}'),
+      () => spawnCapture(["aws", "lambda", "list-functions"]),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toBe('{"Functions":[]}');
+    expect(r.code).toBe(0);
+  });
+
+  test("a non-zero exit is ok:false with stdout still captured", async () => {
+    const r = await withStub(
+      () => fakeChild(1, "partial"),
+      () => spawnCapture(["aws", "x"]),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.stdout).toBe("partial");
+  });
+
+  test("a synchronous spawn throw resolves rather than rejecting", async () => {
+    // Every call site degrades on `!ok` instead of catching, so a rejection here would turn a
+    // handled no-op into an unhandled sync failure.
+    const r = await withStub(
+      () => {
+        throw new Error("ENOENT");
+      },
+      () => spawnCapture(["definitely-not-a-real-binary"]),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.code).toBeNull();
+  });
+
+  test("an empty argv is refused without spawning", async () => {
+    let called = false;
+    const r = await withStub(
+      () => {
+        called = true;
+        return fakeChild(0);
+      },
+      () => spawnCapture([]),
+    );
+    expect(called).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  test("passes cwd and env through when supplied, and omits them when not", async () => {
+    let seen: Record<string, unknown> | undefined;
+    await withStub(
+      (_c, _a, opts) => {
+        seen = opts;
+        return fakeChild(0);
+      },
+      () => spawnCapture(["aws"], { env: { A: "1" }, cwd: "/tmp" }),
+    );
+    expect(seen?.["env"]).toEqual({ A: "1" });
+    expect(seen?.["cwd"]).toBe("/tmp");
+
+    let bare: Record<string, unknown> | undefined;
+    await withStub(
+      (_c, _a, opts) => {
+        bare = opts;
+        return fakeChild(0);
+      },
+      () => spawnCapture(["aws"]),
+    );
+    expect("env" in (bare ?? {})).toBe(false);
+    expect("cwd" in (bare ?? {})).toBe(false);
+  });
+});

--- a/packages/gateway/src/platform/spawn-capture.ts
+++ b/packages/gateway/src/platform/spawn-capture.ts
@@ -1,0 +1,131 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Spawn a CLI, capture stdout, and — on Windows — do it WITHOUT flashing a console window.
+ *
+ * ## Why this exists
+ *
+ * Every connector that shells out to a vendor CLI (`aws`, `gcloud`, `az`, `bq`, `kubectl`) used
+ * `Bun.spawn` directly. On Windows that pops a visible console window for the lifetime of the
+ * child, because the Gateway runs DETACHED: a parent with no console of its own gets a brand-new
+ * console — and a `conhost.exe` to host it — allocated for each console-subsystem child.
+ *
+ * The user-visible result was console windows opening and closing continuously on an otherwise
+ * idle machine. It is not cosmetic at the rate the syncs produce it: `cloudwatch` and `sagemaker`
+ * spawn one CLI process PER INDEXED ITEM through `runAwsCliPaginatedWalk`'s `processEntry`, and
+ * `aws` re-lists Lambda functions every 120 s, so a burst of dozens of windows arrives on every
+ * sync tick.
+ *
+ * ## Why `node:child_process` rather than `Bun.spawn`
+ *
+ * `windowsHide` sets `CREATE_NO_WINDOW` on the child. It is a documented `child_process` option
+ * and this repo already depends on it working in three places (`vault/win32.ts`,
+ * `extensions/install-from-local.ts`, `platform/browser.ts` — all `spawnSync`). It is **not** part
+ * of Bun's spawn API: `windowsHide` appears nowhere in `@types/bun`, so passing it to `Bun.spawn`
+ * needs a cast and has no declared effect. A fix that MIGHT be a no-op is not a fix, so this goes
+ * through the API where the flag is specified.
+ *
+ * ## What this does NOT do
+ *
+ * It does not scope the environment — that is invariant I1's job, and callers still pass an env
+ * they built with `extensionProcessEnv()`. This helper only spawns, hides, and captures.
+ */
+/**
+ * The indirection point tests spy on.
+ *
+ * A module-scope `import { spawn }` binding cannot be replaced after load, and this repo prefers
+ * dependency injection over `mock.module` (which is process-global and leaks across files in the
+ * combined CI run). An exported object property is spy-able with `spyOn` and costs one property
+ * read per spawn.
+ */
+export const spawnCaptureInternals = { spawn };
+
+export type SpawnCaptureOptions = {
+  /** Full child environment. Callers scope it with `extensionProcessEnv()` (I1) before passing. */
+  readonly env?: Record<string, string>;
+  readonly cwd?: string;
+  /**
+   * Kill the child after this many ms. A vendor CLI that hangs on a network read would otherwise
+   * pin a sync forever; every existing caller was already unbounded, so this is a strict
+   * improvement, but it stays OPTIONAL so no current behaviour changes silently.
+   */
+  readonly timeoutMs?: number;
+};
+
+export type SpawnCaptureResult = {
+  /** Exit code was 0. */
+  readonly ok: boolean;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** `null` when the child was killed by a signal or by `timeoutMs`. */
+  readonly code: number | null;
+};
+
+/**
+ * Never rejects: a missing executable, a non-zero exit and a timeout all resolve to
+ * `ok: false`. Every call site this replaced already degraded on `!ok` rather than catching, so
+ * throwing here would turn a handled no-op into an unhandled sync failure.
+ */
+export function spawnCapture(
+  argv: readonly string[],
+  options: SpawnCaptureOptions = {},
+): Promise<SpawnCaptureResult> {
+  const [cmd, ...args] = argv;
+  if (cmd === undefined) {
+    return Promise.resolve({ ok: false, stdout: "", stderr: "", code: null });
+  }
+
+  return new Promise<SpawnCaptureResult>((resolve) => {
+    // Declared BEFORE `done`, which reads it: the synchronous-throw path calls `done` from the
+    // `catch` below, i.e. before a `let` declared further down has initialized. That is a
+    // ReferenceError in the temporal dead zone, not an undefined read.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    const done = (r: SpawnCaptureResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(r);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnCaptureInternals.spawn(cmd, args, {
+        // The whole point of the module. Ignored on non-Windows platforms.
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        ...(options.env === undefined ? {} : { env: options.env }),
+        ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+      });
+    } catch {
+      // `spawn` can throw synchronously on a malformed command.
+      return done({ ok: false, stdout: "", stderr: "", code: null });
+    }
+
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (c: Buffer) => {
+      out += c.toString();
+    });
+    child.stderr?.on("data", (c: Buffer) => {
+      err += c.toString();
+    });
+
+    if (options.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        child.kill();
+        done({ ok: false, stdout: out, stderr: err, code: null });
+      }, options.timeoutMs);
+      // Do not hold the event loop open on the timeout alone.
+      timer.unref?.();
+    }
+
+    // ENOENT (CLI not installed) arrives as an `error` event, not a non-zero exit.
+    child.on("error", () => {
+      done({ ok: false, stdout: out, stderr: err, code: null });
+    });
+    child.on("close", (code) => {
+      done({ ok: code === 0, stdout: out, stderr: err, code });
+    });
+  });
+}

--- a/packages/gateway/src/platform/spawn-capture.ts
+++ b/packages/gateway/src/platform/spawn-capture.ts
@@ -116,8 +116,10 @@ export function spawnCapture(
         child.kill();
         done({ ok: false, stdout: out, stderr: err, code: null });
       }, options.timeoutMs);
-      // Do not hold the event loop open on the timeout alone.
-      timer.unref?.();
+      // NOT unref'd. An unref'd timer does not hold the event loop open, so when the child is
+      // hung and nothing else has work queued the timeout can fail to fire at all — defeating it
+      // in precisely the case it exists for. It cannot leak: `done()` always clears it, and
+      // `done()` runs on every exit path.
     }
 
     // ENOENT (CLI not installed) arrives as an `error` event, not a non-zero exit.

--- a/packages/gateway/test/helpers/mock-spawn.ts
+++ b/packages/gateway/test/helpers/mock-spawn.ts
@@ -1,4 +1,7 @@
 import { type Mock, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import { spawnCaptureInternals } from "../../src/platform/spawn-capture.ts";
 
 export type SpawnCall = {
   readonly binary: string;
@@ -24,6 +27,11 @@ export class MockSpawn {
   readonly calls: SpawnCall[] = [];
   private readonly stubs: Stub[] = [];
   private spy: Mock<typeof Bun.spawn> | null = null;
+  // Connector CLI runners moved off `Bun.spawn` to `platform/spawn-capture.ts` so the child is
+  // spawned with `windowsHide` (the Gateway runs detached, so an unhidden child pops a console
+  // window). Both paths are stubbed from ONE stub table, so a test written against either API
+  // asserts the same argv and env.
+  private captureSpy: Mock<typeof spawnCaptureInternals.spawn> | null = null;
 
   respond(
     binary: string,
@@ -66,12 +74,42 @@ export class MockSpawn {
       }
       throw new Error(`MockSpawn: no stub matched ${binary} ${argv.join(" ")}`);
     }) as unknown as typeof Bun.spawn);
+
+    this.captureSpy = spyOn(spawnCaptureInternals, "spawn").mockImplementation(((
+      cmd: string,
+      args: readonly string[],
+      options?: { env?: Record<string, string> },
+    ) => {
+      this.calls.push({
+        binary: cmd,
+        argv: [...args],
+        env: Object.freeze({ ...(options?.env ?? {}) }),
+      });
+      const r = this.match(cmd, args);
+      return fakeChildProcess(r);
+    }) as unknown as typeof spawnCaptureInternals.spawn);
+  }
+
+  private match(
+    binary: string,
+    argv: readonly string[],
+  ): { exitCode: number; stdout: string; stderr: string } {
+    for (const stub of this.stubs) {
+      if (stub.binary !== binary) continue;
+      if (stub.argvMatch !== undefined && !stub.argvMatch(argv)) continue;
+      return stub.response();
+    }
+    throw new Error(`MockSpawn: no stub matched ${binary} ${argv.join(" ")}`);
   }
 
   restore(): void {
     if (this.spy !== null) {
       this.spy.mockRestore();
       this.spy = null;
+    }
+    if (this.captureSpy !== null) {
+      this.captureSpy.mockRestore();
+      this.captureSpy = null;
     }
   }
 }
@@ -93,4 +131,29 @@ function streamFromString(bytes: Uint8Array): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
+}
+
+/**
+ * A `node:child_process` stand-in for the `spawnCapture` path: emits stdout/stderr then `close`
+ * on the next tick, so the promise in `spawnCapture` settles exactly as it does for a real child.
+ */
+function fakeChildProcess(r: { exitCode: number; stdout: string; stderr: string }): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: () => void;
+} {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = (): void => {};
+  queueMicrotask(() => {
+    if (r.stdout !== "") proc.stdout.emit("data", Buffer.from(r.stdout));
+    if (r.stderr !== "") proc.stderr.emit("data", Buffer.from(r.stderr));
+    proc.emit("close", r.exitCode);
+  });
+  return proc;
 }

--- a/packages/gateway/test/unit/connectors/cloud-logging-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/cloud-logging-sync.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-
+import { EventEmitter } from "node:events";
 import {
   createCloudLoggingSyncable,
   type RunGcloud,
 } from "../../../src/connectors/cloud-logging-sync.ts";
+import { spawnCaptureInternals } from "../../../src/platform/spawn-capture.ts";
 import {
   type ConnectorSyncFixture,
   createConnectorSyncFixture,
@@ -182,14 +183,7 @@ describe("cloud-logging-sync — sink metadata walk", () => {
   });
 });
 
-// Exercise the real (non-DI) `gcloudLoggingSinksList` runner body without spawning
-// a real subprocess: mock Bun.spawn to return a fake process. `new Response(<string>)`
-// reads the canned stdout, so the spawn → exited → parse path is covered hermetically.
-function fakeProc(code: number, stdout: string): ReturnType<typeof Bun.spawn> {
-  return { exited: Promise.resolve(code), stdout } as unknown as ReturnType<typeof Bun.spawn>;
-}
-
-describe("cloud-logging-sync — default gcloud runner (hermetic Bun.spawn mock)", () => {
+describe("cloud-logging-sync — default gcloud runner (hermetic spawn mock)", () => {
   let fx: ConnectorSyncFixture;
   beforeEach(async () => {
     fx = createConnectorSyncFixture();
@@ -201,7 +195,8 @@ describe("cloud-logging-sync — default gcloud runner (hermetic Bun.spawn mock)
     const sinks = [
       { name: "s1", destination: "storage.googleapis.com/b", filter: "severity>=ERROR" },
     ];
-    const spy = spyOn(Bun, "spawn").mockReturnValue(fakeProc(0, JSON.stringify(sinks)));
+    const spy = spyOn(spawnCaptureInternals, "spawn").mockImplementation((() =>
+      fakeChild(0, JSON.stringify(sinks))) as never);
     try {
       const res = await createCloudLoggingSyncable(ENSURE).sync(
         fx.createSyncContext("cloud_logging"),
@@ -215,9 +210,9 @@ describe("cloud-logging-sync — default gcloud runner (hermetic Bun.spawn mock)
   });
 
   test("spawn throws (gcloud absent) → graceful empty pass, no throw", async () => {
-    const spy = spyOn(Bun, "spawn").mockImplementation(() => {
+    const spy = spyOn(spawnCaptureInternals, "spawn").mockImplementation((() => {
       throw new Error("ENOENT: gcloud not found");
-    });
+    }) as never);
     try {
       const res = await createCloudLoggingSyncable(ENSURE).sync(
         fx.createSyncContext("cloud_logging"),
@@ -230,3 +225,25 @@ describe("cloud-logging-sync — default gcloud runner (hermetic Bun.spawn mock)
     }
   });
 });
+
+/**
+ * A `node:child_process` stand-in. The connector CLI runners moved off `Bun.spawn` to
+ * `platform/spawn-capture.ts`, which spawns with `windowsHide` — the Gateway runs detached, so an
+ * unhidden child pops a console window on every sync tick. These tests stub the seam that module
+ * exports rather than `Bun.spawn`, which it no longer uses.
+ */
+function fakeChild(exitCode: number, stdout: string): unknown {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = (): void => {};
+  queueMicrotask(() => {
+    if (stdout !== "") proc.stdout.emit("data", Buffer.from(stdout));
+    proc.emit("close", exitCode);
+  });
+  return proc;
+}

--- a/packages/gateway/test/unit/connectors/vertex-ai-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/vertex-ai-sync.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-
+import { EventEmitter } from "node:events";
 import { createVertexAiSyncable, type RunGcloud } from "../../../src/connectors/vertex-ai-sync.ts";
+import { spawnCaptureInternals } from "../../../src/platform/spawn-capture.ts";
 import {
   type ConnectorSyncFixture,
   createConnectorSyncFixture,
@@ -224,11 +225,8 @@ describe("vertex-ai-sync — model metadata walk", () => {
 // Exercise the real (non-DI) `gcloudAiModelsList` runner body without spawning
 // a real subprocess: mock Bun.spawn to return a fake process. `new Response(<string>)`
 // reads the canned stdout, so the spawn → exited → parse path is covered hermetically.
-function fakeProc(code: number, stdout: string): ReturnType<typeof Bun.spawn> {
-  return { exited: Promise.resolve(code), stdout } as unknown as ReturnType<typeof Bun.spawn>;
-}
 
-describe("vertex-ai-sync — default gcloud runner (hermetic Bun.spawn mock)", () => {
+describe("vertex-ai-sync — default gcloud runner (hermetic spawn mock)", () => {
   let fx: ConnectorSyncFixture;
   beforeEach(async () => {
     fx = createConnectorSyncFixture();
@@ -238,7 +236,8 @@ describe("vertex-ai-sync — default gcloud runner (hermetic Bun.spawn mock)", (
 
   test("spawn exits 0 with model JSON → models upserted", async () => {
     const models = [{ name: "projects/p/locations/us-central1/models/m1", displayName: "Model 1" }];
-    const spy = spyOn(Bun, "spawn").mockReturnValue(fakeProc(0, JSON.stringify(models)));
+    const spy = spyOn(spawnCaptureInternals, "spawn").mockImplementation((() =>
+      fakeChild(0, JSON.stringify(models))) as never);
     try {
       const res = await createVertexAiSyncable(ENSURE).sync(
         fx.createSyncContext("vertex_ai"),
@@ -252,9 +251,9 @@ describe("vertex-ai-sync — default gcloud runner (hermetic Bun.spawn mock)", (
   });
 
   test("spawn throws (gcloud absent) → graceful empty pass, no throw", async () => {
-    const spy = spyOn(Bun, "spawn").mockImplementation(() => {
+    const spy = spyOn(spawnCaptureInternals, "spawn").mockImplementation((() => {
       throw new Error("ENOENT: gcloud not found");
-    });
+    }) as never);
     try {
       const res = await createVertexAiSyncable(ENSURE).sync(
         fx.createSyncContext("vertex_ai"),
@@ -267,3 +266,25 @@ describe("vertex-ai-sync — default gcloud runner (hermetic Bun.spawn mock)", (
     }
   });
 });
+
+/**
+ * A `node:child_process` stand-in. The connector CLI runners moved off `Bun.spawn` to
+ * `platform/spawn-capture.ts`, which spawns with `windowsHide` — the Gateway runs detached, so an
+ * unhidden child pops a console window on every sync tick. These tests stub the seam that module
+ * exports rather than `Bun.spawn`, which it no longer uses.
+ */
+function fakeChild(exitCode: number, stdout: string): unknown {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = (): void => {};
+  queueMicrotask(() => {
+    if (stdout !== "") proc.stdout.emit("data", Buffer.from(stdout));
+    proc.emit("close", exitCode);
+  });
+  return proc;
+}

--- a/scripts/structure-audit/check-nimbus-invariants.test.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.test.ts
@@ -5,6 +5,7 @@ import { CO_OWNED_ENTITY_TYPES } from "../../packages/gateway/src/graph/relation
 import {
   assertScanIsMeaningful,
   checkAgentEmitterImportConfinement,
+  checkConnectorSpawnIsHidden,
   checkConnectorWriteConfinement,
   checkEgressChokepointConfinement,
   checkFlatUpsertGraphEntityCoOwnedTypes,
@@ -1189,5 +1190,65 @@ describe("D24 — a syncable cannot reach a raw vault or db handle", () => {
       files.push({ relPath: f.relPath, contents: f.contents });
     }
     expect(checkSyncContextNoRawHandles(files)).toEqual([]);
+  });
+});
+
+describe("D25 — a connector cannot spawn without windowsHide", () => {
+  const syncable = (contents: string) => [
+    { relPath: "packages/gateway/src/connectors/evil-sync.ts", contents },
+  ];
+
+  test("flags a plain Bun.spawn in a connector", () => {
+    const v = checkConnectorSpawnIsHidden(syncable('Bun.spawn(["aws", "s3", "ls"]);\n'));
+    expect(v.map((x) => x.rule)).toEqual(["connector-spawn-must-be-hidden"]);
+    expect(v[0]?.line).toBe(1);
+  });
+
+  test("flags a Bun.spawn SPLIT ACROSS LINES", () => {
+    // The rule scanned line by line at first. `Bun` on one line and `.spawn` on the next is
+    // valid TypeScript that matches NEITHER line, so an unhidden spawn slipped through while
+    // the audit stayed green — the failure mode a guard must not have.
+    const v = checkConnectorSpawnIsHidden(syncable('const p = Bun\n  .spawn(["aws"]);\n'));
+    expect(v).toHaveLength(1);
+    // Reported against the line the match STARTS on, derived from the offset.
+    expect(v[0]?.line).toBe(1);
+  });
+
+  test("reports the correct line for a spawn further down the file", () => {
+    const src = `${"const a = 1;\n".repeat(9)}Bun.spawn(["aws"]);\n`;
+    expect(checkConnectorSpawnIsHidden(syncable(src))[0]?.line).toBe(10);
+  });
+
+  test("a commented-out Bun.spawn is not flagged", () => {
+    // `stripComments` runs first, which is also what keeps this file's own explanatory
+    // comments about `Bun.spawn` from tripping the rule.
+    expect(
+      checkConnectorSpawnIsHidden(
+        syncable('// Bun.spawn is forbidden here\nspawnCapture(["aws"]);\n'),
+      ),
+    ).toEqual([]);
+  });
+
+  test("spawnCapture is clean", () => {
+    expect(checkConnectorSpawnIsHidden(syncable('await spawnCapture(["aws"]);\n'))).toEqual([]);
+  });
+
+  test("the two injected-seam files stay exempt, and lazy-mesh is out of scope", () => {
+    const files = [
+      {
+        relPath: "packages/gateway/src/connectors/blame-index-sync.ts",
+        contents: "Bun.spawn(x);\n",
+      },
+      {
+        relPath: "packages/gateway/src/connectors/filesystem-v2-sync.ts",
+        contents: "Bun.spawn(x);\n",
+      },
+      {
+        relPath: "packages/gateway/src/connectors/lazy-mesh/runner.ts",
+        contents: "Bun.spawn(x);\n",
+      },
+      { relPath: "packages/gateway/src/connectors/evil-sync.test.ts", contents: "Bun.spawn(x);\n" },
+    ];
+    expect(checkConnectorSpawnIsHidden(files)).toEqual([]);
   });
 });

--- a/scripts/structure-audit/check-nimbus-invariants.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.ts
@@ -741,6 +741,54 @@ export function checkSyncContextNoRawHandles(files: readonly FileEntry[]): Viola
   return out;
 }
 
+// D25: a CONNECTOR SYNCABLE may not call `Bun.spawn` — it must go through
+// `platform/spawn-capture.ts`, which spawns with `windowsHide`.
+//
+// The Gateway runs DETACHED, so on Windows a console-subsystem child with no console to inherit
+// gets a brand-new one allocated, plus a `conhost.exe` to host it — i.e. a visible window that
+// opens and closes for the lifetime of every CLI call. That is not a rare event at connector
+// rates: `cloudwatch` and `sagemaker` spawn one `aws` process PER INDEXED ITEM through
+// `runAwsCliPaginatedWalk`'s `processEntry`, and `aws` re-lists Lambda functions every 120 s, so
+// the unhidden version flashed dozens of windows per sync tick on an otherwise idle machine.
+//
+// This is a STATIC rule because the failure is invisible to every test and to CI: it reproduces
+// only on Windows, only when the parent has no console, and it breaks nothing — the sync still
+// works. A reviewer on macOS or Linux cannot see it, and neither can the 3-OS matrix, whose
+// Windows leg runs tests from a shell that HAS a console.
+//
+// `blame-index-sync.ts` and `filesystem-v2-sync.ts` are exempted: they take `Bun.spawn` as an
+// INJECTED default parameter (`spawn: SpawnFn = Bun.spawn`) rather than calling it inline, and
+// converting that seam is a wider change than this rule's subject. They spawn `git`, which is
+// equally affected — tracked separately rather than silently blessed.
+const D25_BUN_SPAWN_RE = /\bBun\s*\.\s*spawn\b/;
+const D25_BUN_SPAWN_ALLOWED: readonly string[] = [
+  "packages/gateway/src/connectors/blame-index-sync.ts",
+  "packages/gateway/src/connectors/filesystem-v2-sync.ts",
+];
+
+export function checkConnectorSpawnIsHidden(files: readonly FileEntry[]): Violation[] {
+  const out: Violation[] = [];
+  for (const f of files) {
+    if (f.relPath.endsWith(".test.ts")) continue;
+    if (!f.relPath.startsWith("packages/gateway/src/connectors/")) continue;
+    if (f.relPath.startsWith("packages/gateway/src/connectors/lazy-mesh/")) continue;
+    if (D25_BUN_SPAWN_ALLOWED.includes(f.relPath)) continue;
+    const stripped = stripComments(f.contents).split("\n");
+    const original = f.contents.split("\n");
+    for (let i = 0; i < stripped.length; i++) {
+      if (D25_BUN_SPAWN_RE.test(stripped[i] ?? "")) {
+        out.push({
+          rule: "connector-spawn-must-be-hidden",
+          file: f.relPath,
+          line: i + 1,
+          snippet: (original[i] ?? "").trim(),
+        });
+      }
+    }
+  }
+  return out;
+}
+
 // D23 (I33): `runConfined` — the confined-spawn primitive that turns user-supplied code into a
 // running process — may be CALLED only from the exec gate (which performs the config/policy checks,
 // the sandbox-posture assertion and the owner-HITL approval first) plus its own definition file.
@@ -1326,6 +1374,13 @@ async function run(): Promise<void> {
       );
     }
     if (handleViolations.length > 0) exit = 1;
+    const spawnViolations = checkConnectorSpawnIsHidden(files);
+    for (const e of spawnViolations) {
+      console.error(
+        `::error file=${e.file},line=${e.line}::D25 a connector called Bun.spawn — use platform/spawn-capture.ts, which passes windowsHide (the detached Gateway pops a console window otherwise): ${e.snippet}`,
+      );
+    }
+    if (spawnViolations.length > 0) exit = 1;
     const v = checkRunConfinedConfinement(files);
     for (const e of v) {
       console.error(

--- a/scripts/structure-audit/check-nimbus-invariants.ts
+++ b/scripts/structure-audit/check-nimbus-invariants.ts
@@ -773,17 +773,21 @@ export function checkConnectorSpawnIsHidden(files: readonly FileEntry[]): Violat
     if (!f.relPath.startsWith("packages/gateway/src/connectors/")) continue;
     if (f.relPath.startsWith("packages/gateway/src/connectors/lazy-mesh/")) continue;
     if (D25_BUN_SPAWN_ALLOWED.includes(f.relPath)) continue;
-    const stripped = stripComments(f.contents).split("\n");
+    // Scans the WHOLE stripped source, not line by line. `Bun` and `.spawn` may sit on
+    // different lines — `Bun` then a newline then `.spawn(...)` is valid TypeScript, and a
+    // per-line test matches NEITHER line, so the rule would silently miss it. `stripComments`
+    // preserves length, so a match offset maps 1:1 onto the original's line numbering.
+    const stripped = stripComments(f.contents);
     const original = f.contents.split("\n");
-    for (let i = 0; i < stripped.length; i++) {
-      if (D25_BUN_SPAWN_RE.test(stripped[i] ?? "")) {
-        out.push({
-          rule: "connector-spawn-must-be-hidden",
-          file: f.relPath,
-          line: i + 1,
-          snippet: (original[i] ?? "").trim(),
-        });
-      }
+    const re = new RegExp(D25_BUN_SPAWN_RE.source, "g");
+    for (const m of stripped.matchAll(re)) {
+      const line = stripped.slice(0, m.index).split("\n").length;
+      out.push({
+        rule: "connector-spawn-must-be-hidden",
+        file: f.relPath,
+        line,
+        snippet: (original[line - 1] ?? "").trim(),
+      });
     }
   }
   return out;


### PR DESCRIPTION
Fixes the console windows opening and closing continuously on an idle Windows machine, diagnosed live on a v6.0.0 install.

## What was happening

```
conhost.exe  <  aws.exe  <  nimbus-gateway.exe
aws lambda list-functions --max-items 35 --output json
```

20 of 23 shell-process starts in a 60-second sample, roughly one every 1.8 s. The Gateway runs **detached**, so on Windows a console-subsystem child with no console to inherit gets a brand-new console allocated — plus a `conhost.exe` to host it, which is the visible window.

It is not a rare event at connector rates:

| Syncable | CLI calls per run | Interval |
| --- | --- | --- |
| `cloudwatch`, `sagemaker` | **one `aws` process per indexed item** (`runAwsCliPaginatedWalk` → `processEntry`) | 10 min |
| `aws` (Lambda) | 1 per page | **120 s** |

So a burst of dozens of windows arrives on each sync tick.

## The fix

New `platform/spawn-capture.ts`: spawn via `node:child_process` with `windowsHide` (`CREATE_NO_WINDOW`), capture stdout, never reject. The six connector CLI runners move onto it — `aws`, `gcloud` (×2), `az`, `bq`, `kubectl`.

**Why not `Bun.spawn` + `windowsHide`.** `windowsHide` appears nowhere in `@types/bun`; passing it to `Bun.spawn` requires a cast and has no declared effect. The repo already depends on the flag working in three places, all via `node:child_process`. A fix that *might* be a no-op is not a fix, so this goes through the API where the flag is specified.

**Static rule D25** stops a new connector reintroducing a raw `Bun.spawn`. It is static because the failure is invisible to every other gate: it reproduces only on Windows, only when the parent has no console, and it **breaks nothing** — the sync still succeeds. A reviewer on macOS or Linux cannot see it, and neither can the Windows CI leg, which runs tests from a shell that *has* a console. `blame-index-sync.ts` and `filesystem-v2-sync.ts` are exempted by name: they take `Bun.spawn` as an injected default parameter rather than calling it inline, so converting that seam is a wider change — they spawn `git` and are equally affected, tracked rather than silently blessed.

## Verification — and one honest limit

- `spawn-capture.test.ts` asserts `windowsHide: true` reaches the spawn call on **every** invocation, plus capture, non-zero exit, synchronous-throw, empty-argv and option-passthrough behaviour.
- That test caught a real bug in the first draft: `done()` read `timer` from the temporal dead zone on the synchronous-throw path, a `ReferenceError` rather than the intended graceful `ok: false`.
- D25 red-proved: reintroducing a `Bun.spawn` into `gcp-sync.ts` fails the audit with the D25 message; clean before and after.
- All 33 `aws-sync` tests pass **unchanged** — `MockSpawn` now stubs both spawn paths from one stub table, so tests keep asserting the same argv and env.
- Full CI command `bun test packages/gateway packages/cli scripts`: **19,449 pass, 0 fail**.
- `bun run preflight:fast` — pass.

**What is NOT proven here:** that no window appears end to end. Demonstrating that needs a parent with *no console at all*, and every way I could launch one from tooling (`Start-Process -WindowStyle Hidden`, a Bun parent, a Node parent) gives the parent a console the child then inherits — so no new console is allocated either way and both paths measure identically. Two earlier probes produced confident-looking, inverted results for exactly this reason before I caught it. The remaining confirmation is running the built Gateway on Windows and watching for `conhost` children; the mechanism, the flag and the option-boundary assertion are what this PR stands on.

## Not addressed here

The `aws` syncable re-lists Lambda functions every **120 s** while every other AWS-derived syncable uses 10 minutes. That asymmetry looks unintentional and is real outbound API traffic, but it is a behaviour change rather than a Windows fix, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent command execution with captured output, error details, exit status, optional timeouts, and working-directory support.
  * Improved handling of failed, missing, or timed-out command-line operations.
  * Windows command windows are now hidden during execution.

* **Bug Fixes**
  * Cloud connector operations now handle command failures and empty results more reliably.

* **Tests**
  * Added comprehensive coverage for command output, failures, timeouts, environment settings, and platform-specific behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->