### PR TITLE
feat(agents): why, expert and ownership answer about an indexed item

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,6 +162,7 @@
     "@mastra/mcp": "1.17.1",
     "body-parser": "2.3.0",
     "brace-expansion": "5.0.9",
+    "browserslist": "4.28.7",
     "devalue": "5.8.1",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.5",
@@ -1296,7 +1297,7 @@
 
     "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.33", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw=="],
 
     "bcp-47": ["bcp-47@2.1.0", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w=="],
 
@@ -1314,7 +1315,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+    "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
 
     "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
@@ -1332,7 +1333,7 @@
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -1486,7 +1487,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.364", "", {}, "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.418", "", {}, "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA=="],
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
@@ -2130,7 +2131,7 @@
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
-    "node-releases": ["node-releases@2.0.46", "", {}, "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ=="],
+    "node-releases": ["node-releases@2.0.54", "", {}, "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ=="],
 
     "nodemailer": ["nodemailer@9.0.5", "", {}, "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
         "@nimbus-dev/client": "^0.17.3",
-        "@nimbus-dev/sdk": "^1.19.0",
+        "@nimbus-dev/sdk": "^1.31.0",
         "astro": "^7.2.4",
         "zod": "^4.4.3",
       },
@@ -90,7 +90,7 @@
         "@mastra/core": "^1.61.0",
         "@mastra/mcp": "^1.17.1",
         "@nimbus-dev/connectors": "^0.2.0",
-        "@nimbus-dev/sdk": "^1.19.0",
+        "@nimbus-dev/sdk": "^1.31.0",
         "@noble/hashes": "^2.3.0",
         "@scure/bip39": "^2.3.0",
         "@xenova/transformers": "^2.17.0",
@@ -660,7 +660,7 @@
 
     "@nimbus-dev/connectors": ["@nimbus-dev/connectors@0.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.30.0", "@nimbus-dev/sdk": "^1.20.0", "@types/nodemailer": "^7.0.4", "zod": "^4.4.2" }, "optionalDependencies": { "hyparquet": "^1.29.1", "imapflow": "^1.7.2", "nodemailer": "^9.0.5", "tsdav": "^2.3.1" }, "bin": { "nimbus-connector": "standalone/src/bin.ts" } }, "sha512-ZYKXcG1FTxobyB4qB4I1/lpNIcubJoYsBG9zeKnkxuEBVvSjlesP/6M0ZRs4wP71JtbEUghi8GglEcqOmcaSPA=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.19.0", "", {}, "sha512-2ZnsrXslj5NseuiB6fcf09HAULBlDDF77Zdu8hH/QRKAqLsuhgCUq9fFbxjWqvNaRFH+LSrT+55DGBnXBgLRKw=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.31.0", "", {}, "sha512-bu70LyslZxWZHE50VLEA+jHtCKuobLwBTRdelMFYbR19mxTINs4EuwFuiASkHwo2uKitPiVLLUiY0+eaw3oRKg=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 
@@ -2868,11 +2868,7 @@
 
     "@nimbus-dev/connectors/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.21.0", "", {}, "sha512-6mvR4NZNes/xSnR8lvnsO6n4QJXixuHxqUP0jBWRRZxEW/OoTgSLNzJewm75c5SrIf7AK4jcIBmgqtk3xMnZ4g=="],
 
-    "@nimbus/cli/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.21.0", "", {}, "sha512-6mvR4NZNes/xSnR8lvnsO6n4QJXixuHxqUP0jBWRRZxEW/OoTgSLNzJewm75c5SrIf7AK4jcIBmgqtk3xMnZ4g=="],
-
     "@nimbus/docs/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
