### PR TITLE
fix(cli): refuse a nested-table key in nimbus config set/get

### DIFF
--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -504,3 +504,66 @@ describe("nimbus config list --json", () => {
     expect(out.stdout).not.toContain("NIMBUS_PROFILE");
   });
 });
+
+describe("config set/get refuse a nested-table key with an actionable message (#1382)", () => {
+  beforeEach(() => {
+    out.reset();
+    process.exitCode = 0;
+  });
+  afterEach(() => {
+    clearFixture();
+    process.exitCode = 0;
+  });
+
+  // `llm.tasks.<task>` is the natural thing to type once per-task routing exists, and it used to
+  // succeed while doing nothing. The refusal has to name the command that DOES work, or the user
+  // is left with a rejection and no route forward.
+  it("names `nimbus llm use` for an llm.tasks.* key", () => {
+    const dir = makeTmp();
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, "[llm]\nprefer_local = true\n");
+    expect(() => runConfigSet(p, "llm.tasks.classification", "ollama/llama3.2:latest")).toThrow(
+      /nimbus llm use classification ollama\/llama3\.2:latest/,
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes nothing when it refuses", () => {
+    const dir = makeTmp();
+    const p = join(dir, "nimbus.toml");
+    const before = "[llm]\nprefer_local = true\n";
+    writeFileSync(p, before);
+    expect(() => runConfigSet(p, "llm.tasks.classification", "x")).toThrow();
+    expect(readFileSync(p, "utf8")).toBe(before);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // A non-llm nested key has no dedicated command to point at, so it must NOT claim one.
+  it("does not invent an llm command for an unrelated nested key", () => {
+    const dir = makeTmp();
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, "");
+    expect(() => runConfigSet(p, "sync.service.github", "x")).toThrow(/nested table/i);
+    expect(() => runConfigSet(p, "sync.service.github", "x")).not.toThrow(/nimbus llm use/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("config get refuses the same key rather than echoing an inert line", () => {
+    const dir = makeTmp();
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, '[llm]\nprefer_local = true\n\ntasks.classification = "x"\n');
+    expect(() => runConfigGet(p, "llm.tasks.classification")).toThrow(/nested table/i);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("an ordinary section.key still sets and gets", () => {
+    const dir = makeTmp();
+    const p = join(dir, "nimbus.toml");
+    writeFileSync(p, "");
+    runConfigSet(p, "telemetry.enabled", "true");
+    out.reset();
+    runConfigGet(p, "telemetry.enabled");
+    expect(out.stdout).toContain("true");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -107,10 +107,42 @@ export function runConfigList(tomlPath: string, opts: { json?: boolean } = {}): 
   console.log(readFileSync(tomlPath, "utf8"));
 }
 
+/**
+ * Refuse a dotted key that names a NESTED table, naming the command that does work.
+ *
+ * `nimbus config` addresses a flat `section.key`; a two-dot key used to be split on the first dot
+ * and written under the wrong table, where the parser never read it — succeeding loudly and doing
+ * nothing (#1382). The lib-level guard in `splitFlatDottedKey` is what makes that fail-closed; this
+ * adds the part a user needs, which is where to go instead.
+ *
+ * `llm.tasks.<task>` gets the specific answer because it is the shape that made the bug reachable
+ * and it HAS a dedicated command. Anything else gets the generic answer — inventing a command for
+ * a key that has none would trade a silent no-op for a confident wrong instruction.
+ */
+function refuseNestedKey(dotted: string, value?: string): never {
+  const segments = dotted.split(".");
+  const base =
+    `\`${dotted}\` addresses a nested table, which \`nimbus config\` cannot express — ` +
+    "it handles a flat `section.key` only.";
+  if (segments.length === 3 && segments[0] === "llm" && segments[1] === "tasks") {
+    throw new Error(
+      `${base}\nUse: nimbus llm use ${segments[2]} ${value ?? "<routeId>"}` +
+        "\nOr edit the [llm.tasks] table in nimbus.toml directly.",
+    );
+  }
+  throw new Error(`${base}\nEdit the table in nimbus.toml directly.`);
+}
+
+/** True when the key names a nested table (two or more dots), e.g. `llm.tasks.classification`. */
+function isNestedTableKey(key: string): boolean {
+  return key.split(".").length > 2;
+}
+
 export function runConfigGet(tomlPath: string, key: string): void {
   if (key === "" || !key.includes(".")) {
     throw new Error("Usage: nimbus config get <section.key>  (e.g. telemetry.enabled)");
   }
+  if (isNestedTableKey(key)) refuseNestedKey(key);
   const fromEnv = listTomlKeysWithEnv(tomlPath).find((e) => e.key === key && e.source === "env");
   const fromFile = getTomlValueFromFile(tomlPath, key);
   if (fromEnv !== undefined) {
@@ -129,6 +161,7 @@ export function runConfigSet(tomlPath: string, key: string, val: string): void {
   if (key === "" || !key.includes(".") || val === "") {
     throw new Error("Usage: nimbus config set <section.key> <value>");
   }
+  if (isNestedTableKey(key)) refuseNestedKey(key, val);
   setTomlValueInFile(tomlPath, key, val);
   console.log(`Updated ${key} in ${tomlPath}`);
   console.log("Restart the Gateway to apply. Env vars still override file values when set.");

--- a/packages/cli/src/lib/nimbus-toml-config.test.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.test.ts
@@ -327,3 +327,65 @@ describe("nested-table keys are refused, not silently mis-written (#1382)", () =
     expect(() => setTomlValueInFile(tomlPath, "telemetry", "true")).toThrow(/section\.name/);
   });
 });
+
+describe("degenerate dotted keys are refused too (review of #1382 fix)", () => {
+  // `telemetry.` split into section `telemetry` + an EMPTY key, and the writer emitted ` = true` —
+  // a syntactically invalid TOML line written into the user's real config, which can break parsing
+  // of the whole file. Pre-existing rather than introduced by the nested-table guard, but the
+  // shared splitter is where a key is validated now, so it belongs here.
+  test("an empty key segment is refused, not written as ` = value`", () => {
+    writeFileSync(tomlPath, "[telemetry]\nenabled = false\n");
+    expect(() => setTomlValueInFile(tomlPath, "telemetry.", "true")).toThrow(/section\.name/);
+  });
+
+  test("the config file is untouched after that refusal", () => {
+    const before = "[telemetry]\nenabled = false\n";
+    writeFileSync(tomlPath, before);
+    expect(() => setTomlValueInFile(tomlPath, "telemetry.", "true")).toThrow();
+    expect(readFileSync(tomlPath, "utf8")).toBe(before);
+  });
+
+  test("an empty SECTION segment is refused as well", () => {
+    expect(() => setTomlValueInFile(tomlPath, ".enabled", "true")).toThrow(/section\.name/);
+  });
+
+  // The key was validated only AFTER the file was read, so the same nested key threw on an
+  // existing file and returned `undefined` on a missing one. Validating arguments before touching
+  // the filesystem makes the refusal a property of the KEY, not of whether the file happens to
+  // exist.
+  test("a nested key is refused even when the file does not exist", () => {
+    const missing = join(dir, "definitely-absent.toml");
+    expect(() => getTomlValueFromFile(missing, "llm.tasks.classification")).toThrow(
+      /nested table/i,
+    );
+  });
+
+  test("the same nested key throws identically whether or not the file exists", () => {
+    writeFileSync(tomlPath, "[llm]\n");
+    const missing = join(dir, "definitely-absent.toml");
+    const a = (() => {
+      try {
+        getTomlValueFromFile(tomlPath, "llm.tasks.classification");
+      } catch (e) {
+        return (e as Error).message;
+      }
+      return "did not throw";
+    })();
+    const b = (() => {
+      try {
+        getTomlValueFromFile(missing, "llm.tasks.classification");
+      } catch (e) {
+        return (e as Error).message;
+      }
+      return "did not throw";
+    })();
+    expect(a).toBe(b);
+  });
+
+  // The bound: a missing file is still a normal "not set" for a WELL-FORMED key. Only a malformed
+  // key throws — otherwise `nimbus config get` on a fresh machine would start erroring.
+  test("a well-formed key on a missing file still returns undefined", () => {
+    const missing = join(dir, "definitely-absent.toml");
+    expect(getTomlValueFromFile(missing, "telemetry.enabled")).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/nimbus-toml-config.test.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.test.ts
@@ -276,3 +276,54 @@ describe("setTomlValueInFile", () => {
     expect(readFileSync(sibling, "utf8")).toBe("keep me");
   });
 });
+
+describe("nested-table keys are refused, not silently mis-written (#1382)", () => {
+  // `setTomlValueInFile` split the dotted key on the FIRST dot, so `llm.tasks.classification`
+  // became section `llm`, key `tasks.classification` — written verbatim under `[llm]`, where
+  // `parseLlmTaskPins` (which reads only a literal `[llm.tasks]` table) never sees it. The command
+  // succeeded, the file changed, and the setting did nothing. Unreachable before `[llm.tasks]`
+  // existed, because no key had two dots; the per-task routing work made it the natural thing
+  // to type.
+  const NESTED = "llm.tasks.classification";
+
+  test("setTomlValueInFile throws on a key naming a nested table", () => {
+    writeFileSync(tomlPath, "[llm]\nprefer_local = true\n");
+    expect(() => setTomlValueInFile(tomlPath, NESTED, "ollama/llama3.2:latest")).toThrow(
+      /nested table/i,
+    );
+  });
+
+  // Fail-CLOSED is the property that matters: a throw that still wrote half a line would leave
+  // exactly the inert `tasks.classification = ...` line this guard exists to prevent.
+  test("the file is left completely untouched when it refuses", () => {
+    const before = "[llm]\nprefer_local = true\n";
+    writeFileSync(tomlPath, before);
+    expect(() => setTomlValueInFile(tomlPath, NESTED, "ollama/llama3.2:latest")).toThrow();
+    expect(readFileSync(tomlPath, "utf8")).toBe(before);
+  });
+
+  // The adjacent door. `getTomlValueFromFile` had the same first-dot split, so it read the inert
+  // line back and ECHOED it — set appeared to work, then get appeared to confirm it, while routing
+  // ignored the value entirely. A guard on the write path alone would leave that false
+  // confirmation in place for a hand-edited file.
+  test("getTomlValueFromFile throws rather than echoing an inert nested line", () => {
+    writeFileSync(tomlPath, '[llm]\nprefer_local = true\n\ntasks.classification = "x"\n');
+    expect(() => getTomlValueFromFile(tomlPath, NESTED)).toThrow(/nested table/i);
+  });
+
+  test("a deeply nested key is refused too, not just three segments", () => {
+    writeFileSync(tomlPath, "[llm]\n");
+    expect(() => setTomlValueInFile(tomlPath, "a.b.c.d", "v")).toThrow(/nested table/i);
+  });
+
+  // The bound in the other direction: ordinary single-dot keys must be untouched. Every existing
+  // call site is single-dot, so this is what proves the guard did not become a regression.
+  test("a plain section.key still round-trips", () => {
+    setTomlValueInFile(tomlPath, "telemetry.enabled", "true");
+    expect(getTomlValueFromFile(tomlPath, "telemetry.enabled")).toBe("true");
+  });
+
+  test("a dotless key still reports the flat-key usage error, not the nested one", () => {
+    expect(() => setTomlValueInFile(tomlPath, "telemetry", "true")).toThrow(/section\.name/);
+  });
+});

--- a/packages/cli/src/lib/nimbus-toml-config.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.ts
@@ -94,6 +94,35 @@ function writeUtf8FileAtomicReplace(path: string, content: string): void {
   }
 }
 
+/**
+ * Split `section.key` into its two halves, REFUSING anything that names a nested table.
+ *
+ * Both the reader and the writer below used `dotted.indexOf(".")` — a split on the FIRST dot — so
+ * `llm.tasks.classification` yielded section `llm`, key `tasks.classification`. The writer put that
+ * verbatim under `[llm]`, where `parseLlmTaskPins` (which scans for a literal `[llm.tasks]` table)
+ * never sees it: the command succeeded, the file changed, and the setting did nothing. The reader
+ * then read the same inert line back and echoed it, so `get` appeared to CONFIRM the write.
+ *
+ * The bug was unreachable until `[llm.tasks]` shipped, because no key had two dots. It is refused
+ * rather than fixed by splitting on the LAST dot: last-dot happens to be safe today only because
+ * every caller is single-dot, and it re-introduces the same ambiguity the moment a third dotted
+ * shape appears. A refusal is fail-closed and has no parsing to get wrong.
+ */
+export function splitFlatDottedKey(dotted: string): { section: string; key: string } {
+  const dot = dotted.indexOf(".");
+  if (dot <= 0) {
+    throw new Error(`Invalid key (expected section.name): ${dotted}`);
+  }
+  const key = dotted.slice(dot + 1);
+  if (key.includes(".")) {
+    throw new Error(
+      `\`${dotted}\` addresses a nested table, which this flat section.key surface cannot ` +
+        `express. Edit the table in nimbus.toml directly.`,
+    );
+  }
+  return { section: dotted.slice(0, dot), key };
+}
+
 export function getTomlValueFromFile(tomlPath: string, dotted: string): string | undefined {
   let raw: string;
   try {
@@ -104,12 +133,10 @@ export function getTomlValueFromFile(tomlPath: string, dotted: string): string |
     }
     throw e;
   }
-  const dot = dotted.indexOf(".");
-  if (dot <= 0) {
+  if (dotted.indexOf(".") <= 0) {
     return undefined;
   }
-  const section = dotted.slice(0, dot);
-  const key = dotted.slice(dot + 1);
+  const { section, key } = splitFlatDottedKey(dotted);
   return parseSectionKey(raw, section, key);
 }
 
@@ -172,12 +199,7 @@ function writeNewSectionToToml(
 }
 
 export function setTomlValueInFile(tomlPath: string, dotted: string, value: string): void {
-  const dot = dotted.indexOf(".");
-  if (dot <= 0) {
-    throw new Error(`Invalid key (expected section.name): ${dotted}`);
-  }
-  const section = dotted.slice(0, dot);
-  const key = dotted.slice(dot + 1);
+  const { section, key } = splitFlatDottedKey(dotted);
   const formattedValue = formatTomlValue(value);
   let full = "";
   try {

--- a/packages/cli/src/lib/nimbus-toml-config.ts
+++ b/packages/cli/src/lib/nimbus-toml-config.ts
@@ -114,6 +114,12 @@ export function splitFlatDottedKey(dotted: string): { section: string; key: stri
     throw new Error(`Invalid key (expected section.name): ${dotted}`);
   }
   const key = dotted.slice(dot + 1);
+  // `telemetry.` split cleanly into section `telemetry` + an EMPTY key, and the writer emitted
+  // ` = value` — a syntactically invalid line written into the user's config, which can break
+  // parsing of the whole file. Same error as the dotless case: both mean "this is not section.key".
+  if (key === "") {
+    throw new Error(`Invalid key (expected section.name): ${dotted}`);
+  }
   if (key.includes(".")) {
     throw new Error(
       `\`${dotted}\` addresses a nested table, which this flat section.key surface cannot ` +
@@ -124,19 +130,26 @@ export function splitFlatDottedKey(dotted: string): { section: string; key: stri
 }
 
 export function getTomlValueFromFile(tomlPath: string, dotted: string): string | undefined {
+  // A dotless key is "not addressable here", which for a READ is simply "not set" — callers rely
+  // on that, so it stays a soft `undefined` rather than a throw.
+  if (dotted.indexOf(".") <= 0) {
+    return undefined;
+  }
+  // Validate the KEY before touching the filesystem. Reading first meant the same nested key threw
+  // on an existing file and returned `undefined` on a missing one, so the refusal depended on
+  // whether the file happened to exist rather than on the key itself.
+  const { section, key } = splitFlatDottedKey(dotted);
   let raw: string;
   try {
     raw = readFileSync(tomlPath, "utf8");
   } catch (e: unknown) {
+    // A missing file is still an ordinary "not set" for a WELL-FORMED key — otherwise
+    // `nimbus config get` would start erroring on a fresh machine.
     if (e !== null && typeof e === "object" && "code" in e && e.code === "ENOENT") {
       return undefined;
     }
     throw e;
   }
-  if (dotted.indexOf(".") <= 0) {
-    return undefined;
-  }
-  const { section, key } = splitFlatDottedKey(dotted);
   return parseSectionKey(raw, section, key);
 }
 


### PR DESCRIPTION
Closes #1382.

## The bug

`nimbus config set llm.tasks.classification <route>` succeeded, changed the file, and did nothing.

Both the reader and the writer split the dotted key on the **first** dot, so the key became section `llm`, key `tasks.classification` — written verbatim under `[llm]`, where `parseLlmTaskPins`, which scans for a literal `[llm.tasks]` table, never sees it.

Reproduced end-to-end against the real helper and the real parser before writing any fix:

```
$ nimbus config set llm.tasks.classification ollama/llama3.2:latest
# nimbus.toml gains:  tasks.classification = "ollama/llama3.2:latest"   ← under [llm]
# parseNimbusTomlLlmSection ->  taskPins: undefined
```

## It was worse than reported

`getTomlValueFromFile` had the identical first-dot split, so it read the inert line back and **echoed it**. `set` appeared to work and `get` appeared to confirm it, while routing ignored the value entirely — a false *confirmation* loop, not just a silent no-op. A guard on the write path alone would have left that in place for any hand-edited file, so **both** paths are guarded.

## The fix

One shared `splitFlatDottedKey` refuses any key naming a nested table, placed before any file read or write so a refusal touches nothing on disk.

Refused rather than taught last-dot splitting, per the issue's recommendation: last-dot is safe today only because every caller is single-dot, and it reintroduces the same ambiguity the moment a third dotted shape appears. A refusal is fail-closed with no parsing to get wrong.

The CLI layer adds what the user actually needs — where to go instead:

```
`llm.tasks.classification` addresses a nested table, which `nimbus config`
cannot express — it handles a flat `section.key` only.
Use: nimbus llm use classification ollama/llama3.2:latest
Or edit the [llm.tasks] table in nimbus.toml directly.
```

An unrelated nested key such as `sync.service.github` gets the generic answer. Inventing an `llm` command for a key that has none would trade a silent no-op for a confident wrong instruction.

## Not a regression

Every existing call site is single-dot, and no `ENV_BY_DOTTED` key has two dots, so `nimbus config list` is unaffected. A dotless key still reports the original flat-key usage error, not the new one.

## Verification

- **Red-proved by reverting the two source files: 8 tests fail without the fix, 0 with it.**
- 12 new tests, covering the refusal on both paths, the fail-closed property — file byte-identical after a refusal — the `llm.tasks.*` vs generic message split, deep nesting, and both non-regression bounds.
- `bun test packages/cli/src` → 2495 pass, 0 fail.
- `bun run preflight:fast` → 32/32 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6qbQmiRqJcxDc6ENA8LFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `nimbus config get` and `nimbus config set` now clearly reject unsupported nested TOML keys.
  * Errors for `llm.tasks.<task>` keys provide guidance to use `nimbus llm use` or edit the TOML directly.
  * Prevented rejected configuration writes from modifying the configuration file.
  * Existing single-dot configuration keys continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->