### PR TITLE
test(cli): make tui fallback tests hermetic

### DIFF
--- a/packages/cli/src/tui/dumb-terminal.test.ts
+++ b/packages/cli/src/tui/dumb-terminal.test.ts
@@ -1,11 +1,47 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
 const CLI_ENTRY = join(REPO_ROOT, "packages", "cli", "src", "index.ts");
 
 const BUN_EXECUTABLE = process.execPath;
+
+// `nimbus tui` (`commands/tui.tsx` `runTui`) reads the REAL gateway state file
+// (`<dataDir>/gateway.json`, via `getCliPlatformPaths()` + `readGatewayState()`)
+// BEFORE it ever inspects the terminal. `dataDir` has no env-var override —
+// unlike `configDir`/`socketPath`, it is deliberately fixed in `paths.ts` ("this
+// cannot silently repoint a live gateway's database or socket") — so a spawned
+// CLI here, left pointed at the developer's real profile, finds whatever real
+// gateway the developer happens to have running, takes the real-gateway branch
+// instead of the terminal-fallback branch under test, and hangs against it
+// (issue #1389: passes with no gateway running, fails/times out with one).
+//
+// Isolating every env var `getCliPlatformPaths()` derives a profile root from
+// makes a real `gateway.json` structurally unreachable — never merely absent by
+// chance — regardless of what is running on the host.
+const ISOLATED_HOME = mkdtempSync(join(tmpdir(), "nimbus-tui-fallback-test-"));
+
+afterAll(() => {
+  rmSync(ISOLATED_HOME, { recursive: true, force: true });
+});
+
+function isolationEnv(): NodeJS.ProcessEnv {
+  return {
+    // win32: getCliPlatformPaths() reads these two directly (and throws if unset).
+    APPDATA: join(ISOLATED_HOME, "AppData", "Roaming"),
+    LOCALAPPDATA: join(ISOLATED_HOME, "AppData", "Local"),
+    // darwin/linux: getCliPlatformPaths() derives dataDir from homedir()/XDG_*.
+    HOME: ISOLATED_HOME,
+    XDG_CONFIG_HOME: join(ISOLATED_HOME, "config"),
+    XDG_DATA_HOME: join(ISOLATED_HOME, "data"),
+    // Belt-and-braces: even a code path that fell back to the default socket
+    // must not find anything listening there either.
+    NIMBUS_GATEWAY_SOCKET: join(ISOLATED_HOME, "unreachable-nimbus-gateway.sock"),
+  };
+}
 
 function run(env: NodeJS.ProcessEnv = {}): {
   code: number;
@@ -14,7 +50,7 @@ function run(env: NodeJS.ProcessEnv = {}): {
   error: Error | undefined;
 } {
   const result = spawnSync(BUN_EXECUTABLE, ["run", CLI_ENTRY, "tui"], {
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...isolationEnv(), ...env },
     stdio: ["pipe", "pipe", "pipe"],
     encoding: "utf-8",
     // A cold `bun run` of the CLI entry (transpile + module graph load) can exceed


### PR DESCRIPTION
## Root cause

The three tests in `nimbus tui fallback behavior` (`packages/cli/src/tui/dumb-terminal.test.ts`) spawn `bun run <cli-entry> tui` and merge the child's environment as `{ ...process.env, ...env }`, never touching `APPDATA`/`LOCALAPPDATA`/`HOME`/`XDG_*`.

`runTui` (`packages/cli/src/commands/tui.tsx`) calls `readGatewayState(paths)` — which reads `<dataDir>/gateway.json` — **before it ever inspects the terminal** (`detectFallbackReason`). `dataDir` has no env-var override: unlike `configDir` (`NIMBUS_CONFIG_DIR`) and `socketPath` (`NIMBUS_GATEWAY_SOCKET`), it's derived straight from `APPDATA`/`LOCALAPPDATA` (win32) or `homedir()`/`XDG_*` (darwin/linux) in `packages/cli/src/paths.ts`, deliberately — the comment there says exactly why: "this cannot silently repoint a live gateway's database or socket."

So a spawned test CLI always resolves the developer's **real** Nimbus profile:

- **No real gateway running:** `gateway.json` doesn't exist → `readGatewayState` returns `undefined` → `runTui` prints `Gateway is not running...` and exits immediately. Fast, and happens to satisfy the tests' assertions.
- **A real gateway running:** `gateway.json` exists with a real, connectable socket → `readGatewayState` returns a real state → `runTui` proceeds past the early-return, detects the fallback reason (`TERM=dumb`/non-TTY/`CI=true`), prints the fallback notice, and calls `runRepl()`, which connects to the **real** gateway's socket and then blocks on `rl.question("nimbus> ")` reading from the spawned child's empty/closed stdin — which never resolves. The test hangs until bun's default per-test timeout fires.

Root cause: **the tests dial whatever gateway.json happens to exist in the developer's real profile**, instead of an isolated one. CI never catches this because no user gateway runs there.

## Fix

`packages/cli/src/tui/dumb-terminal.test.ts` now creates one `mkdtempSync` scratch directory per test file and points **every** env var `getCliPlatformPaths()` can derive a profile root from — `APPDATA`, `LOCALAPPDATA` (win32), `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME` (darwin/linux), plus `NIMBUS_GATEWAY_SOCKET` as a belt-and-braces default-socket override — at that scratch directory before spawning the CLI. A real `gateway.json` is then **structurally unreachable**, not merely absent by chance, regardless of what's running on the host. The directory is removed in `afterAll`.

This follows the "write the guard as what CANNOT happen" principle: rather than tolerating a real gateway (e.g. by tightening timeouts or retry logic), the fix makes it impossible for the spawned CLI to ever see one.

## Red-prove

1. **Reproduced the exact reported symptom safely**, without starting a real gateway or touching the real profile: a throwaway script plants a `gateway.json` (valid shape: numeric `pid`, string `socketPath`) pointing at a stub named-pipe listener (not the nimbus-gateway binary — just accepts a connection and does nothing), inside a scratch `mkdtempSync` dir, and points `APPDATA`/`LOCALAPPDATA` there.
2. With the **original** (unfixed) test file (`git stash` to revert), running `bun test packages/cli/src/tui/dumb-terminal.test.ts` with those env vars ambient (simulating "developer has a real gateway running") reproduces the bug exactly:
   ```
   (fail) nimbus tui fallback behavior > TERM=dumb prints fallback notice and does not attempt Ink render [5014.92ms]
     ^ this test timed out after 5000ms.
   (fail) nimbus tui fallback behavior > non-TTY stdout falls back gracefully [5016.86ms]
     ^ this test timed out after 5000ms.
   (fail) nimbus tui fallback behavior > CI=true prints fallback notice [5017.33ms]
     ^ this test timed out after 5000ms.
   0 pass / 3 fail
   ```
   — matching the issue's reported "~5000ms" timeout precisely.
3. With the **fixed** test file, in the exact same ambient environment (same fake "live gateway" `APPDATA`/`LOCALAPPDATA` still set from outside), all 3 tests pass in ~1.2s:
   ```
   3 pass
   0 fail
   Ran 3 tests across 1 file. [1210.00ms]
   ```
   proving the fix's internal override neutralizes whatever the ambient environment claims, not just that it happens to work when nothing is set externally.
4. `bun run preflight:fast` passes clean on the branch.

## Not verified

- I did not start a real Nimbus gateway process (per the task's hard constraint) to reproduce the *original* bug 1:1 — the red-proof above uses a safe stand-in (a stub pipe listener + a synthetic `gateway.json`) that reproduces the same code path (`readGatewayState` finds a live, connectable state → `runRepl` → `rl.question()` hang) and the same observed timeout value, which I'm confident is the real mechanism, but I can't claim byte-for-byte confirmation against an actual `nimbus-gateway` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)