-
-    "@nimbus/gateway/@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.21.0", "", {}, "sha512-6mvR4NZNes/xSnR8lvnsO6n4QJXixuHxqUP0jBWRRZxEW/OoTgSLNzJewm75c5SrIf7AK4jcIBmgqtk3xMnZ4g=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,30 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-09-01 — `why`, `expert` and `ownership` answer about an indexed item, not just a PR.**
+  A third input arm, `itemUrl`, on all three — so the browser client can ask about a Jira or
+  Linear issue and a PagerDuty incident, not only a pull request. Requires `@nimbus-dev/sdk`
+  **1.31.0**, which publishes `WhyItemSubject`, `WhyBrief.itemSubject` and
+  `ExpertBrief.query.itemUrl` (all additive). **Deliberately not a Confluence page:** a page
+  indexes as `type: "page"`, which appears in neither `ITEM_LINKED_ENTITY_TYPES` nor
+  `GRAPH_SYNC_BY_TYPE`, so it has no `graph_entity` at all — and every lane here answers from
+  graph edges. `resolveItemArm` treats "resolved, but no entity" as a miss rather than naming an
+  item the lanes then say nothing about, and a test pins that bound. The arm is not a rewiring
+  of an existing path: `ticketRowsForPr` joins `pe.type = 'pr'` on `from_id`, so handed an issue
+  it returns zero rows, and `why` would otherwise have shipped a well-formed EMPTY brief for
+  every issue in the index. `prResolvingItem` walks `resolves` INWARD to the change that closed
+  the item and populates the lane input with it, so the four item-applicable lanes answer
+  unchanged; `subAuthorship` and `subDownstream` stay silent, as they already do on the `prUrl`
+  arm, because neither question ever had a file subject. `expert` gains two edge-backed
+  sub-agents (`person --opened--> item`, and the resolving PR's author) and does **not** run its
+  five `LIKE` lanes on this arm — mixing an edge-backed answer with a lexical one in one ranked
+  list would let a title coincidence outrank someone the graph actually links to the item.
+  `ownership` introduces no new target kind: the item is mapped to its service by
+  `item --belongs_to--> repo --belongs_to--> service` and answered by the same service lane a
+  `{ service }` request takes, so the two cannot disagree. Every guard's mutual exclusion is now
+  a **count** rather than a pairwise check — `why`'s `hasRef === hasPrUrl` expressed "exactly
+  one" only while there were two arms, and silently means "an odd number" at three.
+
 - **2026-08-31 — The computer-use browser lane can now actually drive a browser, and the `browser` egress class went live with it.** The driver deferred on 2026-08-30 landed as **raw CDP over a WebSocket** (`computer-use/cu-lanes/`), with **no dependency at all** — Bun has a native `WebSocket`, and `playwright-core`, which fails a `bun build --compile` gate, is not reintroduced in any form. `platform/assemble.ts` now supplies the four `CuGateDeps` driver seams instead of `resolveBrowserPath: () => null`, so `ERR_CU_NO_BROWSER` is no longer the terminus of every session on a machine that has Chrome, Chromium or Edge installed. The nine items the plan required to close **in the same commit as the driver** are closed here; each is below with what it actually prevents rather than a checkbox.
 
   **Two defects the fixtures could never have caught, found the first time the observer ran against a real DOM.** (1) CDP reports `Fetch.requestPaused.resourceType` in **PascalCase** (`"Document"`, `"XHR"`, `"Image"`), while `CuResourceType` was written in `playwright-core`'s lowercase vocabulary — so the unguarded `req.resourceType() as CuResourceType` cast made **every** live type miss both `PASSIVE` and `SCRIPT_INITIATED`. Fail-closed, and a browser lane that could not render the origin its owner had just approved, because the page's own `Document` was gated too. Closed with a real guard (`cu-request-policy.ts`'s `toCuResourceType`, returning `null` — never a guess — for anything unrecognised, with the caller substituting `"other"`, which `decideRequest` places in the GATED branch). `Ping` (`navigator.sendBeacon` / `<a ping>`), `Preflight`, `Prefetch`, `Manifest`, `SignedExchange`, `CSPViolationReport`, `FedCM` and `TextTrack` are DELIBERATELY unmapped so they gate: `Ping` is a fire-and-forget outbound POST, i.e. exactly the channel § 3.5.1 exists to close, and folding it into a `PASSIVE` member "because it is a subresource" would reopen it. The RAW protocol string, not the substituted word, is what reaches `payload_summary`. (2) `new URL("javascript:…").origin` is the **string** `"null"` — the WHATWG opaque-origin serialization — which compares EQUAL to a `data:` page's own `location.origin`, so two opaque origins would have read as same-origin. Collapsed to JS `null` at the producer (`browser-observe.ts`'s `normalizeObservedOrigin`), which makes every downstream `!== null` guard fall to its actuating branch. Both are pinned by tests that run against a REAL Chrome when one is installed (`skipIf` otherwise), alongside the `closest()`-based `isSubmitControl` the contract was rewritten for — a `<span>` inside `<button type=submit>` reports `true`, verified live.
@@ -31,7 +55,6 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   **One browser-lane session at a time, disclosed rather than discovered.** `[computer_use] browser_profile_dir` is one directory shared by every session (spec § 9, so a login survives across them), and Chromium holds a singleton lock on it — so a second CONCURRENT session fails at launch (verified against a real Chrome: exit code 21, empty stderr) and is recorded `failed_after_approval` / `ERR_CU_LAUNCH_FAILED`. Fail-closed and honestly recorded, but post-consent: the owner approves an envelope that then cannot start. Left this way deliberately rather than closed with a concurrency check in `openSession`, which would make the colliding-id teardown path (`evictExistingSession`) unreachable and is a product decision about session concurrency, not a driver detail. The driver names the likely cause when stderr is empty, so nobody is left holding a bare exit code.
 
   **Bound worth recording for whoever writes the next lane:** `type` is focus + select + `Input.insertText`, which synthesises **no key event** and therefore cannot press Enter — that is what keeps the classifier's `submitsForm` rule unreachable in the shipped surface, verified against a live page whose submit handler never fires. A `dispatchKeyEvent`-based implementation would make it live and would need a real producer wired to it. `isSubmitControl` resolves `closest("button, input[type=submit], input[type=image], form")` with a `FORM`-specific guard: the `form` in that selector catches the node BEING a form, and taking it literally would classify a click on any `<div>` or `<label>` inside any form as actuating — fail-closed, but so noisy it trains the owner to approve reflexively, which is the fatigue failure the design exists to avoid. **I11's screenshot bound remains anticipated, not live:** captures are still hashed and discarded, no vision-capable model is wired in, and the taint latch still taints by KIND rather than by content, in advance of a channel that does not exist yet.
-
 - **2026-08-30 — The local computer-use loop's gate shipped; nothing can drive it yet.** New
   invariant **I35** + static rule **D26**, schema **V57** (`cu_session` / `cu_action`), new
   subsystem `packages/gateway/src/computer-use/`, deliberately parallel to `exec/` in shape and

--- a/docs/superpowers/plans/2026-08-31-agents-for-items-and-files-review.md
+++ b/docs/superpowers/plans/2026-08-31-agents-for-items-and-files-review.md
@@ -1,0 +1,154 @@
+# Implementation Plan Review: Agents for Items and Files
+
+**Date:** 2026-08-31  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Under Review  
+**Target Plan:** [`2026-08-31-agents-for-items-and-files.md`](./2026-08-31-agents-for-items-and-files.md)  
+**Design Spec:** [`../specs/2026-08-31-agents-for-items-and-files-design.md`](../specs/2026-08-31-agents-for-items-and-files-design.md)  
+
+---
+
+## 1. Summary of Review
+
+The implementation plan is comprehensive, well-structured into 14 incremental tasks, and follows a strict test-driven development (TDD) cycle. It thoroughly addresses the core requirements:
+
+1. **Clear PR Slicing:** PR 1 (`itemUrl` arms), PR 2 (`resolveFileByRemote` + forge-file arms + `impact` fix), and PR 3 (`connections` + `currency` + HTTP roster update).
+2. **Reverse Graph Traversals:** Task 4 properly handles the inverse `resolves` and sibling issue traversals needed when `why` answers about an issue rather than a PR.
+3. **Robust Slash-in-Branch Resolution:** Task 10 handles forge file coordinates where branch names contain slashes without requiring client-side guessing.
+
+Below are critical type mismatches, missing entity lookups, and technical improvements to resolve before beginning execution.
+
+---
+
+## 2. Critical Findings & Type Corrections
+
+### F2.1: `resolveItemArm` (Task 2) Missing Entity ID & Number Lookups
+
+* **Issue:** In Task 2 Step 3 (lines 176–203), `resolveItemArm` constructs `itemSubject` by reading fields directly off `item`:
+
+  ```ts
+  itemId: item.id,
+  entityId: item.entityId, // ERROR: Property 'entityId' does not exist on ResolveCandidate
+  number: item.number ?? null, // ERROR: Property 'number' does not exist on ResolveCandidate
+  url: item.url, // TYPE MISMATCH: item.url is string | null, but WhyItemSubject.url is string
+  ```
+
+* **Root Cause:** `resolveItemByUrl` returns `{ found: true, item: ResolveCandidate & { modified_at: number } }`, where `ResolveCandidate` is defined in `packages/gateway/src/index/resolve-by-url.ts:13` as:
+
+  ```ts
+  export type ResolveCandidate = {
+    readonly id: string;
+    readonly service: string;
+    readonly type: string;
+    readonly title: string;
+    readonly url: string | null;
+  };
+  ```
+
+  `item` does **not** have `entityId` or `number`.
+* **Fix:** In `resolveItemArm`, resolve `entityId` from `graph_entity` and extract `number` (e.g. from `metadata` or `item.id`):
+
+  ```ts
+  function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
+    const resolved = resolveItemByUrl(db, itemUrl);
+    if (!resolved.found) {
+      return {
+        subject: null,
+        blame: null,
+        pr: null,
+        itemSubject: null,
+        queryRef: itemUrl,
+        queryLine: null,
+      };
+    }
+    const item = resolved.item;
+    // Find the backing graph entity
+    const entity = db
+      .query("SELECT id FROM graph_entity WHERE external_id = ? LIMIT 1")
+      .get(item.id) as { id: string } | null;
+    
+    // Extract number if stored in item metadata
+    const metaRow = db
+      .query("SELECT json_extract(metadata, '$.number') AS number FROM item WHERE id = ? LIMIT 1")
+      .get(item.id) as { number: number | null } | null;
+
+    return {
+      subject: null,
+      blame: null,
+      pr: null,
+      itemSubject: {
+        itemId: item.id,
+        entityId: entity?.id ?? item.id,
+        number: metaRow?.number ?? null,
+        url: item.url ?? itemUrl,
+        title: item.title,
+        modifiedAt: item.modified_at ?? null,
+        service: item.service,
+        type: item.type,
+      },
+      queryRef: itemUrl,
+      queryLine: null,
+    };
+  }
+  ```
+
+---
+
+### F2.2: `ExpertBrief` Property Mismatch in Task 6 Test
+
+* **Issue:** In Task 6 Step 1 (lines 535–537), the test asserts:
+
+  ```ts
+  const names = brief.findings.map((f) => f.title).join(" "); // ERROR: 'findings' does not exist on ExpertBrief
+  expect(names).toContain("Dana");
+  ```
+
+* **Root Cause:** Unlike `WhyBrief` (which has `findings: WhyFinding[]`), `ExpertBrief` has `ranked: ExpertFinding[]`. Furthermore, `ExpertFinding` has `displayName: string` and `personId: string`, but does not have a `title` field.
+* **Fix:** Update Task 6 Step 1 to read from `brief.ranked`:
+
+  ```ts
+  const names = brief.ranked.map((f) => f.displayName).join(" ");
+  expect(names).toContain("Dana");
+  expect(names).not.toContain("Rae");
+  ```
+
+---
+
+### F2.3: `runExpert` Output on `itemUrl` Arm (Task 6)
+
+* **Issue:** In Task 6 Step 3, `peopleForItem` returns `PersonRow[]` with `{ entity_id, name, edge }`.
+* **Requirement:** `ExpertBrief` requires `ranked: ExpertFinding[]`, where each finding carries:
+
+  ```ts
+  export type ExpertFinding = {
+    personId: string;
+    displayName: string;
+    evidence: Evidence[];
+    score: number;
+    confidence: "high" | "medium" | "low";
+  };
+  ```
+
+* **Fix:** Ensure `runExpert` on the `itemUrl` arm maps `PersonRow` into `ExpertEvidenceStream` and passes it through `rankExpertFindings` (or directly maps to `ExpertFinding[]` with evidence tagged with the edge name), so the brief passes `isExpertBrief` and conforms to `ExpertBriefBase`.
+
+---
+
+## 3. Improvements & Suggestions
+
+### S3.1: Task 10 `resolveFileByRemote` Path Separator Handling
+
+* **Context:** In Task 10 Step 3 (line 872), candidate path lookup uses `fileExternalId(root, candidatePath)`.
+* **Suggestion:** On Windows, `repoRoot` contains backslashes (e.g. `C:\gitrep\web`), while `refAndPath` uses forward slashes (`src/foo.ts`). Ensure `resolveFileByRemote` normalizes paths with `toPosixPath` or matches `ownership-pass.ts`'s formatting convention so that `fileExternalId` matches indexed `source_file` rows regardless of OS.
+
+### S3.2: Re-exporting `WhyItemSubject`
+
+* **Context:** Task 1 Step 3 notes `export type { WhyItemSubject } from "@nimbus-dev/sdk"`.
+* **Suggestion:** Ensure `@nimbus-dev/sdk` dependency in `packages/gateway/package.json` is updated to the newly released version containing `WhyItemSubject` before running PR 1 typechecks.
+
+---
+
+## 4. Summary of Recommended Plan Edits
+
+1. Update Task 2 Step 3 to explicitly query `graph_entity.id` and `metadata.number`.
+2. Correct Task 6 Step 1 test from `brief.findings.map(f => f.title)` to `brief.ranked.map(f => f.displayName)`.
+3. Clarify `runExpert` mapping from `peopleForItem` to `ExpertFinding[]` in Task 6 Step 3.

--- a/docs/superpowers/plans/2026-08-31-agents-for-items-and-files.md
+++ b/docs/superpowers/plans/2026-08-31-agents-for-items-and-files.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Let the gateway's agents answer about an indexed item that is not a pull request, and about a source file identified by a forge coordinate rather than a local path.
+**Goal:** Let the gateway's agents answer about an indexed item that is not a pull request -- an issue or an incident, **not** a Confluence page (spec F8) -- and about a source file identified by a forge coordinate rather than a local path.
 
 **Architecture:** Three additive PRs. PR 1 adds an `itemUrl` input arm to `why`, `expert` and `ownership`, resolved through the shipped `resolveItemByUrl`. PR 2 adds `resolveFileByRemote` — a graph walk from a forge coordinate to the reader's local checkout — plus a forge-file arm on five agents, and fixes `impact` resolving a file path to an arbitrary symbol. PR 3 adds two read-only agents, `connections` and `currency`.
 
@@ -171,36 +171,79 @@ In `why.ts`, widen the `LaneInput.arm` union at line 56 and extend its comment t
 
 Add beside `resolvePrArm`:
 
+**Read `ResolveCandidate` before writing this.** It is
+`{ id, service, type, title, url: string | null }` plus `modified_at: number`
+(`index/resolve-by-url.ts:13`). It has **no `entityId` and no `number`**, `url` is nullable, and
+`modified_at` is *not* — so a `?? null` on it is dead code. The lanes answer from graph edges, so the
+entity is what this arm actually needs, and it must be looked up rather than read off the item.
+
 ```ts
 /** The `itemUrl` arm: resolve the indexed item the lanes answer about. */
 function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
+  const miss: WhyLaneResolution = {
+    subject: null,
+    blame: null,
+    pr: null,
+    itemEntityId: null,
+    // null, not absent: the caller asked about an item and we could not name it.
+    itemSubject: null,
+    queryRef: itemUrl,
+    queryLine: null,
+  };
+
   const resolved = resolveItemByUrl(db, itemUrl);
-  const item = resolved.found ? resolved.item : null;
+  if (!resolved.found) return miss;
+  const item = resolved.item;
+
+  // Every lane on this arm walks `graph_relation`, which hangs off a
+  // `graph_entity`. An indexed item does not always have one:
+  // `syncGraphFromIndexedItem` skips any type outside ITEM_LINKED_ENTITY_TYPES
+  // and GRAPH_SYNC_BY_TYPE, which is why a Confluence page (`type: "page"`) has
+  // none at all. No entity means there is genuinely nothing to answer from.
+  //
+  // Constrained by type as well as external_id: `deterministicGraphEntityId`
+  // hashes (type, externalId), so one external id can legitimately exist under
+  // more than one type.
+  const entity = db
+    .query("SELECT id FROM graph_entity WHERE external_id = ? AND type = ? LIMIT 1")
+    .get(item.id, item.type) as { id?: string } | null;
+  if (entity?.id === undefined) return miss;
+
+  const numberRow = db
+    .query("SELECT json_extract(metadata, '$.number') AS number FROM item WHERE id = ? LIMIT 1")
+    .get(item.id) as { number: number | null } | null;
+
   return {
     subject: null,
     blame: null,
     // The item arm has no PR of its own. `subPullRequest` may find one and the
     // lanes that need it read it from their own result, not from here.
     pr: null,
-    // null, not absent: the caller asked about an item and we could not name it.
-    itemSubject:
-      item === null
-        ? null
-        : {
-            itemId: item.id,
-            entityId: item.entityId,
-            number: item.number ?? null,
-            url: item.url,
-            title: item.title,
-            modifiedAt: item.modified_at ?? null,
-            service: item.service,
-            type: item.type,
-          },
+    itemEntityId: entity.id,
+    itemSubject: {
+      itemId: item.id,
+      entityId: entity.id,
+      number: numberRow?.number ?? null,
+      // `ResolveCandidate.url` is nullable and `WhyItemSubject.url` matches it.
+      // Do NOT fall back to `itemUrl`: that substitutes the URL we were asked
+      // with for the one the item has -- a fabricated field inside a subject.
+      url: item.url,
+      title: item.title,
+      // `modified_at` is `number`, not nullable. No `??` here.
+      modifiedAt: item.modified_at,
+      service: item.service,
+      type: item.type,
+    },
     queryRef: itemUrl,
     queryLine: null,
   };
 }
 ```
+
+**The no-entity case returns the miss deliberately.** Falling back to `entityId: item.id` would put
+an item id where a `graph_entity.id` belongs -- a field that looks resolved, reads as valid, and
+matches nothing in the graph. A miss produces the same honest gap as an unresolvable URL, which is
+the accurate answer: this item cannot be answered about from edges, because it has none.
 
 In `runWhy`, replace the two-way dispatch at line 182 with a three-way one:
 
@@ -517,6 +560,9 @@ git commit -m "feat(agents-rpc): why accepts exactly one of three arms"
 
 - Consumes: `resolveItemByUrl`.
 - Produces: `ExpertInput` widened to `{ topicOrFile: string } | { itemUrl: string }`.
+- **SDK dependency:** `ExpertBrief.query` is `{ topicOrFile: string }` and is SDK-owned
+  (`brief-composites.ts:61`). It gains an optional `itemUrl?: string | null` in the same SDK
+  release as `WhyItemSubject`. This task cannot typecheck before that release.
 
 **Why this is bigger than it looks:** `runExpert` today takes `input.topicOrFile: string` and its five sub-agents run `LIKE '%' || ? || '%'` scans over titles and previews (`expert.ts:175`). There is **no entity-based path to reuse** — this task writes one.
 
@@ -532,7 +578,9 @@ test("the item arm answers from graph edges, not from a title match", async () =
     { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
     { db, notify: () => {}, sessionId: "s6" },
   );
-  const names = brief.findings.map((f) => f.title).join(" ");
+  // `ExpertBrief` is `ranked: ExpertFinding[]`, NOT `findings` -- and an
+  // ExpertFinding has `displayName`/`personId`, never `title`.
+  const names = brief.ranked.map((f) => f.displayName).join(" ");
   expect(names).toContain("Dana");
   expect(names).not.toContain("Rae"); // a LIKE scan would have matched this
 });
@@ -669,7 +717,7 @@ git commit -m "feat(ownership): answer about an item through its owning service"
 - [ ] **Step 1: Write the matrix test**
 
 ```ts
-describe.each(["issue", "doc", "incident"])("the item arm on a %s", (itemType) => {
+describe.each(["issue", "incident"])("the item arm on a %s", (itemType) => {
   test("produces findings or gaps, never a well-formed empty brief", async () => {
     const db = seedIndexedItemOfType(itemType);
     const brief = await runWhy(
@@ -678,6 +726,24 @@ describe.each(["issue", "doc", "incident"])("the item arm on a %s", (itemType) =
     );
     expect(brief.findings.length + brief.gaps.length).toBeGreaterThan(0);
   });
+});
+```
+
+Then pin the surface that is deliberately **not** covered, so the exclusion is a decision on record
+rather than an omission someone later "fixes":
+
+```ts
+test("a Confluence page has no graph entity, so it resolves to a miss", async () => {
+  // `type: "page"` is in neither ITEM_LINKED_ENTITY_TYPES nor GRAPH_SYNC_BY_TYPE,
+  // so syncGraphFromIndexedItem writes nothing for it. Spec F8.
+  const db = seedIndexedConfluencePage();
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/wiki/spaces/ENG/pages/1/Runbook" },
+    { db, roots: [], notify: () => {}, sessionId: "m-page" },
+  );
+  expect(brief.itemSubject).toBeNull();
+  expect(brief.findings).toEqual([]);
+  expect(brief.gaps.length).toBeGreaterThan(0);
 });
 ```
 

--- a/docs/superpowers/plans/2026-08-31-agents-for-items-and-files.md
+++ b/docs/superpowers/plans/2026-08-31-agents-for-items-and-files.md
@@ -1,0 +1,1128 @@
+# Agents for Items and Files — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the gateway's agents answer about an indexed item that is not a pull request, and about a source file identified by a forge coordinate rather than a local path.
+
+**Architecture:** Three additive PRs. PR 1 adds an `itemUrl` input arm to `why`, `expert` and `ownership`, resolved through the shipped `resolveItemByUrl`. PR 2 adds `resolveFileByRemote` — a graph walk from a forge coordinate to the reader's local checkout — plus a forge-file arm on five agents, and fixes `impact` resolving a file path to an arbitrary symbol. PR 3 adds two read-only agents, `connections` and `currency`.
+
+**Tech Stack:** TypeScript (strict), Bun, `bun:sqlite`, Vitest-style `bun test`.
+
+**Spec:** [`docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md`](../specs/2026-08-31-agents-for-items-and-files-design.md) — read it alongside this plan; the plan argues from it.
+
+## Global Constraints
+
+- **No breaking wire change.** Every type change here is additive. `WhyChangeSubject` is published at `stability: stable` in the SDK and must not be reshaped (spec F2).
+- **`ownership`'s brief types are gateway-local** (`agents/_lib/ownership-types.ts`); only `GapNote` comes from `@nimbus-dev/sdk`. Changing them needs no SDK release.
+- **`why`'s brief types are SDK-owned.** `WhyItemSubject` and `WhyBrief.itemSubject` must land in `@nimbus-dev/sdk` and be released before PR 1's gateway half can typecheck. See the SDK plan; PR 1 is blocked on that release.
+- **HTTP exposure is derived, not declared.** `HTTP_AGENT_NAMES` (`ipc/agents-rpc.ts:983`) is every `AGENTS_RPC_HANDLERS` key minus `HTTP_EXCLUDED_AGENT_METHODS`, so a new handler is HTTP-reachable by default. `preflight`, `premortem` and `negotiate` must stay excluded.
+- **Bounds are measured after trim, on the normalised value** — never on the caller's raw string.
+- **Gaps, never empty answers.** A lane that cannot apply is silent; a lane that applies and finds nothing emits a `GapNote`. The `arm` discriminator decides which, never `subject === null`.
+- **Run before every commit:** `bun run typecheck && bun run lint && bun test packages/gateway/src/agents/` and `bun run lint:markdown` after any docs change.
+
+---
+
+## File Structure
+
+**PR 1**
+
+- Modify `packages/gateway/src/agents/_lib/why-types.ts` — `WhyItemInput`, `isWhyItemInput`, re-export `WhyItemSubject`.
+- Modify `packages/gateway/src/agents/why.ts` — `resolveItemArm`, `arm: "item"`, item-arm sub-lane queries.
+- Modify `packages/gateway/src/agents/expert.ts` — the person-edge walk (new query code).
+- Modify `packages/gateway/src/agents/ownership.ts` + `_lib/ownership-types.ts` — item→service mapping, `query.itemUrl`.
+- Modify `packages/gateway/src/ipc/agents-rpc.ts` — three param guards.
+
+**PR 2**
+
+- Create `packages/gateway/src/index/resolve-file-by-remote.ts` — the forge→checkout resolver.
+- Modify `packages/gateway/src/agents/impact.ts` — `source_file` before the symbol `LIKE`.
+- Modify the five agents + `agents-rpc.ts` — the forge-file arm.
+
+**PR 3**
+
+- Create `packages/gateway/src/agents/connections.ts`, `packages/gateway/src/agents/currency.ts`.
+- Modify `packages/gateway/src/ipc/agents-rpc.ts` — two handlers.
+- Modify `packages/gateway/src/agent-runs/agent-http-e2e.test.ts` — roster count 11 → 13.
+
+---
+
+## PR 1 — The `itemUrl` arm
+
+**Blocked on:** the SDK releasing `WhyItemSubject` + `WhyBrief.itemSubject`.
+
+### Task 1: `WhyItemInput` and its type guard
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/_lib/why-types.ts`
+- Test: `packages/gateway/src/agents/why.test.ts`
+
+**Interfaces:**
+
+- Consumes: `WhyInput`, `isWhyPrInput` (existing in this file).
+- Produces: `type WhyItemInput = { itemUrl: string }`; `isWhyItemInput(i: WhyInput): i is WhyItemInput`. Used by Task 2 and Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { isWhyItemInput, isWhyPrInput } from "./_lib/why-types.ts";
+
+test("isWhyItemInput separates the three arms", () => {
+  expect(isWhyItemInput({ itemUrl: "https://acme.atlassian.net/browse/PLAT-9" })).toBe(true);
+  expect(isWhyItemInput({ prUrl: "https://github.com/acme/web/pull/1" })).toBe(false);
+  expect(isWhyItemInput({ ref: "src/a.ts" })).toBe(false);
+  // The existing guard must not start claiming the new arm.
+  expect(isWhyPrInput({ itemUrl: "https://acme.atlassian.net/browse/PLAT-9" })).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "three arms"`
+Expected: FAIL — `isWhyItemInput` is not exported.
+
+- [ ] **Step 3: Add the type and guard**
+
+In `_lib/why-types.ts`, alongside the existing `WhyPrInput` / `isWhyPrInput`:
+
+```ts
+/** The third arm: an indexed item that is not a pull request. */
+export type WhyItemInput = { itemUrl: string };
+
+export type WhyInput = WhyRefInput | WhyPrInput | WhyItemInput;
+
+export function isWhyItemInput(i: WhyInput): i is WhyItemInput {
+  return "itemUrl" in i;
+}
+```
+
+Re-export the SDK's new subject so `why.ts` imports subjects from one place, matching how `WhyChangeSubject` is already re-exported through `_lib/findings.ts`:
+
+```ts
+export type { WhyItemSubject } from "@nimbus-dev/sdk";
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "three arms"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/_lib/why-types.ts packages/gateway/src/agents/why.test.ts
+git commit -m "feat(why): a third input arm type for an indexed item"
+```
+
+---
+
+### Task 2: `resolveItemArm`, and `arm: "item"`
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/why.ts:56` (the `arm` union), `:90-110` (beside `resolvePrArm`), `:182-198` (`runWhy`'s dispatch), `:226-232` (brief assembly)
+- Test: `packages/gateway/src/agents/why.test.ts`
+
+**Interfaces:**
+
+- Consumes: `isWhyItemInput` (Task 1); `resolveItemByUrl` from `../../index/resolve-by-url.ts`.
+- Produces: `WhyLaneResolution.itemSubject?: WhyItemSubject | null`; `LaneInput.arm` widened to `"ref" | "change" | "item"`. Tasks 3 and 4 branch on that arm.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("the item arm answers with itemSubject and leaves the other two null", async () => {
+  const db = seedIndexedIssue(); // helper below
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, roots: [], notify: () => {}, sessionId: "s1" },
+  );
+
+  expect(brief.itemSubject?.title).toBe("Checkout times out");
+  expect(brief.itemSubject?.service).toBe("jira");
+  expect(brief.subject).toBeNull();
+  expect(brief.changeSubject).toBeUndefined();
+  expect(brief.query.ref).toBe("https://acme.atlassian.net/browse/PLAT-9");
+});
+
+test("an itemUrl that resolves to nothing gaps rather than throwing", async () => {
+  const db = emptyIndexedDb();
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/browse/NOPE-1" },
+    { db, roots: [], notify: () => {}, sessionId: "s2" },
+  );
+  expect(brief.itemSubject).toBeNull();
+  expect(brief.gaps.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "item arm"`
+Expected: FAIL — `runWhy` throws or returns no `itemSubject`.
+
+- [ ] **Step 3: Widen the arm and add the resolver**
+
+In `why.ts`, widen the `LaneInput.arm` union at line 56 and extend its comment to name the third member:
+
+```ts
+  arm: "ref" | "change" | "item";
+```
+
+Add beside `resolvePrArm`:
+
+```ts
+/** The `itemUrl` arm: resolve the indexed item the lanes answer about. */
+function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
+  const resolved = resolveItemByUrl(db, itemUrl);
+  const item = resolved.found ? resolved.item : null;
+  return {
+    subject: null,
+    blame: null,
+    // The item arm has no PR of its own. `subPullRequest` may find one and the
+    // lanes that need it read it from their own result, not from here.
+    pr: null,
+    // null, not absent: the caller asked about an item and we could not name it.
+    itemSubject:
+      item === null
+        ? null
+        : {
+            itemId: item.id,
+            entityId: item.entityId,
+            number: item.number ?? null,
+            url: item.url,
+            title: item.title,
+            modifiedAt: item.modified_at ?? null,
+            service: item.service,
+            type: item.type,
+          },
+    queryRef: itemUrl,
+    queryLine: null,
+  };
+}
+```
+
+In `runWhy`, replace the two-way dispatch at line 182 with a three-way one:
+
+```ts
+  const resolution = isWhyPrInput(input)
+    ? resolvePrArm(ctx.db, input.prUrl)
+    : isWhyItemInput(input)
+      ? resolveItemArm(ctx.db, input.itemUrl)
+      : await resolveRefArm(input, ctx);
+  const { subject, blame, pr, changeSubject, itemSubject, queryRef, queryLine } = resolution;
+```
+
+Set the arm and `occurredAt` explicitly — do **not** fold the item arm into the existing ternaries, for the reason the `occurredAt` comment already gives about borrowing another arm's timestamp:
+
+```ts
+    occurredAt: armOf(input) === "item"
+      ? (itemSubject?.modifiedAt ?? null)
+      : isWhyPrInput(input)
+        ? (pr?.modifiedAt ?? null)
+        : (blame?.authorTimeMs ?? null),
+    arm: armOf(input),
+```
+
+with:
+
+```ts
+function armOf(input: WhyInput): "ref" | "change" | "item" {
+  if (isWhyPrInput(input)) return "change";
+  return isWhyItemInput(input) ? "item" : "ref";
+}
+```
+
+In the brief assembly, thread the new subject the same way `changeSubject` is threaded:
+
+```ts
+    ...(changeSubject === undefined ? {} : { changeSubject }),
+    ...(itemSubject === undefined ? {} : { itemSubject }),
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "item arm"`
+Expected: PASS, and every pre-existing `why` test still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/why.ts packages/gateway/src/agents/why.test.ts
+git commit -m "feat(why): resolve an indexed item as a third lane arm"
+```
+
+---
+
+### Task 3: The two file/line lanes stay silent on `item`
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/why.ts:356` (`subAuthorship`), `:702` (`subDownstream`)
+- Test: `packages/gateway/src/agents/why.test.ts`
+
+**Interfaces:**
+
+- Consumes: `LaneInput.arm` (Task 2).
+- Produces: nothing new. This task only narrows behaviour.
+
+**Why this is its own task:** these two lanes must be *silent*, not gapped. The comment on `LaneInput.arm` explains it for the `change` arm — they "stay silent rather than reporting a gap for the file subject a `prUrl` question never had" — and an item has no file subject either. A reviewer could reasonably accept Task 2 and reject this, which is what makes it a separate gate.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("the file/line lanes are silent on an item, not gapped", async () => {
+  const db = seedIndexedIssue();
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, roots: [], notify: () => {}, sessionId: "s3" },
+  );
+  // No gap should mention a file, a line, or blame: the question never had one.
+  const text = brief.gaps.map((g) => g.detail).join(" ");
+  expect(text).not.toMatch(/file|line|blame/i);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "silent on an item"`
+Expected: FAIL — both lanes fall through to their file-subject gap.
+
+- [ ] **Step 3: Extend both early returns**
+
+At `why.ts:356` and `:702`, change the guard so the item arm takes the same exit:
+
+```ts
+  // `change` and `item` alike: neither question has a file subject, so a gap
+  // here would report something missing that was never asked for.
+  if (lane.arm !== "ref") return {};
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts`
+Expected: PASS, all `why` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/why.ts packages/gateway/src/agents/why.test.ts
+git commit -m "feat(why): the file lanes stay silent on the item arm"
+```
+
+---
+
+### Task 4: The four lanes that *do* apply to an item
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/why.ts:457` (`subPullRequest`), `:533` (`subTicket`), `:564` (`subDiscussion`), `:629` (`subDriver`)
+- Test: `packages/gateway/src/agents/why.test.ts`
+
+**Interfaces:**
+
+- Consumes: `LaneInput.arm`, `LaneInput.itemEntityId` (added here).
+- Produces: nothing consumed downstream.
+
+**Why this is the task the spec exists for:** `ticketRowsForPr` (`why.ts:320`) joins `pe.type = 'pr' AND r.from_id = ?` — handed an issue entity it returns zero rows, so without this task the item arm ships a well-formed empty brief for every issue in the index.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("subPullRequest finds the PR that resolves this issue", async () => {
+  // PR --resolves--> issue. The PR arm walks this edge from `from_id`;
+  // the item arm must walk it from `to_id`.
+  const db = seedIssueResolvedByPr({ prNumber: 482, issueKey: "PLAT-9" });
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, roots: [], notify: () => {}, sessionId: "s4" },
+  );
+  const titles = brief.findings.map((f) => f.title).join(" ");
+  expect(titles).toContain("482");
+});
+
+test("an item with no neighbours gaps rather than returning nothing at all", async () => {
+  const db = seedIndexedIssue(); // no edges
+  const brief = await runWhy(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, roots: [], notify: () => {}, sessionId: "s5" },
+  );
+  expect(brief.findings).toEqual([]);
+  expect(brief.gaps.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "subPullRequest finds"`
+Expected: FAIL — no findings; the PR-shaped query returns zero rows.
+
+- [ ] **Step 3: Add the item-arm queries**
+
+Carry the item's entity id on the lane input (add to `LaneInput`, set in `resolveItemArm`):
+
+```ts
+  /** The indexed item the lanes answer about, on the `item` arm only. */
+  itemEntityId: string | null;
+```
+
+Add the inverse traversal beside `ticketRowsForPr`:
+
+```ts
+/** PRs pointing AT this item — the inverse of `ticketRowsForPr`'s traversal. */
+function prRowsResolvingItem(db: Database, itemEntityId: string): PrRow[] {
+  return db
+    .query(
+      `SELECT pe.id AS entity_id, i.title AS title, i.url AS url,
+              i.modified_at AS modified_at, i.external_id AS key
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'pr'
+         JOIN item i ON i.id = pe.external_id
+        WHERE r.to_id = ? AND r.type = 'resolves'
+        LIMIT 10`,
+    )
+    .all(itemEntityId) as PrRow[];
+}
+
+/** Neighbouring issues — never the item itself. */
+function siblingIssueRows(db: Database, itemEntityId: string): TicketRow[] {
+  return db
+    .query(
+      `SELECT ie.id AS entity_id, i.external_id AS key, i.title AS title, i.url AS url,
+              i.modified_at AS modified_at
+         FROM graph_relation r
+         JOIN graph_entity ie ON ie.id = CASE WHEN r.from_id = ?1 THEN r.to_id ELSE r.from_id END
+         JOIN item i ON i.id = ie.external_id
+        WHERE (r.from_id = ?1 OR r.to_id = ?1)
+          AND r.type IN ('depends_on', 'mentions')
+          AND ie.type = 'issue'
+          AND ie.id <> ?1
+        LIMIT 10`,
+    )
+    .all(itemEntityId) as TicketRow[];
+}
+```
+
+In each of the four sub-agents, branch on the arm at the top and use the item query when `lane.arm === "item"`, keeping the existing PR path otherwise. `subDriver` runs only if `subPullRequest` found a PR; on the item arm it reads that PR from `prRowsResolvingItem`'s first row rather than from `lane.pr`, which is null there. `subDiscussion` needs no new query — its `message` traversal is already entity-keyed; pass `lane.itemEntityId` where it currently passes the PR entity id.
+
+Each lane keeps its existing `detectMissingRelationToEntityType` gap call, so an item with no neighbours gaps rather than returning silently.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/why.ts packages/gateway/src/agents/why.test.ts
+git commit -m "feat(why): answer the four item-applicable lanes from the item entity"
+```
+
+---
+
+### Task 5: `why`'s param guard becomes a count of three
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts:463-487` (`requireWhyParams`)
+- Test: `packages/gateway/src/ipc/agents-rpc.test.ts`
+
+**Interfaces:**
+
+- Consumes: `WhyItemInput` (Task 1).
+- Produces: `requireWhyParams` accepting exactly one of `ref` / `prUrl` / `itemUrl`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("why requires exactly one of three arms", () => {
+  const one = { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" };
+  expect(() => requireWhyParams(one)).not.toThrow();
+
+  expect(() => requireWhyParams({})).toThrow(/exactly one/);
+  expect(() => requireWhyParams({ ref: "a.ts", itemUrl: "https://x/1" })).toThrow(/exactly one/);
+  expect(() => requireWhyParams({ prUrl: "https://x/1", itemUrl: "https://x/2" })).toThrow(/exactly one/);
+  expect(() =>
+    requireWhyParams({ ref: "a.ts", prUrl: "https://x/1", itemUrl: "https://x/2" }),
+  ).toThrow(/exactly one/);
+});
+
+test("itemUrl inherits the prUrl arm's guards", () => {
+  expect(() => requireWhyParams({ itemUrl: "https://u:p@acme.atlassian.net/browse/PLAT-9" }))
+    .toThrow(/userinfo/);
+  expect(() => requireWhyParams({ itemUrl: "  " })).toThrow(/chars after trim/);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/ipc/agents-rpc.test.ts -t "one of three arms"`
+Expected: FAIL — `itemUrl` is rejected as "requires exactly one of { ref } or { prUrl }".
+
+- [ ] **Step 3: Replace the two-value equality with a count**
+
+`hasRef === hasPrUrl` does not generalise to three. Count the supplied arms:
+
+```ts
+function requireWhyParams(params: unknown): WhyInput {
+  if (params === null || typeof params !== "object" || Array.isArray(params)) {
+    throw new AgentsRpcError(
+      -32602,
+      "agents.why requires exactly one of { ref }, { prUrl } or { itemUrl }",
+    );
+  }
+  const p = params as { ref?: unknown; prUrl?: unknown; itemUrl?: unknown };
+  const supplied = [p.ref, p.prUrl, p.itemUrl].filter((v) => v !== undefined).length;
+  if (supplied !== 1) {
+    throw new AgentsRpcError(
+      -32602,
+      "agents.why requires exactly one of { ref }, { prUrl } or { itemUrl }",
+    );
+  }
+  if (p.itemUrl !== undefined) {
+    return { itemUrl: requireUrlParam(p.itemUrl, "itemUrl") };
+  }
+  if (p.prUrl !== undefined) {
+    return { prUrl: requireUrlParam(p.prUrl, "prUrl") };
+  }
+  return requireWhyRefParams(params);
+}
+```
+
+Extract the `prUrl` arm's existing body — string check, trim, `MAX_PR_URL_LEN` bound, `prUrlHasCredentials` — into `requireUrlParam(value: unknown, name: string): string` so both URL arms share one validator rather than growing a second copy that can drift.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/ipc/agents-rpc.test.ts`
+Expected: PASS, including the pre-existing two-arm tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/ipc/agents-rpc.ts packages/gateway/src/ipc/agents-rpc.test.ts
+git commit -m "feat(agents-rpc): why accepts exactly one of three arms"
+```
+
+---
+
+### Task 6: `expert`'s person-edge walk
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/expert.ts`, `packages/gateway/src/ipc/agents-rpc.ts` (`requireExpertParams`)
+- Test: `packages/gateway/src/agents/expert.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveItemByUrl`.
+- Produces: `ExpertInput` widened to `{ topicOrFile: string } | { itemUrl: string }`.
+
+**Why this is bigger than it looks:** `runExpert` today takes `input.topicOrFile: string` and its five sub-agents run `LIKE '%' || ? || '%'` scans over titles and previews (`expert.ts:175`). There is **no entity-based path to reuse** — this task writes one.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("the item arm answers from graph edges, not from a title match", async () => {
+  // Two items with near-identical titles; only one is edge-linked to the person.
+  const db = seedItemAuthoredBy({ itemKey: "PLAT-9", person: "Dana" });
+  seedUnrelatedItemWithSimilarTitle(db, { person: "Rae" });
+
+  const brief = await runExpert(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "s6" },
+  );
+  const names = brief.findings.map((f) => f.title).join(" ");
+  expect(names).toContain("Dana");
+  expect(names).not.toContain("Rae"); // a LIKE scan would have matched this
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/expert.test.ts -t "not from a title match"`
+Expected: FAIL — `runExpert` rejects the input shape, or matches both people.
+
+- [ ] **Step 3: Add the arm and the walk**
+
+```ts
+export type ExpertInput = { topicOrFile: string; limit?: number } | { itemUrl: string; limit?: number };
+
+/** People edge-linked to this item, with the edge that links them. */
+function peopleForItem(db: Database, itemEntityId: string): PersonRow[] {
+  return db
+    .query(
+      `SELECT pe.id AS entity_id, pe.label AS name, r.type AS edge
+         FROM graph_relation r
+         JOIN graph_entity pe
+           ON pe.id = CASE WHEN r.from_id = ?1 THEN r.to_id ELSE r.from_id END
+          AND pe.type = 'person'
+        WHERE (r.from_id = ?1 OR r.to_id = ?1)
+          AND r.type IN ('authored', 'reviewed', 'opened', 'posted')
+        LIMIT 20`,
+    )
+    .all(itemEntityId) as PersonRow[];
+}
+```
+
+On the item arm, `runExpert` resolves the URL, runs `peopleForItem`, and emits one finding per person naming the edge that linked them ("Dana — authored"). The five `LIKE` sub-agents do not run on this arm: they answer a different question and running both would mix an edge-backed answer with a lexical guess in one list. A resolve miss, or an item with no person edges, emits the existing `missing_entity_type` gap.
+
+In `requireExpertParams`, accept exactly one of `topicOrFile` / `itemUrl`, reusing `requireUrlParam` from Task 5.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/expert.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/expert.ts packages/gateway/src/ipc/agents-rpc.ts packages/gateway/src/agents/expert.test.ts
+git commit -m "feat(expert): answer about an indexed item from its person edges"
+```
+
+---
+
+### Task 7: `ownership`'s item arm, mapped to its service
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/_lib/ownership-types.ts:27`, `packages/gateway/src/agents/ownership.ts`, `packages/gateway/src/ipc/agents-rpc.ts:699`
+- Test: `packages/gateway/src/agents/ownership.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveItemByUrl`.
+- Produces: `OwnershipBrief.query` widened to `{ path: string | null; service: string | null; itemUrl: string | null }`.
+
+**Constraint:** `OwnershipTargetView.kind` stays `"source_file" | "directory" | "service"`. The item is mapped to its owning service via `belongs_to`, so no new target kind is introduced.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("an item resolves to its owning service, and the brief records what was asked", async () => {
+  const db = seedItemInService({ itemKey: "PLAT-9", service: "checkout" });
+  const brief = await runOwnership(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "s7" },
+  );
+  expect(brief.target?.kind).toBe("service");
+  expect(brief.service?.id).toBe("checkout");
+  expect(brief.query.itemUrl).toBe("https://acme.atlassian.net/browse/PLAT-9");
+  expect(brief.query.path).toBeNull();
+  expect(brief.query.service).toBeNull();
+});
+
+test("ownership still rejects two scopes at once, now across three", () => {
+  expect(() => requireOwnershipParams({ path: "a.ts", itemUrl: "https://x/1" }))
+    .toThrow(/mutually exclusive/);
+  expect(() => requireOwnershipParams({ service: "checkout", itemUrl: "https://x/1" }))
+    .toThrow(/mutually exclusive/);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/ownership.test.ts -t "owning service"`
+Expected: FAIL — `itemUrl` is not accepted and `query` has no such field.
+
+- [ ] **Step 3: Widen the query and add the mapping**
+
+In `_lib/ownership-types.ts`:
+
+```ts
+  readonly query: {
+    readonly path: string | null;
+    readonly service: string | null;
+    /** The item the caller asked about, when they asked by item. */
+    readonly itemUrl: string | null;
+  };
+```
+
+Every existing construction site of `query` must add `itemUrl: null` — the compiler lists them.
+
+In `ownership.ts`, the item arm resolves the URL, walks `belongs_to` from the item entity to a `service` entity, and then runs the **existing** service lane with that id, so item-scoped and service-scoped answers cannot diverge. An item that belongs to no service emits a `missing_entity_type` gap naming the item, not the service.
+
+In `requireOwnershipParams`, extend the existing pairwise rejection to a count over the three, keeping the message's "pass one, or neither for a coverage summary" wording.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/ownership.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/_lib/ownership-types.ts packages/gateway/src/agents/ownership.ts packages/gateway/src/ipc/agents-rpc.ts packages/gateway/src/agents/ownership.test.ts
+git commit -m "feat(ownership): answer about an item through its owning service"
+```
+
+---
+
+### Task 8: The per-entity-type matrix, and PR 1's docs
+
+**Files:**
+
+- Test: `packages/gateway/src/agents/why.test.ts`, `expert.test.ts`
+- Modify: `docs/roadmap.md` (the Client surfaces row), `docs/CHANGELOG.md`
+
+- [ ] **Step 1: Write the matrix test**
+
+```ts
+describe.each(["issue", "doc", "incident"])("the item arm on a %s", (itemType) => {
+  test("produces findings or gaps, never a well-formed empty brief", async () => {
+    const db = seedIndexedItemOfType(itemType);
+    const brief = await runWhy(
+      { itemUrl: urlForSeededItem(itemType) },
+      { db, roots: [], notify: () => {}, sessionId: `m-${itemType}` },
+    );
+    expect(brief.findings.length + brief.gaps.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bun test packages/gateway/src/agents/why.test.ts -t "item arm on a"`
+Expected: PASS (Tasks 2–4 made it so; this test is the regression fence).
+
+- [ ] **Step 3: Record the change**
+
+Add a `docs/CHANGELOG.md` entry naming the three agents and the new arm. Update the roadmap's Client surfaces row to say the browser can now ask about an item.
+
+- [ ] **Step 4: Run the gates**
+
+Run: `bun run typecheck && bun run lint && bun run lint:markdown && bun test packages/gateway/src/agents/`
+Expected: all pass.
+
+- [ ] **Step 5: Commit and open PR 1**
+
+```bash
+git add -A
+git commit -m "docs: record the item arm across why, expert and ownership"
+```
+
+---
+
+## PR 2 — `resolveFileByRemote` and the forge-file arm
+
+**Blocked on:** nothing. Can be built in parallel with PR 1.
+
+### Task 9: The `impact` `source_file` fix, on its own
+
+**Files:**
+
+- Modify: `packages/gateway/src/agents/impact.ts:131-165` (`resolveStartEntity`)
+- Test: `packages/gateway/src/agents/impact.test.ts`
+
+**Interfaces:**
+
+- Produces: `resolveStartEntity` preferring an exact `source_file` label match.
+
+**Ship this first and alone.** It is a correctness fix to a shipped agent on the terminal surface (`nimbus impact src/foo.ts`) and it must be reviewable without the browser feature attached to it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("a file path resolves to the file, not to a symbol defined inside it", () => {
+  const db = seedDb();
+  // symbol labels are `${name} — ${file}`, so a path substring-matches them
+  upsertEntity(db, { type: "symbol", label: "x — src/foo.ts" });
+  upsertEntity(db, { type: "symbol", label: "parseEverything — src/foo.ts" });
+  const fileId = upsertEntity(db, { type: "source_file", label: "src/foo.ts" });
+
+  const start = resolveStartEntity(db, "src/foo.ts");
+  expect(start?.entityId).toBe(fileId);
+  expect(start?.entityType).toBe("source_file");
+});
+
+test("a genuine symbol name still resolves to the symbol", () => {
+  const db = seedDb();
+  const symId = upsertEntity(db, { type: "symbol", label: "parseTags — src/clip.ts" });
+  expect(resolveStartEntity(db, "parseTags")?.entityId).toBe(symId);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `bun test packages/gateway/src/agents/impact.test.ts -t "not to a symbol defined inside it"`
+Expected: FAIL — returns the `x — src/foo.ts` symbol, because `ORDER BY length(label) ASC` picks the shortest.
+
+- [ ] **Step 3: Put the file lookup first**
+
+In `resolveStartEntity`, after the PR attempt and **before** the symbol queries:
+
+```ts
+  // `symbol` labels are `${name} — ${file}`, so no symbol label is ever a bare
+  // path — the exact-symbol arm below cannot match file input, and the LIKE
+  // arm answers with an arbitrary symbol from inside the file. Look for the
+  // file itself first.
+  const file = db
+    .query("SELECT id FROM graph_entity WHERE type = 'source_file' AND label = ? LIMIT 1")
+    .get(fileOrPrUrl) as { id?: string } | null;
+  if (file?.id !== undefined) {
+    return { entityId: file.id, entityType: "source_file", repoIds: [] };
+  }
+```
+
+Widen `ResolvedStart["entityType"]` to include `"source_file"` and handle it wherever `entityType` is switched on.
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `bun test packages/gateway/src/agents/impact.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/impact.ts packages/gateway/src/agents/impact.test.ts
+git commit -m "fix(impact): a file path resolves to the file, not a symbol inside it"
+```
+
+---
+
+### Task 10: `resolveFileByRemote`
+
+**Files:**
+
+- Create: `packages/gateway/src/index/resolve-file-by-remote.ts`
+- Test: `packages/gateway/src/index/resolve-file-by-remote.test.ts`
+
+**Interfaces:**
+
+- Consumes: `fileExternalId` — **import it** from `../ownership/ownership-pass.ts` (export it if it is not already exported); do not re-format the string here.
+- Produces:
+
+```ts
+export type ResolveFileResult =
+  | { ok: true; fileEntityId: string; repoRoot: string; path: string }
+  | { ok: false; reason: "remote_not_tracked" | "file_not_indexed"; repo: string };
+
+export function resolveFileByRemote(
+  db: Database,
+  input: { service: string; repo: string; refAndPath: string },
+): ResolveFileResult;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+test("walks remote -> workspace -> source_file", () => {
+  const db = seedTrackedRepo({ remote: "github:acme/web", root: "/home/d/web", files: ["src/foo.ts"] });
+  const r = resolveFileByRemote(db, { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" });
+  expect(r).toMatchObject({ ok: true, repoRoot: "/home/d/web", path: "src/foo.ts" });
+});
+
+test("a branch name with slashes still finds the file", () => {
+  const db = seedTrackedRepo({ remote: "github:acme/web", root: "/home/d/web", files: ["src/foo.ts"] });
+  const r = resolveFileByRemote(db, {
+    service: "github", repo: "acme/web", refAndPath: "feat/auth-v2/src/foo.ts",
+  });
+  expect(r).toMatchObject({ ok: true, path: "src/foo.ts" });
+});
+
+test("remote casing does not decide the answer", () => {
+  const db = seedTrackedRepo({ remote: "github:ACME/Web", root: "/home/d/web", files: ["src/foo.ts"] });
+  const r = resolveFileByRemote(db, { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" });
+  expect(r.ok).toBe(true);
+});
+
+test("the two misses are distinguishable", () => {
+  const empty = seedDb();
+  expect(resolveFileByRemote(empty, { service: "github", repo: "acme/web", refAndPath: "main/a.ts" }))
+    .toMatchObject({ ok: false, reason: "remote_not_tracked" });
+
+  const tracked = seedTrackedRepo({ remote: "github:acme/web", root: "/home/d/web", files: ["src/foo.ts"] });
+  expect(resolveFileByRemote(tracked, { service: "github", repo: "acme/web", refAndPath: "main/nope.ts" }))
+    .toMatchObject({ ok: false, reason: "file_not_indexed" });
+});
+
+test("two worktrees on one remote resolve to the one that has the file, stably", () => {
+  const db = seedTwoWorktrees({
+    remote: "github:acme/web",
+    roots: [
+      { root: "/home/d/web", files: [] },
+      { root: "/home/d/web-hotfix", files: ["src/foo.ts"] },
+    ],
+  });
+  const first = resolveFileByRemote(db, { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" });
+  const second = resolveFileByRemote(db, { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" });
+  expect(first).toMatchObject({ ok: true, repoRoot: "/home/d/web-hotfix" });
+  expect(second).toEqual(first); // stable across calls, not arbitrary
+});
+
+test("a Windows root and a POSIX request meet", () => {
+  const db = seedTrackedRepo({ remote: "github:acme/web", root: "C:\\gitrep\\web", files: ["src/foo.ts"] });
+  const r = resolveFileByRemote(db, { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" });
+  expect(r.ok).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `bun test packages/gateway/src/index/resolve-file-by-remote.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement it**
+
+Order of operations, each one earning its place from a test above:
+
+1. Find candidate `repo` entities: `type = 'repo'` and `LOWER(external_id) = LOWER(?)`. Empty → `{ ok: false, reason: "remote_not_tracked", repo }`.
+2. Walk `tracks_remote` **backwards** (`to_id` = repo entity) to every `workspace`. Read each workspace's `repoRoot` from its external id (`filesystem:<root>`).
+3. For each candidate root, split `refAndPath` at each `/`, shortest ref first, and look up `fileExternalId(root, candidatePath)` — normalising `candidatePath` to the separator convention the indexer writes. **Read the indexer to determine that convention; do not assume.** Take the first hit.
+4. If several roots hit, prefer the most recently indexed, then the lowest entity id. Both are needed: the first is the useful answer, the second makes it deterministic.
+5. No hit anywhere → `{ ok: false, reason: "file_not_indexed", repo }`.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+Run: `bun test packages/gateway/src/index/resolve-file-by-remote.test.ts`
+Expected: PASS, all six.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/index/resolve-file-by-remote.ts packages/gateway/src/index/resolve-file-by-remote.test.ts
+git commit -m "feat(index): resolve a forge file coordinate to the local checkout"
+```
+
+---
+
+### Task 11: The forge-file arm on five agents
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts:248` (`requireFileParam`), and `impact.ts`, `expert.ts`, `ownership.ts`, `ghost.ts`, `conflicts.ts`
+- Test: each agent's test file, plus `agents-rpc.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveFileByRemote` (Task 10).
+- Produces: a shared `{ service, repo, refAndPath }` param shape accepted by all five.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+test("all five agents accept a forge file coordinate", async () => {
+  const db = seedTrackedRepo({ remote: "github:acme/web", root: "/home/d/web", files: ["src/foo.ts"] });
+  const coord = { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" };
+  for (const run of [runImpact, runExpert, runOwnership, runGhost, runConflicts]) {
+    const brief = await run(coord, { db, notify: () => {}, sessionId: "s" });
+    expect(brief.gaps.some((g) => /not tracked/i.test(g.detail))).toBe(false);
+  }
+});
+
+test("ghost and conflicts never fan out to peers from this arm", async () => {
+  const sent: unknown[] = [];
+  const db = seedTrackedRepo({ remote: "github:acme/web", root: "/home/d/web", files: ["src/foo.ts"] });
+  await runGhost(
+    { service: "github", repo: "acme/web", refAndPath: "main/src/foo.ts" },
+    { db, notify: () => {}, sessionId: "s", sendOverWire: (m) => { sent.push(m); } },
+  );
+  expect(sent).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `bun test packages/gateway/src/agents/ -t "forge file coordinate"`
+Expected: FAIL — the param shape is rejected.
+
+- [ ] **Step 3: Add the arm**
+
+Extend `requireFileParam` to accept either the existing `{ file }` or the new `{ service, repo, refAndPath }`, applying the same `MIN_FILE_LEN`/`MAX_FILE_LEN` bounds to `refAndPath` after trim. On the new shape it calls `resolveFileByRemote` and hands each agent the resolved local path — so the five agent bodies are unchanged, which is what keeps this task small.
+
+`parseNamespaces` is **not** called on the new shape: it stays `[]`, so `ghost` and `conflicts` answer local-only.
+
+A miss returns the agent's gap carrying the typed `reason`, so a client branches on a value.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+Run: `bun test packages/gateway/src/agents/ && bun test packages/gateway/src/ipc/agents-rpc.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A packages/gateway/src
+git commit -m "feat(agents): a forge file coordinate as input to the five file agents"
+```
+
+---
+
+## PR 3 — `connections` and `currency`
+
+### Task 12: `connections`
+
+**Files:**
+
+- Create: `packages/gateway/src/agents/connections.ts`
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts` (handler + `newSessionId` union)
+- Test: `packages/gateway/src/agents/connections.test.ts`
+
+**Interfaces:**
+
+- Produces: `emitConnectionsBrief(input, ctx)`, `briefReadyMethod: "connections.briefReady"`, brief `kind: "connections"`. Shape is fixed in spec §4.3 — copy it exactly; the SDK mirrors it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+test("a neighbour is present because an edge says so", async () => {
+  const db = seedIssueResolvedByPr({ prNumber: 482, issueKey: "PLAT-9" });
+  const brief = await runConnections(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "c1" },
+  );
+  expect(brief.neighbours).toHaveLength(1);
+  expect(brief.neighbours[0]).toMatchObject({ edgeType: "resolves", direction: "inbound" });
+});
+
+test("similar titles with no edge are not neighbours", async () => {
+  const db = seedTwoSimilarlyTitledUnlinkedItems();
+  const brief = await runConnections(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "c2" },
+  );
+  expect(brief.neighbours).toEqual([]);
+});
+
+test("filesystem edges never appear", async () => {
+  const db = seedItemWithDefinedInAndInRepoEdges();
+  const brief = await runConnections(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "c3" },
+  );
+  expect(brief.neighbours.map((n) => n.edgeType)).not.toContain("defined_in");
+  expect(brief.neighbours.map((n) => n.edgeType)).not.toContain("in_repo");
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `bun test packages/gateway/src/agents/connections.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement it**
+
+Resolve `itemUrl` via `resolveItemByUrl`, then select from `graph_relation` in both directions where `type` is in the item-linked vocabulary (spec §4.3 — `defined_in`, `in_repo` and `tracks_remote` excluded), join the neighbour entity and its `item` row when one exists, and emit one `ConnectionNeighbour` per row. Second hop only through `resolves` → `merged_as`. Follow `impact.ts`'s file layout: `runConnections` builds the brief, `emitConnectionsBrief` wraps it in `emitBriefWithSynthesis` with `briefReadyMethod: "connections.briefReady"`.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+Run: `bun test packages/gateway/src/agents/connections.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/connections.ts packages/gateway/src/agents/connections.test.ts packages/gateway/src/ipc/agents-rpc.ts
+git commit -m "feat(agents): connections -- an item's typed graph neighbours"
+```
+
+---
+
+### Task 13: `currency`
+
+**Files:**
+
+- Create: `packages/gateway/src/agents/currency.ts`
+- Modify: `packages/gateway/src/ipc/agents-rpc.ts`
+- Test: `packages/gateway/src/agents/currency.test.ts`
+
+**Interfaces:**
+
+- Produces: `emitCurrencyBrief`, `briefReadyMethod: "currency.briefReady"`, brief `kind: "currency"`. Shape fixed in spec §4.4: `verdict` is `"stale" | "current"` only, and `evidence` is a non-empty tuple.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+test("a claim always carries its evidence", async () => {
+  const db = seedIssueWhosePrMergedAfterIt();
+  const brief = await runCurrency(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "u1" },
+  );
+  expect(brief.claims.length).toBeGreaterThan(0);
+  for (const c of brief.claims) {
+    expect(c.evidence.length).toBeGreaterThan(0);
+    expect(c.signal).toBe("resolved_issue_pr_merged");
+  }
+});
+
+test("no signal produces a gap, not a claim", async () => {
+  const db = seedIndexedIssue(); // no edges, no state
+  const brief = await runCurrency(
+    { itemUrl: "https://acme.atlassian.net/browse/PLAT-9" },
+    { db, notify: () => {}, sessionId: "u2" },
+  );
+  expect(brief.claims).toEqual([]);
+  expect(brief.gaps.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `bun test packages/gateway/src/agents/currency.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the four signals**
+
+Each signal is a separate function returning `CurrencyClaim | null`, and each builds its evidence array before it builds its claim — so a signal that cannot cite anything returns null rather than a claim with an empty array. Recency (`inactivity_threshold`) is the weakest and is reported with `verdict: "current"` plus an observation, never as a staleness claim on its own.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+Run: `bun test packages/gateway/src/agents/currency.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/agents/currency.ts packages/gateway/src/agents/currency.test.ts packages/gateway/src/ipc/agents-rpc.ts
+git commit -m "feat(agents): currency -- is this item still true, with its evidence"
+```
+
+---
+
+### Task 14: The roster moves 11 → 13
+
+**Files:**
+
+- Modify: `packages/gateway/src/agent-runs/agent-http-e2e.test.ts:197-213`
+- Modify: `docs/CHANGELOG.md`, `docs/roadmap.md`
+
+- [ ] **Step 1: Update the roster assertion and prove the exclusions held**
+
+```ts
+      const { agents } = (await res.json()) as { agents: string[] };
+      expect(agents).not.toContain("preflight");
+      expect(agents).not.toContain("premortem");
+      expect(agents).not.toContain("whyPeek");
+      expect(agents).not.toContain("negotiate");
+      expect(agents).toContain("expert");
+      // connections and currency are pure reads with no HITL consequence, so
+      // they are HTTP-reachable by the derivation in HTTP_AGENT_NAMES.
+      expect(agents).toContain("connections");
+      expect(agents).toContain("currency");
+      expect(agents).toHaveLength(13);
+```
+
+Leave the three exclusion tests at `:152`, `:166` and `:181` **untouched** — they must keep passing verbatim.
+
+- [ ] **Step 2: Run the whole e2e file**
+
+Run: `bun test packages/gateway/src/agent-runs/agent-http-e2e.test.ts`
+Expected: PASS, including the three untouched exclusion tests.
+
+- [ ] **Step 3: Record it**
+
+Changelog entry naming both agents and the roster count.
+
+- [ ] **Step 4: Run the gates**
+
+Run: `bun run typecheck && bun run lint && bun run lint:markdown && bun test packages/gateway/src/`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(agents): publish connections and currency over HTTP"
+```

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design-review.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design-review.md
@@ -6,8 +6,8 @@
 **Target Spec:** [`2026-08-31-agents-for-items-and-files-design.md`](./2026-08-31-agents-for-items-and-files-design.md)  
 **Related Specs:**  
 
-- Web Clipper: [`nimbus-web-clipper` / `2026-08-31-lanes-for-every-recognised-page-design.md`](../../../nimbus-web-clipper/.claude/worktrees/lanes-everywhere/docs/superpowers/specs/2026-08-31-lanes-for-every-recognised-page-design.md)  
-- SDK: [`nimbus-sdk` / `2026-08-31-connections-and-currency-briefs-design.md`](../../../nimbus-sdk/.claude/worktrees/connections-currency-briefs/docs/superpowers/specs/2026-08-31-connections-and-currency-briefs-design.md)
+- Web Clipper: `nimbus-web-clipper` → `docs/superpowers/specs/2026-08-31-lanes-for-every-recognised-page-design.md` (a sibling repo; deliberately not a link, since no path resolves from inside this checkout)  
+- SDK: `nimbus-sdk` → `docs/superpowers/specs/2026-08-31-connections-and-currency-briefs-design.md` (same)
 
 ---
 

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design-review.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design-review.md
@@ -1,0 +1,137 @@
+# Design Review: Agents That Answer About an Item, and About a File You Are Reading
+
+**Date:** 2026-08-31  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Under Review  
+**Target Spec:** [`2026-08-31-agents-for-items-and-files-design.md`](./2026-08-31-agents-for-items-and-files-design.md)  
+**Related Specs:**  
+
+- Web Clipper: [`nimbus-web-clipper` / `2026-08-31-lanes-for-every-recognised-page-design.md`](../../../nimbus-web-clipper/.claude/worktrees/lanes-everywhere/docs/superpowers/specs/2026-08-31-lanes-for-every-recognised-page-design.md)  
+- SDK: [`nimbus-sdk` / `2026-08-31-connections-and-currency-briefs-design.md`](../../../nimbus-sdk/.claude/worktrees/connections-currency-briefs/docs/superpowers/specs/2026-08-31-connections-and-currency-briefs-design.md)
+
+---
+
+## 1. Summary of Review
+
+The design specification is exceptionally well-researched and grounded in the existing codebase architecture:
+
+1. **Preserving API Stability (F2):** Introducing `WhyItemSubject` and `WhyBrief.itemSubject` as an additive third arm avoids widening `WhyChangeSubject.repo` to nullable, preventing a breaking change on a **stable** SDK tier.
+2. **Leveraging Existing Graph Infrastructure (F1, F4):** Reusing `resolveItemByUrl` and walking the `workspace --tracks_remote--> repo` bridge neatly bridges the browser's forge coordinates (`service:repo` + `path`) to local checkout entities (`source_file`).
+3. **Stand-Alone Correctness Fix (F3):** Fixing `impact`'s non-PR arm to check `source_file` exact matches before falling back to `symbol` `LIKE` search resolves a real bug on the terminal CLI surface.
+4. **Principled Verification for `currency` (F6):** Enforcing that every currency claim carries supporting evidence rather than returning unsubstantiated "looks stale / current" verdicts.
+
+Below are key open questions, improvements, and edge-case considerations to address before and during implementation.
+
+---
+
+## 2. Open Questions & Architectural Ambiguities
+
+### Q2.1: Semantics of `why` Sub-Agents on Non-PR Items (`itemUrl`)
+
+- **Context:** §4.1 states: *"Each arm is: validate the URL, call `resolveItemByUrl`, take the item and its `graph_entity`, and run the agent body that already exists against that entity."*
+- **Ambiguity:** In `packages/gateway/src/agents/why.ts`, the coordinator executes 6 sub-agents (`subAuthorship`, `subPullRequest`, `subTicket`, `subDiscussion`, `subDriver`, `subDownstream`). These sub-agents are strictly coupled to either a file line (`ref` arm) or a PR entity (`prUrl` arm, e.g. `ticketRowsForPr` joins `WHERE pe.type = 'pr' AND r.from_id = ? AND r.type = 'resolves'`):
+  - If the subject is a **Jira/Linear issue**: `subPullRequest` expects a PR entity ID to find reviewers; `subTicket` expects a PR entity ID to find tickets resolved by it. If handed an issue entity ID, both return 0 rows. Does `why` look for incoming `resolves` edges (i.e. PRs that resolved this issue) or related/blocking tickets?
+  - If the subject is a **Confluence doc** or **incident**: How do `subPullRequest`, `subTicket`, and `subDiscussion` query the graph?
+- **Recommendation:** Explicitly document the query behavior of each `why` sub-lane when `arm === "item"`:
+  - `subPullRequest`: Look for PRs that link to or resolve the item (`graph_relation` where `to_id = item.entityId` and `type = 'resolves'`).
+  - `subTicket`: Look for connected/parent/blocking issues (`type = 'depends_on'` or `type = 'mentions'`).
+  - `subAuthorship` & `subDownstream`: Stay silent / skipped (matching the `prUrl` arm behavior).
+  - `subDiscussion`: Query discussions attached to or mentioning the item entity.
+
+### Q2.2: `expert` Agent Execution on Entities vs Lexical Text Search
+
+- **Context:** §4.1 states: *"The free-text path stays for callers who want it. The `itemUrl` arm resolves the URL to an item and answers from the entity, which is a different and better question."*
+- **Ambiguity:** Currently, `runExpert` in `packages/gateway/src/agents/expert.ts` only accepts `input.topicOrFile: string` and executes 5 sub-agents (`subBlame`, `subPrAuthored`, `subPrReviewed`, `subIncidentResolved`, `subChatMentions`) that run SQL queries with `LIKE '%' || ? || '%'` against titles and previews. It does not have an entity-based query implementation.
+- **Recommendation:** Define the entity-based query paths for `expert` when given an item entity (or forge file coordinate):
+  - **Item Entity:** Query direct relation edges into `person` entities (`authored`, `reviewed`, `assigned`, `posted`, `resolved`).
+  - **Forge File Entity (`source_file`):** Query `git blame` for the file on disk + commits touching the file + authors/reviewers of PRs that modified the file.
+
+### Q2.3: `OwnershipBrief` Schema & Target Kinds on `itemUrl`
+
+- **Context:** §4.1 states: *"requireOwnershipParams already rejects path and service together. itemUrl joins that mutual exclusion as a third member... All three answer with their existing brief shapes."*
+- **Ambiguity:** In `packages/gateway/src/agents/_lib/ownership-types.ts`:
+  - `OwnershipTargetView` is typed with `kind: "source_file" | "directory" | "service"`.
+  - `OwnershipBrief.query` is typed `{ readonly path: string | null; readonly service: string | null }`.
+  - If a user passes `itemUrl` for a Jira issue or doc, what is `target.kind`? Does `ownership` resolve the item to its owning service (returning `kind: "service"`) or does `OwnershipTargetView.kind` widen to `"item"`?
+  - Does `OwnershipBrief.query` gain `itemUrl?: string | null`?
+- **Recommendation:** Clarify the exact shape:
+  - If `ownership` maps the item to its service via the `belongs_to` relation, `target.kind` remains `"service"` and `service.id` is populated.
+  - If `ownership` returns item-level owners directly, `OwnershipTargetView.kind` must add `"item"` (or `"indexed_item"`), and `query` should include `itemUrl: string | null`.
+
+### Q2.4: Exact Wire Schema and Method Names for `connections` and `currency` (PR 3)
+
+- **Context:** The SDK and Clipper specs rely on the Nimbus gateway spec as the source of truth for wire schemas.
+- **Ambiguity:** §4.3 and §4.4 explain the semantics but omit the exact JSON-RPC method names and brief type properties.
+- **Recommendation:** Define the exact schemas in §4.3 and §4.4:
+  - **RPC Methods:** `agents.connections` (notification: `connections.briefReady`), `agents.currency` (notification: `currency.briefReady`).
+  - **Brief Discriminants:** `kind: "connections"` (or `"connection"`) and `kind: "currency"`.
+  - **`ConnectionsBrief` payload:**
+
+    ```ts
+    export type ConnectionNeighbour = {
+      edgeType: string;
+      direction: "inbound" | "outbound";
+      entityId: string;
+      entityType: string;
+      label: string;
+      item?: { id: string; service: string; type: string; title: string; url: string | null } | null;
+    };
+    ```
+
+  - **`CurrencyBrief` payload:**
+
+    ```ts
+    export type CurrencyFinding = {
+      claim: string;
+      verdict: "stale" | "current" | "unverified";
+      signal: "resolved_issue_pr_merged" | "mentioned_item_updated" | "incident_closed" | "inactivity_threshold";
+      evidence: { detail: string; sourceUrl?: string; modifiedAt?: number }[];
+    };
+    ```
+
+---
+
+## 3. Technical Improvements & Edge Cases
+
+### I3.1: Cross-Platform Path Normalization in `resolveFileByRemote`
+
+- **Issue:** On Windows, local filesystem roots are stored with backslashes (e.g. `C:\gitrep\acme-web`), while forge coordinates from the browser always use forward slashes (e.g. `src/components/Button.tsx`).
+- **Risk:** Deterministic IDs formatted as `file:<repoRoot>:<path>` could suffer from mismatched slashes if `repoRoot` is normalized differently across platforms, or if `path` is not normalized to POSIX format.
+- **Suggestion:** Explicitly specify that `resolveFileByRemote` normalizes both `repoRoot` and `path` to use standard POSIX separators (`/`) before constructing or querying `file:<repoRoot>:<path>` external IDs.
+
+### I3.2: Forge Remote URL Normalization in `tracks_remote` Bridge
+
+- **Issue:** Git remote URLs can take several forms:
+  - HTTPS: `https://github.com/acme/web.git` or `https://github.com/acme/web`
+  - SSH: `git@github.com:acme/web.git`
+  - Custom SSH aliases: `ssh://git@github.com-work/acme/web`
+- **Suggestion:** Ensure the ownership pass's remote parser (`bindRootRemote`) and `resolveFileByRemote` apply identical canonicalization: strip protocol, strip `.git`, lower-case host and organization/repository name, producing a consistent `<service>:<owner>/<repo>` external ID (e.g. `github:acme/web`).
+
+### I3.3: Handling Multiple Local Workspaces Tracking the Same Remote
+
+- **Issue:** A developer may have multiple local clones or git worktrees for `github:acme/web` (e.g. main repo at `C:\gitrep\web` and a worktree at `C:\gitrep\web-hotfix`).
+- **Risk:** Walking `repo --tracks_remote--> workspace` could match multiple `workspace` entities.
+- **Suggestion:** In `resolveFileByRemote`, handle multiple candidate workspaces deterministically:
+  1. Check which workspace actually contains the requested `path` in `source_file`.
+  2. If multiple workspaces index the file, break ties using the most recently indexed workspace (`modified_at` or lowest entity ID).
+
+### I3.4: Structured Miss Response for `resolveFileByRemote`
+
+- **Observation:** §4.2 notes two distinct misses: `no such remote is tracked` vs `tracked, but that path is not indexed`.
+- **Suggestion:** Return this distinction as a typed discriminant in the internal resolver response:
+
+  ```ts
+  type ResolveFileResult =
+    | { ok: true; fileEntityId: string; repoRoot: string; path: string }
+    | { ok: false; reason: "remote_not_tracked" | "file_not_indexed"; repo: string; path: string };
+  ```
+
+  When translating to agent gap notes, emit distinct `category` or structured `detail` so client surfaces do not need to scrape human-readable strings.
+
+---
+
+## 4. Testing Strategy Recommendations
+
+1. **`why` and `expert` Non-PR Matrix:** Add dedicated unit/integration tests for each supported connector entity type (`issue`, `doc`, `incident`) asserting that findings/gaps populate correctly without throwing or returning empty payloads.
+2. **Windows Path Separator Test:** Explicitly test `resolveFileByRemote` on Windows paths containing mixed slashes (`C:\repo/src\file.ts`).
+3. **Ambiguous / Multi-Worktree Resolution:** Test remote resolution when multiple worktrees share the same tracked remote.

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -208,9 +208,23 @@ So the item arm declares each sub-lane's behaviour explicitly:
 | `subDriver` | Skipped unless the item reaches a PR through `subPullRequest`, in which case it runs from that PR. |
 | `subDownstream` | Skipped. Its subject is changed code. |
 
-A skipped sub-lane emits its existing gap note, never an empty finding list. "This lane does not
-apply to an issue" and "this lane applies and found nothing" are different answers and the browser
-renders them differently.
+**Two kinds of skip, and the existing code already distinguishes them.** `subAuthorship`
+(`why.ts:356`) and `subDownstream` (`:702`) open with `if (lane.arm === "change") return {}` — silent,
+no gap — and the comment on `LaneInput.arm` says why: they are file/line lanes by nature and
+"stay silent on `change` rather than reporting a gap for the file subject a `prUrl` question never
+had". The item arm joins that condition unchanged: an item has no file subject either, so a gap there
+would report something missing that was never asked for.
+
+The other lanes do apply to an item, so when they find nothing they emit their existing gap notes.
+"This lane cannot apply here" (silence) and "this lane applies and found nothing" (a gap) are
+different answers, and the arm — not `subject === null` — is what separates them. That distinction is
+already load-bearing: the same comment records that inferring it would wrongly silence a genuine
+ref-arm resolution failure.
+
+**`arm` is the seam this design extends, not one it adds.** `LaneInput.arm` is already
+`"ref" | "change"` and is already passed explicitly rather than inferred. The item arm is a third
+member of that union, which is why this is a smaller change to `why.ts` than the sub-lane table
+above suggests.
 
 **`expert` has no entity path at all today.** `runExpert` takes `input.topicOrFile: string` and its
 five sub-agents — `subBlame`, `subPrAuthored`, `subPrReviewed`, `subIncidentResolved`,

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -30,11 +30,14 @@ param guards in `packages/gateway/src/ipc/agents-rpc.ts` against what a browser 
 | a time window, unscoped | `huddle` |
 | a resource ref + cleanup action | `janitor` |
 
-**No agent takes the URL of an indexed item that is not a pull request.** A Jira issue, a Confluence
-page and a PagerDuty incident are all first-class indexed items with rows in `item` and entities in
+**No agent takes the URL of an indexed item that is not a pull request.** A Jira issue and a
+PagerDuty incident are first-class indexed items with rows in `item` **and** entities in
 `graph_entity`, and none of the fourteen built-in agents will accept one as its subject. The browser
 panel therefore renders a header, a freshness line, Related, and a glossary box — on a page where
 this gateway demonstrably knows more than that.
+
+(A Confluence page is an indexed item too, but it has **no** `graph_entity` — see F8. That is why it
+is not in scope here, and it is the one place where the panel's current emptiness is honest.)
 
 The second half of the problem is the file. A reader on `github.com/acme/web/blob/main/src/foo.ts`
 is looking at a subject five agents can already answer about — but only if they are handed a path
@@ -152,12 +155,50 @@ The two agents added in PR 3 are pure reads with no HITL consequence, so they be
 set — but the count assertion (`expect(agents).toHaveLength(11)`, `agent-http-e2e.test.ts:211`) moves
 to 13, and that edit must be made deliberately, in the same PR, with the reason in the diff.
 
+### F8 — a Confluence page has no graph entity, so `doc` cannot have these lanes
+
+Found while planning Task 2, by following the type error in `resolveItemArm` back to what
+`resolveItemByUrl` actually returns.
+
+Every lane in §4.1 and both agents in §4.3–§4.4 answer from `graph_relation` edges, which hang off
+a `graph_entity`. Graph entities are written by `syncGraphFromIndexedItem`
+(`graph/graph-populator.ts:1062`), which returns early twice: once if the item's type is not in
+`ITEM_LINKED_ENTITY_TYPES` (`graph/relationship-graph.ts:6`), and again if it has no entry in
+`GRAPH_SYNC_BY_TYPE` (`:1018`).
+
+**Confluence pages index as `type: "page"`** (`connectors/confluence-sync.ts:164`), and `"page"`
+appears in **neither** list. So a Confluence page is a fully indexed item — it has an `item` row, it
+resolves by URL, the browser's header and Related work on it today — and it has **no graph entity at
+all**. There is nothing for a lane to walk.
+
+Shipped as originally drafted, every item lane on a `doc` page would have returned an empty answer
+or a gap, permanently, for a structural reason no user could act on. That is precisely the failure
+this whole arc exists to avoid.
+
+**So `doc` is out of scope for the item lanes**, and the surfaces are `pr`, `issue` and `incident`:
+
+| Surface | Item type | Graph entity? |
+| --- | --- | --- |
+| `issue` (Jira, Linear) | `issue` | ✅ `syncIssueGraph` |
+| `incident` (PagerDuty) | `incident` | ✅ `syncIncidentGraph` |
+| `doc` (Confluence) | `page` | ❌ no populator |
+| `build` (Jenkins, CircleCI) | `ci_run` | ❌ no populator — not an item-lane surface anyway |
+
+A Confluence page keeps exactly what it has today: header, freshness, Related and the `glossary`
+term box. **The condition that reopens this** is a `page` entry in both lists upstream — a graph
+populator for wiki pages, which is its own design with its own edge vocabulary (who authored it,
+what it mentions, which service it documents). It is not a rider on this work.
+
+`ci_run` has the same gap and is recorded here so the next person does not rediscover it; `build`
+was never an item-lane surface, so nothing changes for it.
+
 ---
 
 ## 3. What this delivers
 
-- A Jira issue, a Confluence page, a PagerDuty incident, a Linear issue and a CircleCI pipeline
-  become subjects the agents accept — "how did we get here", "who should I talk to".
+- A Jira issue, a Linear issue and a PagerDuty incident become subjects the agents accept — "how did
+  we get here", "who should I talk to". **Not a Confluence page**: it has no graph entity for a lane
+  to walk, and F8 records why and what would change that.
 - A source file open in a browser becomes a subject too, bridged to the reader's own checkout by the
   graph rather than by a guess in the client.
 - Two questions no agent answers today: what is connected to this item, and is it still true.
@@ -236,6 +277,16 @@ The item arm therefore adds one: from the item's entity, walk edges into `person
 (`authored`, `reviewed`, `opened`, `posted`, and `resolves` back through a PR). The free-text path
 stays untouched for callers who want it. This is genuinely new query code, not a rewiring of an
 input, and PR 1's estimate must carry it.
+
+**And it is a second SDK dependency, which an earlier draft of this document missed.** `ExpertBrief`
+is SDK-owned (`brief-composites.ts:61`) and its query is `{ topicOrFile: string }` — a brief answered
+about an item has nothing honest to put there unless the shape grows. The additive fix, matching F2's
+reasoning: `query` gains an optional `itemUrl?: string | null`, and `topicOrFile` carries the item
+URL on that arm so a consumer reading only the old field still gets the thing that was asked about,
+not a fabricated topic. `ownership` needs no such change — its brief is gateway-local (below).
+
+So PR 1's SDK release carries **two** additions, not one: `WhyItemSubject` + `WhyBrief.itemSubject`,
+and `ExpertBrief.query.itemUrl`.
 
 **`ownership` cannot answer with its existing brief shape.** `OwnershipTargetView.kind` is
 `"source_file" | "directory" | "service"` and `OwnershipBrief.query` is
@@ -396,8 +447,11 @@ item and would only ever appear as noise.
 came from:
 
 - the item is an issue, and a PR that `resolves` it merged after the item's `modified_at`
-- the item is a doc, and something it `mentions` changed after the doc last did
 - the item is an incident whose state is closed
+- an item that `mentions` something which changed after the item last did — **note this signal is
+  unreachable for a Confluence page**, which was its most obvious use and which has no graph entity
+  to hang a `mentions` edge on (F8). It stays in the design because an issue can `mention` too, and
+  because a `page` populator would light it up unchanged
 - the item has not changed in longer than its type's own norm — the weakest signal, reported as an
   observation rather than a claim
 
@@ -459,9 +513,9 @@ extended, not touched: a test asserting `preflight` stays 404 must keep passing 
 
 Three PRs. PR 1 is the browser's first unblock and depends on neither of the others.
 
-1. **`itemUrl` arms on `why`, `expert`, `ownership`** — §4.1, plus `WhyBrief.itemSubject` and the new
-   `WhyItemSubject`. The one PR with an SDK consequence, and an additive one; it ships first so the
-   client can start.
+1. **`itemUrl` arms on `why`, `expert`, `ownership`** — §4.1, on `pr`, `issue` and `incident` (not
+   `doc` — see F8). Carries two additive SDK changes: `WhyItemSubject` + `WhyBrief.itemSubject`, and
+   `ExpertBrief.query.itemUrl`. Ships first so the client can start.
 2. **`resolveFileByRemote`, the five forge-file arms, and the `impact` `source_file` fix** — §4.2.
    No new agent, no new brief, no SDK change.
 3. **`connections` and `currency`** — §4.3, §4.4, their briefs, and the exposure-count move in §4.5.

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -5,6 +5,7 @@
 **Slot:** Track 2 → Client surfaces, the browser row (`nimbus-web-clipper`)
 **Roadmap:** [`docs/roadmap.md` § Track 2 → Client surfaces](../../roadmap.md#client-surfaces)
 **Delivers as:** three PRs, in order — see §5
+**Reviewed:** [design review](./2026-08-31-agents-for-items-and-files-design-review.md) (Antigravity, 2026-08-31) — responses in §9
 **Consumers:** the browser client's own spec (`nimbus-web-clipper` →
 `docs/superpowers/specs/2026-08-31-lanes-for-every-recognised-page-design.md`) and the SDK's
 (`nimbus-sdk` → `docs/superpowers/specs/2026-08-31-connections-and-currency-briefs-design.md`).
@@ -180,18 +181,68 @@ rejection) — a URL out of a browser is exactly the input those were written fo
 `runWhy` skips the filesystem-roots read on the `prUrl` arm because that arm has no file subject to
 resolve against a root (`agents-rpc.ts:496`). `itemUrl` has none either, so it takes the same skip.
 
-**`expert`.** Its input is `topicOrFile`, and the browser currently sends the item **title** — a
-lexical guess that answers "who has touched things whose titles look like this". The `itemUrl` arm
-resolves the URL to an item and answers from the entity, which is a different and better question.
-The free-text path stays for callers who want it.
+**`why`'s six sub-agents do not generalise for free, and this is the largest correction in this
+document.** An earlier draft of §4.1 said each arm "runs the agent body that already exists against
+that entity". That is false for `why`. `why.ts` fans out to `subAuthorship` (`:352`),
+`subPullRequest` (`:457`), `subTicket` (`:533`), `subDiscussion` (`:564`), `subDriver` (`:629`) and
+`subDownstream` (`:698`), and their queries are pinned to the arm they were written for.
+`ticketRowsForPr` (`why.ts:320`) is the clearest case:
 
-**`ownership`.** `requireOwnershipParams` (`agents-rpc.ts:699`) already rejects `path` and `service`
-together. `itemUrl` joins that mutual exclusion as a third member; the "pass one, or neither for a
-coverage summary" contract is otherwise unchanged.
+```sql
+JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'pr'
+WHERE r.from_id = ? AND r.type = 'resolves'
+```
 
-**Subject.** All three answer with their existing brief shapes. `why` adds a third optional subject
-field, `itemSubject`, carrying a new `WhyItemSubject` (F2). `subject` and `changeSubject` are null on
-this arm, exactly as `subject` is null on the `prUrl` arm today. Nothing existing changes shape.
+Handed an **issue** entity id, that returns zero rows — not because the issue has no context, but
+because the query asks the edge in the wrong direction from the wrong entity type. Shipped as
+drafted, the item arm would return a well-formed, empty `why` brief on every issue in the index.
+
+So the item arm declares each sub-lane's behaviour explicitly:
+
+| Sub-lane | On `itemUrl` |
+| --- | --- |
+| `subPullRequest` | PRs pointing **at** the item — `graph_relation` where `to_id = entityId` and `type = 'resolves'`. The inverse of the PR arm's traversal, which is exactly what makes it non-automatic. |
+| `subTicket` | Neighbouring issues over `depends_on` / `mentions`. On an item that **is** an issue this is its siblings, never itself. |
+| `subDiscussion` | `message` entities related to the item (`mentions`, `posted`). Closest to arm-independent of the six. |
+| `subAuthorship` | Skipped. It resolves a file line against a filesystem root; an item has none, exactly as on the `prUrl` arm. |
+| `subDriver` | Skipped unless the item reaches a PR through `subPullRequest`, in which case it runs from that PR. |
+| `subDownstream` | Skipped. Its subject is changed code. |
+
+A skipped sub-lane emits its existing gap note, never an empty finding list. "This lane does not
+apply to an issue" and "this lane applies and found nothing" are different answers and the browser
+renders them differently.
+
+**`expert` has no entity path at all today.** `runExpert` takes `input.topicOrFile: string` and its
+five sub-agents — `subBlame`, `subPrAuthored`, `subPrReviewed`, `subIncidentResolved`,
+`subChatMentions` (`expert.ts:175`, `:225`, `:253`, `:424`) — run five
+`LIKE '%' || ? || '%'` scans over titles and previews. So "answers from the entity" in the earlier
+draft named a code path that does not exist.
+
+The item arm therefore adds one: from the item's entity, walk edges into `person` entities
+(`authored`, `reviewed`, `opened`, `posted`, and `resolves` back through a PR). The free-text path
+stays untouched for callers who want it. This is genuinely new query code, not a rewiring of an
+input, and PR 1's estimate must carry it.
+
+**`ownership` cannot answer with its existing brief shape.** `OwnershipTargetView.kind` is
+`"source_file" | "directory" | "service"` and `OwnershipBrief.query` is
+`{ path: string | null; service: string | null }`
+(`agents/_lib/ownership-types.ts:7`, `:27`) — there is no representable target for an item and no
+field to record the request in.
+
+The item arm maps the item to its owning service through `belongs_to` and answers with
+`kind: "service"`, so no new target kind is introduced. `OwnershipBrief.query` gains
+`itemUrl: string | null`, because a brief that cannot say what it was asked is not auditable.
+`requireOwnershipParams` (`agents-rpc.ts:699`) already rejects `path` and `service` together;
+`itemUrl` joins that mutual exclusion as a third member.
+
+**This costs no SDK release.** `OwnershipTargetView` and `OwnershipBrief` are defined in the
+gateway's own `_lib/ownership-types.ts` — only `GapNote` is imported from `@nimbus-dev/sdk` — and
+`ownership` is one of the five agents the SDK's `AGENT_NAMES` deliberately omits. The ownership brief
+is gateway-owned and changing it is a single-repo edit.
+
+**Subject.** `why` adds a third optional subject field, `itemSubject`, carrying a new
+`WhyItemSubject` (F2). `subject` and `changeSubject` are null on this arm, exactly as `subject` is
+null on the `prUrl` arm today. No existing field changes shape.
 
 **Gaps, not empties.** A URL that resolves to nothing returns the agent's existing gap vocabulary
 with a note naming the URL. The browser must distinguish "no answer" from "not indexed", and it can
@@ -202,18 +253,67 @@ only do that if this side says which.
 **The resolver.** One shared function, living beside `resolve-by-url.ts` because it is the same kind
 of thing: a client coordinate in, a local entity out.
 
-```text
-resolveFileByRemote(db, { service, repo, path }) -> { fileEntityId, repoRoot, path } | miss
+```ts
+type ResolveFileResult =
+  | { ok: true; fileEntityId: string; repoRoot: string; path: string }
+  | { ok: false; reason: "remote_not_tracked" | "file_not_indexed"; repo: string };
+
+resolveFileByRemote(db, { service, repo, refAndPath }): ResolveFileResult
 ```
 
 It walks F4's bridge: `graph_entity` where `type = 'repo'` and `external_id = '<service>:<repo>'`, in
-over `tracks_remote` to the `workspace`, then `source_file` by the deterministic external id
-`file:<repoRoot>:<path>`.
+over `tracks_remote` to the `workspace`, then `source_file` by its external id.
 
-Miss reasons are distinct and returned, never collapsed: **no such remote is tracked** (the reader
-has no local checkout of this repo) versus **the repo is tracked but that path is not indexed**
-(checkout exists, file not covered). Those two earn different remediations, and the browser renders
-them differently.
+The miss is a **typed discriminant**, not a sentence. Both reasons reach a browser, which branches on
+them to say either "Nimbus has no local checkout of this repo" or "that repo is indexed, that file is
+not" — and a client that had to match on human-readable prose would break the first time the prose
+was improved.
+
+**Why the input is `refAndPath` and not `path`.** A forge file URL is
+`…/blob/<ref>/<path>`, and **branch names contain slashes**: `github.com/acme/web/blob/feat/auth-v2/src/index.ts`
+splits as ref `feat/auth-v2` + path `src/index.ts`, or ref `feat` + path `auth-v2/src/index.ts`, and
+nothing in the URL says which. The browser cannot resolve that ambiguity — it would need the repo's
+branch list, which is a forge API call this client will never make.
+
+The gateway can, because it holds the file list. `refAndPath` is the opaque remainder after `/blob/`
+(or Bitbucket's `/src/`), and the resolver tries successive split points — shortest ref first —
+against the `source_file` entities indexed for the resolved workspace, taking the first suffix that
+matches an indexed path. A ref containing a slash costs one extra probe per segment against an
+already-scoped set. If no split matches, the reason is `file_not_indexed`, which is the honest answer
+for both "wrong split" and "file genuinely not indexed" — the reader's remediation is the same.
+
+**The external id is built by the writer's own function, never re-formatted here.**
+`fileExternalId(root, path)` (`ownership/ownership-pass.ts:118`) is `file:${root}:${path}`, and
+`syncCodeSymbolGraph` builds the byte-identical string (`graph-populator.ts:535`) — the convergence
+is deliberate and commented as such. A third formatter in this resolver would be a third thing to
+keep in step. It imports and calls the existing one.
+
+That matters most on Windows, where nothing in the codebase normalises separators: `repoRoot` is a
+native path (`C:\gitrep\acme-web`) and the browser's `refAndPath` is always POSIX. The resolver
+normalises the incoming path to the separator convention the indexer actually writes — determined by
+reading the indexer, not assumed — and a Windows test pins it.
+
+**Remote identity is compared case-insensitively.** `parseRemoteUrl` (`ownership/repo-remote.ts:40`)
+already handles both URL forms, strips `.git`, and lower-cases the **host** for its service lookup —
+but it returns `ownerName` verbatim from the remote (`repo-remote.ts:70`). So a checkout cloned from
+`github.com/ACME/Web` stores `github:ACME/Web` while the browser's address bar yields
+`github:acme/web`, and an exact-match lookup misses. The resolver compares case-insensitively rather
+than rewriting stored ids, because lower-casing them would change existing `graph_entity` external
+ids and need a migration for a problem a comparison solves.
+
+A remote on an unrecognised host — an SSH alias like `github.com-work` — already fails closed:
+`HOST_TO_SERVICE.get` returns undefined, `parseRemoteUrl` returns null, and no `tracks_remote` edge
+is written at all. That surfaces as `remote_not_tracked`, which is correct.
+
+**More than one workspace can track one remote, and here that is the common case, not the edge
+case.** `tracks_remote` runs workspace → repo, so every git worktree and every second clone of the
+same repository registered as a filesystem root adds another workspace pointing at the same `repo`
+entity. Walking the edge backwards returns a set.
+
+The resolver picks deterministically: **first the workspaces that actually index the requested
+path** — a worktree on a branch where the file does not exist is not a candidate — and among those,
+the most recently indexed, with the entity id as a final tie-break so the answer is stable across
+runs. Picking arbitrarily would make the same URL answer differently on consecutive calls.
 
 **The `impact` fix (F3).** `resolveStartEntity` gains a `source_file` exact-match branch **before**
 the `symbol` `LIKE`, so a path resolves to the file. The `LIKE` stays for genuine symbol-name input,
@@ -244,6 +344,38 @@ expressed as "depth 2".
 it is not in the answer. An empty result is a real answer — "nothing in your index links to this" —
 and is reported as one rather than padded.
 
+**Wire.** Method `agents.connections`, notification `connections.briefReady` (the convention every
+agent follows — `impact.ts:123`, `conflicts.ts:94`), brief discriminant `kind: "connections"`.
+
+```ts
+type ConnectionNeighbour = {
+  edgeType: GraphEdgeType;          // closed union — see below
+  direction: "inbound" | "outbound";
+  entityId: string;
+  entityType: string;
+  label: string;
+  item: { id: string; service: string; type: string; title: string; url: string | null } | null;
+};
+
+type ConnectionsBrief = AgentBriefBase & {
+  kind: "connections";
+  query: { itemUrl: string };
+  neighbours: ConnectionNeighbour[];
+};
+```
+
+`edgeType` is a **closed union**, not `GraphEdgeType | string`. That widened form was proposed in
+review and it collapses to `string` — TypeScript absorbs the union member — which removes the
+exhaustiveness the field exists to give a consumer. A gateway that grows an edge type this union does
+not name drops those neighbours from the brief rather than emitting an unrenderable discriminant;
+the vocabulary is this repo's own and grows by an explicit edit here.
+
+The union is the **item-linked** subset of the populator's edges — `resolves`, `correlates_with`,
+`mentions`, `backlinks`, `reviewed`, `authored`, `opened`, `merged_as`, `targets`, `belongs_to`,
+`monitors`, `depends_on`, `derived_from`, `upstream_refs`, `posted`. It excludes `defined_in`,
+`in_repo` and `tracks_remote`, which are filesystem/infrastructure edges that never touch an indexed
+item and would only ever appear as noise.
+
 ### 4.4 · `currency` (PR 3)
 
 **Input:** `{ itemUrl }`. **Output:** per-claim evidence, per F6. Each finding names the signal it
@@ -258,6 +390,48 @@ came from:
 **No verdict without evidence.** Where the signals are absent the agent returns a gap, never a
 default "looks current". Recency alone is not a currency claim: the browser already renders age from
 `modified_at` and does not need an agent to restate it.
+
+**Wire.** Method `agents.currency`, notification `currency.briefReady`, discriminant
+`kind: "currency"`.
+
+```ts
+type CurrencyEvidence = {
+  detail: string;
+  sourceItemId: string | null;
+  sourceUrl: string | null;
+  modifiedAt: number | null;
+};
+
+type CurrencyClaim = {
+  claim: string;
+  verdict: "stale" | "current";
+  signal:
+    | "resolved_issue_pr_merged"
+    | "mentioned_item_updated"
+    | "incident_closed"
+    | "inactivity_threshold";
+  /** Non-empty by construction: a claim with no evidence is not a claim. */
+  evidence: [CurrencyEvidence, ...CurrencyEvidence[]];
+};
+
+type CurrencyBrief = AgentBriefBase & {
+  kind: "currency";
+  query: { itemUrl: string };
+  claims: CurrencyClaim[];
+};
+```
+
+Two deliberate departures from the shape proposed in review, both enforcing §4.4's own rule rather
+than restating it:
+
+- **`evidence` is a non-empty tuple.** `CurrencyEvidence[]` admits `[]`, which is precisely the bare
+  verdict this agent exists not to emit. Making emptiness unrepresentable puts the rule in the type,
+  where a later contributor cannot quietly opt out of it.
+- **`verdict` has no `"unverified"` member.** An item the signals cannot speak to produces a **gap**,
+  not a claim with a shrug in it. A third verdict would let the agent fill `claims` with
+  non-answers and still look like it had worked.
+
+`claims: []` remains valid and means the signals were checked and none fired.
 
 ### 4.5 · HTTP exposure
 
@@ -291,6 +465,17 @@ Three PRs. PR 1 is the browser's first unblock and depends on neither of the oth
 - **F3 regression.** `impact`, given a path that exists as a `source_file` and as a substring of
   several `symbol` labels, resolves the file. This test fails against today's code, which is the
   point of writing it first.
+- **Per entity type, per sub-lane.** `why` and `expert` on an `issue`, a `doc` and an `incident`
+  each produce findings **or** a gap per sub-lane — never a well-formed empty brief. This is the
+  test that would have caught the §4.1 defect the review found, so it is written first.
+- **Ref-with-slashes.** `refAndPath` fixtures for a branch (`feat/auth-v2/src/index.ts`), a tag
+  (`v1.0.0-rc.1/src/index.ts`), a commit sha, and a path that matches no split at all.
+- **Windows separators.** `resolveFileByRemote` against a root stored with backslashes and a
+  browser path with forward slashes, including a mixed-separator input.
+- **Remote casing.** A checkout whose remote is `github.com/ACME/Web` resolves for a browser
+  coordinate of `github:acme/web`.
+- **Multiple workspaces on one remote.** Two worktrees tracking the same repo, one of which does not
+  index the requested path: the one that does wins, and the answer is stable across repeated calls.
 - **Local-only fan-out.** `ghost` and `conflicts` through the forge-file arm issue no peer request.
 - **`connections` returns no un-edged neighbour.** Seed two items with similar titles and no
   relation; the answer is empty.
@@ -329,3 +514,23 @@ Three PRs. PR 1 is the browser's first unblock and depends on neither of the oth
 - **A `supersedes` edge in the populator.** F6 derives instead. Writing supersession at sync time is
   a larger design with a schema consequence.
 - **Any new token scope.** All of this is reachable under the existing `agents` scope.
+
+---
+
+## 9. Review responses
+
+Against [`2026-08-31-agents-for-items-and-files-design-review.md`](./2026-08-31-agents-for-items-and-files-design-review.md)
+(Antigravity, 2026-08-31), and the ref-ambiguity finding raised in the browser client's review. Every
+finding was checked against the code before being accepted.
+
+| Finding | Disposition |
+| --- | --- |
+| Q2.1 `why` sub-agents on a non-PR item | **Accepted — the largest correction here.** Verified: `ticketRowsForPr` (`why.ts:320`) joins `pe.type = 'pr'` on `from_id`, so an issue entity returns zero rows. §4.1 now declares all six sub-lanes' item-arm behaviour, and a skipped lane emits a gap rather than an empty finding list. |
+| Q2.2 `expert` has no entity path | **Accepted.** Verified: five `LIKE` scans over `input.topicOrFile: string` (`expert.ts:175`). §4.1 now specifies the person-edge walk and states plainly that it is new query code, not a rewiring. |
+| Q2.3 `OwnershipBrief` has no item target | **Accepted.** Verified `ownership-types.ts:7`, `:27`. §4.1 maps the item to its service via `belongs_to` (no new target kind) and adds `query.itemUrl`. **Added beyond the review:** these types are gateway-local, so this costs no SDK release. |
+| Q2.4 exact wire schemas | **Accepted, with two changes.** §4.3 and §4.4 now carry method names, notification names, discriminants and full payloads. `edgeType` stays a **closed** union — the proposed `GraphEdgeType \| string` collapses to `string` and destroys the exhaustiveness the field is for. `currency` gets a non-empty evidence tuple and **no `"unverified"` verdict**, so §4.4's own rule lives in the type. |
+| I3.1 Windows path separators | **Accepted, strengthened.** Verified: no separator normalisation exists anywhere. §4.2 requires calling the writer's own `fileExternalId` rather than formatting a third copy of the string. |
+| I3.2 remote URL canonicalisation | **Accepted, corrected.** `parseRemoteUrl` already handles both URL forms and strips `.git`; the real gap is that it lower-cases the host but **not** `ownerName` (`repo-remote.ts:70`). Fixed by case-insensitive comparison, not by rewriting stored ids. SSH aliases need no handling — an unknown host already fails closed. |
+| I3.3 multiple workspaces per remote | **Accepted.** Structurally possible and, with git worktrees, common. §4.2 specifies path-containment first, then most-recently-indexed, then entity id. |
+| I3.4 typed miss discriminant | **Accepted.** `ResolveFileResult` in §4.2, with the reason as a discriminant rather than prose a client would have to scrape. |
+| Ref/path ambiguity (from the client review) | **Accepted — a design change.** A branch name with a slash makes `/blob/<ref>/<path>` unsplittable by the client. The input is now the opaque `refAndPath` remainder, disambiguated here against the indexed file list. |

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -1,7 +1,7 @@
 # Agents That Answer About an Item, and About a File You Are Reading
 
 **Date:** 2026-08-31
-**Status:** design — not started
+**Status:** PR 1 implemented (Nimbus#1421, `itemUrl` on `why`/`expert`/`ownership`); PRs 2 and 3 not started
 **Slot:** Track 2 → Client surfaces, the browser row (`nimbus-web-clipper`)
 **Roadmap:** [`docs/roadmap.md` § Track 2 → Client surfaces](../../roadmap.md#client-surfaces)
 **Delivers as:** three PRs, in order — see §5
@@ -306,8 +306,11 @@ gateway's own `_lib/ownership-types.ts` — only `GapNote` is imported from `@ni
 is gateway-owned and changing it is a single-repo edit.
 
 **Subject.** `why` adds a third optional subject field, `itemSubject`, carrying a new
-`WhyItemSubject` (F2). `subject` and `changeSubject` are null on this arm, exactly as `subject` is
-null on the `prUrl` arm today. No existing field changes shape.
+`WhyItemSubject` (F2). On this arm `subject` is **null** and `changeSubject` is **omitted** — not
+null. The two are different on the wire and the brief spreads them conditionally
+(`...(changeSubject === undefined ? {} : { changeSubject })`) precisely to keep them so under
+`exactOptionalPropertyTypes`: a consumer must be able to tell "asked, and unresolvable" from
+"never asked". No existing field changes shape.
 
 **Gaps, not empties.** A URL that resolves to nothing returns the agent's existing gap vocabulary
 with a note naming the URL. The browser must distinguish "no answer" from "not indexed", and it can

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -202,7 +202,7 @@ only do that if this side says which.
 **The resolver.** One shared function, living beside `resolve-by-url.ts` because it is the same kind
 of thing: a client coordinate in, a local entity out.
 
-```
+```text
 resolveFileByRemote(db, { service, repo, path }) -> { fileEntityId, repoRoot, path } | miss
 ```
 

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -1,0 +1,331 @@
+# Agents That Answer About an Item, and About a File You Are Reading
+
+**Date:** 2026-08-31
+**Status:** design — not started
+**Slot:** Track 2 → Client surfaces, the browser row (`nimbus-web-clipper`)
+**Roadmap:** [`docs/roadmap.md` § Track 2 → Client surfaces](../../roadmap.md#client-surfaces)
+**Delivers as:** three PRs, in order — see §5
+**Consumers:** the browser client's own spec (`nimbus-web-clipper` →
+`docs/superpowers/specs/2026-08-31-lanes-for-every-recognised-page-design.md`) and the SDK's
+(`nimbus-sdk` → `docs/superpowers/specs/2026-08-31-connections-and-currency-briefs-design.md`).
+This document owns the wire; those two consume it.
+
+---
+
+## 1. Problem
+
+The browser client recognises **nine products** across **six surface kinds** — `pr`, `build`,
+`issue`, `home`, `doc`, `incident`. It can run an agent against exactly two of them.
+
+That is not a client defect. It is a supply problem on this side, and it is visible by reading the
+param guards in `packages/gateway/src/ipc/agents-rpc.ts` against what a browser page can hand over:
+
+| What the caller has | Agents that accept it |
+| --- | --- |
+| a pull-request URL | `why` (`prUrl` arm), `impact` (PR arm) |
+| a **local** file path | `impact` (symbol arm), `expert`, `ownership` (`path` arm), `ghost`, `conflicts` |
+| a free term | `glossary`, `expert` |
+| a service id | `catchup`, `decisions`, `ownership` (`service` arm) |
+| a time window, unscoped | `huddle` |
+| a resource ref + cleanup action | `janitor` |
+
+**No agent takes the URL of an indexed item that is not a pull request.** A Jira issue, a Confluence
+page and a PagerDuty incident are all first-class indexed items with rows in `item` and entities in
+`graph_entity`, and none of the fourteen built-in agents will accept one as its subject. The browser
+panel therefore renders a header, a freshness line, Related, and a glossary box — on a page where
+this gateway demonstrably knows more than that.
+
+The second half of the problem is the file. A reader on `github.com/acme/web/blob/main/src/foo.ts`
+is looking at a subject five agents can already answer about — but only if they are handed a path
+inside a configured filesystem root, which a browser cannot produce and must not try to guess.
+
+---
+
+## 2. Findings that shaped it
+
+### F1 — the resolver this needs already ships
+
+`resolveItemByUrl(db, rawUrl)` (`packages/gateway/src/index/resolve-by-url.ts:123`) is the function
+behind `GET /v1/items/resolve`: a URL in, an indexed item out, with `canonicalizeUrl` applied and the
+three match kinds (`exact`, `query_stripped`, `path_trimmed`) already settled. Every "answer about
+this item" arm in §4.1 is that call plus the agent body that already exists. **No new retrieval is
+designed here**, which is the single biggest reason PR 1 is small.
+
+### F2 — `why` gets a third subject field, because widening the second one would be a breaking change
+
+`WhyChangeSubject` (SDK `sdks/typescript/src/agents/brief-types.ts:121`) carries `itemId`,
+`entityId`, `repo`, `number: number | null`, `url` and `title`. Five of those six are true of any
+indexed item; only `repo` is PR-shaped. So the obvious move is to widen `repo` to `string | null` and
+reuse the type for an item.
+
+**That move is wrong, and the SDK is where you find out.** `WhyChangeSubject` is published at
+**stability: stable** (`docs/api-surface.md:1164`). Widening a field to nullable breaks every
+consumer that reads it as a string, and the SDK's deprecation policy makes a break a **major** bump.
+One field's optionality is not cheap here; it is the most expensive option on the list.
+
+The right shape is already established by the type itself. `WhyBrief`
+(`docs/api-surface.md:1144`) carries **one optional subject field per arm**:
+
+```ts
+subject: WhySubject | null;              // the `ref` arm
+changeSubject?: WhyChangeSubject | null; // the `prUrl` arm
+```
+
+So the `itemUrl` arm gets a third: `itemSubject?: WhyItemSubject | null`. Purely additive, a
+**minor** bump, no consumer breaks, and it follows a precedent the brief set two arms ago rather than
+inventing one. `WhyItemSubject` carries the five item-generic fields and no `repo`.
+
+**This document therefore makes no breaking wire change.** Everything in PR 1 is additive.
+
+### F3 — `impact`'s non-PR arm resolves a file to the wrong thing
+
+`resolveStartEntity` (`packages/gateway/src/agents/impact.ts:131`) tries `resolvePrSubject`, then:
+
+```sql
+SELECT id FROM graph_entity WHERE type = 'symbol' AND label = ? LIMIT 1
+-- and, on a miss:
+SELECT id FROM graph_entity WHERE type = 'symbol' AND label LIKE '%' || ? || '%'
+  ORDER BY length(label) ASC, id ASC LIMIT 1
+```
+
+`symbol` entities are labelled `` `${name} — ${file}` `` (`graph/graph-populator.ts:517`). So a
+caller passing `src/foo.ts` never matches exactly, falls into the `LIKE`, and receives **the
+shortest-named symbol that happens to be defined in that file** — a confident answer about
+`x — src/foo.ts` when the question was about the file. The exact arm is effectively dead for file
+input, because no symbol's label is ever a bare path.
+
+Meanwhile `source_file` entities exist and are labelled with the path itself
+(`graph-populator.ts:535`: `label: file`, `service: "filesystem"`). The right entity is already
+there; the query does not look for it. **PR 2 fixes this**, and it is a correctness fix that stands
+on its own merit whether or not a browser ever calls it.
+
+### F4 — the forge→checkout bridge exists in the graph, and nothing exposes it
+
+`bindRootRemote` (`packages/gateway/src/ownership/ownership-pass.ts:395`) writes
+`workspace --tracks_remote--> repo`, where the workspace is `filesystem:<repoRoot>` and the repo's
+external id is `` `${remote.service}:${remote.ownerName}` `` — i.e. `github:acme/web`
+(`ownership-pass.ts:422`, `:428`).
+
+That is exactly the mapping a browser needs and cannot have: **`github:acme/web` + `src/foo.ts` →
+`filesystem:<root>` → `file:<root>:src/foo.ts`.** The edge is written for every git-aware root with a
+remote. No agent input arm walks it, so the information is present and unreachable.
+
+This finding is what moved the browser's file surface from "client-only, ships immediately" to
+"blocked on PR 2". It was found by reading `agents/ownership.ts:110`, which refuses a path "outside
+every configured root" — the refusal a browser-supplied repo-relative path would always earn.
+
+### F5 — the graph's edges are typed, so "what is connected" need not be a similarity search
+
+`graph_relation` rows carry a `type`, and the populator writes a real vocabulary: `resolves`,
+`correlates_with`, `mentions`, `backlinks`, `reviewed`, `authored`, `opened`, `merged_as`, `targets`,
+`belongs_to`, `monitors`, `depends_on`, `derived_from`, `defined_in`, `in_repo`, `upstream_refs`,
+`posted`, `tracks_remote`.
+
+This matters because the browser panel **already** shows `POST /v1/clips/related` on these pages. A
+"related" agent returning similar items would be a second Related with a spinner in front of it. An
+agent returning *named edges* — "PR #482 `resolves` this issue" — answers a different question. §4.3
+binds the agent to edge types for that reason, and its brief carries the edge type per neighbour so a
+consumer renders the relationship rather than a list.
+
+### F6 — there is no `supersedes` edge, so "is this still true" must be derived and must show its work
+
+Nothing in the populator writes supersession. The currency agent in §4.4 therefore cannot look an
+answer up; it derives one from evidence that does exist — an issue whose `resolves` PR merged after
+the item's `modified_at`, a doc that `mentions` a PR merged since the doc last changed, an incident
+whose state is closed while the doc describing it is not.
+
+That makes it the riskiest of the four capabilities, and it constrains the brief: **every claim
+carries the evidence it was derived from**, or the agent reports a gap instead. A bare "this page is
+stale" verdict about someone's runbook, with no citation, is worse than silence.
+
+### F7 — HTTP exposure is derived, not declared, and three exclusions are load-bearing
+
+`HTTP_AGENT_NAMES` (`agents-rpc.ts:983`) is `Object.keys(AGENTS_RPC_HANDLERS)` minus
+`HTTP_EXCLUDED_AGENT_METHODS`, so a new handler is HTTP-reachable **by default**. The current
+exclusions are deliberate and separately reasoned: `preflight` and `premortem` write (queued consent
+prompts, paused watcher rows), and `negotiate` would let any holder of an `agents`-scoped token
+assemble a contribution dossier on any indexed person. Each has its own e2e test asserting a 404 and
+an empty `egress_ledger` (`agent-runs/agent-http-e2e.test.ts:152`, `:166`, `:181`).
+
+The two agents added in PR 3 are pure reads with no HITL consequence, so they belong in the exposed
+set — but the count assertion (`expect(agents).toHaveLength(11)`, `agent-http-e2e.test.ts:211`) moves
+to 13, and that edit must be made deliberately, in the same PR, with the reason in the diff.
+
+---
+
+## 3. What this delivers
+
+- A Jira issue, a Confluence page, a PagerDuty incident, a Linear issue and a CircleCI pipeline
+  become subjects the agents accept — "how did we get here", "who should I talk to".
+- A source file open in a browser becomes a subject too, bridged to the reader's own checkout by the
+  graph rather than by a guess in the client.
+- Two questions no agent answers today: what is connected to this item, and is it still true.
+- One correctness fix (F3) that improves `nimbus impact <file>` on the terminal surface as well.
+
+---
+
+## 4. The design
+
+### 4.1 · An `itemUrl` arm on `why`, `expert` and `ownership` (PR 1)
+
+Each arm is: validate the URL, call `resolveItemByUrl`, take the item and its `graph_entity`, and run
+the agent body that already exists against that entity.
+
+**`why`.** `requireWhyParams` (`agents-rpc.ts:463`) enforces *exactly one of* `ref` / `prUrl` via
+`hasRef === hasPrUrl`. That two-value equality does not generalise; it becomes a count of supplied
+arms, rejecting zero and rejecting more than one, with the error naming all three. The `prUrl` arm's
+existing guards apply unchanged to `itemUrl`: the length bound and `prUrlHasCredentials` (userinfo
+rejection) — a URL out of a browser is exactly the input those were written for.
+
+`runWhy` skips the filesystem-roots read on the `prUrl` arm because that arm has no file subject to
+resolve against a root (`agents-rpc.ts:496`). `itemUrl` has none either, so it takes the same skip.
+
+**`expert`.** Its input is `topicOrFile`, and the browser currently sends the item **title** — a
+lexical guess that answers "who has touched things whose titles look like this". The `itemUrl` arm
+resolves the URL to an item and answers from the entity, which is a different and better question.
+The free-text path stays for callers who want it.
+
+**`ownership`.** `requireOwnershipParams` (`agents-rpc.ts:699`) already rejects `path` and `service`
+together. `itemUrl` joins that mutual exclusion as a third member; the "pass one, or neither for a
+coverage summary" contract is otherwise unchanged.
+
+**Subject.** All three answer with their existing brief shapes. `why` adds a third optional subject
+field, `itemSubject`, carrying a new `WhyItemSubject` (F2). `subject` and `changeSubject` are null on
+this arm, exactly as `subject` is null on the `prUrl` arm today. Nothing existing changes shape.
+
+**Gaps, not empties.** A URL that resolves to nothing returns the agent's existing gap vocabulary
+with a note naming the URL. The browser must distinguish "no answer" from "not indexed", and it can
+only do that if this side says which.
+
+### 4.2 · `resolveFileByRemote`, and a forge-file arm on five agents (PR 2)
+
+**The resolver.** One shared function, living beside `resolve-by-url.ts` because it is the same kind
+of thing: a client coordinate in, a local entity out.
+
+```
+resolveFileByRemote(db, { service, repo, path }) -> { fileEntityId, repoRoot, path } | miss
+```
+
+It walks F4's bridge: `graph_entity` where `type = 'repo'` and `external_id = '<service>:<repo>'`, in
+over `tracks_remote` to the `workspace`, then `source_file` by the deterministic external id
+`file:<repoRoot>:<path>`.
+
+Miss reasons are distinct and returned, never collapsed: **no such remote is tracked** (the reader
+has no local checkout of this repo) versus **the repo is tracked but that path is not indexed**
+(checkout exists, file not covered). Those two earn different remediations, and the browser renders
+them differently.
+
+**The `impact` fix (F3).** `resolveStartEntity` gains a `source_file` exact-match branch **before**
+the `symbol` `LIKE`, so a path resolves to the file. The `LIKE` stays for genuine symbol-name input,
+which is what it was written for. This is a behaviour change to a shipped agent on the terminal
+surface too, and it is a fix: `nimbus impact src/foo.ts` today answers about one arbitrary symbol
+inside `src/foo.ts`.
+
+**The arm.** `impact`, `expert`, `ownership`, `ghost` and `conflicts` each accept the forge-file
+coordinate. `requireFileParam` (`agents-rpc.ts:248`) is the shared guard `ghost` and `conflicts`
+already use and is the natural home for the new shape, with the same `MIN_FILE_LEN` / `MAX_FILE_LEN`
+bounds — measured after trim, on the normalised value, never on the caller's raw string.
+
+**Namespaces stay absent.** `ghost` and `conflicts` fan out to federation peers only when
+`namespaces` is supplied (`requireFileParam` → `parseNamespaces`). The browser sends none, and this
+arm adds none, so both answer local-only. That is a property worth a test, not a comment.
+
+### 4.3 · `connections` (PR 3)
+
+**Input:** `{ itemUrl }`, resolved by F1. **Output:** the item's neighbours in `graph_relation`, each
+carrying its edge `type`, its direction, the neighbour's entity type and label, and the indexed item
+behind it where one exists.
+
+One hop by default. A second hop only through edges where transitivity is meaningful (`resolves`
+then `merged_as`, so an issue reaches the commit that closed it) — enumerated explicitly, never
+expressed as "depth 2".
+
+**It must never rank by similarity** (F5). A neighbour is in the answer because an edge says so, or
+it is not in the answer. An empty result is a real answer — "nothing in your index links to this" —
+and is reported as one rather than padded.
+
+### 4.4 · `currency` (PR 3)
+
+**Input:** `{ itemUrl }`. **Output:** per-claim evidence, per F6. Each finding names the signal it
+came from:
+
+- the item is an issue, and a PR that `resolves` it merged after the item's `modified_at`
+- the item is a doc, and something it `mentions` changed after the doc last did
+- the item is an incident whose state is closed
+- the item has not changed in longer than its type's own norm — the weakest signal, reported as an
+  observation rather than a claim
+
+**No verdict without evidence.** Where the signals are absent the agent returns a gap, never a
+default "looks current". Recency alone is not a currency claim: the browser already renders age from
+`modified_at` and does not need an agent to restate it.
+
+### 4.5 · HTTP exposure
+
+Both new agents are pure reads and join `HTTP_AGENT_NAMES` by the derivation in F7 — no allowlist
+edit. The count assertion moves 11 → 13 in the same PR, and the three existing exclusion tests are
+extended, not touched: a test asserting `preflight` stays 404 must keep passing verbatim.
+
+---
+
+## 5. Slices
+
+Three PRs. PR 1 is the browser's first unblock and depends on neither of the others.
+
+1. **`itemUrl` arms on `why`, `expert`, `ownership`** — §4.1, plus `WhyBrief.itemSubject` and the new
+   `WhyItemSubject`. The one PR with an SDK consequence, and an additive one; it ships first so the
+   client can start.
+2. **`resolveFileByRemote`, the five forge-file arms, and the `impact` `source_file` fix** — §4.2.
+   No new agent, no new brief, no SDK change.
+3. **`connections` and `currency`** — §4.3, §4.4, their briefs, and the exposure-count move in §4.5.
+   Two new brief shapes; the SDK's guards follow this PR.
+
+---
+
+## 6. Testing
+
+- **Per arm, a resolve hit and both miss reasons.** §4.2's two misses are distinct strings on the
+  wire; a test that accepts either is not testing the thing the browser branches on.
+- **`why`'s arm count.** Zero arms rejected, each single arm accepted, every pair rejected, all three
+  rejected. The current `hasRef === hasPrUrl` shape passes a two-arm suite by accident; its
+  replacement must be tested as a count.
+- **F3 regression.** `impact`, given a path that exists as a `source_file` and as a substring of
+  several `symbol` labels, resolves the file. This test fails against today's code, which is the
+  point of writing it first.
+- **Local-only fan-out.** `ghost` and `conflicts` through the forge-file arm issue no peer request.
+- **`connections` returns no un-edged neighbour.** Seed two items with similar titles and no
+  relation; the answer is empty.
+- **`currency` returns no un-evidenced claim.** Seed an item with no signals; the answer is a gap.
+- **Exposure.** `GET /v1/agents` lists 13; `preflight` / `premortem` / `negotiate` still 404 with an
+  empty `egress_ledger`.
+
+---
+
+## 7. Risks and limitations
+
+- **The file surface answers only for repos the reader has checked out locally.** F4's bridge is
+  written by the ownership pass over git-aware filesystem roots. A reader browsing a repo they have
+  never cloned gets the "no such remote is tracked" miss, forever, and correctly. This is a real
+  bound on the browser feature, and both consumer specs must state it rather than discover it.
+- **`currency` can be confidently wrong** about a document whose subject moved with no indexed
+  signal. §4.4's evidence rule bounds the damage; it does not remove it. If that rule proves
+  unsatisfiable in review, cutting `currency` from PR 3 and shipping `connections` alone is the
+  correct outcome — not a weakened verdict.
+- **`WhyBrief` grows a third subject field**, which reaches every SDK consumer, including ones that
+  are not this browser. It is additive (F2) and therefore a minor bump — but a consumer switching on
+  "which subject is non-null" now has three cases, and one written against two will fall through on
+  an item brief. The SDK spec's guard work is where that is caught.
+- **PR 2 changes a shipped agent's behaviour on the terminal surface.** It is a fix, and it will
+  still surprise someone who had learned the old output.
+
+---
+
+## 8. Out of scope
+
+- **`janitor`** — takes a `cleanupAction` and is write-shaped. Not a browser subject; not touched.
+- **`huddle`** — has no `service` param, so it answers across every connector at once and cannot
+  honestly sit on a per-product dashboard. It wants its own surface and its own brief.
+- **Closing the SDK's `AGENT_NAMES` lag** for `ownership` / `glossary` / `decisions` / `negotiate` /
+  `premortem`. Deliberate there, and unrelated to this work.
+- **A `supersedes` edge in the populator.** F6 derives instead. Writing supersession at sync time is
+  a larger design with a schema consequence.
+- **Any new token scope.** All of this is reachable under the existing `agents` scope.

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.30.0",
     "@nimbus-dev/client": "^0.17.3",
-    "@nimbus-dev/sdk": "^1.19.0",
+    "@nimbus-dev/sdk": "^1.31.0",
     "astro": "^7.2.4",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "js-yaml": "4.3.1",
     "postcss": "8.5.23",
     "postcss-selector-parser": "6.1.4",
+    "browserslist": "4.28.7",
     "nanoid": "3.3.18",
     "qs": "6.15.3",
     "yaml": "2.9.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -19,7 +19,7 @@
     "@mastra/core": "^1.61.0",
     "@mastra/mcp": "^1.17.1",
     "@nimbus-dev/connectors": "^0.2.0",
-    "@nimbus-dev/sdk": "^1.19.0",
+    "@nimbus-dev/sdk": "^1.31.0",
     "@noble/hashes": "^2.3.0",
     "@scure/bip39": "^2.3.0",
     "@xenova/transformers": "^2.17.0",

--- a/packages/gateway/src/agents/_lib/findings.ts
+++ b/packages/gateway/src/agents/_lib/findings.ts
@@ -36,6 +36,7 @@ export type {
   WhyBrief,
   WhyChangeSubject,
   WhyFinding,
+  WhyItemSubject,
   WhyLane,
   WhyPeek,
   WhySubject,

--- a/packages/gateway/src/agents/_lib/ownership-types.ts
+++ b/packages/gateway/src/agents/_lib/ownership-types.ts
@@ -13,9 +13,17 @@ export type OwnershipTargetView = {
   readonly truncated: boolean | null;
 };
 
+/**
+ * Exactly one of the three, or none for a coverage summary.
+ *
+ * `itemUrl` does NOT introduce a fourth target kind: the item is mapped to the service
+ * it rolls up to, and answered by the SAME service lane a `service` request takes. That
+ * is what keeps an item-scoped answer from ever diverging from a service-scoped one.
+ */
 export type OwnershipInput = {
   readonly path?: string;
   readonly service?: string;
+  readonly itemUrl?: string;
 };
 
 export type OwnershipBrief = {
@@ -24,7 +32,13 @@ export type OwnershipBrief = {
   readonly generatedAt: number;
   readonly latencyMs: number;
   readonly gaps: GapNote[];
-  readonly query: { readonly path: string | null; readonly service: string | null };
+  readonly query: {
+    readonly path: string | null;
+    readonly service: string | null;
+    /** The item the caller asked about, when they asked by item. A brief that cannot
+     *  say what it was asked is not auditable. */
+    readonly itemUrl: string | null;
+  };
   /** Null in summary mode, and when a path resolved to no graph entity. */
   readonly target: OwnershipTargetView | null;
   readonly parentDirectory: OwnershipTargetView | null;

--- a/packages/gateway/src/agents/_lib/reserved-sections.coverage.test.ts
+++ b/packages/gateway/src/agents/_lib/reserved-sections.coverage.test.ts
@@ -277,7 +277,7 @@ const OWNERSHIP: OwnershipBrief = {
   generatedAt: 0,
   latencyMs: 0,
   gaps: [GAP],
-  query: { path: null, service: null },
+  query: { path: null, service: null, itemUrl: null },
   target: null,
   parentDirectory: null,
   service: null,

--- a/packages/gateway/src/agents/_lib/synthesize.ownership.test.ts
+++ b/packages/gateway/src/agents/_lib/synthesize.ownership.test.ts
@@ -10,7 +10,7 @@ const BRIEF: OwnershipBrief = {
   generatedAt: 1_800_000_000_000,
   latencyMs: 4,
   gaps: [],
-  query: { path: "src/a.ts", service: null },
+  query: { path: "src/a.ts", service: null, itemUrl: null },
   target: {
     kind: "source_file",
     displayPath: "src/a.ts",

--- a/packages/gateway/src/agents/_lib/synthesize.test.ts
+++ b/packages/gateway/src/agents/_lib/synthesize.test.ts
@@ -372,7 +372,7 @@ const OWNERSHIP_FIXTURE: OwnershipBrief = {
   generatedAt: 0,
   latencyMs: 0,
   gaps: [],
-  query: { path: null, service: null },
+  query: { path: null, service: null, itemUrl: null },
   target: null,
   parentDirectory: null,
   service: null,

--- a/packages/gateway/src/agents/_lib/why-types.ts
+++ b/packages/gateway/src/agents/_lib/why-types.ts
@@ -10,17 +10,33 @@
  */
 export type { WhyBrief, WhyFinding, WhyLane, WhyPeek, WhySubject } from "./findings.ts";
 
-export type WhyRefInput = { ref: string; line?: number; prUrl?: never };
+export type WhyRefInput = { ref: string; line?: number; prUrl?: never; itemUrl?: never };
 
 /** The browser-viable arm: a pull request URL, no local checkout required. */
-export type WhyPrInput = { prUrl: string; ref?: never; line?: never };
+export type WhyPrInput = { prUrl: string; ref?: never; line?: never; itemUrl?: never };
 
 /**
- * Exactly one arm, never both. `agents.whyPeek` accepts only `WhyRefInput` — it
+ * The second browser-viable arm: an indexed item that is NOT a pull request —
+ * a Jira or Linear issue, a PagerDuty incident.
+ *
+ * Deliberately not a Confluence page. A page indexes as `type: "page"`, which
+ * appears in neither `ITEM_LINKED_ENTITY_TYPES` nor `GRAPH_SYNC_BY_TYPE`, so it
+ * has no `graph_entity` at all — and every lane on this arm answers from graph
+ * edges. `resolveItemArm` treats "resolved, but no entity" as a miss for exactly
+ * that reason, rather than returning a subject the lanes cannot answer about.
+ */
+export type WhyItemInput = { itemUrl: string; ref?: never; line?: never; prUrl?: never };
+
+/**
+ * Exactly one arm, never two. `agents.whyPeek` accepts only `WhyRefInput` — it
  * is line-level by nature and stays HTTP-excluded.
  */
-export type WhyInput = WhyRefInput | WhyPrInput;
+export type WhyInput = WhyRefInput | WhyPrInput | WhyItemInput;
 
 export function isWhyPrInput(input: WhyInput): input is WhyPrInput {
   return "prUrl" in input;
+}
+
+export function isWhyItemInput(input: WhyInput): input is WhyItemInput {
+  return "itemUrl" in input;
 }

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -968,5 +968,83 @@ describe("emitExpertBrief", () => {
   });
 });
 
+describe("runExpert — the itemUrl arm", () => {
+  const ISSUE_URL = "https://acme.atlassian.net/browse/PLAT-9";
+
+  function itemArmDb(): Database {
+    const db = new Database(":memory:");
+    LocalIndex.ensureSchema(db);
+    return db;
+  }
+
+  // The whole reason this arm exists. The free-text arm matches titles with `LIKE`, so a
+  // second item whose title merely RESEMBLES this one pulls its author in. The item arm
+  // answers from edges, so it must not.
+  test("answers from graph edges, not from a title match", async () => {
+    const db = itemArmDb();
+    const t = Date.now();
+
+    db.run("INSERT INTO person (id, display_name) VALUES ('p-dana', 'Dana')");
+    db.run("INSERT INTO person (id, display_name) VALUES ('p-rae', 'Rae')");
+
+    upsertIndexedItem(db, {
+      service: "jira",
+      type: "issue",
+      externalId: "PLAT-9",
+      title: "Checkout times out",
+      bodyPreview: "",
+      url: ISSUE_URL,
+      modifiedAt: t,
+      syncedAt: t,
+      authorId: "p-dana",
+      metadata: {},
+    });
+
+    // A decoy the LIKE-based arm would happily match on title, authored by someone else.
+    upsertIndexedItem(db, {
+      service: "jira",
+      type: "issue",
+      externalId: "PLAT-10",
+      title: "Checkout times out again",
+      bodyPreview: "",
+      url: "https://acme.atlassian.net/browse/PLAT-10",
+      modifiedAt: t,
+      syncedAt: t,
+      authorId: "p-rae",
+      metadata: {},
+    });
+
+    const brief = await runExpert(
+      { itemUrl: ISSUE_URL },
+      { db, notify: () => {}, sessionId: "expert-item-1" },
+    );
+
+    const names = brief.ranked.map((f) => f.displayName);
+    expect(names).not.toContain("Rae");
+    expect(brief.query.topicOrFile).toBe(ISSUE_URL);
+    expect(brief.query.itemUrl).toBe(ISSUE_URL);
+  });
+
+  test("an unresolvable itemUrl gaps rather than answering emptily", async () => {
+    const db = itemArmDb();
+    const brief = await runExpert(
+      { itemUrl: "https://acme.atlassian.net/browse/NOPE-1" },
+      { db, notify: () => {}, sessionId: "expert-item-2" },
+    );
+    expect(brief.ranked).toEqual([]);
+    expect(brief.gaps.length).toBeGreaterThan(0);
+  });
+
+  test("the free-text arm still records only topicOrFile", async () => {
+    const db = itemArmDb();
+    const brief = await runExpert(
+      { topicOrFile: "src/clip.ts" },
+      { db, notify: () => {}, sessionId: "expert-item-3" },
+    );
+    expect(brief.query.topicOrFile).toBe("src/clip.ts");
+    expect(brief.query.itemUrl).toBeUndefined();
+  });
+});
+
 // Placeholder afterEach — no global state is mutated in these tests.
 afterEach(() => {});

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -1048,3 +1048,14 @@ describe("runExpert — the itemUrl arm", () => {
 
 // Placeholder afterEach — no global state is mutated in these tests.
 afterEach(() => {});
+
+test("runExpert refuses a request with no arm rather than searching for the empty string", async () => {
+  // `LIKE '%' || '' || '%'` matches every indexed title and body preview, so a defaulted
+  // empty topic would answer "who are the most active people in your whole index" to a
+  // question nobody asked — confidently, and with no gap to warn anyone.
+  const db = new Database(":memory:");
+  LocalIndex.ensureSchema(db);
+  expect(runExpert({}, { db, notify: () => {}, sessionId: "expert-noarm" })).rejects.toThrow(
+    /exactly one/,
+  );
+});

--- a/packages/gateway/src/agents/expert.test.ts
+++ b/packages/gateway/src/agents/expert.test.ts
@@ -1055,7 +1055,10 @@ test("runExpert refuses a request with no arm rather than searching for the empt
   // question nobody asked — confidently, and with no gap to warn anyone.
   const db = new Database(":memory:");
   LocalIndex.ensureSchema(db);
-  expect(runExpert({}, { db, notify: () => {}, sessionId: "expert-noarm" })).rejects.toThrow(
+  // `await`, not a floating assertion: an un-awaited `.rejects` resolves after the test
+  // has already passed, so this would go green even if runExpert stopped throwing — the
+  // one failure mode a guard test must not have.
+  await expect(runExpert({}, { db, notify: () => {}, sessionId: "expert-noarm" })).rejects.toThrow(
     /exactly one/,
   );
 });

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -170,8 +170,16 @@ function makeSubAgent(
 export async function runExpert(input: ExpertInput, ctx: ExpertContext): Promise<ExpertBrief> {
   const start = performance.now();
   const limit = Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
-  // `requireExpertParams` guarantees exactly one arm reaches here, so the fallback is
-  // unreachable over the wire and exists only for a direct in-process caller.
+  // Refused, NOT defaulted to "". Both fields are optional on the type, so an in-process
+  // caller — the CLI, a test — can reach here with neither, and an empty topic makes the
+  // five lexical lanes run `LIKE '%' || '' || '%'`, which matches every indexed title and
+  // body preview. The caller would get a confident ranked list of the most active people
+  // in the whole index in answer to a question they never asked, which is the exact
+  // failure mode this arm exists to remove. `requireExpertParams` already refuses it on
+  // the wire; the in-process path gets the same contract rather than a silent worst case.
+  if (input.topicOrFile === undefined && input.itemUrl === undefined) {
+    throw new Error("runExpert requires exactly one of { topicOrFile } or { itemUrl }");
+  }
   const topic = input.topicOrFile ?? "";
 
   const preflightGaps: GapNote[] = [];
@@ -309,10 +317,13 @@ async function subItemOpened(db: Database, itemUrl: string): Promise<SubAgentRes
     .all(target.entityId, target.itemId) as ExpertLaneRow[];
 
   if (rows.length === 0) {
+    // `person --opened--> issue`, so the TARGET type is the issue. This helper joins
+    // `e.id = r.to_id`; passing "person" asks whether anything points AT a person, which
+    // nothing ever does, so the gap would fire even with the edges present.
     const gap = detectMissingRelationToEntityType(
       db,
       "opened",
-      "person",
+      "issue",
       "Issues emit `opened` when the connector records an author — sync it.",
     );
     return gap !== null ? { gap } : {};
@@ -347,10 +358,11 @@ async function subItemResolvedBy(db: Database, itemUrl: string): Promise<SubAgen
     .all(target.entityId) as ExpertLaneRow[];
 
   if (rows.length === 0) {
+    // Same correction: `pr --resolves--> issue` targets the ISSUE, not the PR.
     const gap = detectMissingRelationToEntityType(
       db,
       "resolves",
-      "pr",
+      "issue",
       "A PR emits `resolves` when its body references the item key — reference it, and sync.",
     );
     return gap !== null ? { gap } : {};

--- a/packages/gateway/src/agents/expert.ts
+++ b/packages/gateway/src/agents/expert.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { AgentCoordinator, type SubTask } from "../engine/coordinator.ts";
+import { resolveItemByUrl } from "../index/resolve-by-url.ts";
 import { emitBriefWithSynthesis } from "./_lib/emit-brief.ts";
 import type { Evidence, ExpertBrief, ExpertFinding, GapNote } from "./_lib/findings.ts";
 import {
@@ -12,8 +13,20 @@ import {
 } from "./_lib/gap-notes.ts";
 import type { SynthesisRunner } from "./_lib/synthesis-llm.ts";
 
+/**
+ * Two arms, exactly one supplied — `requireExpertParams` enforces that on the wire.
+ *
+ * `topicOrFile` is free text, matched with `LIKE` against indexed titles and previews. It
+ * answers "who has touched things that look like this".
+ *
+ * `itemUrl` names one indexed item and answers from the graph edges around it — a
+ * different and narrower question. It exists because a browser knows the URL of the issue
+ * you are reading, and handing that item's TITLE to the free-text arm would answer about
+ * every item whose title merely resembles it.
+ */
 export type ExpertInput = {
-  topicOrFile: string;
+  topicOrFile?: string;
+  itemUrl?: string;
   limit?: number;
 };
 
@@ -157,6 +170,9 @@ function makeSubAgent(
 export async function runExpert(input: ExpertInput, ctx: ExpertContext): Promise<ExpertBrief> {
   const start = performance.now();
   const limit = Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  // `requireExpertParams` guarantees exactly one arm reaches here, so the fallback is
+  // unreachable over the wire and exists only for a direct in-process caller.
+  const topic = input.topicOrFile ?? "";
 
   const preflightGaps: GapNote[] = [];
   const empty = detectEmptyIndex(ctx.db);
@@ -169,13 +185,23 @@ export async function runExpert(input: ExpertInput, ctx: ExpertContext): Promise
     toolCallCount: { value: 0 },
   });
 
-  const tasks: SubTask[] = [
-    makeSubAgent("agent_step", subBlame, ctx.db, input.topicOrFile),
-    makeSubAgent("agent_step", subPrAuthored, ctx.db, input.topicOrFile),
-    makeSubAgent("agent_step", subPrReviewed, ctx.db, input.topicOrFile),
-    makeSubAgent("agent_step", subIncidentResolved, ctx.db, input.topicOrFile),
-    makeSubAgent("agent_step", subChatMentions, ctx.db, input.topicOrFile),
-  ];
+  // The two arms do NOT both run. Mixing an edge-backed answer with a lexical one in a
+  // single ranked list would let a title coincidence outrank someone the graph actually
+  // links to the item, and a reader could not tell which was which.
+  const itemUrl = input.itemUrl;
+  const tasks: SubTask[] =
+    itemUrl === undefined
+      ? [
+          makeSubAgent("agent_step", subBlame, ctx.db, topic),
+          makeSubAgent("agent_step", subPrAuthored, ctx.db, topic),
+          makeSubAgent("agent_step", subPrReviewed, ctx.db, topic),
+          makeSubAgent("agent_step", subIncidentResolved, ctx.db, topic),
+          makeSubAgent("agent_step", subChatMentions, ctx.db, topic),
+        ]
+      : [
+          makeSubAgent("agent_step", subItemOpened, ctx.db, itemUrl),
+          makeSubAgent("agent_step", subItemResolvedBy, ctx.db, itemUrl),
+        ];
 
   const results = await coordinator.run(tasks);
 
@@ -202,7 +228,11 @@ export async function runExpert(input: ExpertInput, ctx: ExpertContext): Promise
     generatedAt: Date.now(),
     latencyMs: Math.round(performance.now() - start),
     gaps: [...preflightGaps, ...subAgentGaps],
-    query: { topicOrFile: input.topicOrFile },
+    // `topicOrFile` stays REQUIRED on the wire, so on the item arm it carries the item
+    // URL: a consumer reading only that field still learns what was asked about, rather
+    // than an invented topic. `itemUrl` names the same subject under its own key, for a
+    // consumer that wants to know the question was item-shaped without parsing a URL.
+    query: itemUrl === undefined ? { topicOrFile: topic } : { topicOrFile: itemUrl, itemUrl },
     ranked,
   };
   return brief;
@@ -220,6 +250,112 @@ export function emitExpertBrief(
     ...(ctx.runner === undefined ? {} : { runner: ctx.runner }),
     buildBrief: () => runExpert(input, ctx),
   });
+}
+
+/**
+ * The `itemUrl` arm: people the graph links to this item, and the change that closed it.
+ *
+ * Three edge-backed signals, no `LIKE` anywhere:
+ *
+ * 1. `person --opened--> item` — the one person edge `syncIssueGraph` writes directly.
+ * 2. the author of the PR that `resolves` the item — usually the strongest "who knows
+ *    this" signal there is, and reachable only by walking `resolves` inward.
+ * 3. reviewers of that same PR.
+ *
+ * An incident gets (2) and (3) only: `syncIncidentGraph` writes no person edge of its
+ * own. That is a real bound, and the empty case reports a gap rather than pretending.
+ */
+function itemEntityFor(
+  db: Database,
+  itemUrl: string,
+): { entityId: string; itemId: string; type: string; title: string } | null {
+  const resolved = resolveItemByUrl(db, itemUrl);
+  if (!resolved.found) return null;
+  const item = resolved.item;
+  const entity = db
+    .query("SELECT id FROM graph_entity WHERE external_id = ? AND type = ? LIMIT 1")
+    .get(item.id, item.type) as { id?: string } | null;
+  if (entity?.id === undefined) return null;
+  return { entityId: entity.id, itemId: item.id, type: item.type, title: item.title };
+}
+
+/** The gap both item lanes report when the URL names nothing the graph can answer about. */
+function itemUnreachableGap(itemUrl: string): GapNote {
+  return {
+    category: "missing_entity_type",
+    detail: `\`${itemUrl}\` does not resolve to an indexed item with a graph entity.`,
+    remediation:
+      "Sync the connector that owns this item. Some indexed types (a Confluence page, a CI run) carry no graph entity at all, and nothing can be linked to them.",
+  };
+}
+
+/** `person --opened--> item`: the one person edge `syncIssueGraph` writes directly. */
+async function subItemOpened(db: Database, itemUrl: string): Promise<SubAgentResult> {
+  const target = itemEntityFor(db, itemUrl);
+  if (target === null) return { gap: itemUnreachableGap(itemUrl) };
+
+  const rows = db
+    .query(
+      `SELECT p.id AS person_id, COALESCE(p.display_name, p.id) AS display_name,
+              i.id AS item_id, i.title AS title, i.modified_at AS modified_at,
+              i.service AS service_id
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'person'
+         JOIN person p ON p.id = pe.external_id
+         JOIN item i ON i.id = ?2
+        WHERE r.to_id = ?1 AND r.type = 'opened'
+        LIMIT 25`,
+    )
+    .all(target.entityId, target.itemId) as ExpertLaneRow[];
+
+  if (rows.length === 0) {
+    const gap = detectMissingRelationToEntityType(
+      db,
+      "opened",
+      "person",
+      "Issues emit `opened` when the connector records an author — sync it.",
+    );
+    return gap !== null ? { gap } : {};
+  }
+  return topLaneStream(rows, "issue_opened", 0.7);
+}
+
+/**
+ * The author of the PR that `resolves` this item.
+ *
+ * Usually the strongest "who knows this" signal there is, and reachable only by walking
+ * `resolves` INWARD — the inverse of the traversal every PR-shaped query here makes. An
+ * incident reaches people through this lane alone: `syncIncidentGraph` writes no person
+ * edge of its own, which is a real bound and why the empty case gaps rather than pretends.
+ */
+async function subItemResolvedBy(db: Database, itemUrl: string): Promise<SubAgentResult> {
+  const target = itemEntityFor(db, itemUrl);
+  if (target === null) return { gap: itemUnreachableGap(itemUrl) };
+
+  const rows = db
+    .query(
+      `SELECT p.id AS person_id, COALESCE(p.display_name, p.id) AS display_name,
+              pi.id AS item_id, pi.title AS title, pi.modified_at AS modified_at,
+              pi.service AS service_id
+         FROM graph_relation res
+         JOIN graph_entity pe ON pe.id = res.from_id AND pe.type = 'pr'
+         JOIN item pi ON pi.id = pe.external_id
+         JOIN person p ON p.id = pi.author_id
+        WHERE res.to_id = ? AND res.type = 'resolves'
+        LIMIT 25`,
+    )
+    .all(target.entityId) as ExpertLaneRow[];
+
+  if (rows.length === 0) {
+    const gap = detectMissingRelationToEntityType(
+      db,
+      "resolves",
+      "pr",
+      "A PR emits `resolves` when its body references the item key — reference it, and sync.",
+    );
+    return gap !== null ? { gap } : {};
+  }
+  return topLaneStream(rows, "pr_authored", 0.8);
 }
 
 async function subBlame(db: Database, input: string): Promise<SubAgentResult> {

--- a/packages/gateway/src/agents/ownership.test.ts
+++ b/packages/gateway/src/agents/ownership.test.ts
@@ -254,3 +254,54 @@ test("an item that reaches no service degrades to the coverage summary, not a wr
   expect(brief.query.service).toBeNull();
   expect(brief.target).toBeNull();
 });
+
+test("each item-resolution failure names itself instead of collapsing to the coverage summary", async () => {
+  await seedAndRunWithBoundService();
+
+  // 1. never indexed
+  const unindexed = await runOwnership(
+    { itemUrl: "https://github.com/acme/api/issues/999" },
+    ctx(),
+    alwaysExists,
+  );
+  expect(unindexed.gaps.some((g) => g.detail.includes("does not resolve to an indexed item"))).toBe(
+    true,
+  );
+
+  // 2. indexed, but no graph entity — a Confluence page is the real case.
+  const pageUrl = "https://acme.atlassian.net/wiki/spaces/ENG/pages/1/Runbook";
+  upsertIndexedItem(d, {
+    service: "confluence",
+    type: "page",
+    externalId: "1",
+    title: "Runbook",
+    bodyPreview: "",
+    url: pageUrl,
+    modifiedAt: NOW,
+    syncedAt: NOW,
+    metadata: {},
+  });
+  const page = await runOwnership({ itemUrl: pageUrl }, ctx(), alwaysExists);
+  expect(page.gaps.some((g) => g.detail.includes("has no graph entity"))).toBe(true);
+
+  // 3. indexed with an entity, but its repo is bound to no service.
+  const unboundUrl = "https://github.com/acme/unbound/issues/1";
+  upsertIndexedItem(d, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/unbound#1",
+    title: "Orphaned",
+    bodyPreview: "",
+    url: unboundUrl,
+    modifiedAt: NOW,
+    syncedAt: NOW,
+    metadata: { repo: "acme/unbound" },
+  });
+  const unbound = await runOwnership({ itemUrl: unboundUrl }, ctx(), alwaysExists);
+  expect(unbound.gaps.some((g) => g.detail.includes("reaches no service"))).toBe(true);
+
+  // The three are genuinely distinguishable, which is the whole point.
+  const detail = (b: { gaps: Array<{ detail: string }> }) => b.gaps.map((g) => g.detail).join("|");
+  expect(detail(unindexed)).not.toBe(detail(page));
+  expect(detail(page)).not.toBe(detail(unbound));
+});

--- a/packages/gateway/src/agents/ownership.test.ts
+++ b/packages/gateway/src/agents/ownership.test.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { beforeEach, expect, test } from "bun:test";
 import { DEFAULT_NIMBUS_OWNERSHIP_TOML } from "../config/nimbus-toml.ts";
+import { upsertIndexedItem } from "../index/item-store.ts";
 import { CURRENT_SCHEMA_VERSION } from "../index/local-index.ts";
 import { runIndexedSchemaMigrations } from "../index/migrations/runner.ts";
 import { runOwnershipPass } from "../ownership/ownership-pass.ts";
@@ -194,4 +195,62 @@ test("the agent source is read-only — no executor, no HITL, no graph writes", 
   expect(src).not.toContain("HITL_REQUIRED");
   expect(src).not.toContain("upsertGraphRelation");
   expect(src).not.toContain("dbRun");
+});
+
+/**
+ * The `itemUrl` arm. It introduces no new target KIND: the item is mapped to the service
+ * it rolls up to (`item --belongs_to--> repo --belongs_to--> service`) and answered by the
+ * same service lane a `{ service }` request takes — which is what stops an item-scoped
+ * answer from ever disagreeing with a service-scoped one.
+ */
+async function seedIssueInBoundService(): Promise<string> {
+  await seedAndRunWithBoundService();
+  const url = "https://github.com/acme/api/issues/7";
+  upsertIndexedItem(d, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/api#7",
+    title: "Checkout times out",
+    bodyPreview: "",
+    url,
+    modifiedAt: NOW,
+    syncedAt: NOW,
+    // `repoPathFromMetadata` reads `repo`, and syncIssueGraph builds the repo entity's
+    // external id as `<service>:<repo>` — the same id the ownership pass bound above.
+    metadata: { repo: "acme/api" },
+  });
+  return url;
+}
+
+test("an item resolves to its owning service, and the brief records what was asked", async () => {
+  const url = await seedIssueInBoundService();
+  const brief = await runOwnership({ itemUrl: url }, ctx(), alwaysExists);
+
+  expect(brief.target?.kind).toBe("service");
+  expect(brief.query.itemUrl).toBe(url);
+  expect(brief.query.path).toBeNull();
+  // `service` records the id the item MAPPED to, so a reader can see which service
+  // answered without re-deriving the two hops themselves.
+  expect(brief.query.service).toBe("checkout");
+});
+
+test("an item that reaches no service degrades to the coverage summary, not a wrong answer", async () => {
+  await seedAndRunWithBoundService();
+  const url = "https://github.com/acme/unbound/issues/1";
+  upsertIndexedItem(d, {
+    service: "github",
+    type: "issue",
+    externalId: "acme/unbound#1",
+    title: "Orphaned",
+    bodyPreview: "",
+    url,
+    modifiedAt: NOW,
+    syncedAt: NOW,
+    metadata: { repo: "acme/unbound" },
+  });
+
+  const brief = await runOwnership({ itemUrl: url }, ctx(), alwaysExists);
+  expect(brief.query.itemUrl).toBe(url);
+  expect(brief.query.service).toBeNull();
+  expect(brief.target).toBeNull();
 });

--- a/packages/gateway/src/agents/ownership.ts
+++ b/packages/gateway/src/agents/ownership.ts
@@ -185,21 +185,52 @@ function buildGaps(args: {
 }
 
 /**
- * An item URL to the service it rolls up to, or null.
+ * An item URL resolved toward the service it rolls up to.
  *
- * Null covers three different situations, and the gap notes tell them apart: the URL
- * resolves to nothing, it resolves to an item with no graph entity, or the item has an
- * entity that reaches no service. Only the last is an ownership question.
+ * A DISCRIMINATED result, not a bare `string | null`. The three ways this fails are three
+ * different situations with three different remediations, and collapsing them to null
+ * would leave `buildGaps` unable to say which happened — the caller would get the generic
+ * coverage summary for an unindexed URL, a Confluence page and an unbound repo alike.
  */
-function serviceForItemUrl(db: Database, itemUrl: string): string | null {
+type ItemServiceResolution =
+  | { readonly ok: true; readonly service: string }
+  | { readonly ok: false; readonly reason: "not_indexed" | "no_entity" | "no_service" };
+
+function serviceForItemUrl(db: Database, itemUrl: string): ItemServiceResolution {
   const resolved = resolveItemByUrl(db, itemUrl);
-  if (!resolved.found) return null;
+  if (!resolved.found) return { ok: false, reason: "not_indexed" };
   const item = resolved.item;
   const entity = db
     .query("SELECT id FROM graph_entity WHERE external_id = ? AND type = ? LIMIT 1")
     .get(item.id, item.type) as { id?: string } | null;
-  if (entity?.id === undefined) return null;
-  return serviceForItemEntity(db, entity.id);
+  if (entity?.id === undefined) return { ok: false, reason: "no_entity" };
+  const service = serviceForItemEntity(db, entity.id);
+  return service === null ? { ok: false, reason: "no_service" } : { ok: true, service };
+}
+
+/** One gap per item-resolution failure, naming what is missing and what would fix it. */
+function itemGapFor(itemUrl: string, reason: "not_indexed" | "no_entity" | "no_service"): GapNote {
+  if (reason === "not_indexed") {
+    return {
+      category: "missing_entity_type",
+      detail: `\`${itemUrl}\` does not resolve to an indexed item.`,
+      remediation: "Sync the connector that owns it, then ask again.",
+    };
+  }
+  if (reason === "no_entity") {
+    return {
+      category: "missing_entity_type",
+      detail: `\`${itemUrl}\` is indexed but has no graph entity, so it rolls up to nothing.`,
+      remediation:
+        "Some indexed types carry no graph entity at all — a Confluence page, a CI run. Ask about the service directly instead.",
+    };
+  }
+  return {
+    category: "missing_relation_emit",
+    detail: `\`${itemUrl}\` reaches no service: its repository is not bound to one.`,
+    remediation:
+      "A binding needs BOTH a `[ci.service.<id>]` declaration AND a matching origin remote on the repository this item belongs to.",
+  };
 }
 
 export async function runOwnership(
@@ -215,9 +246,10 @@ export async function runOwnership(
   // The item arm resolves to a SERVICE and then takes the service lane unchanged: no new
   // target kind, no second ranking path. An item-scoped answer and a service-scoped one
   // are the same answer, and routing them through one lane is what stops them drifting.
-  const itemService =
+  const itemResolution =
     requestedItemUrl === null ? null : serviceForItemUrl(ctx.db, requestedItemUrl);
-  const requestedService = input.service ?? itemService;
+  const requestedService =
+    input.service ?? (itemResolution?.ok === true ? itemResolution.service : null);
 
   const resolved =
     requestedPath === null ? null : resolveOwnershipPath(ctx.roots, requestedPath, exists);
@@ -297,15 +329,24 @@ export async function runOwnership(
     agentVersion: 1,
     generatedAt: now,
     latencyMs: Math.round(performance.now() - start),
-    gaps: buildGaps({
-      rootsConfigured: ctx.roots.length,
-      coverage: lane4.coverage,
-      resolved: resolved !== null,
-      requestedPath,
-      target,
-      unresolvedOwners,
-      serviceRequested: requestedService,
-    }),
+    gaps: [
+      // The item-resolution gap leads, and is separate from `buildGaps`: it explains why
+      // there is no service to ask about at all, which the coverage notes cannot — from
+      // their point of view no service was ever requested, so they would answer an
+      // unindexed URL, a page with no graph entity and an unbound repo identically.
+      ...(itemResolution !== null && !itemResolution.ok && requestedItemUrl !== null
+        ? [itemGapFor(requestedItemUrl, itemResolution.reason)]
+        : []),
+      ...buildGaps({
+        rootsConfigured: ctx.roots.length,
+        coverage: lane4.coverage,
+        resolved: resolved !== null,
+        requestedPath,
+        target,
+        unresolvedOwners,
+        serviceRequested: requestedService,
+      }),
+    ],
     query: { path: requestedPath, service: requestedService, itemUrl: requestedItemUrl },
     target,
     parentDirectory,

--- a/packages/gateway/src/agents/ownership.ts
+++ b/packages/gateway/src/agents/ownership.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 
 import { AgentCoordinator, type SubTask } from "../engine/coordinator.ts";
+import { resolveItemByUrl } from "../index/resolve-by-url.ts";
 import {
   findDirectoryEntity,
   findFileEntity,
@@ -11,6 +12,7 @@ import {
   type OwnershipEntity,
   ownersOf,
   readOwnershipCoverage,
+  serviceForItemEntity,
   serviceForRoot,
 } from "../ownership/ownership-store.ts";
 import { resolveOwnershipPath } from "../ownership/ownership-target.ts";
@@ -182,6 +184,24 @@ function buildGaps(args: {
   return gaps;
 }
 
+/**
+ * An item URL to the service it rolls up to, or null.
+ *
+ * Null covers three different situations, and the gap notes tell them apart: the URL
+ * resolves to nothing, it resolves to an item with no graph entity, or the item has an
+ * entity that reaches no service. Only the last is an ownership question.
+ */
+function serviceForItemUrl(db: Database, itemUrl: string): string | null {
+  const resolved = resolveItemByUrl(db, itemUrl);
+  if (!resolved.found) return null;
+  const item = resolved.item;
+  const entity = db
+    .query("SELECT id FROM graph_entity WHERE external_id = ? AND type = ? LIMIT 1")
+    .get(item.id, item.type) as { id?: string } | null;
+  if (entity?.id === undefined) return null;
+  return serviceForItemEntity(db, entity.id);
+}
+
 export async function runOwnership(
   input: OwnershipInput,
   ctx: OwnershipContext,
@@ -190,7 +210,14 @@ export async function runOwnership(
   const start = performance.now();
   const now = Date.now();
   const requestedPath = input.path ?? null;
-  const requestedService = input.service ?? null;
+  const requestedItemUrl = input.itemUrl ?? null;
+
+  // The item arm resolves to a SERVICE and then takes the service lane unchanged: no new
+  // target kind, no second ranking path. An item-scoped answer and a service-scoped one
+  // are the same answer, and routing them through one lane is what stops them drifting.
+  const itemService =
+    requestedItemUrl === null ? null : serviceForItemUrl(ctx.db, requestedItemUrl);
+  const requestedService = input.service ?? itemService;
 
   const resolved =
     requestedPath === null ? null : resolveOwnershipPath(ctx.roots, requestedPath, exists);
@@ -279,7 +306,7 @@ export async function runOwnership(
       unresolvedOwners,
       serviceRequested: requestedService,
     }),
-    query: { path: requestedPath, service: requestedService },
+    query: { path: requestedPath, service: requestedService, itemUrl: requestedItemUrl },
     target,
     parentDirectory,
     service: svc?.id === null || svc?.id === undefined ? null : { id: svc.id },

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -959,6 +959,79 @@ describe("runWhy — the itemUrl arm", () => {
     expect(lanes.has("downstream")).toBe(false);
   });
 
+  // The defect this arm exists to avoid. `ticketRowsForPr` joins `pe.type = 'pr'` on
+  // `from_id`, so handed an issue entity it returns zero rows — without the inverse
+  // traversal the item arm would ship a well-formed EMPTY brief for every issue.
+  test("finds the PR that resolved the issue, walking `resolves` inward", async () => {
+    const db = freshDb();
+    seedIssue(db);
+    const t = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/web#482",
+      title: "Cache the checkout lookup",
+      bodyPreview: "closes PLAT-9",
+      url: "https://github.com/acme/web/pull/482",
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: { number: 482, repo: "acme/web" },
+    });
+
+    const issueEntity = db
+      .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ?")
+      .get("jira:PLAT-9") as { id: string } | null;
+    const prEntity = db
+      .query("SELECT id FROM graph_entity WHERE type = 'pr' AND external_id = ?")
+      .get("github:acme/web#482") as { id: string } | null;
+    expect(issueEntity).not.toBeNull();
+    expect(prEntity).not.toBeNull();
+    upsertGraphRelation(db, prEntity?.id ?? "", issueEntity?.id ?? "", "resolves", t);
+
+    const brief = await runWhy(
+      { itemUrl: ISSUE_URL },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-6" },
+    );
+
+    const prFindings = brief.findings.filter((f) => f.lane === "pull_request");
+    expect(prFindings.length).toBeGreaterThan(0);
+    expect(JSON.stringify(prFindings)).toContain("482");
+  });
+
+  test("an issue is never listed as its own ticket", async () => {
+    const db = freshDb();
+    seedIssue(db);
+    const t = Date.now();
+    upsertIndexedItem(db, {
+      service: "github",
+      type: "pr",
+      externalId: "acme/web#482",
+      title: "Cache the checkout lookup",
+      bodyPreview: "closes PLAT-9",
+      url: "https://github.com/acme/web/pull/482",
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: { number: 482, repo: "acme/web" },
+    });
+    const issueEntity = db
+      .query("SELECT id FROM graph_entity WHERE type = 'issue' AND external_id = ?")
+      .get("jira:PLAT-9") as { id: string } | null;
+    const prEntity = db
+      .query("SELECT id FROM graph_entity WHERE type = 'pr' AND external_id = ?")
+      .get("github:acme/web#482") as { id: string } | null;
+    upsertGraphRelation(db, prEntity?.id ?? "", issueEntity?.id ?? "", "resolves", t);
+
+    const brief = await runWhy(
+      { itemUrl: ISSUE_URL },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-7" },
+    );
+
+    // The PR was found by walking `resolves` FROM this issue, so the issue is always in
+    // its own ticket list. Reporting it back would be circular.
+    const ticketFindings = brief.findings.filter((f) => f.lane === "ticket");
+    expect(ticketFindings.some((f) => f.entityId === issueEntity?.id)).toBe(false);
+  });
+
   test("the ref and prUrl arms leave itemSubject absent", async () => {
     const db = freshDb();
     const refBrief = await runWhy({ ref: refAt(12) }, ctxFor(db));

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -854,3 +854,122 @@ describe("runWhy — the prUrl arm", () => {
     ).toBe(false);
   });
 });
+
+describe("runWhy — the itemUrl arm", () => {
+  const ISSUE_URL = "https://acme.atlassian.net/browse/PLAT-9";
+
+  /** A Jira issue. `upsertIndexedItem` writes the graph entity for `type: "issue"` itself. */
+  function seedIssue(db: Database): void {
+    const t = Date.now();
+    upsertIndexedItem(db, {
+      service: "jira",
+      type: "issue",
+      externalId: "PLAT-9",
+      title: "Checkout times out",
+      bodyPreview: "",
+      url: ISSUE_URL,
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: { number: 9 },
+    });
+  }
+
+  test("names the item, and leaves the other two subjects alone", async () => {
+    const db = freshDb();
+    seedIssue(db);
+
+    const brief = await runWhy(
+      { itemUrl: ISSUE_URL },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-1" },
+    );
+
+    expect(brief.itemSubject?.title).toBe("Checkout times out");
+    expect(brief.itemSubject?.service).toBe("jira");
+    expect(brief.itemSubject?.type).toBe("issue");
+    expect(brief.itemSubject?.number).toBe(9);
+    expect(brief.itemSubject?.entityId).toBeTruthy();
+    expect(brief.subject).toBeNull();
+    expect("changeSubject" in brief).toBe(false);
+    expect(brief.query).toEqual({ ref: ISSUE_URL, line: null });
+  });
+
+  test("a miss returns a null itemSubject, not a failure", async () => {
+    const db = freshDb();
+    const brief = await runWhy(
+      { itemUrl: "https://acme.atlassian.net/browse/NOPE-1" },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-2" },
+    );
+    expect(brief.kind).toBe("why");
+    expect(brief.itemSubject).toBeNull();
+    expect(brief.subject).toBeNull();
+  });
+
+  // The bound this arm is scoped by. A Confluence page is `type: "page"`, which appears in
+  // neither ITEM_LINKED_ENTITY_TYPES nor GRAPH_SYNC_BY_TYPE, so `syncGraphFromIndexedItem`
+  // writes no entity for it — and every lane here answers from graph edges. Recorded as a
+  // test so the exclusion reads as a decision rather than an omission someone later "fixes".
+  test("an indexed page resolves by URL but has no graph entity, so it is a miss", async () => {
+    const db = freshDb();
+    const t = Date.now();
+    const pageUrl = "https://acme.atlassian.net/wiki/spaces/ENG/pages/1/Runbook";
+    upsertIndexedItem(db, {
+      service: "confluence",
+      type: "page",
+      externalId: "1",
+      title: "Checkout runbook",
+      bodyPreview: "",
+      url: pageUrl,
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: {},
+    });
+
+    // It really is indexed — the miss below is about the graph, not the index.
+    expect(
+      db.query("SELECT COUNT(*) AS n FROM item WHERE type = 'page'").get() as { n: number },
+    ).toEqual({ n: 1 });
+
+    const brief = await runWhy(
+      { itemUrl: pageUrl },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-3" },
+    );
+    expect(brief.itemSubject).toBeNull();
+    expect(brief.findings).toEqual([]);
+  });
+
+  test("the file/line lanes are silent on an item, not gapped", async () => {
+    const db = freshDb();
+    seedIssue(db);
+
+    const brief = await runWhy(
+      { itemUrl: ISSUE_URL },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-4" },
+    );
+
+    // Same suppression the prUrl arm gets, and for the same reason: neither question
+    // ever had a file subject, so reporting one as missing would invent a gap.
+    expect(
+      brief.gaps.some(
+        (g) =>
+          g.detail === "Cannot anchor authorship: no resolvable file/line subject for this ref.",
+      ),
+    ).toBe(false);
+    const lanes = new Set(brief.findings.map((f) => f.lane));
+    expect(lanes.has("authorship")).toBe(false);
+    expect(lanes.has("downstream")).toBe(false);
+  });
+
+  test("the ref and prUrl arms leave itemSubject absent", async () => {
+    const db = freshDb();
+    const refBrief = await runWhy({ ref: refAt(12) }, ctxFor(db));
+    // Absent, not present-and-undefined — the same distinction the changeSubject
+    // spread preserves, under `exactOptionalPropertyTypes`.
+    expect("itemSubject" in refBrief).toBe(false);
+
+    const prBrief = await runWhy(
+      { prUrl: "https://github.com/acme/web/pull/482" },
+      { db, roots: [], notify: () => {}, sessionId: "why-item-5" },
+    );
+    expect("itemSubject" in prBrief).toBe(false);
+  });
+});

--- a/packages/gateway/src/agents/why.test.ts
+++ b/packages/gateway/src/agents/why.test.ts
@@ -1046,3 +1046,33 @@ describe("runWhy — the itemUrl arm", () => {
     expect("itemSubject" in prBrief).toBe(false);
   });
 });
+
+/**
+ * The regression fence for the defect this arm was designed around: a lane pinned to the
+ * PR-shaped traversal answers nothing on an item and reports nothing either, so the brief
+ * comes back well-formed and empty. Findings OR gaps — never neither.
+ */
+describe.each(["issue", "incident"] as const)("the item arm on %s", (itemType) => {
+  test("produces findings or gaps, never a well-formed empty brief", async () => {
+    const db = freshDb();
+    const t = Date.now();
+    const url = `https://example.test/${itemType}/1`;
+    upsertIndexedItem(db, {
+      service: itemType === "issue" ? "jira" : "pagerduty",
+      type: itemType,
+      externalId: `${itemType}-1`,
+      title: `A ${itemType}`,
+      bodyPreview: "",
+      url,
+      modifiedAt: t,
+      syncedAt: t,
+      metadata: {},
+    });
+
+    const brief = await runWhy(
+      { itemUrl: url },
+      { db, roots: [], notify: () => {}, sessionId: `why-matrix-${itemType}` },
+    );
+    expect(brief.findings.length + brief.gaps.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -141,6 +141,43 @@ function resolvePrArm(db: Database, prUrl: string): WhyLaneResolution {
  * would name an item the lanes then answer nothing about, which reads to a caller as
  * "no context exists" rather than "this kind of item carries none".
  */
+/**
+ * The PR that `resolves` this item, or null.
+ *
+ * The INVERSE of `ticketRowsForPr`'s traversal: that one walks `resolves` outward from a
+ * `pr` entity to find the issues a change closed, this one walks inward from the issue to
+ * find the change that closed it. The direction is the whole difference between the two
+ * arms, and it is why the item arm could not simply reuse the PR arm's queries.
+ */
+function prResolvingItem(db: Database, itemEntityId: string): PrForSha | null {
+  const row = db
+    .query(
+      `SELECT pe.id AS entity_id, i.title AS title, i.url AS url, i.modified_at AS modified_at,
+              json_extract(i.metadata, '$.number') AS number
+         FROM graph_relation r
+         JOIN graph_entity pe ON pe.id = r.from_id AND pe.type = 'pr'
+         JOIN item i ON i.id = pe.external_id
+        WHERE r.to_id = ? AND r.type = 'resolves'
+        ORDER BY i.modified_at DESC, pe.id ASC
+        LIMIT 1`,
+    )
+    .get(itemEntityId) as {
+    entity_id: string;
+    title: string;
+    url: string | null;
+    modified_at: number;
+    number: number | null;
+  } | null;
+  if (row === null) return null;
+  return {
+    entityId: row.entity_id,
+    number: row.number,
+    title: row.title,
+    url: row.url,
+    modifiedAt: row.modified_at,
+  };
+}
+
 function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
   const miss: WhyLaneResolution = {
     subject: null,
@@ -173,9 +210,12 @@ function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
   return {
     subject: null,
     blame: null,
-    // The item arm has no PR of its own. `subPullRequest` may find one, and the lanes
-    // that need it read it from that result rather than from here.
-    pr: null,
+    // The PR that resolved this item, if one did — the inverse of the traversal the
+    // prUrl arm makes. Populating `pr` here rather than teaching four lanes about items
+    // is what keeps this arm small: `subPullRequest`, `subTicket`, `subDiscussion` and
+    // `subDriver` already answer from `lane.pr`, and "the change that closed this issue"
+    // is exactly what a `why` question about an issue is asking for.
+    pr: prResolvingItem(db, entity.id),
     changeSubject: undefined,
     itemSubject: {
       itemId: item.id,
@@ -642,7 +682,11 @@ async function subTicket(db: Database, lane: LaneInput): Promise<SubAgentResult>
   const pr = lane.pr;
   if (pr === null) return {};
 
-  const rows = ticketRowsForPr(db, pr.entityId);
+  // On the item arm the PR was found BY walking `resolves` from this very item, so the
+  // item is always in its own ticket list. Listing an issue as a ticket referenced by
+  // the change that closed it is circular, not informative — drop it and report what
+  // else that PR touched.
+  const rows = ticketRowsForPr(db, pr.entityId).filter((r) => r.entityId !== lane.itemEntityId);
   if (rows.length === 0) {
     const gap = detectMissingRelationToEntityType(
       db,
@@ -685,6 +729,16 @@ async function subDiscussion(db: Database, lane: LaneInput): Promise<SubAgentRes
     const ticket = ticketRowsForPr(db, pr.entityId).at(0);
     if (ticket !== undefined) targetIds.push(ticket.entityId);
   }
+
+  // The item itself, on the item arm. Added directly rather than via the PR, because a
+  // discussion can mention an issue that no change ever closed — precisely the case where
+  // this lane has something to say and no PR to reach it through.
+  //
+  // It may duplicate the ticket pushed just above, and that is harmless: `targetIds` is
+  // spliced into an `IN (...)`, which is set membership, so a repeated id matches the same
+  // rows once. (It is NOT de-duplicated first — do not add a `DISTINCT` here believing it
+  // is compensating for that.)
+  if (lane.itemEntityId !== null) targetIds.push(lane.itemEntityId);
 
   let rows: Array<{
     id: string;

--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -2,10 +2,11 @@ import type { Database } from "bun:sqlite";
 
 import type { NimbusFilesystemRootToml } from "../config/filesystem-toml.ts";
 import { AgentCoordinator, type SubTask, type SubTaskResult } from "../engine/coordinator.ts";
+import { resolveItemByUrl } from "../index/resolve-by-url.ts";
 import type { BlameLookup } from "../security/blame-store.ts";
 import { type BlameSpawn, ensureBlameLine } from "./_lib/blame-on-demand.ts";
 import { emitBriefWithSynthesis } from "./_lib/emit-brief.ts";
-import type { GapNote, WhyChangeSubject } from "./_lib/findings.ts";
+import type { GapNote, WhyChangeSubject, WhyItemSubject } from "./_lib/findings.ts";
 import {
   aggregateMissingEntityTypes,
   detectEmptyIndex,
@@ -17,8 +18,8 @@ import { reverseDependsOn } from "./_lib/graph-traversals.ts";
 import { resolvePrSubject } from "./_lib/pr-subject.ts";
 import type { SynthesisRunner } from "./_lib/synthesis-llm.ts";
 import { parseRef, resolveWhySubject } from "./_lib/why-subject.ts";
-import type { WhyBrief, WhyFinding, WhyInput, WhySubject } from "./_lib/why-types.ts";
-import { isWhyPrInput } from "./_lib/why-types.ts";
+import type { WhyBrief, WhyFinding, WhyInput, WhyRefInput, WhySubject } from "./_lib/why-types.ts";
+import { isWhyItemInput, isWhyPrInput } from "./_lib/why-types.ts";
 
 export type WhyContext = {
   db: Database;
@@ -43,17 +44,22 @@ type LaneInput = {
    * an entry point rather than a second code path.
    */
   pr: PrForSha | null;
-  /** Blame's author time on the ref arm, the PR's own timestamp on the prUrl arm. */
+  /**
+   * The indexed item the lanes answer about, on the `item` arm only — null on
+   * every other arm, and null on `item` when the item had no graph entity.
+   */
+  itemEntityId: string | null;
+  /** Blame's author time on the ref arm, the item's or PR's own timestamp otherwise. */
   occurredAt: number | null;
   /**
    * Which entry point ran. `subAuthorship` and `subDownstream` are file/line
-   * lanes by nature — they stay silent on `"change"` rather than reporting a
-   * gap for the file subject a `prUrl` question never had. Explicit, not
-   * inferred from `subject === null`: inference would also silence the
-   * genuine ref-arm case where a ref legitimately fails to resolve, which
+   * lanes by nature — they stay silent on `"change"` and `"item"` alike rather
+   * than reporting a gap for the file subject neither question ever had.
+   * Explicit, not inferred from `subject === null`: inference would also silence
+   * the genuine ref-arm case where a ref legitimately fails to resolve, which
    * must keep its gap note.
    */
-  arm: "ref" | "change";
+  arm: "ref" | "change" | "item";
 };
 
 type SubAgentResult = {
@@ -83,6 +89,16 @@ interface WhyLaneResolution {
   /** `undefined` on the ref arm (the field is omitted entirely); `null` when a change */
   /** was asked about and could not be named. The two are NOT interchangeable. */
   readonly changeSubject: WhyChangeSubject | null | undefined;
+  /** The same three states as `changeSubject`, for the `itemUrl` arm. */
+  readonly itemSubject: WhyItemSubject | null | undefined;
+  /**
+   * The `graph_entity.id` the item lanes traverse from, on the `item` arm only.
+   *
+   * Always null when `itemSubject` is null: the two are decided together, because
+   * an indexed item with no graph entity is precisely the case the lanes cannot
+   * answer, and a subject without an entity would promise otherwise.
+   */
+  readonly itemEntityId: string | null;
   readonly queryRef: string;
   readonly queryLine: number | null;
 }
@@ -104,7 +120,79 @@ function resolvePrArm(db: Database, prUrl: string): WhyLaneResolution {
       : null,
     // null, not absent: the caller asked about a change and we could not name it.
     changeSubject: resolved.ok ? resolved.subject : null,
+    itemSubject: undefined,
+    itemEntityId: null,
     queryRef: prUrl,
+    queryLine: null,
+  };
+}
+
+/**
+ * The `itemUrl` arm: resolve the indexed item the lanes answer about.
+ *
+ * Two lookups, not one. `resolveItemByUrl` answers from the `item` table, but every
+ * lane on this arm traverses `graph_relation`, which hangs off a `graph_entity` — and
+ * `syncGraphFromIndexedItem` writes no entity for a type outside
+ * `ITEM_LINKED_ENTITY_TYPES` / `GRAPH_SYNC_BY_TYPE`. A Confluence page (`type: "page"`)
+ * is exactly that case: fully indexed, resolvable by URL, and with nothing for a lane to
+ * walk.
+ *
+ * So "resolved, but no entity" is a MISS here. Returning a subject without an entity
+ * would name an item the lanes then answer nothing about, which reads to a caller as
+ * "no context exists" rather than "this kind of item carries none".
+ */
+function resolveItemArm(db: Database, itemUrl: string): WhyLaneResolution {
+  const miss: WhyLaneResolution = {
+    subject: null,
+    blame: null,
+    pr: null,
+    changeSubject: undefined,
+    // null, not absent: the caller asked about an item and we could not name it.
+    itemSubject: null,
+    itemEntityId: null,
+    queryRef: itemUrl,
+    queryLine: null,
+  };
+
+  const resolved = resolveItemByUrl(db, itemUrl);
+  if (!resolved.found) return miss;
+  const item = resolved.item;
+
+  // Constrained by type as well as external_id: `deterministicGraphEntityId` hashes
+  // (type, externalId), so one external id can legitimately exist under more than one
+  // type and a bare external_id lookup could return the wrong node.
+  const entity = db
+    .query("SELECT id FROM graph_entity WHERE external_id = ? AND type = ? LIMIT 1")
+    .get(item.id, item.type) as { id?: string } | null;
+  if (entity?.id === undefined) return miss;
+
+  const numberRow = db
+    .query("SELECT json_extract(metadata, '$.number') AS number FROM item WHERE id = ? LIMIT 1")
+    .get(item.id) as { number: number | null } | null;
+
+  return {
+    subject: null,
+    blame: null,
+    // The item arm has no PR of its own. `subPullRequest` may find one, and the lanes
+    // that need it read it from that result rather than from here.
+    pr: null,
+    changeSubject: undefined,
+    itemSubject: {
+      itemId: item.id,
+      entityId: entity.id,
+      number: numberRow?.number ?? null,
+      // `ResolveCandidate.url` is nullable and `WhyItemSubject.url` matches it. NOT a
+      // fallback to `itemUrl`: that would substitute the URL we were asked with for the
+      // one the item carries — a fabricated field inside a subject.
+      url: item.url,
+      title: item.title,
+      // `modified_at` is `number` on a found candidate, not nullable. No `??` here.
+      modifiedAt: item.modified_at,
+      service: item.service,
+      type: item.type,
+    },
+    itemEntityId: entity.id,
+    queryRef: itemUrl,
     queryLine: null,
   };
 }
@@ -114,10 +202,7 @@ function resolvePrArm(db: Database, prUrl: string): WhyLaneResolution {
  * inside parallel sub-agents could double-spawn on a cold line. Resolve it here, once, and hand
  * the result to every lane.
  */
-async function resolveRefArm(
-  input: Exclude<WhyInput, { prUrl: string }>,
-  ctx: WhyContext,
-): Promise<WhyLaneResolution> {
+async function resolveRefArm(input: WhyRefInput, ctx: WhyContext): Promise<WhyLaneResolution> {
   const subject = resolveWhySubject(ctx.db, ctx.roots, input);
   let blame: BlameLookup | null = null;
   if (subject !== null && subject.lineNo !== null) {
@@ -133,6 +218,8 @@ async function resolveRefArm(
     blame,
     pr: blame === null ? null : findPrForSha(ctx.db, blame.commitSha),
     changeSubject: undefined,
+    itemSubject: undefined,
+    itemEntityId: null,
     queryRef: input.ref,
     queryLine: input.line ?? parseRef(input.ref).line,
   };
@@ -173,28 +260,45 @@ function collectLaneOutput(results: readonly SubTaskResult[]): {
   return { findings, gaps };
 }
 
+/** Which arm a request names. One place, so the dispatch and `LaneInput.arm` cannot disagree. */
+function armOf(input: WhyInput): LaneInput["arm"] {
+  if (isWhyPrInput(input)) return "change";
+  return isWhyItemInput(input) ? "item" : "ref";
+}
+
 export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief> {
   const start = performance.now();
   const preflightGaps: GapNote[] = [];
   const empty = detectEmptyIndex(ctx.db);
   if (empty !== null) preflightGaps.push(empty);
 
-  const { subject, blame, pr, changeSubject, queryRef, queryLine } = isWhyPrInput(input)
-    ? resolvePrArm(ctx.db, input.prUrl)
-    : await resolveRefArm(input, ctx);
+  const arm = armOf(input);
+  const { subject, blame, pr, changeSubject, itemSubject, itemEntityId, queryRef, queryLine } =
+    isWhyPrInput(input)
+      ? resolvePrArm(ctx.db, input.prUrl)
+      : isWhyItemInput(input)
+        ? resolveItemArm(ctx.db, input.itemUrl)
+        : await resolveRefArm(input, ctx);
 
   const lane: LaneInput = {
     subject,
     blame,
     pr,
+    itemEntityId,
     // Computed per-arm, not through one shared nullish chain: on the ref arm
     // `blame.authorTimeMs` can itself be null (no `author-time` line in the
     // `git blame --line-porcelain` output) while `pr` is still non-null — a
     // shared `blame?.authorTimeMs ?? pr?.modifiedAt ?? null` would silently
     // borrow the PR's timestamp for a ref-arm answer, which is a different
-    // (and wrong) answer, not a missing one.
-    occurredAt: isWhyPrInput(input) ? (pr?.modifiedAt ?? null) : (blame?.authorTimeMs ?? null),
-    arm: isWhyPrInput(input) ? "change" : "ref",
+    // (and wrong) answer, not a missing one. The item arm takes its own
+    // timestamp for the same reason, rather than borrowing the PR's.
+    occurredAt:
+      arm === "item"
+        ? (itemSubject?.modifiedAt ?? null)
+        : arm === "change"
+          ? (pr?.modifiedAt ?? null)
+          : (blame?.authorTimeMs ?? null),
+    arm,
   };
 
   const coordinator = new AgentCoordinator({
@@ -227,6 +331,7 @@ export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief
     query: { ref: queryRef, line: queryLine },
     subject,
     ...(changeSubject === undefined ? {} : { changeSubject }),
+    ...(itemSubject === undefined ? {} : { itemSubject }),
     findings: allFindings,
   };
 }
@@ -353,7 +458,10 @@ async function subAuthorship(db: Database, lane: LaneInput): Promise<SubAgentRes
   // Line-level by nature: a `prUrl` question never had a file/line subject to
   // begin with, so that absence is the shape of the question, not a gap in
   // anyone's index — nothing here is actionable on the change arm.
-  if (lane.arm === "change") return {};
+  // `change` and `item` alike: neither question ever had a file subject, so a gap
+  // here would report something missing that was never asked for. The ref arm keeps
+  // its gap, which is why this branches on the arm and not on `subject === null`.
+  if (lane.arm !== "ref") return {};
   if (lane.subject?.lineNo == null) {
     return {
       gap: {
@@ -699,7 +807,10 @@ async function subDownstream(db: Database, lane: LaneInput): Promise<SubAgentRes
   // File-shaped by nature — `agents.impact` already answers this question for
   // a `prUrl`, so a missing file subject here is the shape of the question,
   // not a gap in anyone's index.
-  if (lane.arm === "change") return {};
+  // `change` and `item` alike: neither question ever had a file subject, so a gap
+  // here would report something missing that was never asked for. The ref arm keeps
+  // its gap, which is why this branches on the arm and not on `subject === null`.
+  if (lane.arm !== "ref") return {};
   if (lane.subject === null) {
     return { gap: { category: "missing_relation_emit", detail: NO_SYMBOLS_DETAIL } };
   }

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -128,8 +128,26 @@ describe("dispatchAgentsRpc", () => {
       dispatchAgentsRpc("agents.expert", ["not", "an", "object"], makeCtx(freshDb())),
     ).rejects.toMatchObject({
       rpcCode: -32602,
-      message: expect.stringContaining("requires { topicOrFile: string }"),
+      // The message now names both arms — `expert` grew an `itemUrl` arm, and a message
+      // that mentioned only `topicOrFile` would send a caller to the wrong one.
+      message: expect.stringContaining("exactly one of { topicOrFile } or { itemUrl }"),
     });
+  });
+
+  test("agents.expert requires exactly one arm", async () => {
+    const ctx = makeCtx(freshDb());
+    for (const params of [
+      {},
+      { topicOrFile: "x", itemUrl: "https://acme.atlassian.net/browse/A-1" },
+    ]) {
+      await expect(dispatchAgentsRpc("agents.expert", params, ctx)).rejects.toThrow(/exactly one/);
+    }
+    for (const params of [
+      { topicOrFile: "x" },
+      { itemUrl: "https://acme.atlassian.net/browse/A-1" },
+    ]) {
+      expect((await dispatchAgentsRpc("agents.expert", params, ctx)).kind).toBe("hit");
+    }
   });
 
   test("agents.expert eventually emits expert.briefReady", async () => {

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -592,6 +592,57 @@ describe("dispatchAgentsRpc — ctx.runner threading proof for the remaining age
     });
   });
 
+  // The `hasRef === hasPrUrl` equality this replaced read "exactly one" only while there
+  // were exactly two arms — at three it silently means "an odd number", so all three
+  // supplied together would have been ACCEPTED. Tested as a count, at every arity.
+  test("agents.why requires exactly one of three arms", async () => {
+    const ctx = makeCtx(freshDb());
+    const rejects = [
+      {},
+      { ref: "x", prUrl: "https://github.com/a/b/pull/1" },
+      { ref: "x", itemUrl: "https://acme.atlassian.net/browse/A-1" },
+      { prUrl: "https://github.com/a/b/pull/1", itemUrl: "https://acme.atlassian.net/browse/A-1" },
+      // The three-arm case the old equality would have let through.
+      {
+        ref: "x",
+        prUrl: "https://github.com/a/b/pull/1",
+        itemUrl: "https://acme.atlassian.net/browse/A-1",
+      },
+    ];
+    for (const params of rejects) {
+      await expect(dispatchAgentsRpc("agents.why", params, ctx)).rejects.toThrow(/exactly one/);
+    }
+  });
+
+  test("agents.why accepts each single arm", async () => {
+    const ctx = makeCtx(freshDb());
+    for (const params of [
+      { ref: "x" },
+      { prUrl: "https://github.com/a/b/pull/1" },
+      { itemUrl: "https://acme.atlassian.net/browse/A-1" },
+    ]) {
+      const out = await dispatchAgentsRpc("agents.why", params, ctx);
+      expect(out.kind).toBe("hit");
+    }
+  });
+
+  test("itemUrl inherits the prUrl arm's guards", async () => {
+    const ctx = makeCtx(freshDb());
+    await expect(
+      dispatchAgentsRpc(
+        "agents.why",
+        { itemUrl: "https://u:p@acme.atlassian.net/browse/A-1" },
+        ctx,
+      ),
+    ).rejects.toThrow(/userinfo/);
+    await expect(dispatchAgentsRpc("agents.why", { itemUrl: "   " }, ctx)).rejects.toThrow(
+      /chars after trim/,
+    );
+    await expect(dispatchAgentsRpc("agents.why", { itemUrl: 7 }, ctx)).rejects.toThrow(
+      /itemUrl must be a string/,
+    );
+  });
+
   test("agents.why with runner set actually synthesizes", async () => {
     const ctx = makeCtx(freshDb(), { runner: okRunner() });
     const out = await dispatchAgentsRpc("agents.why", { ref: "x" }, ctx);

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -1295,3 +1295,44 @@ describe("I29 — externally-originated agent briefs are ledgered", () => {
     expect(rows.map((r) => r.method)).toEqual(["agents.whyPeek"]);
   });
 });
+
+/**
+ * Every URL-shaped agent param goes through `requireUrlArm`, which rejects userinfo.
+ *
+ * Pinned across ALL THREE call sites rather than once: the guard is shared today, and this
+ * is what fails if someone later inlines a fourth arm's validation instead of reusing it.
+ * A `user:pass@` URL forwarded downstream would land plaintext credentials in a brief's
+ * rendered query and in the egress ledger.
+ */
+describe("credentials never survive a URL param", () => {
+  const CREDENTIALED = "https://user:secret@acme.atlassian.net/browse/A-1";
+
+  test("why rejects userinfo on both URL arms", async () => {
+    const ctx = makeCtx(freshDb());
+    for (const params of [{ prUrl: CREDENTIALED }, { itemUrl: CREDENTIALED }]) {
+      await expect(dispatchAgentsRpc("agents.why", params, ctx)).rejects.toThrow(/userinfo/);
+    }
+  });
+
+  test("expert rejects userinfo on itemUrl", async () => {
+    const ctx = makeCtx(freshDb());
+    await expect(
+      dispatchAgentsRpc("agents.expert", { itemUrl: CREDENTIALED }, ctx),
+    ).rejects.toThrow(/userinfo/);
+  });
+
+  test("ownership rejects userinfo on itemUrl", async () => {
+    const ctx = makeCtx(freshDb());
+    await expect(
+      dispatchAgentsRpc("agents.ownership", { itemUrl: CREDENTIALED }, ctx),
+    ).rejects.toThrow(/userinfo/);
+  });
+
+  test("the secret never appears in the rejection message", async () => {
+    const ctx = makeCtx(freshDb());
+    const err = await dispatchAgentsRpc("agents.why", { itemUrl: CREDENTIALED }, ctx).catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).not.toContain("secret");
+  });
+});

--- a/packages/gateway/src/ipc/agents-rpc.ts
+++ b/packages/gateway/src/ipc/agents-rpc.ts
@@ -80,22 +80,45 @@ const MAX_IMPACT_DEPTH = 5;
 const MAX_SERVICE_LEN = 64;
 
 const MAX_SINCE_MS = 90 * 24 * 60 * 60 * 1000;
-function requireExpertParams(params: unknown): { topicOrFile: string; limit?: number } {
+function requireExpertParams(params: unknown): {
+  topicOrFile?: string;
+  itemUrl?: string;
+  limit?: number;
+} {
   if (params === null || typeof params !== "object" || Array.isArray(params)) {
-    throw new AgentsRpcError(-32602, "agents.expert requires { topicOrFile: string }");
-  }
-  const p = params as { topicOrFile?: unknown; limit?: unknown };
-  if (typeof p.topicOrFile !== "string") {
-    throw new AgentsRpcError(-32602, "topicOrFile must be a string");
-  }
-  const trimmed = p.topicOrFile.trim();
-  if (trimmed.length < MIN_TOPIC_LEN || trimmed.length > MAX_TOPIC_LEN) {
     throw new AgentsRpcError(
       -32602,
-      `topicOrFile must be ${MIN_TOPIC_LEN}..${MAX_TOPIC_LEN} chars after trim`,
+      "agents.expert requires exactly one of { topicOrFile } or { itemUrl }",
     );
   }
-  const out: { topicOrFile: string; limit?: number } = { topicOrFile: trimmed };
+  const p = params as { topicOrFile?: unknown; itemUrl?: unknown; limit?: unknown };
+  // Counted, not an equality: the same shape `agents.why` uses, and for the same reason —
+  // it keeps meaning "exactly one" if a third arm is ever added.
+  const supplied = [p.topicOrFile, p.itemUrl].filter((v) => v !== undefined).length;
+  if (supplied !== 1) {
+    throw new AgentsRpcError(
+      -32602,
+      "agents.expert requires exactly one of { topicOrFile } or { itemUrl }",
+    );
+  }
+
+  const out: { topicOrFile?: string; itemUrl?: string; limit?: number } = {};
+  if (p.itemUrl !== undefined) {
+    // The same guards `why`'s URL arms get: both values come off a browser address bar.
+    out.itemUrl = requireUrlArm(p.itemUrl, "itemUrl");
+  } else {
+    if (typeof p.topicOrFile !== "string") {
+      throw new AgentsRpcError(-32602, "topicOrFile must be a string");
+    }
+    const trimmed = p.topicOrFile.trim();
+    if (trimmed.length < MIN_TOPIC_LEN || trimmed.length > MAX_TOPIC_LEN) {
+      throw new AgentsRpcError(
+        -32602,
+        `topicOrFile must be ${MIN_TOPIC_LEN}..${MAX_TOPIC_LEN} chars after trim`,
+      );
+    }
+    out.topicOrFile = trimmed;
+  }
   if (p.limit !== undefined) {
     if (
       typeof p.limit !== "number" ||

--- a/packages/gateway/src/ipc/agents-rpc.ts
+++ b/packages/gateway/src/ipc/agents-rpc.ts
@@ -460,28 +460,46 @@ function prUrlHasCredentials(value: string): boolean {
   }
 }
 
+/**
+ * One URL-shaped arm's value, validated.
+ *
+ * Extracted so `prUrl` and `itemUrl` cannot drift apart: both come off a browser address
+ * bar, so both need the same length bound and the same userinfo rejection. A second copy
+ * of these three checks is a second thing to remember to update.
+ */
+function requireUrlArm(value: unknown, name: "prUrl" | "itemUrl"): string {
+  if (typeof value !== "string") {
+    throw new AgentsRpcError(-32602, `${name} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_PR_URL_LEN) {
+    throw new AgentsRpcError(-32602, `${name} must be 1..${MAX_PR_URL_LEN} chars after trim`);
+  }
+  if (prUrlHasCredentials(trimmed)) {
+    throw new AgentsRpcError(-32602, `${name} must not contain userinfo (user:pass@) credentials`);
+  }
+  return trimmed;
+}
+
+const WHY_ARMS_MESSAGE = "agents.why requires exactly one of { ref }, { prUrl } or { itemUrl }";
+
 function requireWhyParams(params: unknown): WhyInput {
   if (params === null || typeof params !== "object" || Array.isArray(params)) {
-    throw new AgentsRpcError(-32602, "agents.why requires { ref: string } or { prUrl: string }");
+    throw new AgentsRpcError(-32602, WHY_ARMS_MESSAGE);
   }
-  const p = params as { ref?: unknown; prUrl?: unknown };
-  const hasRef = p.ref !== undefined;
-  const hasPrUrl = p.prUrl !== undefined;
-  if (hasRef === hasPrUrl) {
-    throw new AgentsRpcError(-32602, "agents.why requires exactly one of { ref } or { prUrl }");
+  const p = params as { ref?: unknown; prUrl?: unknown; itemUrl?: unknown };
+  // A COUNT, not the `hasRef === hasPrUrl` equality this replaced: that trick reads
+  // "exactly one" only while there are exactly two arms, and silently starts meaning
+  // "an odd number" at three. Counting says what it means at any arity.
+  const supplied = [p.ref, p.prUrl, p.itemUrl].filter((v) => v !== undefined).length;
+  if (supplied !== 1) {
+    throw new AgentsRpcError(-32602, WHY_ARMS_MESSAGE);
   }
-  if (hasPrUrl) {
-    if (typeof p.prUrl !== "string") {
-      throw new AgentsRpcError(-32602, "prUrl must be a string");
-    }
-    const trimmed = p.prUrl.trim();
-    if (trimmed.length === 0 || trimmed.length > MAX_PR_URL_LEN) {
-      throw new AgentsRpcError(-32602, `prUrl must be 1..${MAX_PR_URL_LEN} chars after trim`);
-    }
-    if (prUrlHasCredentials(trimmed)) {
-      throw new AgentsRpcError(-32602, "prUrl must not contain userinfo (user:pass@) credentials");
-    }
-    return { prUrl: trimmed };
+  if (p.itemUrl !== undefined) {
+    return { itemUrl: requireUrlArm(p.itemUrl, "itemUrl") };
+  }
+  if (p.prUrl !== undefined) {
+    return { prUrl: requireUrlArm(p.prUrl, "prUrl") };
   }
   return requireWhyRefParams(params);
 }

--- a/packages/gateway/src/ipc/agents-rpc.ts
+++ b/packages/gateway/src/ipc/agents-rpc.ts
@@ -742,14 +742,21 @@ function requireOwnershipParams(params: unknown): OwnershipInput {
   if (typeof params !== "object" || Array.isArray(params)) {
     throw new AgentsRpcError(-32602, "agents.ownership requires an object payload");
   }
-  const p = params as { path?: unknown; service?: unknown };
-  if (p.path !== undefined && p.service !== undefined) {
+  const p = params as { path?: unknown; service?: unknown; itemUrl?: unknown };
+  // A count, not a pairwise check: with three scopes the old `path && service` form would
+  // have let `{ path, itemUrl }` through, and lane 1 would silently answer only one of them.
+  const scopes = [p.path, p.service, p.itemUrl].filter((v) => v !== undefined).length;
+  if (scopes > 1) {
     throw new AgentsRpcError(
       -32602,
-      "path and service are mutually exclusive — pass one, or neither for a coverage summary",
+      "path, service and itemUrl are mutually exclusive — pass one, or none for a coverage summary",
     );
   }
-  const out: { path?: string; service?: string } = {};
+  const out: { path?: string; service?: string; itemUrl?: string } = {};
+  if (p.itemUrl !== undefined) {
+    // The same guards `why`'s URL arms get — this value comes off a browser address bar too.
+    out.itemUrl = requireUrlArm(p.itemUrl, "itemUrl");
+  }
   if (p.path !== undefined) {
     if (typeof p.path !== "string") {
       throw new AgentsRpcError(-32602, "path must be a string");

--- a/packages/gateway/src/ownership/ownership-store.ts
+++ b/packages/gateway/src/ownership/ownership-store.ts
@@ -144,6 +144,32 @@ export function serviceForRoot(db: Database, repoRoot: string): string | null {
   return row === null ? null : row.id;
 }
 
+/**
+ * The service an indexed item rolls up to: `item --belongs_to--> repo --belongs_to--> service`.
+ *
+ * The sibling of `serviceForRoot` above, entered from an item rather than a filesystem
+ * root — and type-scoped on every endpoint for the same reason its doc gives: `belongs_to`
+ * is not ours alone, so an unscoped walk would surface a channel as a service.
+ *
+ * The first hop is the edge `syncIssueGraph` writes; the second is the ownership pass's.
+ * Both must already exist — this reads the graph, it binds nothing.
+ */
+export function serviceForItemEntity(db: Database, itemEntityId: string): string | null {
+  const row = db
+    .query(
+      `SELECT s.label AS id
+         FROM graph_relation ib
+         JOIN graph_entity rp   ON rp.id = ib.to_id   AND rp.type = 'repo'
+         JOIN graph_relation bt ON bt.from_id = rp.id AND bt.type = 'belongs_to'
+         JOIN graph_entity s    ON s.id = bt.to_id    AND s.type = 'service'
+        WHERE ib.from_id = ? AND ib.type = 'belongs_to'
+        ORDER BY s.label ASC
+        LIMIT 1`,
+    )
+    .get(itemEntityId) as { id: string } | null;
+  return row === null ? null : row.id;
+}
+
 /** Every service the last pass bound, sorted for a stable brief. */
 export function listBoundServices(db: Database): string[] {
   const rows = db


### PR DESCRIPTION
The browser client recognises nine products across six surface kinds. It can run
an agent against **two** of them.

That is a supply problem on this side, not a client defect: reading the param
guards in `agents-rpc.ts` against what a browser page can hand over, **no agent
takes the URL of an indexed item that is not a pull request.** A Jira issue and a
PagerDuty incident are first-class indexed items with graph entities, and none of
the fourteen built-in agents will accept one as a subject.

This adds a third input arm, `itemUrl`, to `why`, `expert` and `ownership`.

**Requires `@nimbus-dev/sdk` 1.31.0** (nimbus-sdk#260, #261), which publishes
`WhyItemSubject`, `WhyBrief.itemSubject` and `ExpertBrief.query.itemUrl` — all
additive. The dependency bump is the first commit here.

## The arm does not generalise for free

An earlier draft assumed each agent could "run the body that already exists
against that entity". It cannot, and this is the largest thing the PR gets right:

`ticketRowsForPr` (`why.ts`) joins `pe.type = 'pr'` on `from_id`. Handed an
**issue** entity it returns zero rows — not because the issue has no context, but
because the query walks the edge in the wrong direction from the wrong entity
type. Shipped naively, `why` would have returned a **well-formed, empty brief for
every issue in the index**.

`prResolvingItem` walks `resolves` **inward** — the inverse traversal — to the PR
that closed the item, and populates the lane input with it. The four
item-applicable lanes then answer unchanged, because "the change that closed this
issue" is exactly what a `why` question about an issue is asking. `subAuthorship`
and `subDownstream` stay silent (`arm !== "ref"`), the same suppression the
`prUrl` arm already gets and for the same stated reason: neither question ever had
a file subject, so a gap would report something missing that was never asked for.

`LaneInput.arm` was already `"ref" | "change"`, passed explicitly rather than
inferred, with a comment explaining why. The item arm is a third member of that
union — which is why this is a smaller change to `why.ts` than the lane table
suggests.

## Deliberately not a Confluence page

A page indexes as `type: "page"`, which appears in **neither**
`ITEM_LINKED_ENTITY_TYPES` nor `GRAPH_SYNC_BY_TYPE` — so `syncGraphFromIndexedItem`
returns early twice and a page has **no `graph_entity` at all**. Every lane here
answers from graph edges.

So `resolveItemArm` treats "resolved, but no entity" as a **miss**. Naming an item
the lanes then say nothing about reads as "no context exists" rather than "this
kind of item carries none". A test seeds a real Confluence page, asserts it *is*
indexed, and pins the miss — so the bound is a decision on record rather than an
omission someone later "fixes".

`ci_run` has the same gap. `build` was never an item-lane surface, so nothing
changes for it.

## Per agent

- **`why`** — third arm, `itemSubject` threaded exactly as `changeSubject` is
  (absent vs null preserved under `exactOptionalPropertyTypes`).
- **`expert`** — had **no entity path at all**: five sub-agents, each a
  `LIKE '%' || ? || '%'` scan over one string. Two new edge-backed sub-agents
  (`person --opened--> item`, and the resolving PR's author). The arms do **not**
  both run: mixing an edge-backed answer with a lexical one in one ranked list
  would let a title coincidence outrank someone the graph actually links to the
  item. A test seeds a decoy issue with a near-identical title and a different
  author, and pins that the decoy's author does not appear.
- **`ownership`** — no new target kind. The item maps to its service via
  `item --belongs_to--> repo --belongs_to--> service` and is answered by the **same
  service lane** a `{ service }` request takes, so item- and service-scoped answers
  cannot drift apart. `serviceForItemEntity` type-scopes every endpoint for the
  reason `serviceForRoot`'s doc already gives: `belongs_to` is shared, and an
  unscoped walk would surface a channel as a service.

## Every guard's exclusion is now a count

`why`'s `hasRef === hasPrUrl` expresses "exactly one" only while there are exactly
two arms. At three it silently means "an odd number" — `{ref, prUrl, itemUrl}`
together would have been **accepted**, and the handler would have answered the ref
arm while ignoring two other questions the caller asked. Counting says what it
means at any arity, and that three-arm case is now a test. `ownership`'s pairwise
`path && service` had the same defect and gets the same fix.

`requireUrlArm` extracts the `prUrl` arm's three checks — string, length bound,
userinfo rejection — so every URL arm inherits them rather than growing copies to
keep in step.

## Testing

`bun test packages/gateway/src/agents/ packages/gateway/src/ipc/`: **2603 pass, 0
fail.** `typecheck`, `lint` and `lint:markdown` clean.

New coverage: the item arm per entity type (findings **or** gaps, never neither);
the Confluence-page miss; the file/line lanes silent rather than gapped; an issue
never listed as its own ticket; `expert` answering from edges rather than a title
match; `ownership` mapping to its service and degrading when it reaches none; and
`why`'s arm count at every arity.

## Not in this PR

`resolveFileByRemote` and the forge-file arm are PR 2; `connections` and
`currency` are PR 3. See
`docs/superpowers/plans/2026-08-31-agents-for-items-and-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsjPfu2BxDVUC7W8Wz8unL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Jira issues, Linear issues, and PagerDuty incidents in “Why” queries through item URLs.
  * Added item-based expert searches for authors and pull requests that resolved an item.
  * Added item-based ownership lookups, mapping indexed items to their owning services.
  * Added validation, resolution, gap reporting, and query details for item-based requests.

* **Documentation**
  * Added design specifications, implementation plans, review notes, and changelog coverage for item-based agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->