### PR TITLE
fix(llm): a provider named __proto__ vanished from the availability map

### DIFF
--- a/packages/gateway/src/llm/registry.test.ts
+++ b/packages/gateway/src/llm/registry.test.ts
@@ -283,6 +283,36 @@ describe("LlmRegistry.checkAvailability", () => {
     const out = await reg.checkAvailability();
     expect(out["ollama"]).toBe(false);
   });
+
+  // `providerId` is an open string: `makeRouteId` rejects only "/" and the empty string, so
+  // `__proto__` is a legal id. On a plain `{}` that key hits `Object.prototype`'s setter — the
+  // write silently does nothing, `Object.keys` omits it, `JSON.stringify` omits it — and
+  // `llm.getStatus` would answer as though the route did not exist. Asserted on the KEY's
+  // presence and on the serialized payload, because that is what crosses the RPC boundary; a
+  // bare `expect(out["__proto__"]).toBe(true)` would read back the prototype object and fail
+  // confusingly rather than describing the defect.
+  test("a provider named __proto__ is reported, not silently swallowed", async () => {
+    const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: ROUTING_DB });
+    reg.addRoute(makeProvider("__proto__", { available: true }), DEFAULT_CONFIG.localModel);
+    const out = await reg.checkAvailability();
+    expect(Object.keys(out)).toContain("__proto__");
+    expect(Object.hasOwn(out, "__proto__")).toBe(true);
+    // Read back through `Object.entries` rather than an `out["__proto__"]` index: on a plain
+    // object that index expression returns the PROTOTYPE, so it would fail for a reason unrelated
+    // to the defect — and Biome's `noProto` rejects the literal accessor anyway.
+    const roundTripped = JSON.parse(JSON.stringify(out)) as Record<string, unknown>;
+    expect(Object.entries(roundTripped)).toContainEqual(["__proto__", true]);
+  });
+
+  // The other half of the same property: a legitimately-named provider must not pick up
+  // inherited keys now that the map has no prototype.
+  test("the availability map carries only real providers, with no inherited keys", async () => {
+    const reg = new LlmRegistry({ config: DEFAULT_CONFIG, db: ROUTING_DB });
+    reg.addRoute(makeProvider("ollama", { available: true }), DEFAULT_CONFIG.localModel);
+    const out = await reg.checkAvailability();
+    expect(Object.keys(out)).toEqual(["ollama"]);
+    expect((out as Record<string, unknown>)["toString"]).toBeUndefined();
+  });
 });
 
 describe("LlmRegistry.loadModel / unloadModel", () => {

--- a/packages/gateway/src/llm/registry.ts
+++ b/packages/gateway/src/llm/registry.ts
@@ -169,8 +169,21 @@ export class LlmRegistry {
     return results;
   }
 
+  /**
+   * Availability per provider VENDOR id, for `llm.getStatus`.
+   *
+   * The result is a NULL-PROTOTYPE object, and that is load-bearing rather than defensive style.
+   * `providerId` is an open string — `makeRouteId` rejects only `/` and the empty string — so a
+   * provider could legitimately be named `__proto__`. Assigning that key to a plain `{}` hits
+   * `Object.prototype`'s setter instead of creating a property: the write silently does nothing,
+   * `Object.keys` omits it, `JSON.stringify` omits it, and the RPC answers as though the route did
+   * not exist. A route that IS registered reporting no status at all is worse than reporting it
+   * unavailable — silent omission is indistinguishable from "never configured".
+   *
+   * `Object.create(null)` has no such setter, so every id round-trips as an ordinary key.
+   */
   async checkAvailability(): Promise<Record<string, boolean>> {
-    const result: Record<string, boolean> = {};
+    const result = Object.create(null) as Record<string, boolean>;
     const seen = new Set<string>();
     for (const route of this.router.routes()) {
       const id = route.provider.providerId;


### PR DESCRIPTION
`LlmRegistry.checkAvailability()` built its result on a plain object, so a provider whose `providerId` is `__proto__` was **silently omitted** from the map rather than reported.

## The defect

Assigning `__proto__` to a plain object hits `Object.prototype`'s setter instead of creating a property. Measured, not assumed:

```
plain["__proto__"] = true       ->  Object.keys []            JSON {}                    read-back: the prototype
nullProto["__proto__"] = true   ->  Object.keys ["__proto__"]  JSON {"__proto__":true}
makeRouteId("__proto__", "m")   ->  "__proto__/m"              // accepted
```

So `llm.getStatus` answers as though the route does not exist. **A registered route reporting no status at all is worse than reporting it unavailable** — silent omission is indistinguishable from "never configured", which is the failure shape this codebase treats as the serious one.

## Why it is reachable

`providerId` is an **open string by design**. `makeRouteId` rejects only `/` and the empty string, and the type is deliberately not a closed union — a closed union once capped `LlmRouter.providers` at one provider per kind, so registering a second vendor silently evicted the first. `ipc/llm-rpc.ts` validates a caller-supplied provider for non-empty and no-slash only, so `__proto__` reaches the registry.

Exotic, certainly. But the cost of the fix is one expression, and the failure it prevents is invisible.

## The fix

`Object.create(null)`, which has no such setter, so every id round-trips as an ordinary key.

Two tests:

- the `__proto__` id survives `Object.keys`, `Object.hasOwn` and JSON serialization. The round-trip is asserted through `Object.entries` rather than an `out["__proto__"]` index, because on a plain object that index returns the **prototype** — the test would fail for a reason unrelated to the defect, and Biome's `noProto` rejects the literal accessor anyway.
- an ordinary provider picks up no inherited keys, which is the other half of the same property.

**Red-proved:** reverting to `{}` fails both tests. Confirmed by mutation rather than by observing green.

## Provenance

Found by CodeRabbit on #1441, where it was raised against a file that PR does not touch. I reproduced it before acting rather than taking the description, and kept it out of that PR deliberately: #1441 is a CI fix for a required check that is red on `main`, and squash-merge makes the PR title the commit — folding a gateway correctness fix into a commit titled `fix(ci):` would misfile it permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAVe1kyv95YtYyVxBawZjE
