### PR TITLE
fix(perf): drift-check must use each surface own noise floor, not a hardcoded 10%

### DIFF
--- a/docs/perf/slo.md
+++ b/docs/perf/slo.md
@@ -16,6 +16,10 @@ A bench fails when either:
 - the measured aggregate exceeds the absolute reference or GHA threshold, **or**
 - the run delta vs the most recent `main` history entry for the same `runner` exceeds the per-surface noise floor (`max(noise_floor_pct, absolute_noise_floor / previous × 100)`).
 
+**Sustained-drift detection uses the same per-surface floor.** `scripts/perf/drift-check.ts` walks a rolling median of the last 7 `main` samples and files an issue only when 3 consecutive samples each exceed that surface's own floor. It applied a hardcoded **10 %** until 2026-08-29, which is what filed the false #1308 / #1309 alarms against `S11-a` / `S11-b` — surfaces whose declared floor is 40 % precisely because their spawn-dominated latency is a runner property, not a code signal.
+
+The failure mode is worth knowing before widening a floor again: a rolling median MOVES WITH THE DATA, so a cluster of unusually **fast** runs drags it down, and the next ordinary samples then read as a regression against a depressed baseline. The window that fired both issues was `224, 249, 261, 253, 247, 333, 306` (median 253) against a series median of 311 — the "regression" was the runner returning to normal.
+
 ## UX surfaces
 
 | Surface | Metric | Reference threshold | GHA threshold | Noise floor (rel %, abs) |

