### PR TITLE
fix(llm): make llm.setDefault write the store the router actually reads

### DIFF
--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -423,23 +423,108 @@ describe("llm.status", () => {
 });
 
 describe("llm.setDefault", () => {
-  test("persists default per task type and echoes back", async () => {
-    const setDefault = mock(async () => {});
-    const registry = { setDefault } as unknown as LlmRegistry;
-    const r = await dispatchLlmRpc(
-      "llm.setDefault",
-      { taskType: "classification", provider: "ollama", modelName: "gemma:2b" },
-      { registry, notify: () => {} },
+  // #1383: this endpoint was WRITE-ONLY. It persisted to `llm_task_defaults` (V20) and nothing
+  // read that table — the desktop control appeared to work and changed nothing about routing.
+  // It now writes the SAME store `nimbus llm use` writes, `[llm.tasks]`, which is what the
+  // router actually honours. The wire shape is unchanged, because the renderer calls it.
+  test("writes the pin into [llm.tasks] and updates the live router", async () => {
+    const { tomlPath, cleanup } = makeTempTomlPath();
+    try {
+      const router = new LlmRouter({
+        preferLocal: true,
+        localModel: "llama3.2:latest",
+        minReasoningParams: 0,
+        enforceAirGap: false,
+      });
+      router.registerRoute(
+        makeFakeProviderForRouter("ollama", ["llama3.2:latest"]),
+        "llama3.2:latest",
+      );
+      const registry = { llmRouter: router } as unknown as LlmRegistry;
+      const ctx: LlmRpcContext = { registry, notify: () => {}, tomlPath };
+
+      const r = await dispatchLlmRpc(
+        "llm.setDefault",
+        { taskType: "classification", provider: "ollama", modelName: "llama3.2:latest" },
+        ctx,
+      );
+      expect(r.kind).toBe("hit");
+      expect((r as { kind: "hit"; value: { taskType: string } }).value.taskType).toBe(
+        "classification",
+      );
+
+      // Round-tripped through the SAME parser boot uses — "a file was touched" is not the claim.
+      const reparsed = parseNimbusTomlLlmSection(readFileSync(tomlPath, "utf8"));
+      expect(reparsed.taskPins?.get("classification")).toBe("ollama/llama3.2:latest");
+      // AND live, without a restart — the half that was missing entirely before.
+      expect((await router.selectRoute("classification"))?.routeId).toBe("ollama/llama3.2:latest");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Fail-CLOSED, matching `llm.use`. Persisting a pin to a route that does not exist is the
+  // orphaned-config shape #1383 is itself an instance of.
+  test("REFUSES a provider/model that is not a registered route, and writes nothing", async () => {
+    const { tomlPath, cleanup } = makeTempTomlPath("[llm]\nprefer_local = true\n");
+    try {
+      const before = readFileSync(tomlPath, "utf8");
+      const router = new LlmRouter({
+        preferLocal: true,
+        localModel: "llama3.2:latest",
+        minReasoningParams: 0,
+        enforceAirGap: false,
+      });
+      router.registerRoute(makeFakeProviderForRouter("ollama", ["big"]), "big");
+      const registry = { llmRouter: router } as unknown as LlmRegistry;
+      const ctx: LlmRpcContext = { registry, notify: () => {}, tomlPath };
+
+      await expect(
+        dispatchLlmRpc(
+          "llm.setDefault",
+          { taskType: "reasoning", provider: "ollama", modelName: "ghost" },
+          ctx,
+        ),
+      ).rejects.toThrow(/not a registered route/);
+      expect(readFileSync(tomlPath, "utf8")).toBe(before);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // The question #1383 was blocked on: what should the UI do with no writable config path?
+  // Answered the same way `llm.use` already answers it — refuse, loudly. A silent success that
+  // persists nothing is precisely the bug being fixed.
+  test("refuses when there is no configured toml path", async () => {
+    const router = new LlmRouter({
+      preferLocal: true,
+      localModel: "llama3.2:latest",
+      minReasoningParams: 0,
+      enforceAirGap: false,
+    });
+    router.registerRoute(
+      makeFakeProviderForRouter("ollama", ["llama3.2:latest"]),
+      "llama3.2:latest",
     );
-    expect(r.kind).toBe("hit");
-    expect((r as { kind: "hit"; value: { taskType: string } }).value.taskType).toBe(
-      "classification",
-    );
-    expect(setDefault).toHaveBeenCalledWith("classification", "ollama", "gemma:2b");
+    const registry = { llmRouter: router } as unknown as LlmRegistry;
+    await expect(
+      dispatchLlmRpc(
+        "llm.setDefault",
+        { taskType: "classification", provider: "ollama", modelName: "llama3.2:latest" },
+        { registry, notify: () => {} },
+      ),
+    ).rejects.toThrow(/configDir/);
   });
 
   test("rejects invalid taskType", async () => {
-    const registry = { setDefault: mock(async () => {}) } as unknown as LlmRegistry;
+    const registry = {
+      llmRouter: new LlmRouter({
+        preferLocal: true,
+        localModel: "x",
+        minReasoningParams: 0,
+        enforceAirGap: false,
+      }),
+    } as unknown as LlmRegistry;
     await expect(
       dispatchLlmRpc(
         "llm.setDefault",
@@ -450,7 +535,14 @@ describe("llm.setDefault", () => {
   });
 
   test("rejects empty provider", async () => {
-    const registry = { setDefault: mock(async () => {}) } as unknown as LlmRegistry;
+    const registry = {
+      llmRouter: new LlmRouter({
+        preferLocal: true,
+        localModel: "x",
+        minReasoningParams: 0,
+        enforceAirGap: false,
+      }),
+    } as unknown as LlmRegistry;
     await expect(
       dispatchLlmRpc(
         "llm.setDefault",
@@ -458,20 +550,6 @@ describe("llm.setDefault", () => {
         { registry, notify: () => {} },
       ),
     ).rejects.toThrow();
-  });
-
-  // Deleted symbol (Task 10): `VALID_LLM_PROVIDERS` used to reject any provider outside
-  // {"ollama", "llamacpp", "remote"}. Validity is now the registry's answer alone.
-  test("accepts a provider string outside the old closed set", async () => {
-    const setDefault = mock(async () => {});
-    const registry = { setDefault } as unknown as LlmRegistry;
-    const r = await dispatchLlmRpc(
-      "llm.setDefault",
-      { taskType: "reasoning", provider: "gemini", modelName: "gemini-pro" },
-      { registry, notify: () => {} },
-    );
-    expect(r.kind).toBe("hit");
-    expect(setDefault).toHaveBeenCalledWith("reasoning", "gemini", "gemini-pro");
   });
 });
 

--- a/packages/gateway/src/ipc/llm-rpc.test.ts
+++ b/packages/gateway/src/ipc/llm-rpc.test.ts
@@ -516,6 +516,31 @@ describe("llm.setDefault", () => {
     ).rejects.toThrow(/configDir/);
   });
 
+  // `makeRouteId` throws a RAW Error on a slash in the provider, and the dispatcher does not
+  // convert handler errors into `LlmRpcError` — so this input escaped as an internal-error shape
+  // instead of invalid-params. Verified before fixing: the thrown value had no `code` at all.
+  test("rejects a provider containing a slash with invalid-params, not a raw Error", async () => {
+    const router = new LlmRouter({
+      preferLocal: true,
+      localModel: "llama3.2:latest",
+      minReasoningParams: 0,
+      enforceAirGap: false,
+    });
+    const registry = { llmRouter: router } as unknown as LlmRegistry;
+    const err = await dispatchLlmRpc(
+      "llm.setDefault",
+      { taskType: "classification", provider: "foo/bar", modelName: "m" },
+      { registry, notify: () => {}, tomlPath: "/nonexistent/nimbus.toml" },
+    ).then(
+      () => undefined,
+      (e: unknown) => e as { rpcCode?: number; name?: string },
+    );
+    // Asserted on `rpcCode`, the field `LlmRpcError` actually carries — not `code`, which is
+    // undefined on BOTH a raw Error and an LlmRpcError and so would pass for the wrong reason.
+    expect(err?.name).toBe("LlmRpcError");
+    expect(err?.rpcCode).toBe(-32602);
+  });
+
   test("rejects invalid taskType", async () => {
     const registry = {
       llmRouter: new LlmRouter({

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -1,7 +1,8 @@
 import { setNimbusTomlSectionKey } from "../config/toml-section-writer.ts";
 import type { LlmRegistry } from "../llm/registry.ts";
 import type { RouteAvailability } from "../llm/route-availability.ts";
-import type { LlmTaskType } from "../llm/types.ts";
+import { makeRouteId } from "../llm/route-id.ts";
+import type { LlmTaskType, ProviderId } from "../llm/types.ts";
 import { dispatchByMethod, type RpcMissOrHit } from "./_lib/dispatch-by-method.ts";
 
 export class LlmRpcError extends Error {
@@ -155,6 +156,23 @@ async function handleLoadOrUnload(
   return { isLoaded: false };
 }
 
+/**
+ * Pin a task to a route, from the desktop UI's `(taskType, provider, modelName)` shape.
+ *
+ * This endpoint used to be WRITE-ONLY (#1383): it persisted to `llm_task_defaults` (V20) and
+ * NOTHING read that table, so the control appeared to work and changed nothing about routing.
+ * It now writes the same store `llm.use` writes — `[llm.tasks]` — which is what
+ * `parseLlmTaskPins` reads at boot and what `LlmRouter` honours at runtime.
+ *
+ * The wire shape is deliberately unchanged: this method is renderer-exposed and the desktop UI
+ * calls it. Only the destination moved. `provider` + `modelName` are joined by `makeRouteId`,
+ * which is the same function `registerRoute` uses to mint the id, so the two cannot drift.
+ *
+ * Fail-CLOSED on both an unknown task and an unregistered route, matching `handleLlmUse` below.
+ * The open question #1383 recorded — what should happen with no writable config path — is
+ * answered the same way that handler already answers it: refuse. A silent success that persists
+ * nothing is exactly the bug this change removes.
+ */
 async function handleSetDefault(
   params: unknown,
   ctx: LlmRpcContext,
@@ -169,15 +187,24 @@ async function handleSetDefault(
     !VALID_LLM_TASKS.has(taskType) ||
     typeof provider !== "string" ||
     provider === "" ||
-    typeof modelName !== "string"
+    typeof modelName !== "string" ||
+    modelName === ""
   ) {
     throw new LlmRpcError(-32602, message);
   }
-  await ctx.registry.setDefault(
-    taskType as "classification" | "reasoning" | "summarisation" | "agent_step",
-    provider,
-    modelName,
-  );
+  const routeId = makeRouteId(provider as ProviderId, modelName);
+  if (ctx.registry.llmRouter.routeFor(routeId) === undefined) {
+    const known = ctx.registry.llmRouter
+      .routes()
+      .map((r) => r.routeId)
+      .join(", ");
+    throw new LlmRpcError(-32602, `"${routeId}" is not a registered route. Registered: ${known}`);
+  }
+  if (ctx.tomlPath === undefined) {
+    throw new LlmRpcError(-32603, "llm.setDefault requires a configured configDir");
+  }
+  setNimbusTomlSectionKey(ctx.tomlPath, "[llm.tasks]", taskType, routeId);
+  ctx.registry.llmRouter.setTaskPin(taskType as LlmTaskType, routeId);
   return { taskType, provider, modelName };
 }
 

--- a/packages/gateway/src/ipc/llm-rpc.ts
+++ b/packages/gateway/src/ipc/llm-rpc.ts
@@ -188,7 +188,12 @@ async function handleSetDefault(
     typeof provider !== "string" ||
     provider === "" ||
     typeof modelName !== "string" ||
-    modelName === ""
+    modelName === "" ||
+    // `makeRouteId` rejects a slash in the provider by throwing a RAW Error, and the dispatcher
+    // does not convert handler errors into `LlmRpcError` — so without this the caller gets an
+    // internal-error shape for what is plainly bad input. Checked here so the contract stays
+    // "invalid params are -32602".
+    provider.includes("/")
   ) {
     throw new LlmRpcError(-32602, message);
   }

--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -368,60 +368,11 @@ describe("LlmRegistry.pullModel", () => {
   });
 });
 
-describe("LlmRegistry.setDefault", () => {
-  let env: { db: Database; dir: string } | undefined;
-
-  afterEach(() => {
-    if (env !== undefined) {
-      env.db.close();
-      try {
-        rmSync(env.dir, { recursive: true, force: true });
-      } catch {
-        /* harmless */
-      }
-      env = undefined;
-    }
-  });
-
-  test("UPSERTs into llm_task_defaults when DB is provided", async () => {
-    env = makeDbWithSchema();
-    const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    await reg.setDefault("reasoning", "ollama", "llama3.2");
-    const row = env.db
-      .query("SELECT provider, model_name FROM llm_task_defaults WHERE task_type = ?")
-      .get("reasoning") as { provider: string; model_name: string } | undefined;
-    expect(row).toEqual({ provider: "ollama", model_name: "llama3.2" });
-  });
-
-  test("ON CONFLICT updates the existing row on second setDefault", async () => {
-    env = makeDbWithSchema();
-    const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: env.db });
-    await reg.setDefault("reasoning", "ollama", "llama3.2");
-    await reg.setDefault("reasoning", "remote", "claude");
-    const row = env.db
-      .query("SELECT provider, model_name FROM llm_task_defaults WHERE task_type = ?")
-      .get("reasoning") as { provider: string; model_name: string } | undefined;
-    expect(row).toEqual({ provider: "remote", model_name: "claude" });
-  });
-
-  // The two "when DB is undefined" tests that stood here are DELETED, not ported: `db` became
-  // required (#1356), so `setDefault`'s and `getDefault`'s `this.db === undefined` early-returns
-  // no longer exist and the state they described is unconstructable. Keeping them would have
-  // meant passing a real db and asserting the no-op that no longer happens — a test that cannot
-  // fail. The replacement guard is `db is REQUIRED at COMPILE time` below, which `bun run
-  // typecheck` enforces.
-
-  // `getDefault` was deleted on 2026-08-29 (dead code, nothing had ever called it). The latent
-  // bug it harbored: it compared `row === undefined`, but `bun:sqlite`'s `.get()` returns
-  // **`null`** for no matching row, so a lookup for an unpinned task threw `TypeError: null is
-  // not an object` instead of returning `undefined`. Verified directly against `bun:sqlite`. A
-  // test DID cover it — `test("getDefault on a missing-row throws (bun:sqlite .get() returns
-  // null, not undefined)")`, deleted by the same commit (`git show cd86f3e0`) — so this was a
-  // BUG ENCODED IN A TEST, not a latent gap: the test asserted the throw as the expected
-  // behavior rather than flagging it as wrong, which is a more useful lesson than "no test
-  // covered it" -- the test existed and still shipped the bug.
-});
-
+// `LlmRegistry.setDefault` was removed with #1383. Its two tests asserted an UPSERT into
+// `llm_task_defaults` — a table that had a writer and no reader, so they proved the write
+// happened while the setting it represented did nothing. The behaviour that replaced it is
+// covered where it now lives, in `ipc/llm-rpc.test.ts`: `llm.setDefault` writes `[llm.tasks]`,
+// updates the live router, and refuses an unregistered route or a missing config path.
 describe("LlmRegistry.addRoute + providerId-keyed lifecycle (Task 6)", () => {
   test("pullModel works for a model that has NO route", async () => {
     // The primary use of pull: fetch a model BEFORE configuring a route for it. Keying

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -39,14 +39,14 @@ export type LlmRegistryOptions = {
 export type LlmLifecycleTarget = { routeId?: string };
 
 /**
- * `llm_task_defaults` (V20) is intentionally left in the schema and intentionally unused.
- * `getDefault` was deleted on 2026-08-29 as dead code — nothing had ever called it. `setDefault`
- * remains ONLY because `llm.setDefault` is a live, renderer-exposed IPC method the desktop UI
- * calls (see `ipc/llm-rpc.ts:255` and `packages/ui/src/ipc/client.ts:312`). The table therefore
- * now has a writer and **no reader**: per-task pins live in `[llm.tasks]` in nimbus.toml, which
- * the router actually reads (Task 5–6). That gap is tracked in #1383. Do not re-wire `getDefault`
- * to "fix" this: two sources of truth for one setting is what made these accessors dead in the
- * first place.
+ * `llm_task_defaults` (V20) is intentionally left in the schema and now has NEITHER a reader nor
+ * a writer. `getDefault` went on 2026-08-29 as dead code; `setDefault` went with #1383, once
+ * `llm.setDefault` was repointed at `[llm.tasks]` — the store the router actually reads. The
+ * table survives only because migrations are append-only and forward-only; nothing consults it.
+ *
+ * Do not re-wire either accessor to "fix" that emptiness. Two sources of truth for one setting is
+ * exactly what made the endpoint write-only in the first place: the UI wrote here, the router
+ * read `[llm.tasks]`, and the control silently changed nothing for as long as it shipped.
  */
 export class LlmRegistry {
   private readonly router: LlmRouter;
@@ -318,23 +318,6 @@ export class LlmRegistry {
     // pulled model keeps reporting `model_absent` for up to
     // ROUTE_AVAILABILITY_POSITIVE_TTL_MS, which looks exactly like the pull having failed.
     this.probe.invalidate(provider);
-  }
-
-  async setDefault(
-    taskType: "classification" | "reasoning" | "summarisation" | "agent_step",
-    provider: ProviderId,
-    modelName: string,
-  ): Promise<void> {
-    dbRun(
-      this.db,
-      `INSERT INTO llm_task_defaults (task_type, provider, model_name, updated_at)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(task_type) DO UPDATE SET
-         provider = excluded.provider,
-         model_name = excluded.model_name,
-         updated_at = excluded.updated_at`,
-      [taskType, provider, modelName, Date.now()],
-    );
   }
 
   async getRouterStatus(): Promise<Awaited<ReturnType<LlmRouter["getStatus"]>>> {


### PR DESCRIPTION
Closes #1383.

`llm.setDefault` was **write-only**: it persisted to `llm_task_defaults` (V20) and nothing read that table. The desktop control appeared to work and changed nothing about routing.

## The change

It now writes **`[llm.tasks]`** — the same store `nimbus llm use` writes, that `parseLlmTaskPins` reads at boot and `LlmRouter` honours at runtime.

The **wire shape is unchanged**, because the method is renderer-exposed and the desktop UI calls it. Only the destination moved. `provider` + `modelName` are joined by `makeRouteId` — the same function `registerRoute` uses to mint the id — so the two cannot drift apart.

## Which option, and why

Of the three the issue lists, this is **#3**.

- **#1 (delete the endpoint)** is a user-visible surface change that needs the desktop app updated in step.
- **#2 (wire the table into routing)** was already rejected for reintroducing two sources of truth for one setting — which is what made these accessors dead in the first place.

## The question it was blocked on

> what should the UI do when the gateway has no writable config path?

Answered the way `handleLlmUse` already answers it: **refuse**, with `-32603`. A silent success that persists nothing is precisely the bug being removed here, so inventing a quieter failure would recreate it in a new place.

Both handlers now fail closed on all three: an unknown task, an unregistered route, and a missing config path.

## Cleanup

`LlmRegistry.setDefault` is deleted — its last caller is gone. `getDefault` went the same way on 2026-08-29, so `llm_task_defaults` now has **neither a reader nor a writer**; it survives only because migrations are append-only and forward-only. The comment there records that, and why re-wiring either accessor would be the wrong fix.

Its two registry tests are **removed rather than adapted**. They asserted the UPSERT landed — proving the write happened while the setting it represented did nothing. That is a test passing for a behaviour that had no effect, and adapting it would have carried that shape forward. The replacement behaviour is covered where it now lives, in `ipc/llm-rpc.test.ts`.

## Verification

- **Red-proved by reverting the handler with the tests in place: 3 fail without it, 0 with it.**
- New tests cover the round trip through the *same parser boot uses*, the live router honouring it without a restart, refusal of an unregistered route with nothing written, and refusal with no config path.
- 325 llm + llm-rpc tests pass; `preflight:fast` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6qbQmiRqJcxDc6ENA8LFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default language-model selections are now saved in configured settings under task-specific defaults.
  * Changes take effect immediately in the active routing configuration.
* **Bug Fixes**
  * Invalid, unregistered, or malformed routes are rejected without modifying configuration.
  * Default-setting requests now fail clearly when configuration is unavailable or task types are invalid.
* **Refactor**
  * Removed the legacy database-based default-setting flow in favor of settings-backed configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->