### PR TITLE
feat(agents): publish the gateway version on the roster response

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -175,7 +175,7 @@
     "postcss": "8.5.23",
     "postcss-selector-parser": "6.1.4",
     "protobufjs": "7.6.5",
-    "qs": "6.15.3",
+    "qs": "6.16.0",
     "sharp": "0.35.3",
     "shell-quote": "1.10.0",
     "svgo": "4.0.2",
@@ -2279,7 +2279,7 @@
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -165,7 +165,7 @@
     "browserslist": "4.28.7",
     "devalue": "5.8.1",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "form-data": "4.0.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
@@ -1575,7 +1575,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,34 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-09-02 — `GET /v1/agents` publishes the gateway's version alongside the names, because a
+  NAME does not imply an ARM.** One additive field, and it unblocks a client feature that is
+  already shipped and currently dark. `why`, `expert` and `ownership` have been published for
+  releases; the `itemUrl` arms added to them the day before have not — so a client deciding
+  whether to offer an item-scoped lane cannot learn what it needs from the name list, and nothing
+  on the HTTP surface answered a version question: `GET /v1/health` returns
+  `{ status, gateway: "read_only_http" }` and `HTTP_ROUTES` carried no version route at all.
+
+  **It rides on the roster response rather than taking a route of its own, or going on
+  `/v1/health`.** That is the request such a client already makes at the moment it needs the
+  answer, so both facts arrive in one round trip; and it is bearer-authed under the `agents` scope
+  the caller already holds, where `/v1/health` is tokenless. The alternative — read a version at
+  pair time and cache it — goes stale the first time an owner upgrades their gateway without
+  re-pairing, and the symptom is a client's lanes staying dark forever with nothing on screen to
+  explain it.
+
+  **The consumer is `nimbus-web-clipper` PR #96**, whose `meetsFloor` fails **closed** on an
+  absent version: until this ships in a release, that client's three item lanes are withheld on
+  every gateway, its own developers included — a local build reports no version rather than
+  `0.0.0`, so its development-build allowance never fires either. That is why an additive field is
+  worth its own delivery entry.
+
+  **The better long-run shape is for this route to publish each agent's ARMS** rather than a
+  version, retiring the question instead of proxying it through a release number. Not done here:
+  the arms live inside each handler's param types, so deriving them honestly is real work, and
+  hand-listing them is exactly the drift `EXTERNAL_AGENT_NAMES` is derived to prevent. Recorded in
+  the design's § 4.5 addendum so the next reader does not have to rediscover the trade.
+
 - **2026-09-01 — The computer-use TERMINAL lane shipped: a sandboxed, line-oriented shell in which no byte reaches the child process before the owner has approved the whole command.** Slice 2 of 3 per the design's own sequencing (§ 14). It reuses the browser lane's chokepoint entirely — `cu-gate.ts`'s `openSession`/`runAction` stay the only path to the host, and the fix rounds recorded in `runActionExclusive`'s comments were inherited rather than re-derived. What generalised is the gate's browser-shaped parts: `CuEnvelope` and `OpenSessionRequest` became discriminated unions on `lane`, `LiveSession` holds a tagged `CuLaneHandle`, and `performActuation` stays the ONE actuation primitive with a per-lane switch. `nimbus computer terminal --cwd <dir> [--shell <id>]`. **DEFAULT OFF**, with `allowed_lanes` still empty by default — `enabled = true` alone grants nothing. **No new config keys, no migration: V57 is reused as-is.**
 
   **The security core is one sentence, and everything else serves it: no byte reaches the shell before the owner approved the COMPLETE line.** Model-supplied bytes accumulate in `computer-use/cu-terminal-buffer.ts` and nothing is written until a submit character arrives, the assembled line is shown in full, and the owner approves it. A per-keystroke write path violates that **even if every keystroke is individually classified** — the design's first shape, and a complete bypass rather than a rough edge, since inside vi or fzf a single character IS the destructive action and a model that never sent a newline would have driven the host with every action auto-satisfied. Four properties make it true rather than customary. Refusals are **wholesale** and leave the buffer untouched — asserted on every branch that can refuse, after an earlier draft cleared it on one of them, which made "a refusal changes nothing" unassertable as a single test. Control characters are **refused, not buffered**: a lane that cannot safely deliver `y` cannot safely deliver Ctrl-C, and buffering a control byte until a newline that never arrives is a silent hang rather than an honest refusal. The approved line is **read once** and not re-derived at write time — the TOCTOU that would defeat the gate, since here the human IS the boundary. And `classifyTerminalAction` returns `actuating` unconditionally and takes **exactly one parameter**, so the model's description cannot be passed to it: spec § 4.3.1's "the terminal lane has no `observing` class at all" is enforced by ARITY, not by convention. The lane gets no command allow-list, deliberately — an allow-list over shell text is defeated by quoting, substitution, aliasing and encoding, and a defense that can be quoted around is worse than none because it is believed.

