### PR TITLE
fix(embedding): ship the onnx binding and stub sharp so the worker can start

### DIFF
--- a/packages/gateway/src/workers/sharp-stub.test.ts
+++ b/packages/gateway/src/workers/sharp-stub.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import sharpStub from "./sharp-stub.ts";
+
+/**
+ * These assertions look trivial and are not: the stub's FALSINESS is the contract.
+ *
+ * `@xenova/transformers` selects its image backend with `else if (sharp)` in
+ * `src/utils/image.js`. A stub that is truthy — `{}`, a no-op function, a class — would send it
+ * down the sharp branch and then fail at the first real call, turning a clean "no image support"
+ * into a crash inside the embedding worker. That is the failure this file exists to prevent, and
+ * it is invisible to a type check, since every one of those shapes satisfies the same import.
+ *
+ * The stub is substituted into the worker bundle by `stubSharpPlugin` in
+ * `scripts/build-workers.ts` — see `sharp-stub.ts` for why bundling the real native `sharp` broke
+ * the embedding runtime outright (#1396).
+ */
+describe("sharp stub", () => {
+  test("is falsy, which is what selects the non-sharp branch upstream", () => {
+    expect(sharpStub).toBeFalsy();
+  });
+
+  // Pinned as `undefined` specifically, not merely falsy: `null`, `0` and `""` are also falsy but
+  // would each be a deliberate signal to a reader. `undefined` is what an absent module yields.
+  test("is exactly undefined", () => {
+    expect(sharpStub).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/workers/sharp-stub.ts
+++ b/packages/gateway/src/workers/sharp-stub.ts
@@ -1,0 +1,21 @@
+/**
+ * Falsy stand-in for `sharp`, substituted into the embedding worker bundle.
+ *
+ * `@xenova/transformers` imports `sharp` statically from `src/utils/image.js` for IMAGE
+ * preprocessing, and `sharp` is a native module. Bundled into the worker it fails at load with
+ * "Could not load the \"sharp\" module using the <platform> runtime", which killed the whole
+ * embedding runtime before a single vector was produced — semantic search dead, and until the
+ * logging fix it reported only `err: {}` (#1396).
+ *
+ * The embedding worker does TEXT feature-extraction only; it never reaches an image path. Two
+ * things make stubbing safe rather than a workaround:
+ *
+ * 1. `image.js` guards its use with `else if (sharp)`, so a falsy value selects the non-sharp
+ *    branch by design rather than by accident.
+ * 2. Upstream already does exactly this — `@xenova/transformers`'s own manifest maps
+ *    `"sharp": false` in its browser field for non-Node builds.
+ *
+ * If an image or audio model is ever added to this worker, this stub is the first thing to
+ * revisit: the failure would be a missing capability at an image path, not a load error.
+ */
+export default undefined;

--- a/scripts/build-workers.ts
+++ b/scripts/build-workers.ts
@@ -8,21 +8,42 @@
  * Output goes to `packages/gateway/dist/workers/<name>.js`, which is gitignored, and is embedded
  * by `packages/gateway/src/workers/embedded-workers.ts` with `{ type: "file" }`.
  *
- * `--target bun` keeps `bun:sqlite` and friends external, which is what the worker realm wants;
+ * `target: "bun"` keeps `bun:sqlite` and friends external, which is what the worker realm wants;
  * everything else is bundled in, so the emitted file has no relative imports to resolve at load.
+ *
+ * Built through `Bun.build()` rather than the `bun build` CLI for one reason: the CLI has no
+ * aliasing flag, and the embedding worker needs `sharp` replaced with a falsy stub. Bundling the
+ * real native `sharp` makes the worker fail at load and takes the whole embedding runtime with it
+ * (#1396). See `packages/gateway/src/workers/sharp-stub.ts`.
  */
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { WORKER_ENTRIES, WORKER_OUT_DIR } from "../packages/gateway/src/workers/worker-entries.ts";
+import { copyOnnxSidecar } from "./copy-onnx-sidecar.ts";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const gatewayDir = join(repoRoot, "packages", "gateway");
 const outDir = join(gatewayDir, ...WORKER_OUT_DIR.split("/"));
 
-function main(): void {
+/**
+ * Replace `sharp` with a falsy stub. `@xenova/transformers` imports it statically for IMAGE
+ * preprocessing; it is a NATIVE module, so bundling the real one makes the worker fail at load
+ * and takes the entire embedding runtime with it (#1396). This worker does text only, and
+ * transformers guards every use with `else if (sharp)` — upstream maps `"sharp": false` in its
+ * own browser field for exactly this reason.
+ */
+const stubSharpPlugin: import("bun").BunPlugin = {
+  name: "stub-sharp",
+  setup(build) {
+    build.onResolve({ filter: /^sharp$/ }, () => ({
+      path: join(gatewayDir, "src", "workers", "sharp-stub.ts"),
+    }));
+  },
+};
+
+async function main(): Promise<void> {
   mkdirSync(outDir, { recursive: true });
 
   for (const entry of WORKER_ENTRIES) {
@@ -36,20 +57,31 @@ function main(): void {
       process.exit(1);
     }
     const outfile = join(outDir, `${entry.name}.js`);
-    const r = spawnSync(
-      process.execPath,
-      ["build", sourceAbs, "--target", "bun", "--outfile", outfile],
-      { cwd: gatewayDir, stdio: "inherit", env: process.env },
-    );
-    if ((r.status ?? 1) !== 0) {
+    const result = await Bun.build({
+      entrypoints: [sourceAbs],
+      target: "bun",
+      outdir: outDir,
+      naming: `${entry.name}.js`,
+      plugins: [stubSharpPlugin],
+    });
+    if (!result.success) {
       process.stderr.write(`build-workers: bun build failed for ${entry.source}\n`);
-      process.exit(r.status ?? 1);
+      for (const log of result.logs) {
+        process.stderr.write(`  ${String(log)}\n`);
+      }
+      process.exit(1);
     }
     process.stdout.write(
       `build-workers: ${entry.source} → ${WORKER_OUT_DIR}/${entry.name}.js ` +
         `(${String(statSync(outfile).size)} bytes)\n`,
     );
   }
+  // The onnxruntime binding must sit beside the bundled worker or the embedding runtime dies at
+  // init — see copy-onnx-sidecar.ts. Done here rather than only in compile-gateway.ts because the
+  // release pipeline does not run that script; vec0 shipped broken once for exactly that reason.
+  const binding = copyOnnxSidecar(outDir);
+  process.stdout.write(`build-workers: onnx sidecar -> ${binding}
+`);
 }
 
-main();
+await main();

--- a/scripts/copy-onnx-sidecar.ts
+++ b/scripts/copy-onnx-sidecar.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+import { copyFileSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The onnxruntime native binding, copied next to the bundled embedding worker.
+ *
+ * Without it semantic search is DEAD — not degraded. `@xenova/transformers` reaches
+ * `onnxruntime-node`, whose own code does `require("../bin/napi-v3/<platform>/<arch>/
+ * onnxruntime_binding.node")` relative to itself. Once the worker is bundled to
+ * `dist/workers/embedding-worker.js` that relative path resolves to `dist/bin/napi-v3/...`, which
+ * nothing ever created, so the worker died at init on every install. A real gateway reported
+ * `embeddings: "unavailable"` across 397 consecutive heartbeats (#1396).
+ *
+ * This mirrors `copy-vec0-sidecar.ts`, deliberately — including the lesson recorded there. That
+ * copy "previously lived only in `compile-gateway.ts`, which the release pipeline never runs", so
+ * released binaries shipped without it and failed silently. Same shape of bug, same remedy: a
+ * standalone script both call sites invoke.
+ *
+ * The destination is NOT beside the executable like `vec0`. It is beside the bundled worker,
+ * because the path is computed by third-party code we do not control — we place the file where
+ * `onnxruntime-node` already looks rather than teaching it a new location.
+ */
+export function onnxOsSegment(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "win32";
+  if (platform === "darwin") return "darwin";
+  return "linux";
+}
+
+/** `dist/bin/napi-v3/<platform>/<arch>` — the path the bundled worker's own require computes. */
+export function onnxSidecarRelDir(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  return join("bin", "napi-v3", onnxOsSegment(platform), arch);
+}
+
+const GATEWAY_PACKAGE_JSON = fileURLToPath(
+  new URL("../packages/gateway/package.json", import.meta.url),
+);
+
+/**
+ * `onnxruntime-node` is a TRANSITIVE dependency (via `@xenova/transformers`), so resolution starts
+ * from the gateway manifest and hops through the package that actually declares it.
+ */
+export function resolveOnnxBindingOrThrow(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  const rel = `bin/napi-v3/${onnxOsSegment(platform)}/${arch}/onnxruntime_binding.node`;
+  try {
+    const req = createRequire(GATEWAY_PACKAGE_JSON);
+    const transformersIndex = req.resolve("@xenova/transformers");
+    const onnxIndex = createRequire(transformersIndex).resolve("onnxruntime-node");
+    // `onnxIndex` is `.../onnxruntime-node/dist/index.js`; the binding sits two levels up.
+    return join(dirname(dirname(onnxIndex)), ...rel.split("/"));
+  } catch (e: unknown) {
+    throw new Error(
+      `copy-onnx-sidecar: cannot resolve ${rel} for ${platform}/${arch}. ` +
+        "Without it the embedding worker dies at init and semantic search is silently disabled. " +
+        `Cause: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+export function copyOnnxSidecar(
+  workerOutDir: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  const src = resolveOnnxBindingOrThrow(platform, arch);
+  // `workerOutDir` is `<gateway>/dist/workers`; the require resolves one level up from there.
+  const destDir = join(dirname(workerOutDir), onnxSidecarRelDir(platform, arch));
+  mkdirSync(destDir, { recursive: true });
+  const dest = join(destDir, "onnxruntime_binding.node");
+  copyFileSync(src, dest);
+  return dest;
+}
+
+if (import.meta.main) {
+  const gatewayDist = fileURLToPath(new URL("../packages/gateway/dist", import.meta.url));
+  const out = copyOnnxSidecar(join(gatewayDist, "workers"));
+  process.stdout.write(`copy-onnx-sidecar: ${out}\n`);
+}

--- a/scripts/structure-audit/check-gateway-native-deps.ts
+++ b/scripts/structure-audit/check-gateway-native-deps.ts
@@ -16,7 +16,15 @@ const GATEWAY_MANIFEST = join(REPO_ROOT, "packages", "gateway", "package.json");
  * Adding an entry means committing to that sidecar work on all three platforms. "It built on Linux
  * CI" is not evidence that it loads on a user's Windows machine.
  */
-const ALLOWED_NATIVE: ReadonlySet<string> = new Set(["sqlite-vec"]);
+const ALLOWED_NATIVE: ReadonlySet<string> = new Set([
+  "sqlite-vec",
+  // Transitive via `@xenova/transformers`, so this audit never actually SAW it — the gate scans
+  // declared dependencies only, and reported `ok` while the embedding worker was dead in every
+  // install (#1396). Listed explicitly so the exemption is a recorded decision rather than a blind
+  // spot, and so adding it to the manifest later does not read as new. The sidecar commitment it
+  // implies is met by `copy-onnx-sidecar.ts`, called from `build-workers.ts`.
+  "onnxruntime-node",
+]);
 
 export type NativeFinding = { readonly pkg: string; readonly evidence: readonly string[] };
 


### PR DESCRIPTION
Addresses the load failure in #1396. **Semantic search was dead in every install** — not degraded, dead.

## The single-binding theory in the issue was wrong

There are **two** native modules in the chain, and fixing only the first moves the error rather than clearing it.

**1. `onnxruntime-node`** does `require("../bin/napi-v3/<platform>/<arch>/onnxruntime_binding.node")` relative to itself. Once the worker is bundled to `dist/workers/embedding-worker.js`, that resolves to `dist/bin/napi-v3/…` — which nothing ever created.

`copy-onnx-sidecar.ts` places it there, mirroring `copy-vec0-sidecar.ts` **including its recorded lesson**: that copy once lived only in `compile-gateway.ts`, which the release pipeline never runs, so binaries shipped without it and failed silently. This is called from `build-workers.ts` for exactly that reason.

**2. `sharp`** then fails identically. Transformers imports it statically for **image** preprocessing and it is also native. The embedding worker does text feature-extraction only; transformers guards every use with `else if (sharp)`; and upstream already maps `"sharp": false` in its own browser field. A falsy stub is the sanctioned shape here, not a workaround.

`build-workers.ts` moves from the `bun build` CLI to `Bun.build()` purely because the CLI has no aliasing flag.

## Why no gate caught this

`onnxruntime-node` joins `ALLOWED_NATIVE`, with the reasoning inline. The audit never fired because it scans **declared** dependencies and this arrives transitively — it reported `ok (19 declared dependencies checked)` while the capability was dead. Its own doc comment predicted this gap.

## Verification, from source

```
before          -> ResolveMessage: Cannot find module '…/onnxruntime_binding.node'
binding only    -> Could not load the "sharp" module using the win32-x64 runtime
binding + stub  -> embedding worker initialized; semantic search is now active
```

That last line is the first success on this machine. 728 structure-audit + worker tests pass; `preflight:fast` 32/32.

## ⚠️ Not yet verified — please weigh this in review

**The compiled binary.** Inside it the worker lives on a virtual FS (`B:/~BUN/root/…`), and a native `.node` cannot load from there — so the relative lookup may need to become an absolute one, the way `tryLoadFromSidecar()` works for `vec0`. Source-tree success is **not** evidence about the packaged build, and that exact gap is the bug class this sits in (F15/F22, both of which shipped dead workers while every source test passed).

The release packaging path is untouched by this PR. If the binary needs the absolute lookup, that is a follow-up on top of this, not a revision of it — the sidecar still has to exist either way.

Also unverified: macOS and Linux. The copier derives platform/arch and the layout is identical, but only `win32/x64` has actually been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6qbQmiRqJcxDc6ENA8LFc
