### PR TITLE
feat(doctor): report embedding runtime state

### DIFF
--- a/packages/cli/src/commands/doctor-core.test.ts
+++ b/packages/cli/src/commands/doctor-core.test.ts
@@ -13,6 +13,7 @@ import {
   type DoctorGatewayState,
   type DoctorVoiceConfig,
   doctorPrintConfigValidation,
+  doctorPrintEmbeddingFromSnapshot,
   doctorPrintHealthFromSnapshot,
   doctorPrintIndexFromSnapshot,
   doctorVoiceLines,
@@ -175,6 +176,66 @@ describe("doctorPrintIndexFromSnapshot", () => {
   it("returns 0 and prints the count when totalItems is positive", () => {
     expect(doctorPrintIndexFromSnapshot({ index: { totalItems: 1234 } })).toBe(0);
     expect(out.stdout).toContain("[ok] Index: 1234 items.");
+  });
+});
+
+describe("doctorPrintEmbeddingFromSnapshot", () => {
+  beforeEach(() => {
+    out.reset();
+  });
+
+  // The gap this closes: the gateway knew semantic search was dead and never said so. A real
+  // gateway logged `embeddings: "unavailable"` across 397 consecutive heartbeats while
+  // `nimbus doctor` reported nothing at all — `doctor-core.ts` had zero mentions of "embedding".
+  // Same blind spot #925 closed for the Vault, one subsystem over.
+  it("returns 2 and FAILS when the runtime is unavailable, naming the reason", () => {
+    expect(
+      doctorPrintEmbeddingFromSnapshot({
+        embedding: { state: "unavailable", reason: "Cannot find module onnxruntime_binding.node" },
+      }),
+    ).toBe(2);
+    expect(out.stdout).toContain("[fail] Embeddings:");
+    // The REASON is the whole point — a bare "unavailable" is what we already had in the log.
+    expect(out.stdout).toContain("onnxruntime_binding.node");
+  });
+
+  it("returns 0 when ready, naming the model", () => {
+    expect(
+      doctorPrintEmbeddingFromSnapshot({
+        embedding: { state: "ready", model: "Xenova/all-MiniLM-L6-v2", dims: 384 },
+      }),
+    ).toBe(0);
+    expect(out.stdout).toContain("[ok] Embeddings:");
+    expect(out.stdout).toContain("Xenova/all-MiniLM-L6-v2");
+  });
+
+  // `warming` is TRANSIENT (embedding-readiness.ts is explicit about this), so it must not read as
+  // a failure — a cold first run would otherwise always report broken.
+  it("returns 1 and warns while warming", () => {
+    expect(
+      doctorPrintEmbeddingFromSnapshot({ embedding: { state: "warming", elapsedMs: 4200 } }),
+    ).toBe(1);
+    expect(out.stdout).toContain("[warn] Embeddings:");
+  });
+
+  // `disabled` is BY DESIGN, not a fault. Reporting it as a failure would train users to ignore
+  // the line, which is how the Vault check lost its meaning before #925.
+  it("returns 0 when disabled by configuration", () => {
+    expect(doctorPrintEmbeddingFromSnapshot({ embedding: { state: "disabled" } })).toBe(0);
+    expect(out.stdout).toContain("[ok] Embeddings:");
+    expect(out.stdout).toContain("disabled");
+  });
+
+  // An older gateway has no `embedding` key at all. Doctor must not invent a verdict about a
+  // capability it cannot see — silence beats a false green.
+  it("returns 0 and says nothing when the gateway reports no embedding state", () => {
+    expect(doctorPrintEmbeddingFromSnapshot({})).toBe(0);
+    expect(out.stdout).not.toContain("Embeddings:");
+  });
+
+  it("returns 2 on an unrecognised state rather than assuming it is fine", () => {
+    expect(doctorPrintEmbeddingFromSnapshot({ embedding: { state: "wat" } })).toBe(2);
+    expect(out.stdout).toContain("[fail] Embeddings:");
   });
 });
 

--- a/packages/cli/src/commands/doctor-core.ts
+++ b/packages/cli/src/commands/doctor-core.ts
@@ -469,6 +469,71 @@ export function doctorPrintIndexFromSnapshot(snap: { index?: { totalItems?: unkn
   return 0;
 }
 
+/**
+ * Report the embedding runtime, so a dead semantic search cannot stay silent.
+ *
+ * The gap this closes: the gateway KNEW the capability was off and never said so. A real gateway
+ * logged `embeddings: "unavailable"` across 397 consecutive heartbeats while `nimbus doctor`
+ * reported nothing — this file had zero mentions of "embedding". That is the same blind spot
+ * #925 closed for the Vault, one subsystem over, and it is why the onnxruntime failure (#1396)
+ * went unnoticed for so long.
+ *
+ * Severity follows the state's own documented lifetime in `embedding-readiness.ts`:
+ * `warming` is TRANSIENT so it warns rather than fails (a cold first run would otherwise always
+ * look broken), and `disabled` is BY DESIGN so it passes — reporting a deliberate setting as a
+ * fault is how a check trains people to ignore it.
+ *
+ * `reason` is the payload that matters. "unavailable" alone is what the log already said and what
+ * nobody could act on.
+ */
+export function doctorPrintEmbeddingFromSnapshot(snap: { embedding?: unknown }): number {
+  const emb = snap.embedding;
+  // A gateway that predates this field says nothing about embeddings. Stay silent rather than
+  // invent a verdict about a capability we cannot observe — a false green is worse than no line.
+  if (emb === null || typeof emb !== "object") {
+    return 0;
+  }
+  const rec = emb as Record<string, unknown>;
+  const state = typeof rec["state"] === "string" ? rec["state"] : "";
+  const reason = typeof rec["reason"] === "string" && rec["reason"] !== "" ? rec["reason"] : null;
+  const model = typeof rec["model"] === "string" && rec["model"] !== "" ? rec["model"] : null;
+
+  if (state === "ready") {
+    console.log(`[ok] Embeddings: ready${model === null ? "" : ` (${model})`}.`);
+    return 0;
+  }
+  if (state === "disabled") {
+    console.log(
+      `[ok] Embeddings: disabled by configuration — semantic search is off by design${
+        reason === null ? "" : ` (${reason})`
+      }.`,
+    );
+    return 0;
+  }
+  if (state === "warming") {
+    const ms = rec["elapsedMs"];
+    const secs =
+      typeof ms === "number" && Number.isFinite(ms) ? Math.max(0, Math.round(ms / 1000)) : null;
+    console.log(
+      `[warn] Embeddings: still loading${secs === null ? "" : ` (${String(secs)}s)`} — semantic search is not available yet.`,
+    );
+    return 1;
+  }
+  if (state === "unavailable") {
+    console.log(
+      `[fail] Embeddings: unavailable — semantic search is disabled for this gateway run${
+        reason === null ? "" : `: ${reason}`
+      }`,
+    );
+    return 2;
+  }
+  // An unrecognised state is not evidence of health. Fail loudly rather than pass by default.
+  console.log(
+    `[fail] Embeddings: unrecognised runtime state ${JSON.stringify(state)} — treat as not working.`,
+  );
+  return 2;
+}
+
 export function doctorPrintHealthFromSnapshot(snap: { connectorHealth?: unknown }): number {
   const healthRaw = snap.connectorHealth;
   const health: ConnectorHealthRow[] = Array.isArray(healthRaw)
@@ -503,8 +568,12 @@ async function doctorRunGatewayRpcs(client: IPCClient): Promise<number> {
   const snap = await client.call<{
     index?: { totalItems?: unknown };
     connectorHealth?: unknown;
+    embedding?: unknown;
   }>("diag.snapshot", {});
   exit = Math.max(exit, doctorPrintIndexFromSnapshot(snap));
+  // Reported BEFORE connector health: a dead embedding runtime disables semantic search for the
+  // whole gateway run, which outranks any one connector being unreachable.
+  exit = Math.max(exit, doctorPrintEmbeddingFromSnapshot(snap));
   exit = Math.max(exit, doctorPrintHealthFromSnapshot(snap));
   return exit;
 }

--- a/packages/gateway/src/ipc/diagnostics-rpc.ts
+++ b/packages/gateway/src/ipc/diagnostics-rpc.ts
@@ -19,6 +19,7 @@ import { runReadOnlySelect, SqlGuardError } from "../db/query-guard.ts";
 import { formatRepairReport, repairIndex } from "../db/repair.ts";
 import { listSnapshots, previewRestore, pruneSnapshots, takeSnapshot } from "../db/snapshot.ts";
 import { formatVerifyResult, verifyIndex } from "../db/verify.ts";
+import type { EmbeddingReadiness } from "../embedding/embedding-readiness.ts";
 import { preT2DisabledCount, signatureDisabledRegistry } from "../extensions/hard-disable.ts";
 import { buildItemListSql } from "../index/item-list-query.ts";
 import type { LocalIndex } from "../index/local-index.ts";
@@ -50,6 +51,12 @@ export type DiagnosticsRpcContext = {
   readonly gatewayVersion: string;
   readonly startedAtMs: number;
   readonly sandboxRunner?: SandboxRunner;
+  /**
+   * Live embedding-runtime readiness, so `nimbus doctor` can report a dead semantic search.
+   * Optional because a gateway assembled without an embedding runtime has nothing to report —
+   * the CLI stays silent on a missing field rather than inventing a verdict (#1396).
+   */
+  readonly embeddingReadiness?: () => EmbeddingReadiness;
   readonly autoUpdateDiag?: {
     cachedUpdatesCount: () => number;
     intervalHours: number;
@@ -611,6 +618,7 @@ function rpcDiagSnapshot(ctx: DiagnosticsRpcContext): DiagnosticsRpcOutcome {
       },
       connectorHealth: health,
       index: metrics,
+      embedding: ctx.embeddingReadiness?.(),
       hitl: { pendingConsentRequests: pendingConsent },
       watchers,
       auditLogTail: audit,

--- a/packages/gateway/src/ipc/server/dispatchers.ts
+++ b/packages/gateway/src/ipc/server/dispatchers.ts
@@ -1538,6 +1538,12 @@ export async function tryDispatchDiagnosticsRpc(
       ...(ctx.options.extensionsAutoUpdateDiag === undefined
         ? {}
         : { autoUpdateDiag: ctx.options.extensionsAutoUpdateDiag }),
+      // Forwarded so `diag.snapshot` can report embedding readiness and `nimbus doctor` can say
+      // when semantic search is dead. Omitted when the gateway has no embedding runtime, which
+      // the CLI renders as silence rather than a verdict (#1396).
+      ...(ctx.options.embeddingReadiness === undefined
+        ? {}
+        : { embeddingReadiness: ctx.options.embeddingReadiness }),
     };
     const diagCtx =
       ctx.options.localIndex === undefined


### PR DESCRIPTION
## The gap

`nimbus doctor` had **zero mentions of "embedding"**. The gateway knew semantic search was dead and never said so — a real gateway logged `embeddings: "unavailable"` across **397 consecutive heartbeats** while doctor reported nothing wrong.

That is the same blind spot #925 closed for the Vault, one subsystem over: doctor "probed nothing but `Bun.which('secret-tool')` and so reported `[ok]` where the Vault could not work". It is also why #1396 went unnoticed for so long.

## The change

`diag.snapshot` now carries `embedding` — the existing `EmbeddingReadiness`, already computed in `assemble.ts` and until now consumed only by `index.searchRanked` — threaded through the diagnostics dispatcher. The CLI renders it with `doctorPrintEmbeddingFromSnapshot`.

## Severity follows each state's documented lifetime

Deliberately not "anything that isn't ready is broken":

| State | Verdict | Why |
| --- | --- | --- |
| `ready` | `[ok]` | names the model |
| `disabled` | `[ok]` | off **by design** — calling a deliberate setting a fault is how a check trains people to ignore it |
| `warming` | `[warn]` | **transient**, per `embedding-readiness.ts` — a cold first run must not read as broken |
| `unavailable` | `[fail]` | names the **reason**, which is the whole point |
| unrecognised | `[fail]` | an unknown state is not evidence of health |
| absent | *silent* | an older gateway reports no field — say nothing rather than invent a verdict about a capability we cannot observe |

The `reason` is the payload that matters. A bare "unavailable" is exactly what the log already said and what nobody could act on.

## Verified across the real wire

Not both ends faked — that is the failure mode where a test per side proves the ends and never the wire. A **source gateway** and a **source CLI** over real IPC:

```
[fail] Embeddings: unavailable — semantic search is disabled for this gateway run:
       ResolveMessage: Cannot find module
       '../bin/napi-v3/win32/x64/onnxruntime_binding.node'
       from '...\dist\workers\embedding-worker.js'
```

That is #1396's root cause, surfaced by the tool a user actually runs.

## Why now

This is the measuring instrument for #1396. Fix the meter before the engine: without it the three-platform sidecar fix would be verified by grepping log files, and nothing would stop the capability going silently dead again.

## Verification

- Red-proved by reverting the source — the suite fails without it.
- 6 new tests, one per state plus the absent-field and unrecognised-state bounds.
- 138 tests pass across `doctor-core` and `diagnostics-rpc`; `preflight:fast` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6qbQmiRqJcxDc6ENA8LFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added embedding readiness diagnostics to the CLI health check.
  - Reports whether embeddings are ready, warming up, disabled, unavailable, or in an unknown state.
  - Displays relevant model and status details when available.
  - Overall diagnostic results now reflect embedding availability and severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->