### PR TITLE
fix(sonar): clear 23 findings, and document five that should not be applied

### DIFF
--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -4,7 +4,17 @@ import { withGatewayIpc } from "../lib/with-gateway-ipc.ts";
 // Mirrors gateway `llm/route-availability.ts`'s `RouteAvailability["reason"]` — kept as an
 // open string here (not re-imported: cli has no source dependency on gateway, IPC-only) so a
 // future reason value degrades to its raw text rather than a type error.
-type RouteReason = "ok" | "provider_unreachable" | "model_absent" | "not_configured" | string;
+//
+// The `string & {}` arm is what keeps that openness WITHOUT the four literals being swallowed.
+// A bare `| string` collapses the whole union to `string`, so the known values stop being
+// suggested and a typo in one of them stops being visible. This form accepts any string exactly
+// as before and keeps the four as named members.
+type RouteReason =
+  | "ok"
+  | "provider_unreachable"
+  | "model_absent"
+  | "not_configured"
+  | (string & {});
 
 type RouteStatus = {
   routeId: string;

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -100,7 +100,7 @@ function printRouteTable(routes: RouteStatus[]): void {
 function requireRoutesArray(res: unknown): unknown[] {
   const routes = (res as { routes?: unknown } | null | undefined)?.routes;
   if (!Array.isArray(routes)) {
-    throw new Error(
+    throw new TypeError(
       "llm.status returned an unexpected payload: no `routes` array. " +
         "The gateway is likely a different version than this CLI.",
     );

--- a/packages/gateway/src/agent-commands/parse-agent-command.ts
+++ b/packages/gateway/src/agent-commands/parse-agent-command.ts
@@ -11,19 +11,36 @@ export type AgentCommand =
 
 const KV_RE = /^([A-Za-z][\w.-]*)=(.+)$/;
 
-function coerce(raw: string, kind: ParamKind, field: string): unknown | { error: string } {
+/**
+ * A coerced parameter, or why it could not be coerced.
+ *
+ * Discriminated on `ok` rather than returning the value directly beside an `{ error }` object.
+ * The previous shape was `unknown | { error: string }`, which collapses to plain `unknown` — the
+ * error arm told the type system nothing and the caller narrowed with a hand-written
+ * `"error" in v` guard. That guard also could not distinguish a FAILURE from a successfully
+ * coerced value that happened to carry an `error` key; no current `kind` produces an object, so
+ * it never fired wrongly, but that was a fact about the arms below rather than a guarantee.
+ */
+type Coerced =
+  | { readonly ok: true; readonly value: unknown }
+  | { readonly ok: false; readonly error: string };
+
+function coerce(raw: string, kind: ParamKind, field: string): Coerced {
   switch (kind) {
     case "string":
-      return raw;
+      return { ok: true, value: raw };
     case "stringArray":
-      return raw
-        .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+      return {
+        ok: true,
+        value: raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0),
+      };
     case "boolean": {
-      if (raw === "true") return true;
-      if (raw === "false") return false;
-      return { error: `${field} must be true or false` };
+      if (raw === "true") return { ok: true, value: true };
+      if (raw === "false") return { ok: true, value: false };
+      return { ok: false, error: `${field} must be true or false` };
     }
     case "number": {
       const n = Number(raw);
@@ -31,14 +48,10 @@ function coerce(raw: string, kind: ParamKind, field: string): unknown | { error:
       // validator (`typeof !== "number" || < 0 || > 1`) is entirely false for NaN — so NaN would
       // reach the agent and every `confidence >= NaN` comparison would be false, producing a brief
       // with zero decisions and no error. Infinity is rejected for the same class of reason.
-      if (!Number.isFinite(n)) return { error: `${field} must be a finite number` };
-      return n;
+      if (!Number.isFinite(n)) return { ok: false, error: `${field} must be a finite number` };
+      return { ok: true, value: n };
     }
   }
-}
-
-function isError(v: unknown): v is { error: string } {
-  return typeof v === "object" && v !== null && "error" in v;
 }
 
 /**
@@ -96,8 +109,8 @@ export function parseAgentCommand(
         detail: `'${agent}' has no parameter '${field}'.`,
       };
     const coerced = coerce(value, kind, field);
-    if (isError(coerced)) return { ok: false, reason: "bad_agent_params", detail: coerced.error };
-    params[field] = coerced;
+    if (!coerced.ok) return { ok: false, reason: "bad_agent_params", detail: coerced.error };
+    params[field] = coerced.value;
   }
   return { ok: true, agent, params };
 }

--- a/packages/gateway/src/chatops/brief-truncate.ts
+++ b/packages/gateway/src/chatops/brief-truncate.ts
@@ -93,7 +93,8 @@ function truncateUtf8Bytes(text: string, maxBytes: number): string {
  * because this function exists specifically to shrink that one block; it is not a generic
  * markdown-entry heuristic applied blind.
  */
-const GLOSSARY_ENTRY_START_RE = /^- \*\*/;
+/** The literal an entry line opens with. Anchored, so `startsWith` says it directly. */
+const GLOSSARY_ENTRY_START = "- **";
 
 /** Line indices where a glossary entry starts within an already-extracted `## Terms` block's
  *  markdown. Found dynamically rather than an assumed line offset, so this stays correct even if
@@ -103,7 +104,7 @@ function glossaryEntryStarts(blockMarkdown: string): number[] {
   const lines = blockMarkdown.split("\n");
   const starts: number[] = [];
   for (let i = 0; i < lines.length; i++) {
-    if (GLOSSARY_ENTRY_START_RE.test(lines[i] ?? "")) starts.push(i);
+    if ((lines[i] ?? "").startsWith(GLOSSARY_ENTRY_START)) starts.push(i);
   }
   return starts;
 }
@@ -112,9 +113,7 @@ function glossaryEntryStarts(blockMarkdown: string): number[] {
  *  both narrowed and handled inside this one function so a caller never needs its own
  *  `x !== undefined && x.heading === ...` guard just to satisfy the type checker. */
 function glossaryEntryStartsOf(block: ReservedBlock | undefined): number[] {
-  return block !== undefined && block.heading === GLOSSARY_TERMS_HEADING
-    ? glossaryEntryStarts(block.markdown)
-    : [];
+  return block?.heading === GLOSSARY_TERMS_HEADING ? glossaryEntryStarts(block.markdown) : [];
 }
 
 /** The glossary `## Terms` block's own preamble plus its first `kept` entries (never a byte cut
@@ -173,7 +172,7 @@ function assembleReservedForcedFit(
   // `SYNTHESIS_RESERVED_HEADINGS` — and, until it is, it stays correctly classified as disclosure
   // rather than silently becoming droppable.
   const synthBlock = reservedBlocks.find((b) => !isDisclosureOnlyHeading(b.heading));
-  const isGlossaryTerms = synthBlock !== undefined && synthBlock.heading === GLOSSARY_TERMS_HEADING;
+  const isGlossaryTerms = synthBlock?.heading === GLOSSARY_TERMS_HEADING;
   const entryStarts = glossaryEntryStartsOf(synthBlock);
   // A recognised (glossary) synthesis block shrinks per-entry; an unrecognised one — none exist
   // today — is opaque and can only be present (1) or fully dropped (0).

--- a/packages/gateway/src/computer-use/cu-consent-broker.ts
+++ b/packages/gateway/src/computer-use/cu-consent-broker.ts
@@ -1,5 +1,5 @@
 import { ConsentBroker } from "../util/consent-broker.ts";
-import type { CuActionClass, CuEnvelope } from "./cu-types.ts";
+import type { CuActionClass } from "./cu-types.ts";
 
 /**
  * The DISCRIMINANT that routes an approval request to its broker.
@@ -95,4 +95,4 @@ export class CuActionConsentBroker extends ConsentBroker<CuActionApprovalInput> 
 export const cuEnvelopeConsent = new CuEnvelopeConsentBroker();
 export const cuActionConsent = new CuActionConsentBroker();
 
-export type { CuEnvelope };
+export type { CuEnvelope } from "./cu-types.ts";

--- a/packages/gateway/src/computer-use/cu-lanes/browser.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/browser.ts
@@ -276,12 +276,12 @@ export async function openBrowserLane(
     const created = await conn.send("Target.createTarget", { url: "about:blank" });
     const targetId = created["targetId"];
     if (typeof targetId !== "string") {
-      throw new Error("browser did not return a target id for the lane's page");
+      throw new TypeError("browser did not return a target id for the lane's page");
     }
     const attached = await conn.send("Target.attachToTarget", { targetId, flatten: true });
     const sessionId = attached["sessionId"];
     if (typeof sessionId !== "string") {
-      throw new Error("browser did not return a CDP session id for the lane's page");
+      throw new TypeError("browser did not return a CDP session id for the lane's page");
     }
 
     // Track the page's own origin from protocol events, because `BrowserLane.currentOrigin()` is

--- a/packages/gateway/src/computer-use/cu-lanes/cdp-session.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/cdp-session.ts
@@ -175,7 +175,18 @@ export class CdpConnection {
       clearTimeout(pending.timer);
       const err = asRecord(msg["error"]);
       if (err !== undefined) {
-        pending.reject(new CdpError(pending.method, String(err["message"] ?? "unknown error")));
+        // Only a string message is used verbatim. `String(someObject)` yields
+        // "[object Object]", which is worse than saying nothing — a CDP error whose
+        // `message` is structured would produce a diagnostic that names no cause.
+        const rawMessage = err["message"];
+        pending.reject(
+          new CdpError(
+            pending.method,
+            typeof rawMessage === "string" && rawMessage !== ""
+              ? rawMessage
+              : JSON.stringify(err) || "unknown error",
+          ),
+        );
         return;
       }
       pending.resolve(asRecord(msg["result"]) ?? {});

--- a/packages/gateway/src/computer-use/cu-lanes/terminal-launch.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/terminal-launch.ts
@@ -64,7 +64,7 @@ export function buildTerminalLaunchPolicy(opts: {
   // read — and on Linux bwrap binds the resolved target, so the grant and the prompt would describe
   // different directories. REFUSED rather than normalised, matching this file's posture everywhere
   // else: silently rewriting a caller's path grants something they did not type.
-  if (opts.cwd.split("\\").join("/").split("/").includes("..")) {
+  if (opts.cwd.replaceAll("\\", "/").split("/").includes("..")) {
     throw new CuLaunchPolicyError(
       "ERR_CU_TERMINAL_TRAVERSAL_CWD",
       `the terminal lane's working directory must not contain a ".." segment: ${opts.cwd}`,

--- a/packages/gateway/src/connectors/connector-sync-test-helpers.ts
+++ b/packages/gateway/src/connectors/connector-sync-test-helpers.ts
@@ -17,12 +17,15 @@ import type { NimbusVault } from "../vault/nimbus-vault.ts";
 import type { ConnectorServiceId } from "./connector-catalog.ts";
 
 export type LocalOnlySyncServiceId = "blame" | "filesystem" | "obsidian" | "openapi";
-const LOCAL_ONLY_SYNC_SERVICE_IDS: readonly LocalOnlySyncServiceId[] = [
+// A Set, so membership is `has` rather than `includes` — which also removes the
+// `as LocalOnlySyncServiceId` the array form needed at the call site to narrow a
+// wider ConnectorServiceId, i.e. a cast that asserted the very thing being tested.
+const LOCAL_ONLY_SYNC_SERVICE_IDS: ReadonlySet<string> = new Set<LocalOnlySyncServiceId>([
   "blame",
   "filesystem",
   "obsidian",
   "openapi",
-];
+]);
 
 export const EMPTY_NIMBUS_VAULT: NimbusVault = {
   set: async () => {},
@@ -132,7 +135,7 @@ export function syncTestContext(
   const caps =
     serviceId === undefined
       ? unboundSyncCapabilities()
-      : LOCAL_ONLY_SYNC_SERVICE_IDS.includes(serviceId as LocalOnlySyncServiceId)
+      : LOCAL_ONLY_SYNC_SERVICE_IDS.has(serviceId)
         ? buildLocalOnlySyncCapabilities(capDeps, serviceId as LocalOnlySyncServiceId)
         : buildSyncCapabilities(capDeps, serviceId as ConnectorServiceId);
   // `extras` carries the UNBOUND capability set as its default, so it must be spread FIRST — the

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -554,7 +554,9 @@ export function syncFilesystemMediaForRoot(
 
   for (const file of files) {
     let sizeBytes: number | null = null;
-    let modifiedAt = now;
+    // Not seeded with `now`: the catch below `continue`s, so nothing downstream can
+    // observe a pre-stat value and seeding one only hides a missing assignment.
+    let modifiedAt: number;
     try {
       const st = statSync(file.path);
       sizeBytes = st.size;


### PR DESCRIPTION
Clears 23 of the 75 open SonarCloud issues on this repo. Every finding was read
against the code before being applied — which mattered, because five of the ones
I looked at should NOT be applied, and two of those would have introduced bugs.

## The two that would have broken things

S7747 flags `for (const x of [...collection])` as an unnecessary array
conversion. In both places the spread is load-bearing:

- `llm/route-availability.ts` iterates `[...this.cache.keys()]` and calls
  `this.cache.delete()` inside the loop. Dropping the spread mutates a Map
  during its own iteration.
- `computer-use/cu-lanes/cdp-session.ts` copies `#listeners` before invoking
  them, so a listener that unsubscribes itself cannot corrupt the walk.

## The three others left alone

- S6353 wants `[A-Za-z0-9_]` written as `\w` in `index/item-store.ts`. Equivalent
  in JavaScript, but that regex is an injection guard on a value heading for SQL
  identifier handling, and `\w` reads as unicode-aware to plenty of people when
  it is not. Explicit wins in a security check.
- The fourth S7786, at `cu-lanes/browser.ts:413`, throws "no element matched
  selector". That is a not-found condition; the `typeof` guard on the box
  coordinates is incidental, and `TypeError` would misdescribe it.
- S6564 on `ProviderId = string`. Its doc comment says it names "a place data can
  go" and that it reaches the egress ledger as `destination`. Deleting a domain
  alias to satisfy a rule erases meaning from an egress-relevant type.

## What actually changed

Four of these are more than tidying — in each case a type or a
human-facing string was saying less than the code meant:

- `agent-commands/parse-agent-command.ts` — `coerce` returned
  `unknown | { error: string }`, which collapses to plain `unknown`. The error
  arm told the type system nothing, so the single caller narrowed with a
  hand-written `"error" in v` guard, which also could not tell a failure from a
  successfully coerced value carrying an `error` key. No current `kind` returns
  an object, so it never misfired — a fact about the arms, not a guarantee. Now
  a discriminated result; the guard is deleted.
- `cli/src/commands/llm.ts` — `RouteReason`'s `| string` arm swallowed its four
  literals, so the known reasons stopped being suggested and a typo in one
  stopped being visible. `(string & {})` keeps the openness the comment asks for
  while keeping the members.
- `cu-lanes/cdp-session.ts` — `CdpError` built its message with
  `String(err["message"] ?? …)`, which yields "[object Object]" for a structured
  CDP error: a diagnostic naming no cause, from the layer whose job is
  explaining why the browser refused.
- `connectors/connector-sync-test-helpers.ts` — a Set instead of an array, which
  also removed the `as LocalOnlySyncServiceId` cast its `includes` call needed —
  a cast asserting the very thing the check was testing.

The rest are mechanical: `replaceAll` over `split().join()`, a genuinely dead
`modifiedAt = now` initialiser (the catch below it `continue`s, so nothing could
read it), an anchored `/^- \*\*/` regex expressed as `startsWith`, two optional
chains, three `TypeError`s where the guard really is a type check, and a pure
re-export tidied to `export type … from`.

## Verification

`preflight:fast` 33/33. 1006 tests pass across the touched areas.

One correction I made to myself along the way: the first `RouteReason` version
carried a `biome-ignore` for `noBannedTypes`, a rule that does not fire there.
`--error-on-warnings` rejected the unused suppression, correctly.

Remaining after this: 52. The largest groups are 19 S5906 assertion-strictness
findings in tests, 12 CRITICAL cognitive-complexity refactors, and 9 `String.raw`
findings in escape-handling code. The 12 are worth doing one at a time rather
than as a batch — restructuring complex functions is where a sweep can do real
damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZCGCkVMD9JaKuiKvqRdAb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for LLM and computer-use operations, including clearer messages for structured, empty, or unexpected errors.
  * Strengthened command parsing so successful and failed results are handled consistently.
  * Improved path traversal detection across Windows and Unix-style paths.
  * Prevented stale timestamps from being used when files disappear or cannot be inspected.
  * Preserved glossary and reserved-section detection behavior while improving reliability.
* **Refactor**
  * Improved internal handling of local-only service checks and shared type exports without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->