### PR TITLE
fix(index): extract `export default` symbols in the code indexer

### DIFF
--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -876,6 +876,84 @@ export async function drawAsync() { return "ok"; }
   expect(rows.some((r) => r.title.includes("drawAsync"))).toBe(true);
 });
 
+// ── extractExportedSymbols: `export default` (#1388) ─────────────────────────
+
+// Found by performing the Gate 1 Windows runbook against a real third-party repo
+// (sindresorhus/is-plain-obj), whose entire public surface is
+// `export default function isPlainObject(value) {`. Every extractor regex requires `export`
+// to be followed directly by the declaration keyword, so `export default ...` matched none of
+// them: the repo indexed 29 commits and 3 dependencies and ZERO code symbols. That is the wedge
+// path — `nimbus init` then has no `file:line` to suggest and `nimbus why` reports "No indexed
+// code symbols for this file", advising the user to enable a setting that is already on.
+test("code index picks up `export default function`", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-defaultfn-"));
+  writeFileSync(
+    join(dir, "index.js"),
+    `export default function isPlainObject(value) { return true; }\n`,
+  );
+  const sync = createFilesystemV2Syncable({
+    roots: [{ path: dir, gitAware: false, codeIndex: true, dependencyGraph: false, exclude: [] }],
+  });
+  const db = createMemoryIndexDb();
+  await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
+  const rows = db
+    .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
+    .all() as Array<{ title: string }>;
+  expect(rows.some((r) => r.title.includes("isPlainObject"))).toBe(true);
+});
+
+test("code index picks up `export default class` and `export default async function`", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-defaultmore-"));
+  writeFileSync(join(dir, "widget.ts"), `export default class Widget { id = 1; }\n`);
+  writeFileSync(join(dir, "load.ts"), `export default async function loadThing() { return 1; }\n`);
+  const sync = createFilesystemV2Syncable({
+    roots: [{ path: dir, gitAware: false, codeIndex: true, dependencyGraph: false, exclude: [] }],
+  });
+  const db = createMemoryIndexDb();
+  await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
+  const rows = db
+    .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
+    .all() as Array<{ title: string }>;
+  expect(rows.some((r) => r.title.includes("Widget"))).toBe(true);
+  expect(rows.some((r) => r.title.includes("loadThing"))).toBe(true);
+});
+
+// The bound in the other direction: `export default` must not swallow the NAMED forms, and a
+// file whose only `default` is an anonymous expression still yields nothing rather than a
+// garbage symbol — naming an anonymous default is a separate design question, deliberately
+// not invented here.
+test("named exports still resolve alongside a default export in the same file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-mixed-"));
+  writeFileSync(
+    join(dir, "mixed.ts"),
+    `export const NAMED = 1;\nexport default function theDefault() { return NAMED; }\n`,
+  );
+  const sync = createFilesystemV2Syncable({
+    roots: [{ path: dir, gitAware: false, codeIndex: true, dependencyGraph: false, exclude: [] }],
+  });
+  const db = createMemoryIndexDb();
+  await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
+  const rows = db
+    .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
+    .all() as Array<{ title: string }>;
+  expect(rows.some((r) => r.title.includes("NAMED"))).toBe(true);
+  expect(rows.some((r) => r.title.includes("theDefault"))).toBe(true);
+});
+
+test("an ANONYMOUS default export still yields no symbol", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-anon-"));
+  writeFileSync(join(dir, "anon.ts"), `export default { a: 1 };\n`);
+  const sync = createFilesystemV2Syncable({
+    roots: [{ path: dir, gitAware: false, codeIndex: true, dependencyGraph: false, exclude: [] }],
+  });
+  const db = createMemoryIndexDb();
+  await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
+  const rows = db
+    .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
+    .all() as Array<{ title: string }>;
+  expect(rows.length).toBe(0);
+});
+
 // ── excerptWithStartLine: flat fallback fits within maxChars (no truncation) ──
 
 test("excerptWithStartLine: flat fallback that fits within maxChars is returned as-is", () => {

--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -899,7 +899,9 @@ test("code index picks up `export default function`", async () => {
   const rows = db
     .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
     .all() as Array<{ title: string }>;
-  expect(rows.some((r) => r.title.includes("isPlainObject"))).toBe(true);
+  // Title is `${name} (${kind})`, so this pins the CLASSIFICATION too — `includes("isPlainObject")`
+  // alone would pass if the symbol were mis-kinded.
+  expect(rows.map((r) => r.title)).toEqual(["isPlainObject (function)"]);
 });
 
 test("code index picks up `export default class` and `export default async function`", async () => {
@@ -914,8 +916,9 @@ test("code index picks up `export default class` and `export default async funct
   const rows = db
     .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
     .all() as Array<{ title: string }>;
-  expect(rows.some((r) => r.title.includes("Widget"))).toBe(true);
-  expect(rows.some((r) => r.title.includes("loadThing"))).toBe(true);
+  // Kind matters: a name-only assertion passes if `Widget` were indexed as a function or
+  // `loadThing` as a class, which would silently break the classification this PR adds.
+  expect(rows.map((r) => r.title).sort()).toEqual(["Widget (class)", "loadThing (function)"]);
 });
 
 // The bound in the other direction: `export default` must not swallow the NAMED forms, and a
@@ -932,12 +935,16 @@ test("named exports still resolve alongside a default export in the same file", 
     roots: [{ path: dir, gitAware: false, codeIndex: true, dependencyGraph: false, exclude: [] }],
   });
   const db = createMemoryIndexDb();
-  await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
+  const result = await sync.sync(syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem"), null);
   const rows = db
     .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
     .all() as Array<{ title: string }>;
-  expect(rows.some((r) => r.title.includes("NAMED"))).toBe(true);
-  expect(rows.some((r) => r.title.includes("theDefault"))).toBe(true);
+  // EXACTLY ONCE is the actual claim — `some()` proves only that both names exist, which a
+  // double-extracting regex would also satisfy. `itemsUpserted` is the load-bearing assertion:
+  // `extId` keys on `name:kind`, so a symbol matched twice by the same pattern collapses to ONE
+  // row while still being upserted twice. Row count alone would not see it.
+  expect(result.itemsUpserted).toBe(2);
+  expect(rows.map((r) => r.title).sort()).toEqual(["NAMED (const)", "theDefault (function)"]);
 });
 
 test("an ANONYMOUS default export still yields no symbol", async () => {

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -533,6 +533,21 @@ function extractExportedSymbols(
   const exportConst = /export\s+const\s+(\w+)/g;
   const exportClass = /export\s+class\s+(\w+)/g;
   const exportType = /export\s+type\s+(\w+)/g;
+  // `export default ...` — every regex above requires `export` to be followed DIRECTLY by the
+  // declaration keyword, so the whole `default` family matched none of them and a module whose
+  // entire public surface is a default export indexed ZERO symbols (#1388). That is not an edge
+  // case: it is the ordinary shape of a small npm package, a React component and most config
+  // modules. Found by running the Gate 1 runbook against sindresorhus/is-plain-obj, whose
+  // `index.js` is exactly `export default function isPlainObject(value) {`.
+  //
+  // These cannot double-count against the five above: an intervening `default` (and, for the
+  // async form, an intervening `async`) means only one pattern can match any given site.
+  // An ANONYMOUS default (`export default { … }`, `export default () => …`) still yields
+  // nothing — there is no name to record, and inventing one from the filename is a separate
+  // design question, not a bug fix.
+  const exportDefaultAsyncFn = /export\s+default\s+async\s+function\s+(\w+)/g;
+  const exportDefaultFn = /export\s+default\s+function\s+(\w+)/g;
+  const exportDefaultClass = /export\s+default\s+class\s+(\w+)/g;
   const add = (re: RegExp, kind: string): void => {
     re.lastIndex = 0;
     for (;;) {
@@ -551,6 +566,9 @@ function extractExportedSymbols(
   add(exportConst, "const");
   add(exportClass, "class");
   add(exportType, "type");
+  add(exportDefaultAsyncFn, "function");
+  add(exportDefaultFn, "function");
+  add(exportDefaultClass, "class");
   if (out.length === 0 && filePath !== "") {
     return [];
   }


### PR DESCRIPTION
Closes #1388.

## Root cause

Every regex in `extractExportedSymbols` requires `export` to be followed **directly** by a declaration keyword:

```js
/export\s+async\s+function\s+(\w+)/   /export\s+function\s+(\w+)/
/export\s+const\s+(\w+)/              /export\s+class\s+(\w+)/
/export\s+type\s+(\w+)/
```

So the entire `export default` family matches none of them, and a module whose whole public surface is a default export indexes **zero** code symbols.

## How it was found

Performing the Gate 1 Windows runbook against a real third-party repo — `sindresorhus/is-plain-obj`, whose `index.js` is exactly `export default function isPlainObject(value) {`. On a fresh profile it indexed 29 commits, 3 dependencies, and no symbols at all. Verified directly against that file: **0 symbols before, 1 after**.

## Why it matters

Not an edge case — it is the ordinary shape of a small npm package, a React component, and most config modules. And it lands on the wedge path. With no symbols:

- `nimbus init` prints "no symbol to suggest yet", while the README promises it "prints a real `file:line` from your own repo to try first"
- `nimbus why` reports "No indexed code symbols for this file — **enable code_index on the root and sync**", advising the user to turn on a setting that is already `true` in the config `init` just generated

That is the first command a new user runs, and the advice it gives them is unactionable.

## The change

Adds the three **named** default forms: `export default function`, `export default async function`, `export default class`.

They cannot double-count against the existing five — an intervening `default`, and for the async form an intervening `async`, means only one pattern can match any given site. Pinned by a test that a file mixing a named export and a default export yields both, exactly once.

## Deliberately not done

- **Anonymous defaults** stay unnamed and yield nothing, pinned by test. Naming one from the filename is a design question, not a bug fix. Worth noting the dead `if (out.length === 0 && filePath !== "") return []` branch takes `filePath` and does nothing with it, which suggests that fallback was once intended and never implemented — left alone here.
- Still invisible to the indexer, and unchanged by this PR: `export { a, b }` lists, `export * from`, and CommonJS `module.exports`.

## Verification

- **Red-proved by reverting the source: 3 tests fail without the fix, 0 with it.**
- 4 new tests: the reproducing case, the class/async forms, the named-alongside-default bound, and the anonymous-default bound.
- `bun test packages/gateway/src/connectors` → 3020 pass, 0 fail.
- `bun run preflight:fast` → 32/32 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6qbQmiRqJcxDc6ENA8LFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Code indexing now recognizes named default exports for functions, asynchronous functions, and classes.
  - Named exports in files that also contain a default export are preserved and indexed correctly.

- **Bug Fixes**
  - Anonymous default expressions continue to be excluded from indexing, preventing unsupported or unclear symbols from appearing in search results.

- **Tests**
  - Added coverage for named default exports, mixed export files, and anonymous default expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->