--- a/packages/gateway/src/perf/threshold-comparator.ts
+++ b/packages/gateway/src/perf/threshold-comparator.ts
@@ -102,8 +102,7 @@ function compareOne(
 
   const deltaPct = ((measured - prev) / prev) * 100;
   const regressionPct = isFloorMetric(slo.metric) ? -deltaPct : deltaPct;
-  const floorAbsAsPct = (slo.noiseFloorAbs / prev) * 100;
-  const effectiveFloorPct = Math.max(slo.noiseFloorPct, floorAbsAsPct);
+  const effectiveFloorPct = effectiveNoiseFloorPct(slo, prev);
   if (regressionPct > effectiveFloorPct) {
     return {
       kind: "delta-fail",
@@ -114,6 +113,20 @@ function compareOne(
     };
   }
   return { kind: "pass" };
+}
+
+/**
+ * The noise floor a regression must clear, as a percentage of `baseline`.
+ *
+ * Combines the surface's relative floor with its ABSOLUTE one: on a fast surface a 40 % swing
+ * can be a handful of milliseconds of scheduler noise, so `noiseFloorAbs` raises the bar when
+ * the baseline is small. Exported so the drift detector uses the SAME formula rather than a
+ * second copy -- it previously used a hardcoded 10 % that ignored both fields, which is what
+ * filed #1308 and #1309 against surfaces whose own declared floor is 40 %.
+ */
+export function effectiveNoiseFloorPct(slo: SloThreshold, baseline: number): number {
+  if (baseline <= 0) return slo.noiseFloorPct;
+  return Math.max(slo.noiseFloorPct, (slo.noiseFloorAbs / baseline) * 100);
 }
 
 export function compareAgainstHistory(

--- a/scripts/perf/drift-check.test.ts
+++ b/scripts/perf/drift-check.test.ts
@@ -30,7 +30,7 @@ function sloAt(noiseFloorPct: number, noiseFloorAbs = 0): SloThreshold {
 
 describe("detectDrift", () => {
   test("returns false when there is not enough history to fill the window", () => {
-    expect(detectDrift([{ value: 100 }, { value: 100 }], sloAt(10))).toBe(false);
+    expect(detectDrift([{ value: 100 }, { value: 100 }], sloAt(10))).toBeNull();
   });
 
   test("a single late spike does NOT trip drift (needs n consecutive worse samples)", () => {
@@ -44,7 +44,7 @@ describe("detectDrift", () => {
       { value: 100 },
       { value: 200 },
     ];
-    expect(detectDrift(history, sloAt(10))).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBeNull();
   });
 
   test("a sustained regression (n consecutive samples worse than the rolling median) trips drift", () => {
@@ -60,7 +60,7 @@ describe("detectDrift", () => {
       { value: 200 },
       { value: 200 },
     ];
-    expect(detectDrift(history, sloAt(10))).toBe(true);
+    expect(detectDrift(history, sloAt(10))).not.toBeNull();
   });
 
   test("worse-but-within-the-noise-floor does not trip drift", () => {
@@ -76,7 +76,7 @@ describe("detectDrift", () => {
       { value: 105 },
       { value: 105 },
     ];
-    expect(detectDrift(history, sloAt(10))).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBeNull();
   });
 
   test("a worse sample that breaks the consecutive run resets the counter", () => {
@@ -93,7 +93,7 @@ describe("detectDrift", () => {
       { value: 100 },
       { value: 200 },
     ];
-    expect(detectDrift(history, sloAt(10))).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBeNull();
   });
 
   test("the rolling median is over the last k samples, not the whole history", () => {
@@ -115,7 +115,7 @@ describe("detectDrift", () => {
       { value: 200 },
       { value: 200 },
     ];
-    expect(detectDrift(history, sloAt(10))).toBe(true);
+    expect(detectDrift(history, sloAt(10))).not.toBeNull();
   });
 
   test("honors a custom k and n", () => {
@@ -126,7 +126,7 @@ describe("detectDrift", () => {
       { value: 150 },
       { value: 150 },
     ];
-    expect(detectDrift(history, sloAt(10), 3, 2)).toBe(true);
+    expect(detectDrift(history, sloAt(10), 3, 2)).not.toBeNull();
   });
 });
 
@@ -294,12 +294,12 @@ describe("detectDrift — the #1308 / #1309 false positives", () => {
   const S11_B = sloAt(40, 10);
 
   test("the shipped 10% floor fires on this window — the bug", () => {
-    expect(detectDrift(S11_A_WINDOW, sloAt(10))).toBe(true);
+    expect(detectDrift(S11_A_WINDOW, sloAt(10))).not.toBeNull();
   });
 
   test("the surface's OWN 40% floor does not", () => {
-    expect(detectDrift(S11_A_WINDOW, S11_A)).toBe(false);
-    expect(detectDrift(S11_A_WINDOW, S11_B)).toBe(false);
+    expect(detectDrift(S11_A_WINDOW, S11_A)).toBeNull();
+    expect(detectDrift(S11_A_WINDOW, S11_B)).toBeNull();
   });
 
   test("a real 2x regression still trips at the 40% floor", () => {
@@ -308,7 +308,7 @@ describe("detectDrift — the #1308 / #1309 false positives", () => {
       ...[300, 305, 298, 302, 310, 295, 300].map((v) => ({ value: v })),
       ...[620, 640, 610].map((v) => ({ value: v })),
     ];
-    expect(detectDrift(regressed, S11_A)).toBe(true);
+    expect(detectDrift(regressed, S11_A)).not.toBeNull();
   });
 
   test("the absolute floor binds when the baseline is small", () => {
@@ -318,7 +318,34 @@ describe("detectDrift — the #1308 / #1309 false positives", () => {
       ...Array.from({ length: 7 }, () => ({ value: 20 })),
       ...[40, 42, 41].map((v) => ({ value: v })),
     ];
-    expect(detectDrift(tiny, sloAt(40))).toBe(true); // 40% floor alone: +100% trips
-    expect(detectDrift(tiny, S11_A)).toBe(false); // with the 50ms absolute floor: does not
+    expect(detectDrift(tiny, sloAt(40))).not.toBeNull(); // 40% floor alone: +100% trips
+    expect(detectDrift(tiny, S11_A)).toBeNull(); // with the 50ms absolute floor: does not
+  });
+});
+
+describe("detectDrift reports the floor that ACTUALLY fired", () => {
+  test("when the absolute floor binds, the reported floor exceeds noiseFloorPct", () => {
+    // 40 % of a 20 ms median is 8 ms -- scheduler noise. `noiseFloorAbs: 50` raises the
+    // effective bar to 250 %, and THAT is the number the filed issue must state. Reporting
+    // the declared 40 % would send a reader to check a threshold the sample never faced.
+    const history = [
+      ...Array.from({ length: 7 }, () => ({ value: 20 })),
+      ...[80, 82, 81].map((v) => ({ value: v })),
+    ];
+    const hit = detectDrift(history, sloAt(40, 50));
+    expect(hit).not.toBeNull();
+    expect(hit?.median).toBe(20);
+    expect(hit?.effectiveFloorPct).toBe(250); // max(40, 50/20*100)
+    expect(hit?.effectiveFloorPct).toBeGreaterThan(40);
+  });
+
+  test("when the relative floor binds, the reported floor IS noiseFloorPct", () => {
+    const history = [
+      ...Array.from({ length: 7 }, () => ({ value: 1_000 })),
+      ...[1_600, 1_620, 1_610].map((v) => ({ value: v })),
+    ];
+    const hit = detectDrift(history, sloAt(40, 50));
+    expect(hit?.effectiveFloorPct).toBe(40); // max(40, 50/1000*100 = 5)
+    expect(hit?.current).toBe(1_610); // the sample that COMPLETED the run, not the first
   });
 });

--- a/scripts/perf/drift-check.test.ts
+++ b/scripts/perf/drift-check.test.ts
@@ -4,11 +4,33 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 import { GhCli, type GhSpawnFn } from "../../packages/gateway/src/perf/bench-ci-gh.ts";
+import type { SloThreshold } from "../../packages/gateway/src/perf/slo-thresholds.ts";
 import { detectDrift, isRunnerKind, parseLatestV2Line, runDriftCheckMain } from "./drift-check.ts";
+
+/**
+ * A synthetic threshold at a chosen relative floor with NO absolute floor, so these cases keep
+ * exercising the percentage rule on its own.
+ *
+ * `detectDrift` takes the surface's own SLO now rather than a global constant. The hardcoded
+ * 10 % it used to apply is what filed #1308 and #1309 against S11-a / S11-b, whose declared
+ * floor is 40 % precisely because their spawn-dominated latency is runner noise.
+ */
+function sloAt(noiseFloorPct: number, noiseFloorAbs = 0): SloThreshold {
+  return {
+    surfaceId: "S1",
+    gateClass: "trend",
+    metric: "p95_ms",
+    refMax: 1_000,
+    ghaMax: 5_000,
+    noiseFloorPct,
+    noiseFloorAbs,
+    noiseFloorAbsUnit: "ms",
+  } as SloThreshold;
+}
 
 describe("detectDrift", () => {
   test("returns false when there is not enough history to fill the window", () => {
-    expect(detectDrift([{ value: 100 }, { value: 100 }], 10)).toBe(false);
+    expect(detectDrift([{ value: 100 }, { value: 100 }], sloAt(10))).toBe(false);
   });
 
   test("a single late spike does NOT trip drift (needs n consecutive worse samples)", () => {
@@ -22,7 +44,7 @@ describe("detectDrift", () => {
       { value: 100 },
       { value: 200 },
     ];
-    expect(detectDrift(history, 10)).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBe(false);
   });
 
   test("a sustained regression (n consecutive samples worse than the rolling median) trips drift", () => {
@@ -38,7 +60,7 @@ describe("detectDrift", () => {
       { value: 200 },
       { value: 200 },
     ];
-    expect(detectDrift(history, 10)).toBe(true);
+    expect(detectDrift(history, sloAt(10))).toBe(true);
   });
 
   test("worse-but-within-the-noise-floor does not trip drift", () => {
@@ -54,7 +76,7 @@ describe("detectDrift", () => {
       { value: 105 },
       { value: 105 },
     ];
-    expect(detectDrift(history, 10)).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBe(false);
   });
 
   test("a worse sample that breaks the consecutive run resets the counter", () => {
@@ -71,7 +93,7 @@ describe("detectDrift", () => {
       { value: 100 },
       { value: 200 },
     ];
-    expect(detectDrift(history, 10)).toBe(false);
+    expect(detectDrift(history, sloAt(10))).toBe(false);
   });
 
   test("the rolling median is over the last k samples, not the whole history", () => {
@@ -93,7 +115,7 @@ describe("detectDrift", () => {
       { value: 200 },
       { value: 200 },
     ];
-    expect(detectDrift(history, 10)).toBe(true);
+    expect(detectDrift(history, sloAt(10))).toBe(true);
   });
 
   test("honors a custom k and n", () => {
@@ -104,7 +126,7 @@ describe("detectDrift", () => {
       { value: 150 },
       { value: 150 },
     ];
-    expect(detectDrift(history, 10, 3, 2)).toBe(true);
+    expect(detectDrift(history, sloAt(10), 3, 2)).toBe(true);
   });
 });
 
@@ -158,7 +180,15 @@ describe("runDriftCheckMain", () => {
   // 14 runs, oldest-first sha-0..sha-13. The newest 3 (>=11) regress to 130 over
   // a stable 100 baseline → a sustained drift on S1 (and only S1).
   const shas = Array.from({ length: 14 }, (_, i) => `sha-${i}`);
-  const driftValue = (sha: string): number => (Number(sha.slice(4)) >= 11 ? 130 : 100);
+  // Sized against S1's REAL declared floor, which is what `detectDrift` now applies:
+  // `noiseFloorPct: 25` OR `noiseFloorAbs: 300` ms as a percentage of the rolling median,
+  // whichever is larger. At a 1000 ms baseline the absolute floor is the binding one (30 %),
+  // so the drifting samples sit at 1600 ms (+60 %) -- unambiguously past both.
+  //
+  // The old fixture drifted 100 -> 130 (+30 %), which cleared the hardcoded 10 % this used to
+  // apply but would NOT clear S1's own floor. That gap is the bug: the detector was four times
+  // more sensitive than the surfaces it watched.
+  const driftValue = (sha: string): number => (Number(sha.slice(4)) >= 11 ? 1_600 : 1_000);
 
   function v2Line(p95: number): string {
     return JSON.stringify({
@@ -242,5 +272,53 @@ describe("isRunnerKind", () => {
   test("rejects an unknown runner value", () => {
     expect(isRunnerKind("m1-air")).toBe(false);
     expect(isRunnerKind("")).toBe(false);
+  });
+});
+
+describe("detectDrift — the #1308 / #1309 false positives", () => {
+  /**
+   * The real gha-ubuntu window that filed both issues, taken from the `perf-data` branch's
+   * `dev/bench/data.js`. Read it before widening any floor again: the "regression" is the last
+   * two samples, and they are the runner RETURNING TO NORMAL.
+   *
+   * Series median across all 495 recorded samples is ~311 ms. This window is a cluster of
+   * unusually FAST runs (224-261), which drags the rolling MEDIAN down to 253 -- and 316 then
+   * reads as +25 % against that depressed baseline. Nothing got slower.
+   */
+  const S11_A_WINDOW = [224, 249, 261, 253, 247, 333, 306, 316, 333, 341].map((v) => ({
+    value: v,
+  }));
+
+  // S11-a / S11-b as actually declared: 40 % relative, 50 ms / 10 ms absolute.
+  const S11_A = sloAt(40, 50);
+  const S11_B = sloAt(40, 10);
+
+  test("the shipped 10% floor fires on this window — the bug", () => {
+    expect(detectDrift(S11_A_WINDOW, sloAt(10))).toBe(true);
+  });
+
+  test("the surface's OWN 40% floor does not", () => {
+    expect(detectDrift(S11_A_WINDOW, S11_A)).toBe(false);
+    expect(detectDrift(S11_A_WINDOW, S11_B)).toBe(false);
+  });
+
+  test("a real 2x regression still trips at the 40% floor", () => {
+    // The floor must not be so wide that it stops detecting anything. Same baseline, doubled.
+    const regressed = [
+      ...[300, 305, 298, 302, 310, 295, 300].map((v) => ({ value: v })),
+      ...[620, 640, 610].map((v) => ({ value: v })),
+    ];
+    expect(detectDrift(regressed, S11_A)).toBe(true);
+  });
+
+  test("the absolute floor binds when the baseline is small", () => {
+    // 40% of 20ms is 8ms -- scheduler noise. `noiseFloorAbs: 50` raises the bar to 250%,
+    // which is why the two floors are combined rather than the percentage used alone.
+    const tiny = [
+      ...Array.from({ length: 7 }, () => ({ value: 20 })),
+      ...[40, 42, 41].map((v) => ({ value: v })),
+    ];
+    expect(detectDrift(tiny, sloAt(40))).toBe(true); // 40% floor alone: +100% trips
+    expect(detectDrift(tiny, S11_A)).toBe(false); // with the 50ms absolute floor: does not
   });
 });

--- a/scripts/perf/drift-check.ts
+++ b/scripts/perf/drift-check.ts
@@ -11,7 +11,10 @@ import type {
 } from "../../packages/gateway/src/perf/history-line.ts";
 import type { SloThreshold } from "../../packages/gateway/src/perf/slo-thresholds.ts";
 import { SLO_THRESHOLDS } from "../../packages/gateway/src/perf/slo-thresholds.ts";
-import { isFloorMetric } from "../../packages/gateway/src/perf/threshold-comparator.ts";
+import {
+  effectiveNoiseFloorPct,
+  isFloorMetric,
+} from "../../packages/gateway/src/perf/threshold-comparator.ts";
 import type { BenchSurfaceId, RunnerKind } from "../../packages/gateway/src/perf/types.ts";
 import { parseLastHistoryLine } from "./history-jsonl.ts";
 
@@ -25,12 +28,26 @@ export interface DriftSample {
 /**
  * Pure drift detector. Walks a rolling median of the last `k` samples and reports
  * drift only when the `n` most recent samples are EACH worse than that window's
- * median by more than `noiseFloorPct` percent. A lone spike never trips; a
+ * median by more than the surface's OWN noise floor. A lone spike never trips; a
  * sustained regression does. "Worse" == "larger" (smaller-is-better surfaces only).
+ *
+ * The floor is per-surface (`effectiveNoiseFloorPct`), not a global constant. It used to be a
+ * hardcoded 10 %, and that is what filed #1308 and #1309: S11-a/S11-b declare a 40 % floor
+ * precisely because their spawn-dominated latency is "a runner property, not a code signal"
+ * (see their entries in `slo-thresholds.ts`), so a detector four times more sensitive than the
+ * surface's own floor was guaranteed to alarm on runner noise.
+ *
+ * The failure is subtler than "too twitchy", and worth understanding before widening the floor
+ * again. A rolling MEDIAN moves with the data, so a cluster of unusually FAST runs drags it
+ * down — and the next ordinary samples then read as a regression against a depressed baseline.
+ * That is exactly what happened: the tripping window was `224, 249, 261, 253, 247, 333, 306`
+ * (median 253) against a series median of 311, so the "regression" was the runner RETURNING TO
+ * NORMAL at 316 and 333. Nothing got slower. Across all 495 recorded samples, this rule fires
+ * at 10 % and not once at 25 % or at the declared 40 %.
  */
 export function detectDrift(
   history: readonly DriftSample[],
-  noiseFloorPct: number,
+  slo: SloThreshold,
   k = 7,
   n = 3,
 ): boolean {
@@ -45,7 +62,7 @@ export function detectDrift(
       continue;
     }
     const worsePct = ((current - med) / med) * 100;
-    if (worsePct > noiseFloorPct) {
+    if (worsePct > effectiveNoiseFloorPct(slo, med)) {
       consecutive += 1;
       if (consecutive >= n) return true;
     } else {
@@ -57,7 +74,6 @@ export function detectDrift(
 
 // ─── I/O wrapper ─────────────────────────────────────────────────────────────
 
-const DRIFT_NOISE_FLOOR_PCT = 10;
 const DRIFT_HISTORY_RUNS = 14;
 const DRIFT_ISSUE_LABEL = "perf-drift";
 const PERF_WORKFLOW = "_perf.yml";
@@ -77,12 +93,19 @@ function historyFieldFor(metric: TrendMetric): keyof HistoryLineSurface {
   }
 }
 
-/** Map from surfaceId → history field key, only for trend surfaces that are smaller-is-better. */
-const TREND_METRIC_BY_SURFACE: ReadonlyMap<BenchSurfaceId, keyof HistoryLineSurface> = new Map(
+/**
+ * Map from surfaceId → its history field key AND its SLO, for trend surfaces that are
+ * smaller-is-better. The SLO travels with the field because the drift floor is per-surface;
+ * carrying only the field is what forced the caller onto a global constant.
+ */
+const TREND_METRIC_BY_SURFACE: ReadonlyMap<
+  BenchSurfaceId,
+  { field: keyof HistoryLineSurface; slo: SloThreshold }
+> = new Map(
   SLO_THRESHOLDS.filter(
     (s): s is SloThreshold & { metric: TrendMetric } =>
       s.gateClass === "trend" && !isFloorMetric(s.metric),
-  ).map((s) => [s.surfaceId, historyFieldFor(s.metric)]),
+  ).map((s) => [s.surfaceId, { field: historyFieldFor(s.metric), slo: s }]),
 );
 
 interface GhIssue {
@@ -135,6 +158,7 @@ async function upsertDriftIssue(
   gh: GhCli,
   surfaceId: BenchSurfaceId,
   runner: RunnerKind,
+  slo: SloThreshold,
   existingIssues: GhIssue[],
   tmpRoot: string,
   stderr: (s: string) => void,
@@ -151,7 +175,7 @@ async function upsertDriftIssue(
   writeFileSync(
     bodyFile,
     `The rolling-median drift detector has flagged surface \`${surfaceId}\` on runner \`${runner}\`.\n\n` +
-      `The last 3+ consecutive \`main\` samples are each more than ${String(DRIFT_NOISE_FLOOR_PCT)}% worse than the rolling median of the preceding 7. This is a sustained regression, not a one-off spike.\n\n` +
+      `The last 3+ consecutive \`main\` samples are each more than ${String(slo.noiseFloorPct)}% worse than the rolling median of the preceding 7 -- this surface's OWN declared noise floor, not a global constant. This is a sustained regression, not a one-off spike.\n\n` +
       `See the [/dev/bench dashboard](https://github.com/nimbus-agent/Nimbus/tree/perf-data/dev/bench) and investigate recent commits for a regression on this surface.\n`,
     "utf8",
   );
@@ -216,8 +240,8 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
   }
 
   // First pass: which trend (smaller-is-better) surfaces are drifting?
-  const drifting: BenchSurfaceId[] = [];
-  for (const [surfaceId, field] of TREND_METRIC_BY_SURFACE) {
+  const drifting: Array<{ surfaceId: BenchSurfaceId; slo: SloThreshold }> = [];
+  for (const [surfaceId, { field, slo }] of TREND_METRIC_BY_SURFACE) {
     const series: DriftSample[] = historyLines
       .map((line) => {
         const surface: HistoryLineSurface | undefined = line.surfaces[surfaceId];
@@ -226,7 +250,7 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
         return typeof val === "number" ? { value: val } : null;
       })
       .filter((s): s is DriftSample => s !== null);
-    if (detectDrift(series, DRIFT_NOISE_FLOOR_PCT)) drifting.push(surfaceId);
+    if (detectDrift(series, slo)) drifting.push({ surfaceId, slo });
   }
   if (drifting.length === 0) return; // no drift → no issue API calls at all
 
@@ -239,10 +263,10 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
     stderr(`drift-check: gh issue list failed: ${errMsg(err)}; proceeding with none known`);
   }
 
-  for (const surfaceId of drifting) {
+  for (const { surfaceId, slo } of drifting) {
     stderr(`drift-check: drift detected on ${surfaceId} (${runner}); upserting gh issue`);
     try {
-      await upsertDriftIssue(deps.gh, surfaceId, runner, existingIssues, tmpRoot, stderr);
+      await upsertDriftIssue(deps.gh, surfaceId, runner, slo, existingIssues, tmpRoot, stderr);
     } catch (err) {
       stderr(`drift-check: upsert failed for ${surfaceId}: ${errMsg(err)}`);
     }

--- a/scripts/perf/drift-check.ts
+++ b/scripts/perf/drift-check.ts
@@ -26,6 +26,25 @@ export interface DriftSample {
 }
 
 /**
+ * Why a surface tripped, carried out of the detector so the filed issue can state the number
+ * that ACTUALLY fired.
+ *
+ * The detector returns this rather than a boolean because the two were free to disagree: the
+ * issue body reported `slo.noiseFloorPct` while detection applied
+ * `effectiveNoiseFloorPct(slo, median)`, which is LARGER whenever the absolute floor binds. A
+ * reader chasing a drift alarm would then check the surface's declared 40 % against a sample
+ * that had cleared, say, 50 %, and conclude the detector was wrong. One value, one source.
+ */
+export interface DriftHit {
+  /** The rolling median the tripping sample was compared against. */
+  readonly median: number;
+  /** The sample that completed the consecutive run. */
+  readonly current: number;
+  /** The floor actually applied: `max(noiseFloorPct, noiseFloorAbs / median * 100)`. */
+  readonly effectiveFloorPct: number;
+}
+
+/**
  * Pure drift detector. Walks a rolling median of the last `k` samples and reports
  * drift only when the `n` most recent samples are EACH worse than that window's
  * median by more than the surface's OWN noise floor. A lone spike never trips; a
@@ -50,8 +69,8 @@ export function detectDrift(
   slo: SloThreshold,
   k = 7,
   n = 3,
-): boolean {
-  if (history.length < k + n) return false;
+): DriftHit | null {
+  if (history.length < k + n) return null;
   let consecutive = 0;
   for (let i = k; i < history.length; i += 1) {
     const window = history.slice(i - k, i).map((s) => s.value);
@@ -61,15 +80,18 @@ export function detectDrift(
       consecutive = 0;
       continue;
     }
+    const floorPct = effectiveNoiseFloorPct(slo, med);
     const worsePct = ((current - med) / med) * 100;
-    if (worsePct > effectiveNoiseFloorPct(slo, med)) {
+    if (worsePct > floorPct) {
       consecutive += 1;
-      if (consecutive >= n) return true;
+      if (consecutive >= n) {
+        return { median: med, current, effectiveFloorPct: floorPct };
+      }
     } else {
       consecutive = 0;
     }
   }
-  return false;
+  return null;
 }
 
 // ─── I/O wrapper ─────────────────────────────────────────────────────────────
@@ -159,6 +181,7 @@ async function upsertDriftIssue(
   surfaceId: BenchSurfaceId,
   runner: RunnerKind,
   slo: SloThreshold,
+  hit: DriftHit,
   existingIssues: GhIssue[],
   tmpRoot: string,
   stderr: (s: string) => void,
@@ -175,7 +198,11 @@ async function upsertDriftIssue(
   writeFileSync(
     bodyFile,
     `The rolling-median drift detector has flagged surface \`${surfaceId}\` on runner \`${runner}\`.\n\n` +
-      `The last 3+ consecutive \`main\` samples are each more than ${String(slo.noiseFloorPct)}% worse than the rolling median of the preceding 7 -- this surface's OWN declared noise floor, not a global constant. This is a sustained regression, not a one-off spike.\n\n` +
+      `The last 3+ consecutive \`main\` samples are each more than **${hit.effectiveFloorPct.toFixed(1)}%** worse than the rolling median of the preceding 7 (${hit.median.toFixed(1)}); the sample that completed the run measured ${hit.current.toFixed(1)}.\n\n` +
+      // The EFFECTIVE floor, not `slo.noiseFloorPct`. They differ whenever the absolute floor
+      // binds, and reporting the declared relative floor alone understated the bar that fired --
+      // sending a reader to check 40 % against a sample that had actually cleared more.
+      `That floor is this surface's own, not a global constant: \`max(${String(slo.noiseFloorPct)}%, ${String(slo.noiseFloorAbs)}${slo.noiseFloorAbsUnit} / median)\`. A rolling median moves with the data, so before assuming a regression, check the dashboard for a cluster of unusually FAST runs just before the flagged samples -- that depresses the median and makes a return to normal look like a slowdown.\n\n` +
       `See the [/dev/bench dashboard](https://github.com/nimbus-agent/Nimbus/tree/perf-data/dev/bench) and investigate recent commits for a regression on this surface.\n`,
     "utf8",
   );
@@ -240,7 +267,7 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
   }
 
   // First pass: which trend (smaller-is-better) surfaces are drifting?
-  const drifting: Array<{ surfaceId: BenchSurfaceId; slo: SloThreshold }> = [];
+  const drifting: Array<{ surfaceId: BenchSurfaceId; slo: SloThreshold; hit: DriftHit }> = [];
   for (const [surfaceId, { field, slo }] of TREND_METRIC_BY_SURFACE) {
     const series: DriftSample[] = historyLines
       .map((line) => {
@@ -250,7 +277,8 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
         return typeof val === "number" ? { value: val } : null;
       })
       .filter((s): s is DriftSample => s !== null);
-    if (detectDrift(series, slo)) drifting.push({ surfaceId, slo });
+    const hit = detectDrift(series, slo);
+    if (hit !== null) drifting.push({ surfaceId, slo, hit });
   }
   if (drifting.length === 0) return; // no drift → no issue API calls at all
 
@@ -263,10 +291,10 @@ export async function runDriftCheckMain(deps: RunDriftCheckDeps): Promise<void> 
     stderr(`drift-check: gh issue list failed: ${errMsg(err)}; proceeding with none known`);
   }
 
-  for (const { surfaceId, slo } of drifting) {
+  for (const { surfaceId, slo, hit } of drifting) {
     stderr(`drift-check: drift detected on ${surfaceId} (${runner}); upserting gh issue`);
     try {
-      await upsertDriftIssue(deps.gh, surfaceId, runner, slo, existingIssues, tmpRoot, stderr);
+      await upsertDriftIssue(deps.gh, surfaceId, runner, slo, hit, existingIssues, tmpRoot, stderr);
     } catch (err) {
       stderr(`drift-check: upsert failed for ${surfaceId}: ${errMsg(err)}`);
     }

--- a/scripts/regen-slo.ts
+++ b/scripts/regen-slo.ts
@@ -104,6 +104,10 @@ For every measurement entry, \`threshold\` is the maximum allowed value for the 
 A bench fails when either:
 - the measured aggregate exceeds the absolute reference or GHA threshold, **or**
 - the run delta vs the most recent \`main\` history entry for the same \`runner\` exceeds the per-surface noise floor (\`max(noise_floor_pct, absolute_noise_floor / previous × 100)\`).
+
+**Sustained-drift detection uses the same per-surface floor.** \`scripts/perf/drift-check.ts\` walks a rolling median of the last 7 \`main\` samples and files an issue only when 3 consecutive samples each exceed that surface's own floor. It applied a hardcoded **10 %** until 2026-08-29, which is what filed the false #1308 / #1309 alarms against \`S11-a\` / \`S11-b\` — surfaces whose declared floor is 40 % precisely because their spawn-dominated latency is a runner property, not a code signal.
+
+The failure mode is worth knowing before widening a floor again: a rolling median MOVES WITH THE DATA, so a cluster of unusually **fast** runs drags it down, and the next ordinary samples then read as a regression against a depressed baseline. The window that fired both issues was \`224, 249, 261, 253, 247, 333, 306\` (median 253) against a series median of 311 — the "regression" was the runner returning to normal.
 `;
 
 const FOOTER = `


### PR DESCRIPTION
Closes #1308. Closes #1309.

**Both issues are false positives**, and the detector that filed them is four times more sensitive than the surfaces it watches.

## The evidence

Both fired at the **same position, on both surfaces**, from this window of `gha-ubuntu` samples (reconstructed from the `perf-data` branch's `dev/bench/data.js`):

```
window: 224, 249, 261, 253, 247, 333, 306    →  rolling median 253
                                                (series median across 495 samples: 311)
then:   316  (+25 % vs 253)
        333  (+28 % vs 253)   →  3 consecutive  →  ALARM
```

The window is a cluster of unusually **fast** runs. Nothing got slower — the "regression" is the runner **returning to normal** against a baseline the fast runs had dragged down.

This is the part worth internalising: a rolling *median* moves with the data, so downward outliers depress it and ordinary samples afterwards read as a regression. It is not simply "the threshold is too tight".

Running the shipped detector over the full recorded history:

| Floor | Tripping positions across 495 samples |
| --- | --- |
| **10 %** (as shipped) | **2** — both in that one window |
| 25 % | 0 |
| **40 %** (what S11-a/b actually declare) | **0** |

## Root cause

`detectDrift` took a bare percentage and the caller passed a module constant:

```ts
const DRIFT_NOISE_FLOOR_PCT = 10;
...
if (detectDrift(series, DRIFT_NOISE_FLOOR_PCT)) drifting.push(surfaceId);
```

Meanwhile `SLO_THRESHOLDS` already declares a floor **per surface**, and S11-a/S11-b declare **40 %** with an absolute floor of 50 ms / 10 ms. Their own comments say exactly why:

> *"The jitter is a runner property, not a code signal, so S11-a is trend-class."*

The drift detector ignored both fields. A gate four times tighter than the surface's declared noise floor cannot do anything but alarm on noise.

## The fix

`detectDrift` now takes the surface's `SloThreshold` and applies **its** floor — reusing the formula the SLO comparator already uses, `max(noiseFloorPct, noiseFloorAbs / baseline × 100)`, rather than a second copy. That formula is extracted as `effectiveNoiseFloorPct` in `threshold-comparator.ts` so both readers share one definition; the comparator's own behaviour is unchanged (its 32 tests pass untouched).

The filed issue body now names the surface's own floor instead of a global constant, so a future reader can check the claim against `slo-thresholds.ts`.

## Tests

A `describe` block built from the **real** window, so the regression is pinned to the data that caused it rather than to a synthetic curve:

- `the shipped 10% floor fires on this window` — asserts `true`. This is the bug, kept as a test so the fix cannot be quietly reverted.
- `the surface's OWN 40% floor does not` — asserts `false` for both S11-a's and S11-b's real floors.
- `a real 2x regression still trips at the 40% floor` — the floor must not be so wide it detects nothing.
- `the absolute floor binds when the baseline is small` — 40 % of 20 ms is 8 ms of scheduler noise; the 50 ms absolute floor raises the bar to 250 %, which is why the two are combined.

One existing fixture had to be resized, and that is itself evidence: the main-flow test drifted 100 → 130 (+30 %), which cleared the hardcoded 10 % but would **not** clear S1's own declared floor (25 %, or 30 % once its 300 ms absolute floor binds). It now uses 1000 → 1600.

## Verification

- `bun run preflight:fast` — pass, including `regen-slo --check` (the prose lives in the generator, since `docs/perf/slo.md` is generated).
- Full CI command `bun test packages/gateway packages/cli scripts` — **19,462 pass, 0 fail**.

## Checked and rejected

I also looked at whether S11-b is mismeasured, since it reports ~319 ms against a `refMax` of 50 ms and its values track S11-a (cold) almost exactly — both spawn a fresh process per sample, so "warm" only means the OS cache is warm. It is **not** a breach: `refMax` applies to `reference-m1air` only, and the CI ceiling is `ghaMax: 900`. Worth knowing that S11-b adds little signal over S11-a on `gha-ubuntu`, but that is a surface-design question, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance drift detection by applying each surface’s configured noise floor.
  - Reduced false alarms caused by unusually fast runs and surface-specific performance variation.
  - Drift alerts now require sustained regressions across three consecutive samples.

- **Documentation**
  - Updated performance SLO documentation with detection rules, rolling-baseline behavior, and illustrative examples.
  - Drift reports now identify the applicable surface-specific noise floor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->