### PR TITLE
fix(sonar): specific matchers and named decisions, minus two arity assertions

### DIFF
--- a/packages/gateway/src/agents/why.ts
+++ b/packages/gateway/src/agents/why.ts
@@ -306,6 +306,20 @@ function armOf(input: WhyInput): LaneInput["arm"] {
   return isWhyItemInput(input) ? "item" : "ref";
 }
 
+/**
+ * Which arm resolves this input's subject.
+ *
+ * The three arms are mutually exclusive and ORDERED — `isWhyPrInput` before `isWhyItemInput`
+ * before the ref fallback — so the fallback is genuinely a fallback rather than a fourth case.
+ * Written as guarded early returns rather than a chained conditional so that ordering is the
+ * shape of the function instead of something a reader reconstructs from indentation.
+ */
+async function resolveArm(input: WhyInput, ctx: WhyContext): Promise<WhyLaneResolution> {
+  if (isWhyPrInput(input)) return resolvePrArm(ctx.db, input.prUrl);
+  if (isWhyItemInput(input)) return resolveItemArm(ctx.db, input.itemUrl);
+  return resolveRefArm(input, ctx);
+}
+
 export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief> {
   const start = performance.now();
   const preflightGaps: GapNote[] = [];
@@ -314,11 +328,7 @@ export async function runWhy(input: WhyInput, ctx: WhyContext): Promise<WhyBrief
 
   const arm = armOf(input);
   const { subject, blame, pr, changeSubject, itemSubject, itemEntityId, queryRef, queryLine } =
-    isWhyPrInput(input)
-      ? resolvePrArm(ctx.db, input.prUrl)
-      : isWhyItemInput(input)
-        ? resolveItemArm(ctx.db, input.itemUrl)
-        : await resolveRefArm(input, ctx);
+    await resolveArm(input, ctx);
 
   const lane: LaneInput = {
     subject,

--- a/packages/gateway/src/chatops/channel-salt.test.ts
+++ b/packages/gateway/src/chatops/channel-salt.test.ts
@@ -23,7 +23,7 @@ describe("channel salt", () => {
   test("generates a 32-byte salt on first use and persists it", async () => {
     const vault = fakeVault();
     const first = await ensureChannelSalt(vault);
-    expect(Buffer.from(first, "base64").length).toBe(32);
+    expect(Buffer.from(first, "base64")).toHaveLength(32);
     expect(await vault.get(CHATOPS_CHANNEL_SALT)).toBe(first);
   });
 
@@ -36,7 +36,7 @@ describe("channel salt", () => {
     const vault = fakeVault();
     await vault.set(CHATOPS_CHANNEL_SALT, "truncated");
     const salt = await ensureChannelSalt(vault);
-    expect(Buffer.from(salt, "base64").length).toBe(32);
+    expect(Buffer.from(salt, "base64")).toHaveLength(32);
   });
 
   test("the hash is deterministic per salt and never contains the channel id", () => {

--- a/packages/gateway/src/chatops/chatops-boot.test.ts
+++ b/packages/gateway/src/chatops/chatops-boot.test.ts
@@ -527,7 +527,7 @@ describe("buildChatopsBoot — full production graph", () => {
 
     // The ledger half.
     const rows = listEgress(db, { limit: 10 });
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     expect(rows[0]?.sourceType).toBe("chatops");
     expect(rows[0]?.method).toBe("chatops.reply");
   });
@@ -730,7 +730,7 @@ describe("buildChatopsBoot — full production graph", () => {
     h.socket.emit(mention("C0", "U_BOB", "@nimbus who is on call for payment-service?", "40"));
     await until(() => logErrorCalls.length === 1);
     // Fail-closed: the append happens BEFORE the post, so a failed append means nothing posted.
-    expect(h.posts.length).toBe(0);
+    expect(h.posts).toHaveLength(0);
     expect(logErrorCalls[0]?.msg).toContain("egress ledger append failed");
     // Unhashed, per §13.1 — the log is not the ledger and carries a different threat model.
     expect(logErrorCalls[0]?.fields["channelId"]).toBe("C0");

--- a/packages/gateway/src/chatops/chatops-flow.integration.test.ts
+++ b/packages/gateway/src/chatops/chatops-flow.integration.test.ts
@@ -453,10 +453,10 @@ describe("ChatOps end-to-end: real buildChatopsBoot wires an agent command throu
     // a stray second post could still be in flight, not merely past the first.
     await boot.service.stop();
 
-    expect(posts.length).toBe(1); // still the only post: the ledger and the wire agree
+    expect(posts).toHaveLength(1); // still the only post: the ledger and the wire agree
     const rows = listEgress(db, { limit: 10 });
     // ONE row, from PR 1's post appender. NOT two: the invoker deliberately appends nothing.
-    expect(rows.length).toBe(1);
+    expect(rows).toHaveLength(1);
     expect(rows[0]?.method).toBe("chatops.agentBrief");
   });
 

--- a/packages/gateway/src/chatops/intent-router.test.ts
+++ b/packages/gateway/src/chatops/intent-router.test.ts
@@ -133,7 +133,7 @@ describe("IntentRouter", () => {
     });
     await r.handle(msg("@nimbus agent why ref=a.ts"));
     // Asserting the refusal alone would pass against an implementation that refused AFTER running.
-    expect(agentCalls.length).toBe(0);
+    expect(agentCalls).toHaveLength(0);
     expect(replies).toContainEqual({ text: "You are not enrolled for this channel." });
   });
 

--- a/packages/gateway/src/computer-use/cu-actuate.ts
+++ b/packages/gateway/src/computer-use/cu-actuate.ts
@@ -47,9 +47,9 @@ export async function performActuation(
     // printed nothing within the first-byte window may have finished silently or may still be
     // running, and saying "it produced no output" without saying which would assert the one thing
     // this driver cannot know.
-    return r.settled === "quiet"
-      ? r.output
-      : `${r.output}\n[nimbus: output collection ended by ${r.settled}${r.truncated ? ", truncated" : ""}]`;
+    if (r.settled === "quiet") return r.output;
+    const truncatedNote = r.truncated ? ", truncated" : "";
+    return `${r.output}\n[nimbus: output collection ended by ${r.settled}${truncatedNote}]`;
   }
 
   if (req.kind === "terminal_write") {

--- a/packages/gateway/src/computer-use/cu-gate.ts
+++ b/packages/gateway/src/computer-use/cu-gate.ts
@@ -1188,6 +1188,24 @@ function isCuOutcomeString(v: string): boolean {
  * calls next. The one thing read from THIS call's `deps` is the live policy re-check and the
  * consent broker, both of which must reflect the CURRENT world, not a frozen one.
  */
+/**
+ * Why a live session is being terminated mid-flight, in the order the gate checks them.
+ *
+ * Named rather than inlined as a ternary chain because this string is what the audit row and
+ * the owner both see: "disabled by local config" and "disabled by org policy" are different
+ * events with different remediations, and the lane case is neither — the capability is still
+ * on, this session's lane simply stopped being allowed. Reading that off a three-arm
+ * conditional at the call site made the ordering, which is the part that matters, easy to miss.
+ *
+ * Takes CuRunDeps, not CuGateDeps: the I35 split deliberately keeps lane construction out of
+ * the deps the model-facing tool layer holds, and this decision needs neither.
+ */
+function policyRefusalReason(deps: CuRunDeps, lane: CuLane): string {
+  if (!deps.config.enabled) return "disabled by local config";
+  if (deps.enforced.capabilitiesDisabled.has(CAPABILITY)) return "disabled by org policy";
+  return `lane no longer allowed: ${lane}`;
+}
+
 export async function runAction(req: RunActionRequest, deps: CuRunDeps): Promise<RunActionOutput> {
   const live = liveSessions.get(req.sessionId);
   if (live === undefined) {
@@ -1232,11 +1250,7 @@ async function runActionExclusive(
     deps.enforced.capabilitiesDisabled.has(CAPABILITY) ||
     !laneStillAllowed
   ) {
-    const reason = !deps.config.enabled
-      ? "disabled by local config"
-      : deps.enforced.capabilitiesDisabled.has(CAPABILITY)
-        ? "disabled by org policy"
-        : `lane no longer allowed: ${session.envelope.lane}`;
+    const reason = policyRefusalReason(deps, session.envelope.lane);
     session.close("terminated_policy", openDeps.now());
     await finalizeSession({
       deps: openDeps,

--- a/packages/gateway/src/computer-use/cu-lanes/browser-observe.test.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/browser-observe.test.ts
@@ -127,9 +127,9 @@ describe("parseObservedNode — a REAL guard over renderer-supplied data", () =>
   });
 
   test("a non-string accessibleName becomes null rather than reaching the prompt as an object", () => {
-    expect(parseObservedNode({ ...honest, accessibleName: { toString: 1 } })?.accessibleName).toBe(
-      null,
-    );
+    expect(
+      parseObservedNode({ ...honest, accessibleName: { toString: 1 } })?.accessibleName,
+    ).toBeNull();
   });
 });
 

--- a/packages/gateway/src/computer-use/cu-lanes/browser.test.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/browser.test.ts
@@ -662,7 +662,7 @@ describe("openBrowserLane — the BrowserLane surface", () => {
       configure: (f) =>
         f.respondWith("Runtime.evaluate", { result: { value: "x".repeat(250_000) } }),
     });
-    expect((await lane.readText()).length).toBe(100_000);
+    expect(await lane.readText()).toHaveLength(100_000);
   });
 
   test("domSnapshot() returns the document HTML, and empty rather than null when absent", async () => {

--- a/packages/gateway/src/computer-use/cu-lanes/cdp-session.test.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/cdp-session.test.ts
@@ -227,7 +227,7 @@ describe("CdpConnection — sendAndForget", () => {
     conn.close();
     const before = f.sent.length;
     expect(() => conn.sendAndForget("Fetch.failRequest", { requestId: "r" })).not.toThrow();
-    expect(f.sent.length).toBe(before);
+    expect(f.sent).toHaveLength(before);
   });
 
   test("swallows a socket write failure rather than replacing a lane-level error", () => {

--- a/packages/gateway/src/computer-use/cu-terminal-buffer.test.ts
+++ b/packages/gateway/src/computer-use/cu-terminal-buffer.test.ts
@@ -60,7 +60,7 @@ describe("TerminalLineBuffer", () => {
     b.append("x".repeat(MAX_TERMINAL_LINE_UNITS - 1));
     const r = b.append("yy");
     expect(r.status).toBe("refused");
-    expect(b.pending().length).toBe(MAX_TERMINAL_LINE_UNITS - 1);
+    expect(b.pending()).toHaveLength(MAX_TERMINAL_LINE_UNITS - 1);
   });
 
   test("a tab is ordinary text, not a control character", () => {

--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -1021,7 +1021,7 @@ test("an ANONYMOUS default export still yields no symbol", async () => {
   const rows = db
     .query(`SELECT title FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`)
     .all() as Array<{ title: string }>;
-  expect(rows.length).toBe(0);
+  expect(rows).toHaveLength(0);
 });
 
 // ── excerptWithStartLine: flat fallback fits within maxChars (no truncation) ──

--- a/packages/gateway/src/egress/browser-egress.test.ts
+++ b/packages/gateway/src/egress/browser-egress.test.ts
@@ -78,7 +78,7 @@ describe("wrapLedgeredBrowserContext", () => {
     await h.fire(fakeRoute("https://example.com/a", "document", cap));
     await h.fire(fakeRoute("https://example.com/b", "image", cap));
     await h.fire(fakeRoute("https://example.com/c", "image", cap));
-    expect(rows(h.db).length).toBe(1);
+    expect(rows(h.db)).toHaveLength(1);
     expect(cap.continued).toBe(3);
   });
 

--- a/packages/gateway/src/egress/chatops-egress.test.ts
+++ b/packages/gateway/src/egress/chatops-egress.test.ts
@@ -64,7 +64,7 @@ describe("chatops egress appender", () => {
     db.close(); // make the append fail
     await expect(posts.reply("slack", "C1", "hi")).rejects.toBeInstanceOf(EgressAppendFailedError);
     // The whole point of fail-closed: proving it threw is not proving nothing left.
-    expect(s.calls.length).toBe(0);
+    expect(s.calls).toHaveLength(0);
     db = new Database(":memory:"); // so afterEach's close() is valid
   });
 

--- a/packages/gateway/src/ipc/agent-param-kinds.test.ts
+++ b/packages/gateway/src/ipc/agent-param-kinds.test.ts
@@ -20,7 +20,7 @@ describe("agent param kinds", () => {
     // this, a future change that removed every `stringArray` field entirely would still pass this
     // test. The real claim is "there are exactly three (ghost/conflicts/huddle's `namespaces`),
     // and every one of them is `.namespaces`", so the count has to be pinned too.
-    expect(arrays.length).toBe(3);
+    expect(arrays).toHaveLength(3);
     expect(arrays.every((x) => x.endsWith(".namespaces"))).toBe(true);
   });
 

--- a/packages/gateway/src/ipc/agents-rpc.test.ts
+++ b/packages/gateway/src/ipc/agents-rpc.test.ts
@@ -1043,7 +1043,7 @@ describe("dispatchAgentsRpc — agents.negotiate", () => {
 
 describe("the externally-invokable agent set", () => {
   test("the external agent set is exactly eleven and excludes the four", () => {
-    expect(EXTERNAL_AGENT_NAMES.length).toBe(11);
+    expect(EXTERNAL_AGENT_NAMES).toHaveLength(11);
     for (const excluded of ["preflight", "premortem", "whyPeek", "negotiate"]) {
       expect(EXTERNAL_AGENT_NAMES).not.toContain(excluded);
       expect(resolveExternalAgentMethod(excluded)).toBeNull();

--- a/packages/gateway/src/security-invariants.test.ts
+++ b/packages/gateway/src/security-invariants.test.ts
@@ -2849,7 +2849,7 @@ describe("I35 — computer-use actuation only inside an approved envelope", () =
     // The SAME binding, not a rebuild: both `openLane` calls take the prepared object. A
     // `buildLaunchPolicy` call inside an `openLane` argument would typecheck and silently
     // reintroduce the drift this replaced, so it must appear nowhere in that position.
-    expect((gate.match(/launch: prepared\.launch/g) ?? []).length).toBe(2);
+    expect(gate.match(/launch: prepared\.launch/g) ?? []).toHaveLength(2);
     expect(gate).not.toMatch(/openLane\([^)]*buildLaunchPolicy/);
 
     // And each driver spawns what it was handed, verbatim.


### PR DESCRIPTION
Third Sonar pass: 17 S5906 assertion findings and 3 S3358 nested-ternary
findings. Takes this repo from 52 open to roughly 32.

## Assertions

`expect(x.length).toBe(n)` becomes `toHaveLength(n)`, plus one `toBe(null)` to
`toBeNull()`. Not cosmetic: on failure `toHaveLength` prints the collection,
where the old form prints two integers and leaves you working out which array
it was.

## The two left alone

Two of the nineteen are untouched, and they are why this was not a blind
rewrite. `classifyTerminalAction.length` in `cu-classify.test.ts` and
`security-invariants.test.ts` is **not a collection length — it is function
arity**. The comment above one reads:

> provable by SIGNATURE: the function takes ONE parameter, so a model-supplied
> description cannot even be passed to it, let alone read. I3 transplanted,
> enforced by arity.

That is the I35 property those tests exist to pin.
`expect(classifyTerminalAction).toHaveLength(1)` is valid and would satisfy the
rule, but it reads as "this function has one element" and buries what is being
proven. The suggestion improves the failure report and degrades the meaning.

## Named decisions

The three ternary changes name a decision rather than restructuring logic:

- `cu-gate.ts` — the mid-flight termination reason is now `policyRefusalReason`.
  That string is what the audit row and the owner both see, and its arms are
  ORDERED: local config, then org policy, then the lane. Guarded returns put
  that ordering into the shape of the function.

  Typing it turned up something worth keeping. My first version took
  `CuGateDeps` and failed to compile: the call site only holds `CuRunDeps` —
  the I35 split that keeps lane construction out of the deps the model-facing
  tool layer holds. The helper takes the narrower type and records why.

- `why.ts` — three-arm subject resolution becomes `resolveArm`, with the
  ordering documented as load-bearing: PR before item before the ref fallback,
  so the fallback is genuinely a fallback and not a fourth case.

- `cu-actuate.ts` — a ternary inside a template literal inside a ternary; the
  truncation suffix is a named const.

## Not done

The remaining four S3358 findings are chained dispatch conditionals where the
`const` binding is worth keeping and an `if`/`else` would cost it. They want the
same extract-and-name treatment rather than a mechanical rewrite, and deserve a
pass that can give each one that.

## Verification

`preflight:fast` 33/33, including the whole-repo test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZCGCkVMD9JaKuiKvqRdAb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of input resolution, policy termination messages, and terminal output formatting.
  - Existing behavior remains unchanged.

- **Tests**
  - Standardized collection-size assertions across gateway, ChatOps, browser, connector, egress, IPC, and security test coverage.
  - Preserved existing test expectations while improving assertion consistency and readability.
  - Updated formatting in browser observation tests without changing coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->