--- a/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
+++ b/docs/superpowers/specs/2026-08-31-agents-for-items-and-files-design.md
@@ -510,6 +510,33 @@ Both new agents are pure reads and join `HTTP_AGENT_NAMES` by the derivation in 
 edit. The count assertion moves 11 → 13 in the same PR, and the three existing exclusion tests are
 extended, not touched: a test asserting `preflight` stays 404 must keep passing verbatim.
 
+**Addendum (2026-09-02): `GET /v1/agents` also publishes `version`.** Found by the browser client
+after PR 1 landed, and it is a wire change this document owns rather than one the consumer may make
+for itself.
+
+A NAME does not imply an ARM. `why`, `expert` and `ownership` have been published for releases; the
+`itemUrl` arms this design adds to them have not. So a client deciding whether to offer an
+item-scoped lane cannot learn what it needs from the name list — it has to ask a version question,
+and nothing on the HTTP surface answered one: `GET /v1/health` returns
+`{ status, gateway: "read_only_http" }` and `HTTP_ROUTES` carried no version route at all.
+
+The field rides on the roster response rather than getting a route of its own, and rather than
+going on `/v1/health`. That is the request such a client already makes at the moment it needs the
+answer, so both facts arrive in one round trip; and it is bearer-authed under the `agents` scope the
+caller already holds, where `/v1/health` is tokenless. The alternative — reading a version at pair
+time and caching it — goes stale the first time an owner upgrades their gateway without re-pairing,
+and the symptom is lanes that stay dark forever with nothing on screen to explain it.
+
+The better long-run shape is for this route to publish each agent's *arms* rather than a version,
+which would retire the whole question instead of proxying it through a release number. That is not
+this change: the arms live inside each handler's param types, so deriving them honestly is real
+work, and hand-listing them is exactly the drift `EXTERNAL_AGENT_NAMES` is derived to prevent. This
+addendum does not block it.
+
+The consumer's half is `agents-capability.ts` in `nimbus-web-clipper` (shipped in its PR #96), whose
+`meetsFloor` fails **closed** on an absent version. Until this field ships in a release, that
+client's three item lanes are withheld on every gateway — so this is not a cosmetic addition.
+
 ---
 
 ## 5. Slices

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-selector-parser": "6.1.4",
     "browserslist": "4.28.7",
     "nanoid": "3.3.18",
-    "qs": "6.15.3",
+    "qs": "6.16.0",
     "yaml": "2.9.0",
     "body-parser": "2.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sharp": "0.35.3",
     "protobufjs": "7.6.5",
     "svgo": "4.0.2",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "esbuild": "0.28.1",
     "devalue": "5.8.1",
     "ws": "8.21.0",

--- a/packages/gateway/src/agent-runs/agent-http-e2e.test.ts
+++ b/packages/gateway/src/agent-runs/agent-http-e2e.test.ts
@@ -4,6 +4,7 @@
 // suites cover each piece; this proves the pieces are wired to each other.
 
 import { describe, expect, test } from "bun:test";
