### PR TITLE
fix(llm): stop Ollama reasoning tokens truncating answers and costing ~16s per ask

### DIFF
--- a/packages/gateway/src/llm/ollama-provider.test.ts
+++ b/packages/gateway/src/llm/ollama-provider.test.ts
@@ -303,6 +303,42 @@ describe("OllamaProvider", () => {
     expect(body.options.temperature).toBe(0.7);
   });
 
+  test("BOTH generate paths send think:false", async () => {
+    // Thinking tokens come out of the SAME `num_predict` budget as the answer, so a reasoning
+    // model can spend the budget deliberating and return a truncated reply -- or, at the
+    // classifier's 512-token cap, no parseable JSON at all. Measured on qwen3:14b: a summary
+    // was cut off mid-sentence at 17,974 ms with thinking on, and complete at 1,497 ms with it
+    // off. Missing this flag on EITHER path is the regression; the streaming path is the one a
+    // batch-only test would silently leave uncovered.
+    const bodies: string[] = [];
+    globalThis.fetch = mock(async (_url: string, opts?: RequestInit) => {
+      if (typeof opts?.body === "string") bodies.push(opts.body);
+      return new Response(JSON.stringify(FAKE_GENERATE_RESPONSE), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const p = new OllamaProvider("http://127.0.0.1:11434");
+    await p.generate({ task: "classification", prompt: "batch" });
+    globalThis.fetch = mock(async (_url: string, opts?: RequestInit) => {
+      if (typeof opts?.body === "string") bodies.push(opts.body);
+      return new Response(
+        `${JSON.stringify({ response: "hi", done: true })}
+`,
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    await p.generate({ task: "classification", prompt: "stream", stream: true });
+
+    expect(bodies).toHaveLength(2);
+    for (const raw of bodies) {
+      const body = JSON.parse(raw) as { think?: unknown; stream?: boolean };
+      expect(body.think).toBe(false);
+    }
+    // ...and the two really are the batch and stream paths, so this cannot pass by testing
+    // the same path twice.
+    const streams = bodies.map((b) => (JSON.parse(b) as { stream?: boolean }).stream);
+    expect(streams).toEqual([false, true]);
+  });
+
   test("generate (stream) throws on HTTP error", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("Forbidden", { status: 403 });

--- a/packages/gateway/src/llm/ollama-provider.test.ts
+++ b/packages/gateway/src/llm/ollama-provider.test.ts
@@ -303,40 +303,51 @@ describe("OllamaProvider", () => {
     expect(body.options.temperature).toBe(0.7);
   });
 
-  test("BOTH generate paths send think:false", async () => {
+  test("BOTH generate paths send the complete expected request body", async () => {
     // Thinking tokens come out of the SAME `num_predict` budget as the answer, so a reasoning
     // model can spend the budget deliberating and return a truncated reply -- or, at the
     // classifier's 512-token cap, no parseable JSON at all. Measured on qwen3:14b: a summary
     // was cut off mid-sentence at 17,974 ms with thinking on, and complete at 1,497 ms with it
-    // off. Missing this flag on EITHER path is the regression; the streaming path is the one a
-    // batch-only test would silently leave uncovered.
+    // off. `think: false` is the fix, and missing it on EITHER path is the regression.
+    //
+    // Asserted as WHOLE-BODY equality rather than field-by-field, which is wider than the
+    // change that prompted it: before this, `prompt` and `system` were asserted nowhere in
+    // this file, so a change that dropped the system prompt passed the entire suite. Equality
+    // also means a newly added field fails here and has to be acknowledged, rather than
+    // arriving unnoticed on the wire.
     const bodies: string[] = [];
-    globalThis.fetch = mock(async (_url: string, opts?: RequestInit) => {
-      if (typeof opts?.body === "string") bodies.push(opts.body);
-      return new Response(JSON.stringify(FAKE_GENERATE_RESPONSE), { status: 200 });
-    }) as unknown as typeof fetch;
+    const capture = (res: string) =>
+      mock(async (_url: string, opts?: RequestInit) => {
+        if (typeof opts?.body === "string") bodies.push(opts.body);
+        return new Response(res, { status: 200 });
+      }) as unknown as typeof fetch;
 
     const p = new OllamaProvider("http://127.0.0.1:11434");
-    await p.generate({ task: "classification", prompt: "batch" });
-    globalThis.fetch = mock(async (_url: string, opts?: RequestInit) => {
-      if (typeof opts?.body === "string") bodies.push(opts.body);
-      return new Response(
-        `${JSON.stringify({ response: "hi", done: true })}
-`,
-        { status: 200 },
-      );
-    }) as unknown as typeof fetch;
-    await p.generate({ task: "classification", prompt: "stream", stream: true });
+    const call = {
+      task: "classification",
+      prompt: "find my notes",
+      systemPrompt: "reply with JSON",
+      maxTokens: 512,
+      temperature: 0,
+    } as const;
+
+    globalThis.fetch = capture(JSON.stringify(FAKE_GENERATE_RESPONSE));
+    await p.generate({ ...call });
+    globalThis.fetch = capture(`${JSON.stringify({ response: "hi", done: true })}
+`);
+    await p.generate({ ...call, stream: true });
 
     expect(bodies).toHaveLength(2);
-    for (const raw of bodies) {
-      const body = JSON.parse(raw) as { think?: unknown; stream?: boolean };
-      expect(body.think).toBe(false);
-    }
-    // ...and the two really are the batch and stream paths, so this cannot pass by testing
-    // the same path twice.
-    const streams = bodies.map((b) => (JSON.parse(b) as { stream?: boolean }).stream);
-    expect(streams).toEqual([false, true]);
+    const expected = (stream: boolean) => ({
+      model: "llama3.2",
+      prompt: "find my notes",
+      system: "reply with JSON",
+      stream,
+      think: false,
+      options: { num_ctx: 8192, num_predict: 512, temperature: 0 },
+    });
+    expect(JSON.parse(bodies[0] ?? "{}")).toEqual(expected(false));
+    expect(JSON.parse(bodies[1] ?? "{}")).toEqual(expected(true));
   });
 
   test("generate (stream) throws on HTTP error", async () => {

--- a/packages/gateway/src/llm/ollama-provider.ts
+++ b/packages/gateway/src/llm/ollama-provider.ts
@@ -96,6 +96,26 @@ function parseOllamaModel(raw: OllamaTagsModel): LlmModelInfo | undefined {
  */
 export const DEFAULT_LOCAL_CONTEXT_TOKENS = 8192;
 
+/**
+ * Ollama's opt-out from a reasoning model's `<think>` phase.
+ *
+ * Sent on every generate, and the reason is CORRECTNESS before speed: thinking tokens are drawn
+ * from the SAME `num_predict` budget as the answer, so a reasoning model can spend the budget
+ * deliberating and return a TRUNCATED reply — or, at the classifier's 512-token cap, no parseable
+ * JSON at all. Measured on qwen3:14b against a live daemon:
+ *
+ *   summarise, thinking on  -> 17,974 ms, answer cut off mid-sentence
+ *   summarise, thinking off ->  1,497 ms, complete answer
+ *   classify,  thinking on  -> 19,416 ms
+ *   classify,  thinking off ->  3,103 ms
+ *
+ * Harmless on a model with no thinking mode: `llama3.2` returns HTTP 200 either way, so this
+ * needs no per-model branch. If a route ever wants deliberation back, the place to add it is a
+ * `[llm.local.<name>]` key, not a silent default — the default should not cost every `ask`
+ * ~16 s and risk a half-finished answer.
+ */
+const OLLAMA_DISABLE_THINKING = false;
+
 export class OllamaProvider implements LlmProvider {
   readonly providerId = "ollama" as const;
   /**
@@ -161,6 +181,7 @@ export class OllamaProvider implements LlmProvider {
       prompt: opts.prompt,
       system: opts.systemPrompt,
       stream: false,
+      think: OLLAMA_DISABLE_THINKING,
       options: {
         num_ctx: this.contextTokens,
         num_predict: opts.maxTokens ?? 2048,
@@ -191,6 +212,7 @@ export class OllamaProvider implements LlmProvider {
       prompt: opts.prompt,
       system: opts.systemPrompt,
       stream: true,
+      think: OLLAMA_DISABLE_THINKING,
       options: {
         num_ctx: this.contextTokens,
         num_predict: opts.maxTokens ?? 2048,


### PR DESCRIPTION
A local `nimbus ask` paid **~16 seconds** before it began answering, and could still return a half-finished answer. Found while configuring a local-LLM install on v6.0.1.

## Correctness first, speed second

Ollama draws a reasoning model's `<think>` phase from the **same `num_predict` budget as the answer**. So thinking does not merely cost time — it *takes tokens away from the reply*. Measured against a live daemon on `qwen3:14b`:

| Call | Thinking on | Thinking off |
| --- | --- | --- |
| Summarise (`num_predict` 2048) | **17,974 ms**, cut off mid-sentence | **1,497 ms**, complete |
| Classify (`num_predict` 512) | 19,416 ms | 3,103 ms |

The truncated one ended `"…It only transmits data"`. That is the shape of the bug: it is not a slow-but-correct answer, it is an incomplete one, and it gets worse the tighter the budget.

At the classifier's 512-token cap the failure is sharper still — no parseable JSON means the intent degrades to `unknown` (the graceful path added in #1366), so the router silently loses classification on exactly the local setups this is meant to serve.

## The change

`think: false` on **both** the batch and stream request bodies in `ollama-provider.ts`.

No per-model branch is needed: a model with no thinking mode ignores it. Verified on `llama3.2:latest`, which returns HTTP 200 with or without the flag.

The constant is named and carries the measurements, because the tempting future edit is "let the model think, it'll answer better" — and the numbers above say the opposite while the budget is shared.

## Deliberately not configurable (yet)

If a route ever wants deliberation back, the right home is a `[llm.local.<name>] think = true` key rather than a silent default. That is not in this PR: the default should not cost every `ask` ~16 s and risk a truncated answer, and adding a config surface is a separate decision from fixing the default.

## Tests

One test asserting `think: false` on **both** paths, plus that the two captured bodies really are the batch and stream paths (`stream: [false, true]`) — so it cannot pass by exercising the same path twice.

**Red-proved:** removing the flag from the **stream** body alone fails the test. That is the miss a batch-only test would have shipped.

## Verification

- `bun run preflight:fast` — pass.
- Full CI command `bun test packages/gateway packages/cli scripts` — 19,462 pass. The 3 `tui` failures are the known load-flake; they pass in isolation on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Classification requests now disable reasoning-token generation for more efficient responses.
  * Applies consistently to both standard and streaming requests.

* **Tests**
  * Added regression coverage to verify the setting across both request modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->