### PR TITLE
fix(connectors): align the aws sync interval with its AWS-CLI siblings

### DIFF
--- a/packages/gateway/src/connectors/aws-sync.ts
+++ b/packages/gateway/src/connectors/aws-sync.ts
@@ -118,7 +118,15 @@ export function createAwsSyncable(options: AwsSyncableOptions): Syncable {
   const initialSyncDepthDays = 1;
   return {
     serviceId: SERVICE_ID,
-    defaultIntervalMs: 120 * 1000,
+    // 10 minutes, matching every sibling AWS-CLI syncable (`cloudwatch`, `sagemaker`,
+    // `athena`). This was 120 s, which made `aws` re-list Lambda functions FIVE TIMES more
+    // often than any of them for no stated reason — a real outbound API call every two
+    // minutes, indefinitely, on any machine with `aws.*` credentials in the Vault.
+    //
+    // The cost was not only traffic. Each run shells out to the AWS CLI, and until
+    // `platform/spawn-capture.ts` landed that spawn popped a console window on Windows, so
+    // the shortest interval in the group was also the most visible symptom.
+    defaultIntervalMs: 10 * 60 * 1000,
     initialSyncDepthDays,
     async sync(ctx: SyncContext, cursor: string | null): Promise<SyncResult> {
       const t0 = performance.now();

--- a/packages/gateway/test/unit/connectors/aws-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/aws-sync.test.ts
@@ -426,11 +426,13 @@ describe("AWS-CLI syncables share one sync cadence", () => {
   // reason for the difference. Pinned as a GROUP rather than as `aws === 600_000`, so the next
   // divergence fails here whichever member drifts.
   test("aws, cloudwatch, sagemaker and athena all use the same defaultIntervalMs", () => {
+    // Each factory names its own ensure-running hook, so `ENSURE_MCP` is not reusable here.
+    const noop = async (): Promise<void> => {};
     const intervals = {
-      aws: createAwsSyncable(ENSURE_MCP).defaultIntervalMs,
-      cloudwatch: createCloudwatchSyncable(ENSURE_MCP).defaultIntervalMs,
-      sagemaker: createSagemakerSyncable(ENSURE_MCP).defaultIntervalMs,
-      athena: createAthenaSyncable(ENSURE_MCP).defaultIntervalMs,
+      aws: createAwsSyncable({ ensureAwsMcpRunning: noop }).defaultIntervalMs,
+      cloudwatch: createCloudwatchSyncable({ ensureCloudwatchMcpRunning: noop }).defaultIntervalMs,
+      sagemaker: createSagemakerSyncable({ ensureSagemakerMcpRunning: noop }).defaultIntervalMs,
+      athena: createAthenaSyncable({ ensureAthenaMcpRunning: noop }).defaultIntervalMs,
     };
     expect(new Set(Object.values(intervals)).size).toBe(1);
     expect(intervals.aws).toBe(10 * 60 * 1000);

--- a/packages/gateway/test/unit/connectors/aws-sync.test.ts
+++ b/packages/gateway/test/unit/connectors/aws-sync.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { createAthenaSyncable } from "../../../src/connectors/athena-sync.ts";
 import { createAwsSyncable } from "../../../src/connectors/aws-sync.ts";
+import { createCloudwatchSyncable } from "../../../src/connectors/cloudwatch-sync.ts";
+import { createSagemakerSyncable } from "../../../src/connectors/sagemaker-sync.ts";
 import {
   type ConnectorSyncFixture,
   createConnectorSyncFixture,
@@ -414,5 +417,22 @@ describe("aws-sync — with shared fixture", () => {
         .all();
       expect(rows.map((r) => r.external_id)).toEqual(["arn:1", "arn:2", "arn:3"]);
     });
+  });
+});
+
+describe("AWS-CLI syncables share one sync cadence", () => {
+  // `aws` ran at 120 s while every sibling ran at 10 min — five times the outbound API traffic,
+  // indefinitely, on any machine with `aws.*` credentials in the Vault, and with no stated
+  // reason for the difference. Pinned as a GROUP rather than as `aws === 600_000`, so the next
+  // divergence fails here whichever member drifts.
+  test("aws, cloudwatch, sagemaker and athena all use the same defaultIntervalMs", () => {
+    const intervals = {
+      aws: createAwsSyncable(ENSURE_MCP).defaultIntervalMs,
+      cloudwatch: createCloudwatchSyncable(ENSURE_MCP).defaultIntervalMs,
+      sagemaker: createSagemakerSyncable(ENSURE_MCP).defaultIntervalMs,
+      athena: createAthenaSyncable(ENSURE_MCP).defaultIntervalMs,
+    };
+    expect(new Set(Object.values(intervals)).size).toBe(1);
+    expect(intervals.aws).toBe(10 * 60 * 1000);
   });
 });


### PR DESCRIPTION
The `aws` syncable re-listed Lambda functions every **120 s** while every sibling AWS-CLI syncable used **10 minutes**:

| Syncable | Interval before |
| --- | --- |
| `aws` | **120 s** |
| `cloudwatch` | 10 min |
| `sagemaker` | 10 min |
| `athena` | 10 min |

Five times the outbound API traffic of any sibling, indefinitely, on any machine with `aws.*` credentials in the Vault — and nothing in the code or history explains the difference. It reads as an oversight rather than a decision, which is why this aligns rather than tunes.

## How it surfaced

It was the visible half of the console-window storm fixed in #1370. Each run shells out to the AWS CLI, and until `platform/spawn-capture.ts` landed, every one of those spawns popped a console window on Windows — so the shortest interval in the group was also the loudest symptom. Observed live as a `conhost.exe` under `aws.exe` under `nimbus-gateway.exe`, roughly one every 1.8 s during a sync tick.

#1370 stopped the windows appearing. This stops the underlying traffic being five times what the design intends.

## Pinned as a group, not as a number

The test asserts two things: that the four intervals collapse to a **single distinct value**, and that the value the group settled on is ten minutes.

Asserting only that `aws` equals ten minutes would have kept passing if a **sibling** drifted instead — the same divergence, just discovered from the other side. The set check fails whichever member moves; the second assertion pins which value they agreed on.

**Red-proved:** restoring the 120 s literal fails the test.

## Verification

- `bun run preflight:fast` — pass.
- Full CI command `bun test packages/gateway packages/cli scripts` — 19,462 pass. The three `tui` failures are the known load-flake; they pass in isolation.

## Note for anyone who wanted the faster cadence

If a two-minute Lambda index is genuinely wanted, `nimbus connector set-interval aws 2m` sets it per-install without putting the cost on everyone by default. And an install that never queries Lambda functions is better served by `nimbus connector pause aws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
