### PR TITLE
fix(sonar): raw path literals, media flag validators, and the two findings the last pass added

### DIFF
--- a/packages/cli/src/commands/computer.ts
+++ b/packages/cli/src/commands/computer.ts
@@ -469,7 +469,7 @@ const REFUSAL_MESSAGES: Readonly<Record<string, string>> = {
     "nimbus: the browser failed to launch after the owner approved the session.",
   ERR_CU_NO_SHELL:
     "nimbus: no usable shell was found for the terminal lane. On Windows that means cmd.exe was " +
-    "not found under %SystemRoot%\\System32; elsewhere, /usr/bin/sh or /bin/sh.",
+    String.raw`not found under %SystemRoot%\System32; elsewhere, /usr/bin/sh or /bin/sh.`,
   ERR_CU_UNKNOWN_SHELL:
     "nimbus: --shell named an id this build does not register. Supported ids: sh (POSIX), cmd " +
     "(Windows). Omit --shell to use the platform default.",

--- a/packages/cli/src/commands/media-cmd.ts
+++ b/packages/cli/src/commands/media-cmd.ts
@@ -40,6 +40,47 @@ export interface ParsedMediaArgs {
   };
 }
 
+/**
+ * `--modality`, which accepts exactly one value today.
+ *
+ * `image` is a real MediaModality and a real registry entry, but this slice ships no vision
+ * model: every image candidate is skipped as `unresolvable_modality`. Accepting the flag would
+ * return "understood 0 of 0" and let a user conclude they have no images, when in fact nothing
+ * can read one yet. So it is refused BY NAME with the reason, rather than falling through to
+ * the generic "must be av" message, which would describe the restriction without explaining it.
+ */
+function parseModality(value: string): "av" {
+  if (value === "image") {
+    throw new Error(
+      "nimbus media: --modality image is not available yet — this release understands " +
+        "audio and video only. Image captioning needs a local vision model, which ships in " +
+        "a later slice.",
+    );
+  }
+  if (value !== "av") {
+    throw new Error('nimbus media: --modality must be "av"');
+  }
+  return value;
+}
+
+/** `--limit`: a positive integer, so `0`, `-1` and `1.5` are all refused rather than clamped. */
+function parseLimit(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error("nimbus media: --limit must be a positive integer");
+  }
+  return n;
+}
+
+/** `--since`: a non-negative number of days. Fractional is fine; NaN and Infinity are not. */
+function parseSinceDays(value: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error("nimbus media: --since must be a non-negative number of days");
+  }
+  return n;
+}
+
 export function parseMediaArgs(argv: readonly string[]): ParsedMediaArgs {
   const sub = argv[0];
   if (sub !== "understand") {
@@ -57,38 +98,14 @@ export function parseMediaArgs(argv: readonly string[]): ParsedMediaArgs {
         params.service = value;
         break;
       case "--modality":
-        // `image` is a real MediaModality and a real registry entry, but this slice ships no
-        // vision model: every image candidate is skipped as `unresolvable_modality`. Accepting
-        // the flag would return "understood 0 of 0" and let a user conclude they have no images,
-        // when in fact nothing can read one yet. Refuse with the reason instead.
-        if (value === "image") {
-          throw new Error(
-            "nimbus media: --modality image is not available yet — this release understands " +
-              "audio and video only. Image captioning needs a local vision model, which ships in " +
-              "a later slice.",
-          );
-        }
-        if (value !== "av") {
-          throw new Error('nimbus media: --modality must be "av"');
-        }
-        params.modality = value;
+        params.modality = parseModality(value);
         break;
-      case "--limit": {
-        const n = Number(value);
-        if (!Number.isInteger(n) || n <= 0) {
-          throw new Error("nimbus media: --limit must be a positive integer");
-        }
-        params.limit = n;
+      case "--limit":
+        params.limit = parseLimit(value);
         break;
-      }
-      case "--since": {
-        const n = Number(value);
-        if (!Number.isFinite(n) || n < 0) {
-          throw new Error("nimbus media: --since must be a non-negative number of days");
-        }
-        params.sinceDays = n;
+      case "--since":
+        params.sinceDays = parseSinceDays(value);
         break;
-      }
       default:
         throw new Error(`nimbus media: unknown flag "${flag ?? ""}"`);
     }

--- a/packages/cli/src/mcp/agent-tools.ts
+++ b/packages/cli/src/mcp/agent-tools.ts
@@ -100,7 +100,7 @@ interface AgentToolDef {
   readonly tool: string;
   readonly agent: string;
   readonly description: string;
-  readonly schema: Record<string, z.ZodTypeAny>;
+  readonly schema: Record<string, z.core.$ZodType>;
   readonly build: (args: Record<string, unknown>) => Record<string, unknown>;
 }
 

--- a/packages/cli/src/mcp/tool-runtime.ts
+++ b/packages/cli/src/mcp/tool-runtime.ts
@@ -41,7 +41,7 @@ export interface AdapterDeps {
 export interface ToolSpec {
   name: string;
   description: string;
-  schema: Record<string, z.ZodTypeAny>;
+  schema: Record<string, z.core.$ZodType>;
   run(deps: AdapterDeps, args: Record<string, unknown>): Promise<ToolResult>;
 }
 

--- a/packages/gateway/src/computer-use/cu-lanes/cdp-session.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/cdp-session.ts
@@ -58,6 +58,24 @@ interface PendingCommand {
  * mid-action surfaces as a prompt failure the gate can classify (`terminated_target_lost`) rather
  * than as a promise that never settles. That property is why `BrowserLane.isAlive()` exists at all.
  */
+/**
+ * The human-readable half of a CDP error object.
+ *
+ * Only a string `message` is used verbatim. `String(someObject)` yields "[object Object]",
+ * which is worse than saying nothing — a CDP error whose `message` is structured would produce
+ * a diagnostic that names no cause, from the layer whose entire job is explaining why the
+ * browser refused. Falls back to the serialised error so the caller still gets the fields.
+ *
+ * Lifted out of `#onMessage` rather than inlined there: that method already carries the parse,
+ * dispatch and listener fan-out branches, and adding this one pushed it past the cognitive
+ * complexity limit. The extraction is the fix for that, not a second concern.
+ */
+function cdpErrorMessage(err: Record<string, unknown>): string {
+  const raw = err["message"];
+  if (typeof raw === "string" && raw !== "") return raw;
+  return JSON.stringify(err) || "unknown error";
+}
+
 export class CdpConnection {
   #nextId = 0;
   #closed = false;
@@ -175,18 +193,7 @@ export class CdpConnection {
       clearTimeout(pending.timer);
       const err = asRecord(msg["error"]);
       if (err !== undefined) {
-        // Only a string message is used verbatim. `String(someObject)` yields
-        // "[object Object]", which is worse than saying nothing — a CDP error whose
-        // `message` is structured would produce a diagnostic that names no cause.
-        const rawMessage = err["message"];
-        pending.reject(
-          new CdpError(
-            pending.method,
-            typeof rawMessage === "string" && rawMessage !== ""
-              ? rawMessage
-              : JSON.stringify(err) || "unknown error",
-          ),
-        );
+        pending.reject(new CdpError(pending.method, cdpErrorMessage(err)));
         return;
       }
       pending.resolve(asRecord(msg["result"]) ?? {});

--- a/packages/gateway/src/computer-use/cu-lanes/chromium-path.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/chromium-path.ts
@@ -14,7 +14,7 @@ export interface ChromiumEnv {
  * Where a Chromium-family browser lives on `platform`, in preference order.
  *
  * A FUNCTION of `(platform, env)` rather than a module-level constant, and that is not a style
- * choice. As a constant it read `process.env[...] ?? "C:\\Program Files"` inline, which is
+ * choice. As a constant it read `process.env[...] ?? String.raw`C:\Program Files`` inline, which is
  * unreachable-by-half on every runner: on Linux only the fallback side of each `??` ever executes,
  * on a Windows box only the env side. So the WINDOWS candidate ORDER — the part with real decisions
  * in it (Chrome before Edge; the per-user `%LOCALAPPDATA%` install that is the default when Chrome
@@ -33,20 +33,22 @@ export interface ChromiumEnv {
  * installed should get Chrome.
  */
 export function chromiumCandidates(platform: string, env: ChromiumEnv): readonly string[] {
-  const programFiles = env.programFiles ?? "C:\\Program Files";
-  const programFilesX86 = env.programFilesX86 ?? "C:\\Program Files (x86)";
+  const programFiles = env.programFiles ?? String.raw`C:\Program Files`;
+  const programFilesX86 = env.programFilesX86 ?? String.raw`C:\Program Files (x86)`;
   const localAppData = env.localAppData ?? "";
   switch (platform) {
     case "win32":
       return [
-        join(programFiles, "Google\\Chrome\\Application\\chrome.exe"),
-        join(programFilesX86, "Google\\Chrome\\Application\\chrome.exe"),
+        join(programFiles, String.raw`Google\Chrome\Application\chrome.exe`),
+        join(programFilesX86, String.raw`Google\Chrome\Application\chrome.exe`),
         // The per-user install. `localAppData` can be absent, which yields a RELATIVE path here —
         // harmless because every candidate is existence-checked before use, and `resolveChromiumPath`
         // additionally skips an empty one.
-        localAppData === "" ? "" : join(localAppData, "Google\\Chrome\\Application\\chrome.exe"),
-        join(programFilesX86, "Microsoft\\Edge\\Application\\msedge.exe"),
-        join(programFiles, "Microsoft\\Edge\\Application\\msedge.exe"),
+        localAppData === ""
+          ? ""
+          : join(localAppData, String.raw`Google\Chrome\Application\chrome.exe`),
+        join(programFilesX86, String.raw`Microsoft\Edge\Application\msedge.exe`),
+        join(programFiles, String.raw`Microsoft\Edge\Application\msedge.exe`),
       ];
     case "darwin":
       return [

--- a/packages/gateway/src/computer-use/cu-lanes/terminal-shells.ts
+++ b/packages/gateway/src/computer-use/cu-lanes/terminal-shells.ts
@@ -90,7 +90,7 @@ const SH_SHELL: CuShell = {
 const CMD_SHELL: CuShell = {
   id: "cmd",
   detect: (exists = existsSync) => {
-    const p = join(process.env["SystemRoot"] ?? "C:\\Windows", "System32", "cmd.exe");
+    const p = join(process.env["SystemRoot"] ?? String.raw`C:\Windows`, "System32", "cmd.exe");
     return exists(p) ? p : null;
   },
   /**


### PR DESCRIPTION
Fourth Sonar pass, and the first one that had to correct the previous ones.

## A correction to #1434's description

Checking the board rather than my own tally showed #1434 removed **16** issues,
not the 23 it claimed. I had counted edits rather than resolved findings: the
`coerce` change alone cleared five S6571s, while several other edits shared one
issue between them. Rule by rule: S6571 -5, S7786 -3, S6582 -2, and one each of
S1854, S6551, S6557, S7763, S7776, S7781.

It also **added three**, which this PR repays.

## Repaying them

`cdp-session.ts` gained an S3776 at complexity 17, and that one was mine. The
`CdpError` message fix in #1434 replaced a one-line `String(...)` with a
branching block inside `#onMessage` — a method already carrying the parse,
dispatch and listener fan-out branches. The derivation is now
`cdpErrorMessage`, whose docstring says outright that the extraction is the fix
for what the inline version cost rather than a separate concern.

The two S1874s are `z.ZodTypeAny`, deprecated by the zod 4.5.4 bump in #1432.
They are now `z.core.$ZodType`.

That migration is worth a note, because it is the same edit attempted at the
very start of this sweep and reverted. It failed then with TS2322 — but not
because the call site was wrong. `@modelcontextprotocol/sdk` still resolved
zod 4.4.3 while the workspace had moved to 4.5.4, so the two `$ZodType`s were
structurally distinct types and nothing crossing that seam could typecheck.
Pinning zod in `overrides` collapsed the tree onto one copy, which is what makes
the migration correct now for exactly the reason it was wrong then. Reverting it
at the time was the right call.

## Also in this PR

- Ten S7780 findings: Windows path literals as `String.raw`. Already the idiom
  here — 47 files use it — and none of these literals contains a backtick, a
  `${`, or a trailing backslash, which are the three things that would make a
  raw template behave differently from the quoted form.
- One S3776: `parseMediaArgs` had four flags' validation inline in one switch.
  `parseModality`, `parseLimit` and `parseSinceDays` are named functions now.
  Nothing is lost by that split, which is why it was worth doing — there is no
  ordering property and no invariant in the branch structure, just four
  validations that arrived one at a time. The `--modality image` refusal keeps
  its reasoning and gains a sentence explaining why it is refused by name rather
  than falling through to the generic message.

## One attempted and reverted

`connector-sync-test-helpers`' capability dispatch resists extraction:
`buildSyncCapabilities` is generic over the service id and returns
`SyncCapabilities<S>`, so the chained ternary's two casts express something a
non-generic helper cannot. Making the helper generic to satisfy a style rule, in
a test helper, would leave the code worse. That finding stays open on purpose.

## Verification

`preflight:fast` 33/33. 122 MCP tests, 18 cdp-session tests, 23 media-cmd tests.
Because this ran on Windows, the platform-specific `chromium-path` and
`terminal-shells` tests actually executed rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZCGCkVMD9JaKuiKvqRdAb