+import { GATEWAY_VERSION } from "../version.ts";
 import { startAgentTestServer } from "./agent-test-server.ts";
 
 const LEGACY_TOKEN = "legacy-bare-string-token-0123456789abcdef";
@@ -210,6 +211,30 @@ describe("agents over HTTP — end to end", () => {
       expect(agents).not.toContain("negotiate");
       expect(agents).toContain("expert");
       expect(agents).toHaveLength(11);
+    } finally {
+      s.stop();
+    }
+  });
+
+  test("GET /v1/agents publishes the gateway version alongside the names", async () => {
+    const s = await startAgentTestServer();
+    try {
+      const res = await fetch(`http://127.0.0.1:${String(s.port)}/v1/agents`, {
+        headers: { authorization: `Bearer ${s.token}` },
+      });
+      expect(res.status).toBe(200);
+      // A NAME does not imply an ARM, which is why this field exists. `why`, `expert` and
+      // `ownership` have been published for releases and their `itemUrl` arms have not, so a
+      // client gating on the arm cannot learn what it needs from the roster alone. It rides on
+      // THIS response rather than getting a route of its own because this is the request such a
+      // client already makes at the moment it needs the answer — so it learns both facts in one
+      // round trip, with no version to cache and go stale the next time the owner upgrades.
+      //
+      // The web clipper is the first consumer: it withholds the item-scoped lanes below a floor
+      // and fails closed when no version is reported, so an absent field here is not cosmetic —
+      // it keeps those lanes dark.
+      const { version } = (await res.json()) as { version: string };
+      expect(version).toBe(GATEWAY_VERSION);
     } finally {
       s.stop();
     }

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -28,6 +28,7 @@ import { ftsMatchQuery } from "../search/hybrid-internal.ts";
 import { formatPrometheus } from "../status/prometheus-format.ts";
 import type { TargetedFetchOutcome } from "../sync/targeted-fetch.ts";
 import type { NimbusVault } from "../vault/nimbus-vault.ts";
+import { GATEWAY_VERSION } from "../version.ts";
 import { contentTypeFor, resolveConsoleAsset, safeAssetPath } from "./admin-console-assets.ts";
 import { buildStatus, type StatusReaders } from "./admin-status-rpc.ts";
 import { EXTERNAL_AGENT_NAMES } from "./agents-rpc.ts";
@@ -852,7 +853,18 @@ async function handleAgentsList(req: Request, opts: ReadOnlyHttpServerOptions): 
   const auth = await requireScopedClipToken(req, clipsVault, ROUTE_KEY_AGENTS_LIST);
   if (!auth.ok) return auth.response;
   // Derived from AGENTS_RPC_HANDLERS, so it cannot advertise a name that POST would then 404.
-  return json({ agents: [...EXTERNAL_AGENT_NAMES] }, 200);
+  //
+  // `version` rides along because a NAME does not imply an ARM. `why`, `expert` and `ownership`
+  // have been published for releases and their `itemUrl` arms have not, so a client gating on the
+  // arm cannot learn what it needs from the name list alone. It goes HERE rather than on a route
+  // of its own, or on `GET /v1/health`, because this is the request such a client already makes at
+  // the moment it needs the answer: both facts arrive in one round trip, and there is no version
+  // to cache and then serve stale after the owner upgrades without re-pairing.
+  //
+  // The web clipper is the first consumer (`agents-capability.ts`'s `meetsFloor`): it withholds
+  // its item-scoped lanes below a floor and fails CLOSED when no version is reported, so an
+  // absent field here is not cosmetic — it keeps those lanes dark on every gateway.
+  return json({ agents: [...EXTERNAL_AGENT_NAMES], version: GATEWAY_VERSION }, 200);
 }
 
 async function handleAgentRunGet(


### PR DESCRIPTION
## Summary

`GET /v1/agents` now returns `{ agents, version }` instead of `{ agents }`. One additive field, and it unblocks a client feature that is already merged and currently dark on every gateway.

**A NAME does not imply an ARM, which is the whole reason this exists.** `why`, `expert` and `ownership` have been published for releases; the `itemUrl` arms #1421 added to them have not. So a client deciding whether to offer an item-scoped lane cannot learn what it needs from the name list — it has to ask a version question, and nothing on the HTTP surface answered one: `GET /v1/health` returns `{ status, gateway: "read_only_http" }`, and `HTTP_ROUTES` carried no version route at all.

**Why it rides on the roster response**, rather than taking a route of its own or going on `/v1/health`:

- It is the request such a client already makes at the moment it needs the answer, so both facts arrive in one round trip.
- It is bearer-authed under the `agents` scope the caller already holds; `/v1/health` is tokenless.
- The alternative — read a version at pair time and cache it — goes stale the first time an owner upgrades their gateway without re-pairing, and the symptom is a client's lanes staying dark forever with nothing on screen to explain it.

**The consumer is [`nimbus-web-clipper` #96](https://github.com/nimbus-agent/nimbus-web-clipper/pull/96), merged**, whose `meetsFloor` fails **closed** on an absent version. Until this ships in a release, that client's three item lanes are withheld on every gateway — its own developers included, since a local build reports no version rather than `0.0.0` and so never reaches the development-build allowance. That is why an additive field gets its own delivery-log entry.

**Publishing each agent's *arms* would retire the question** instead of proxying it through a release number, and is the better long-run shape. Deliberately not done here: the arms live inside each handler's param types, so deriving them honestly is real work, and hand-listing them is exactly the drift `EXTERNAL_AGENT_NAMES` is derived to prevent. Recorded as an addendum to §4.5 of `2026-08-31-agents-for-items-and-files-design.md` — that document owns this wire and did not mention a version field — so the trade does not have to be rediscovered.

## Related Issue

No issue. Relates to nimbus-agent/nimbus-web-clipper#96, which is the consumer and is already merged and waiting on this.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation only *(partly — the design addendum and the delivery-log entry)*

Additive: an existing response object gains a field. No route added, no auth change, no allowlist edit, no config key.

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors
- [x] `bun run lint` passes (Biome — format + lint)
- [x] All existing tests pass (`bun test`) — gateway **16080 pass / 0 fail** across 1151 files; `scripts` **1660 pass / 0 fail**
- [x] New behaviour is covered by tests
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction — n/a, no platform code touched
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable — untouched
- [x] `docs/README.md` not touched

## Coverage (if engine/ or vault/ was changed)

Neither was changed.

## Testing

Written test-first. The new case in `packages/gateway/src/agent-runs/agent-http-e2e.test.ts` failed before the change:

```
error: expect(received).toBe(expected)
Expected: "7.6.0"
Received: undefined
```

and passes after. It asserts against the imported `GATEWAY_VERSION` rather than a literal, so the release-please bump cannot drift it.

Full runs after the change:

```
bun run typecheck   →  clean
bun run lint        →  exit 0
bun run lint:markdown → 0 issues in 0 files
bun test packages/gateway → 16080 pass, 56 skip, 0 fail (1151 files)
bun test scripts    → 1660 pass, 27 skip, 0 fail (118 files)
```

## Notes for Reviewers

The existing test `GET /v1/agents publishes exactly the invokable set` is untouched and still asserts `toHaveLength(11)` and the four exclusions — destructuring `{ agents }` from a body that now has a second key is unaffected, which is the point of an additive change.

`markdownlint-cli2` was run because two docs files changed; this repo's gate over `docs/` is easy to miss locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bqLXtgadH9pbDCDodmXb5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The `GET /v1/agents` endpoint now includes the gateway version alongside the available agent roster.
  - Consumers can use the returned version information when processing agent roster responses and performing compatibility checks.

- **Documentation**
  - Updated the changelog and design documentation to describe the new version field and client behavior.

- **Tests**
  - Added end-to-end coverage verifying that agent roster responses include the gateway version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->