### PR TITLE
fix(ci): the sdk release-train tagPattern never matched a real tag, and that only warned

### DIFF
--- a/.github/release-train.json
+++ b/.github/release-train.json
@@ -27,7 +27,7 @@
       "name": "sdk",
       "npm": "@nimbus-dev/sdk",
       "repo": "nimbus-agent/nimbus-sdk",
-      "tagPattern": "^sdk-v(\\d+\\.\\d+\\.\\d+)$",
+      "tagPattern": "^typescript-v(\\d+\\.\\d+\\.\\d+)$",
       "consumers": [
         { "repo": "nimbus-agent/nimbus-client", "lockfile": "bun.lock" },
         { "repo": "nimbus-agent/nimbus-vscode", "lockfile": "bun.lock" },

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
         "@clack/prompts": "^1.7.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@nimbus-dev/client": "^0.17.3",
-        "@nimbus-dev/sdk": "^1.19.0",
+        "@nimbus-dev/sdk": "^1.32.0",
         "ink": "^7.1.1",
         "pino": "^10.3.1",
         "react": "^19.2.7",
@@ -84,7 +84,7 @@
         "@mastra/core": "^1.61.0",
         "@mastra/mcp": "^1.17.1",
         "@nimbus-dev/connectors": "^0.2.0",
-        "@nimbus-dev/sdk": "^1.31.0",
+        "@nimbus-dev/sdk": "^1.32.0",
         "@noble/hashes": "^2.3.0",
         "@scure/bip39": "^2.3.0",
         "@xenova/transformers": "^2.17.0",
@@ -639,7 +639,7 @@
 
     "@nimbus-dev/connectors": ["@nimbus-dev/connectors@0.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.30.0", "@nimbus-dev/sdk": "^1.20.0", "@types/nodemailer": "^7.0.4", "zod": "^4.4.2" }, "optionalDependencies": { "hyparquet": "^1.29.1", "imapflow": "^1.7.2", "nodemailer": "^9.0.5", "tsdav": "^2.3.1" }, "bin": { "nimbus-connector": "standalone/src/bin.ts" } }, "sha512-ZYKXcG1FTxobyB4qB4I1/lpNIcubJoYsBG9zeKnkxuEBVvSjlesP/6M0ZRs4wP71JtbEUghi8GglEcqOmcaSPA=="],
 
-    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.31.0", "", {}, "sha512-bu70LyslZxWZHE50VLEA+jHtCKuobLwBTRdelMFYbR19mxTINs4EuwFuiASkHwo2uKitPiVLLUiY0+eaw3oRKg=="],
+    "@nimbus-dev/sdk": ["@nimbus-dev/sdk@1.32.0", "", {}, "sha512-JqTBbIXJlomRbjUN0kenU7LwWXuCGgww6SNLN2ewGZqtr6If0zpUgUiwBk+gkeoRbrIXm764WhdI977wjCZUSQ=="],
 
     "@nimbus/cli": ["@nimbus/cli@workspace:packages/cli"],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@nimbus-dev/client": "^0.17.3",
-    "@nimbus-dev/sdk": "^1.19.0",
+    "@nimbus-dev/sdk": "^1.32.0",
     "ink": "^7.1.1",
     "pino": "^10.3.1",
     "react": "^19.2.7",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -19,7 +19,7 @@
     "@mastra/core": "^1.61.0",
     "@mastra/mcp": "^1.17.1",
     "@nimbus-dev/connectors": "^0.2.0",
-    "@nimbus-dev/sdk": "^1.31.0",
+    "@nimbus-dev/sdk": "^1.32.0",
     "@noble/hashes": "^2.3.0",
     "@scure/bip39": "^2.3.0",
     "@xenova/transformers": "^2.17.0",

--- a/scripts/structure-audit/_release-train-dep.test.ts
+++ b/scripts/structure-audit/_release-train-dep.test.ts
@@ -187,6 +187,7 @@ describe("evaluatePackage", () => {
     npm: "@nimbus-dev/sdk",
     taggedRelease: { version: "1.6.0", publishedAt: "x" },
     taggedReleaseAgeHours: 48,
+    taggedReleaseListRead: true,
     latest: { version: "1.6.0", publishedAt: "x" },
     latestAgeHours: 48,
     graceHours: 6,
@@ -296,11 +297,44 @@ describe("evaluatePackage", () => {
     expect(r.find((e) => e.edge === "sdk:nimbus-vscode")?.verdict).toBe("indeterminate");
   });
 
-  test("no tagged release => publish edge indeterminate, not phantom", () => {
+  test("no tagged release AND the list was unreadable => indeterminate, not phantom", () => {
     const r = evaluatePackage({
       ...green,
       taggedRelease: null,
       taggedReleaseAgeHours: null,
+      taggedReleaseListRead: false,
+      consumers: [],
+    });
+    expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");
+  });
+
+  /**
+   * The regression this pair exists for. `release-train.json` shipped the sdk
+   * train with `^sdk-v(...)$` while the upstream repo tags `typescript-v*`, so
+   * the pattern matched nothing — and because that produced `indeterminate`,
+   * which `decideExit` renders as a warning and exits 0 on, the edge announced
+   * no problem for as long as it was broken. A readable list that matched
+   * nothing is a manifest bug and must be reported as hard as any other.
+   */
+  test("no tagged release but the list WAS readable => stale (manifest bug), not indeterminate", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: null,
+      taggedReleaseAgeHours: null,
+      taggedReleaseListRead: true,
+      consumers: [],
+    });
+    const edge = r.find((e) => e.edge === "sdk:publish");
+    expect(edge?.verdict).toBe("stale");
+    expect(edge?.detail).toContain("tagPattern");
+  });
+
+  test("an unknown-read caller keeps the old warning-only behaviour", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: null,
+      taggedReleaseAgeHours: null,
+      taggedReleaseListRead: null,
       consumers: [],
     });
     expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");

--- a/scripts/structure-audit/_release-train-dep.test.ts
+++ b/scripts/structure-audit/_release-train-dep.test.ts
@@ -5,6 +5,7 @@ import {
   evaluatePackage,
   matchesBumpPr,
   parseNpmLatest,
+  parseReleaseList,
   resolvedFromBunLock,
   selectTaggedRelease,
   stripTrailingCommas,
@@ -187,7 +188,7 @@ describe("evaluatePackage", () => {
     npm: "@nimbus-dev/sdk",
     taggedRelease: { version: "1.6.0", publishedAt: "x" },
     taggedReleaseAgeHours: 48,
-    taggedReleaseListRead: true,
+    taggedReleaseListStatus: "read" as const,
     latest: { version: "1.6.0", publishedAt: "x" },
     latestAgeHours: 48,
     graceHours: 6,
@@ -302,7 +303,7 @@ describe("evaluatePackage", () => {
       ...green,
       taggedRelease: null,
       taggedReleaseAgeHours: null,
-      taggedReleaseListRead: false,
+      taggedReleaseListStatus: "indeterminate" as const,
       consumers: [],
     });
     expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");
@@ -321,7 +322,7 @@ describe("evaluatePackage", () => {
       ...green,
       taggedRelease: null,
       taggedReleaseAgeHours: null,
-      taggedReleaseListRead: true,
+      taggedReleaseListStatus: "read",
       consumers: [],
     });
     const edge = r.find((e) => e.edge === "sdk:publish");
@@ -329,14 +330,93 @@ describe("evaluatePackage", () => {
     expect(edge?.detail).toContain("tagPattern");
   });
 
+  /**
+   * The SECOND fail-open on the same shape, caught in review on #1445: a 404
+   * means the configured `repo` is gone, renamed, or misspelled. That edge can
+   * never go green on its own, so warning about it is a permanent silence — the
+   * same defect the tagPattern case had, one field over. `ConsumerReading`
+   * already treats an absent lockfile as `stale`; this matches it.
+   */
+  test("a 404 on the upstream repo => stale (manifest bug), not indeterminate", () => {
+    const r = evaluatePackage({
+      ...green,
+      taggedRelease: null,
+      taggedReleaseAgeHours: null,
+      taggedReleaseListStatus: "absent",
+      consumers: [],
+    });
+    const edge = r.find((e) => e.edge === "sdk:publish");
+    expect(edge?.verdict).toBe("stale");
+    expect(edge?.detail).toContain("404");
+  });
+
   test("an unknown-read caller keeps the old warning-only behaviour", () => {
     const r = evaluatePackage({
       ...green,
       taggedRelease: null,
       taggedReleaseAgeHours: null,
-      taggedReleaseListRead: null,
+      taggedReleaseListStatus: null,
       consumers: [],
     });
     expect(r.find((e) => e.edge === "sdk:publish")?.verdict).toBe("indeterminate");
+  });
+});
+
+describe("parseReleaseList", () => {
+  const page = (rows: unknown[]) => JSON.stringify([rows]);
+  const row = (over: Record<string, unknown> = {}) => ({
+    tag_name: "typescript-v1.32.0",
+    prerelease: false,
+    draft: false,
+    published_at: "2026-09-04T04:15:55Z",
+    assets: [{ name: "SHA256SUMS" }],
+    ...over,
+  });
+
+  test("flattens EVERY page, not just the first", () => {
+    // The whole point of --paginate: nimbus-sdk releases three SDKs from one
+    // repo, so the newest typescript-v* can sit behind a run of python/go tags.
+    const text = JSON.stringify([
+      [row({ tag_name: "python-v0.21.0" })],
+      [row({ tag_name: "typescript-v1.32.0" })],
+    ]);
+    const rels = parseReleaseList(text);
+    expect(rels?.map((r) => r.tag)).toEqual(["python-v0.21.0", "typescript-v1.32.0"]);
+  });
+
+  test("maps GitHub's field names and flattens asset names", () => {
+    expect(parseReleaseList(page([row()]))?.[0]).toEqual({
+      tag: "typescript-v1.32.0",
+      prerelease: false,
+      draft: false,
+      publishedAt: "2026-09-04T04:15:55Z",
+      assets: ["SHA256SUMS"],
+    });
+  });
+
+  test("a DRAFT's null published_at is kept, not treated as malformed", () => {
+    // Drafts legitimately have no publish date. Rejecting the row would let one
+    // draft invalidate the entire list; every consumer filters drafts first.
+    const rels = parseReleaseList(page([row({ draft: true, published_at: null })]));
+    expect(rels?.[0]?.publishedAt).toBe("");
+    expect(rels?.[0]?.draft).toBe(true);
+  });
+
+  test.each([
+    ["a non-string tag", row({ tag_name: 42 })],
+    ["a non-boolean draft", row({ draft: "no" })],
+    ["a non-array assets", row({ assets: "none" })],
+    ["an asset with no name", row({ assets: [{ label: "x" }] })],
+    ["a non-object row", "not-a-release"],
+  ])("returns null for %s — one bad row invalidates the list", (_label, bad) => {
+    // Deliberately all-or-nothing: a SKIPPED row is indistinguishable from a repo
+    // with no matching release, and that outcome is now a hard failure. Better to
+    // lose the check for one run than to red the build with a wrong reason.
+    expect(parseReleaseList(page([row(), bad]))).toBeNull();
+  });
+
+  test("returns null on malformed JSON and on a non-array body", () => {
+    expect(parseReleaseList("{not json")).toBeNull();
+    expect(parseReleaseList('{"message":"Not Found"}')).toBeNull();
   });
 });

--- a/scripts/structure-audit/_release-train-dep.ts
+++ b/scripts/structure-audit/_release-train-dep.ts
@@ -19,6 +19,78 @@ export interface NpmLatest {
 }
 
 /**
+ * How a repo's release LIST read turned out, independent of what the tag pattern
+ * then matched in it.
+ *
+ * `absent` is a REAL FINDING — a 404 means the configured `repo` does not exist
+ * (deleted, renamed, or a typo in `release-train.json`), and an edge pointed at a
+ * repo that is not there can never go green on its own. `indeterminate` is the
+ * transient bucket: rate limit, network, auth, unparseable body. Collapsing the
+ * two would fail open on the misconfiguration exactly the way a bare `null` used
+ * to — see `parseReleaseList` and `evaluatePublishEdge`.
+ */
+export type ReleaseListStatus = "read" | "absent" | "indeterminate";
+
+/** One raw GitHub release row -> `ReleaseInfo`, or null if any field is the wrong shape. */
+function toReleaseInfo(raw: unknown): ReleaseInfo | null {
+  if (!isRecord(raw)) return null;
+  const tag = raw["tag_name"];
+  const prerelease = raw["prerelease"];
+  const draft = raw["draft"];
+  const publishedAt = raw["published_at"];
+  const assets = raw["assets"];
+  if (typeof tag !== "string") return null;
+  if (typeof prerelease !== "boolean" || typeof draft !== "boolean") return null;
+  // A DRAFT carries `published_at: null` — legitimately, since it was never
+  // published. Rejecting the row would let one draft invalidate the whole list;
+  // "" is safe because every consumer filters drafts before reading the date.
+  if (publishedAt !== null && typeof publishedAt !== "string") return null;
+  if (!Array.isArray(assets)) return null;
+  const names: string[] = [];
+  for (const a of assets) {
+    if (!isRecord(a) || typeof a["name"] !== "string") return null;
+    names.push(a["name"]);
+  }
+  return { tag, prerelease, draft, assets: names, publishedAt: publishedAt ?? "" };
+}
+
+/**
+ * Every release across every page, from `gh api --paginate --slurp` output — an
+ * array of PAGES, each an array of raw release objects.
+ *
+ * Returns `null` if anything is malformed, and deliberately does so for a SINGLE
+ * bad row rather than skipping it. A skipped row is indistinguishable from a repo
+ * that genuinely has no matching release, and that outcome is now a hard failure
+ * (`evaluatePublishEdge`) — so a lenient parser would let one unexpected payload
+ * red the build with a wrong reason. Losing the check for a run is the cheaper
+ * error than asserting a manifest bug that is not there.
+ *
+ * Reading EVERY page matters for the same reason: `nimbus-sdk` releases three
+ * SDKs from one repo and sat at 97 releases when this was written, so a single
+ * `per_page=100` page was three releases away from being able to miss the newest
+ * `typescript-v*` behind a run of `python-v*` and `sdks/go/v*` tags.
+ */
+export function parseReleaseList(text: string): ReleaseInfo[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const out: ReleaseInfo[] = [];
+  for (const page of parsed) {
+    if (!Array.isArray(page)) return null;
+    for (const raw of page) {
+      const rel = toReleaseInfo(raw);
+      if (rel === null) return null;
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+/**
  * `dist-tags.latest` + its publish timestamp from a FULL npm registry document.
  * The `/<pkg>/latest` endpoint is not usable here: it omits `time`, and the
  * grace rule is measured from the version's own publish time.
@@ -213,20 +285,20 @@ export interface PackageEvalInput {
   taggedRelease: PublishedRelease | null;
   taggedReleaseAgeHours: number | null;
   /**
-   * Whether the upstream repo's release LIST was read successfully, independent
-   * of whether `tagPattern` then matched anything in it.
+   * How the upstream repo's release LIST read went, independent of whether
+   * `tagPattern` then matched anything in it.
    *
-   * The two collapse into `taggedRelease === null` otherwise, and they are not
-   * the same finding: an unreadable list is transient, while a readable list
-   * that nothing matched is a manifest bug in `release-train.json`. Conflating
-   * them is what let the sdk train ship a `tagPattern` (`^sdk-v(...)$`) that
-   * never matched a real tag — the repo tags TypeScript releases `typescript-v*`
-   * — while the edge reported a mere warning for as long as it was broken.
+   * All three outcomes collapse into `taggedRelease === null` otherwise, and
+   * they are not the same finding. A readable list that nothing matched is a
+   * manifest bug — that is what let the sdk train ship `^sdk-v(...)$` against a
+   * repo tagging `typescript-v*` while the edge reported a mere warning for as
+   * long as it was broken. A 404 is a DIFFERENT manifest bug: the configured
+   * `repo` does not exist. Only a transient failure deserves a warning.
    *
-   * `null` for a caller that cannot distinguish the two; that keeps the old
+   * `null` for a caller that cannot distinguish them; that keeps the old
    * warning-only behaviour rather than manufacturing a failure.
    */
-  taggedReleaseListRead: boolean | null;
+  taggedReleaseListStatus: ReleaseListStatus | null;
   latest: NpmLatest | null;
   latestAgeHours: number | null;
   consumers: ConsumerReading[];
@@ -242,19 +314,28 @@ function shortRepo(repo: string): string {
 function evaluatePublishEdge(i: PackageEvalInput): EdgeResult {
   const edge = `${i.name}:publish`;
   if (i.taggedRelease === null) {
-    // A readable list that matched nothing is a manifest bug, not a transient
-    // read failure, and must fail rather than warn — see `taggedReleaseListRead`.
-    return i.taggedReleaseListRead === true
-      ? {
-          edge,
-          verdict: "stale",
-          detail: `manifest error: no release in the upstream repo matches this train's tagPattern for ${i.npm} — the pattern names a component that does not tag under that prefix, so this edge has never been evaluated. Derive it from \`gh release list\`, not from the package name`,
-        }
-      : {
-          edge,
-          verdict: "indeterminate",
-          detail: `no release tag matched for ${i.npm} — releases unreadable`,
-        };
+    // Two of the three outcomes are manifest bugs and must FAIL, not warn — a
+    // config error never fixes itself, so a warning here is a permanent silence.
+    // Only a transient read failure is worth a warning. See `taggedReleaseListStatus`.
+    if (i.taggedReleaseListStatus === "absent") {
+      return {
+        edge,
+        verdict: "stale",
+        detail: `manifest error: the repo configured for ${i.npm} returned 404 — it is deleted, renamed, or misspelled in release-train.json, so this edge can never go green`,
+      };
+    }
+    if (i.taggedReleaseListStatus === "read") {
+      return {
+        edge,
+        verdict: "stale",
+        detail: `manifest error: no release in the upstream repo matches this train's tagPattern for ${i.npm} — the pattern names a component that does not tag under that prefix, so this edge has never been evaluated. Derive it from \`gh release list\`, not from the package name`,
+      };
+    }
+    return {
+      edge,
+      verdict: "indeterminate",
+      detail: `no release tag matched for ${i.npm} — releases unreadable`,
+    };
   }
   if (i.latest === null) {
     return { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` };

--- a/scripts/structure-audit/_release-train-dep.ts
+++ b/scripts/structure-audit/_release-train-dep.ts
@@ -45,8 +45,20 @@ export function parseNpmLatest(doc: string): NpmLatest | null {
 /**
  * Highest stable release whose tag matches `pattern`, which MUST carry one
  * capture group holding the bare version. Upstream tags are component-prefixed
- * (`sdk-v1.6.0`), which Phase 1's `selectPublished` deliberately rejects — so
- * dep edges need their own selector rather than reusing it.
+ * (`typescript-v1.32.0`, `client-v0.17.3`), which Phase 1's `selectPublished`
+ * deliberately rejects — so dep edges need their own selector rather than
+ * reusing it.
+ *
+ * The prefix is the RELEASING COMPONENT's name, not the npm package's: the
+ * `@nimbus-dev/sdk` train releases out of the polyglot `nimbus-sdk` repo, whose
+ * TypeScript tags read `typescript-v*` (its Go and Python SDKs tag their own).
+ * `release-train.json` carried `^sdk-v(...)$` for that train from the start and
+ * so never matched a real tag — and because an unmatched pattern yields
+ * `indeterminate`, which `decideExit` downgrades to a warning, the sdk publish
+ * edge reported no failure for as long as it was broken. Every fixture in this
+ * module's tests supplies BOTH the pattern and the tags, so they agreed with
+ * each other and never with the repo. Derive a pattern from `gh release list`,
+ * not from the package name.
  */
 export function selectTaggedRelease(
   releases: readonly ReleaseInfo[],
@@ -200,6 +212,21 @@ export interface PackageEvalInput {
   npm: string;
   taggedRelease: PublishedRelease | null;
   taggedReleaseAgeHours: number | null;
+  /**
+   * Whether the upstream repo's release LIST was read successfully, independent
+   * of whether `tagPattern` then matched anything in it.
+   *
+   * The two collapse into `taggedRelease === null` otherwise, and they are not
+   * the same finding: an unreadable list is transient, while a readable list
+   * that nothing matched is a manifest bug in `release-train.json`. Conflating
+   * them is what let the sdk train ship a `tagPattern` (`^sdk-v(...)$`) that
+   * never matched a real tag — the repo tags TypeScript releases `typescript-v*`
+   * — while the edge reported a mere warning for as long as it was broken.
+   *
+   * `null` for a caller that cannot distinguish the two; that keeps the old
+   * warning-only behaviour rather than manufacturing a failure.
+   */
+  taggedReleaseListRead: boolean | null;
   latest: NpmLatest | null;
   latestAgeHours: number | null;
   consumers: ConsumerReading[];
@@ -215,11 +242,19 @@ function shortRepo(repo: string): string {
 function evaluatePublishEdge(i: PackageEvalInput): EdgeResult {
   const edge = `${i.name}:publish`;
   if (i.taggedRelease === null) {
-    return {
-      edge,
-      verdict: "indeterminate",
-      detail: `no release tag matched for ${i.npm} — releases unreadable or none published`,
-    };
+    // A readable list that matched nothing is a manifest bug, not a transient
+    // read failure, and must fail rather than warn — see `taggedReleaseListRead`.
+    return i.taggedReleaseListRead === true
+      ? {
+          edge,
+          verdict: "stale",
+          detail: `manifest error: no release in the upstream repo matches this train's tagPattern for ${i.npm} — the pattern names a component that does not tag under that prefix, so this edge has never been evaluated. Derive it from \`gh release list\`, not from the package name`,
+        }
+      : {
+          edge,
+          verdict: "indeterminate",
+          detail: `no release tag matched for ${i.npm} — releases unreadable`,
+        };
   }
   if (i.latest === null) {
     return { edge, verdict: "indeterminate", detail: `npm registry unreadable for ${i.npm}` };

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -26,6 +26,8 @@ import {
   type NpmLatest,
   type PrRef,
   parseNpmLatest,
+  parseReleaseList,
+  type ReleaseListStatus,
   resolvedFromBunLock,
   selectTaggedRelease,
 } from "./_release-train-dep.ts";
@@ -392,19 +394,16 @@ function readIntended(train: TrainSpec): { intended: string; intendedBumpAgeHour
   return { intended, intendedBumpAgeHours };
 }
 
-/** The published head: the latest stable Release that actually carries assets. */
+/**
+ * The published head: the latest stable Release that actually carries assets.
+ *
+ * Shares `readReleaseList` with the package edges. It previously ran its own
+ * single-page read with a bare `JSON.parse` OUTSIDE a try — a malformed body
+ * would have thrown out of the gate rather than degrading to null.
+ */
 function readPublished(train: TrainSpec): PublishedRelease | null {
-  const relRes = runGh([
-    "gh",
-    "api",
-    `repos/${train.source.manifestRepo}/releases?per_page=100`,
-    "--jq",
-    "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
-  ]);
-  if (!relRes.ok) return null;
-  const rels: unknown = JSON.parse(relRes.stdout);
-  if (!Array.isArray(rels)) return null;
-  return selectPublished(rels as ReleaseInfo[], train.source.releaseAsset);
+  const { releases } = readReleaseList(train.source.manifestRepo);
+  return releases === null ? null : selectPublished(releases, train.source.releaseAsset);
 }
 
 /**
@@ -427,33 +426,50 @@ async function readNpmLatest(pkg: string): Promise<NpmLatest | null> {
 }
 
 /**
+ * EVERY release in `repo`, with how the read went.
+ *
+ * The single release-list reader for this gate — both the train's published head
+ * and each package's tagged release come through here, so neither can drift into
+ * reading one page or trusting an unvalidated cast while the other does not.
+ *
+ * `--paginate` because a repo that releases several components from one tree
+ * (`nimbus-sdk`: `typescript-v*`, `python-v*`, `sdks/go/v*`) can push the newest
+ * tag of one component off a single page. `--slurp` instead of the old `--jq`
+ * reshape because the two are mutually exclusive in `gh`, and doing the shaping
+ * in TypeScript is what lets `parseReleaseList` VALIDATE rather than cast.
+ */
+function readReleaseList(repo: string): {
+  releases: ReleaseInfo[] | null;
+  status: ReleaseListStatus;
+} {
+  const res = runGh(["gh", "api", "--paginate", "--slurp", `repos/${repo}/releases?per_page=100`]);
+  // A 404 is `absent` -- the repo is gone or misnamed, a real finding -- while
+  // anything else is transient. `classifyReadFailure` is the one place that call
+  // is made across this audit family.
+  if (!res.ok) return { releases: null, status: classifyReadFailure(res.httpStatus) };
+  const releases = parseReleaseList(res.stdout);
+  return releases === null
+    ? { releases: null, status: "indeterminate" }
+    : { releases, status: "read" };
+}
+
+/**
  * The upstream repo's highest release whose tag matches the package pattern.
  *
- * `listRead` reports whether the release list itself came back and parsed, which
- * the caller needs to tell a transient read failure from a `tagPattern` that
- * matched nothing in a perfectly good list — the latter is a manifest bug. Both
- * used to surface as a bare `null`, and the sdk train sat on an unmatchable
- * pattern for the life of the gate as a result.
+ * `status` is what lets the caller tell a transient read failure from a repo that
+ * is not there from a `tagPattern` that matched nothing in a perfectly good list.
+ * The last two are manifest bugs; all three used to surface as a bare `null`, and
+ * the sdk train sat on an unmatchable pattern for the life of the gate as a result.
  */
 function readTaggedRelease(pkg: PackageSpec): {
   release: PublishedRelease | null;
-  listRead: boolean;
+  status: ReleaseListStatus;
 } {
-  const res = runGh([
-    "gh",
-    "api",
-    `repos/${pkg.repo}/releases?per_page=100`,
-    "--jq",
-    "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
-  ]);
-  if (!res.ok) return { release: null, listRead: false };
-  try {
-    const rels: unknown = JSON.parse(res.stdout);
-    if (!Array.isArray(rels)) return { release: null, listRead: false };
-    return { release: selectTaggedRelease(rels as ReleaseInfo[], pkg.tagPattern), listRead: true };
-  } catch {
-    return { release: null, listRead: false };
-  }
+  const { releases, status } = readReleaseList(pkg.repo);
+  return {
+    release: releases === null ? null : selectTaggedRelease(releases, pkg.tagPattern),
+    status,
+  };
 }
 
 /**
@@ -568,7 +584,7 @@ if (import.meta.main) {
         taggedReleaseAgeHours: taggedRelease.release
           ? ageHours(taggedRelease.release.publishedAt)
           : null,
-        taggedReleaseListRead: taggedRelease.listRead,
+        taggedReleaseListStatus: taggedRelease.status,
         latest,
         latestAgeHours: latest ? ageHours(latest.publishedAt) : null,
         consumers,

--- a/scripts/structure-audit/check-release-staleness.ts
+++ b/scripts/structure-audit/check-release-staleness.ts
@@ -426,8 +426,19 @@ async function readNpmLatest(pkg: string): Promise<NpmLatest | null> {
   }
 }
 
-/** The upstream repo's highest release whose tag matches the package pattern. */
-function readTaggedRelease(pkg: PackageSpec): PublishedRelease | null {
+/**
+ * The upstream repo's highest release whose tag matches the package pattern.
+ *
+ * `listRead` reports whether the release list itself came back and parsed, which
+ * the caller needs to tell a transient read failure from a `tagPattern` that
+ * matched nothing in a perfectly good list — the latter is a manifest bug. Both
+ * used to surface as a bare `null`, and the sdk train sat on an unmatchable
+ * pattern for the life of the gate as a result.
+ */
+function readTaggedRelease(pkg: PackageSpec): {
+  release: PublishedRelease | null;
+  listRead: boolean;
+} {
   const res = runGh([
     "gh",
     "api",
@@ -435,13 +446,13 @@ function readTaggedRelease(pkg: PackageSpec): PublishedRelease | null {
     "--jq",
     "[.[] | {tag: .tag_name, prerelease: .prerelease, draft: .draft, publishedAt: .published_at, assets: [.assets[].name]}]",
   ]);
-  if (!res.ok) return null;
+  if (!res.ok) return { release: null, listRead: false };
   try {
     const rels: unknown = JSON.parse(res.stdout);
-    if (!Array.isArray(rels)) return null;
-    return selectTaggedRelease(rels as ReleaseInfo[], pkg.tagPattern);
+    if (!Array.isArray(rels)) return { release: null, listRead: false };
+    return { release: selectTaggedRelease(rels as ReleaseInfo[], pkg.tagPattern), listRead: true };
   } catch {
-    return null;
+    return { release: null, listRead: false };
   }
 }
 
@@ -553,8 +564,11 @@ if (import.meta.main) {
       ...evaluatePackage({
         name: pkg.name,
         npm: pkg.npm,
-        taggedRelease,
-        taggedReleaseAgeHours: taggedRelease ? ageHours(taggedRelease.publishedAt) : null,
+        taggedRelease: taggedRelease.release,
+        taggedReleaseAgeHours: taggedRelease.release
+          ? ageHours(taggedRelease.release.publishedAt)
+          : null,
+        taggedReleaseListRead: taggedRelease.listRead,
         latest,
         latestAgeHours: latest ? ageHours(latest.publishedAt) : null,
         consumers,


### PR DESCRIPTION
`Release channel drift` has failed daily since 2026-09-01. Fixing the three edges it reported surfaced a second defect that had never been reported at all — because it could not be.

## 1. The sdk publish edge has never worked

`.github/release-train.json` gave the sdk train:

```
"tagPattern": "^sdk-v(\d+\.\d+\.\d+)$"
```

But `nimbus-sdk` is a polyglot repo and tags its TypeScript releases **`typescript-v1.32.0`** — Go and Python tag their own. No release has ever matched, so `selectTaggedRelease` returned `null` and `sdk:publish`, the phantom-release detector for the SDK, has been inert for the life of the gate.

The prefix is the **releasing component's** name, not the npm package's. The `client` train's `^client-v(...)$` is correct and was unaffected.

## 2. It was inert silently, which is the part worth fixing

`readTaggedRelease` returned a bare `null` for three different situations:

- the `gh` call failed
- the JSON was unparseable
- **the pattern matched nothing in a perfectly readable list**

The third is a manifest bug. The other two are transient. Collapsed into one `null` they all became `indeterminate`, which `decideExit` renders as a `::warning::` and exits 0 on. So the gate reported no failure for as long as it was broken, and the only reason it surfaced now was someone reading tag names by hand.

The module already draws exactly this distinction one type over — `ConsumerReading.status` has a `not-a-dependency` arm documented as *"a MANIFEST bug"*. This mirrors it: `readTaggedRelease` now reports `listRead` alongside the release, and a readable list that matched nothing is `stale`, not `indeterminate`. A caller that genuinely cannot tell passes `null` and keeps the old warning-only behaviour.

### Why the tests did not catch it

Every fixture in `_release-train-dep.test.ts` supplies **both** the pattern and the tags:

```ts
const P = "^sdk-v(\d+\.\d+\.\d+)$";
// ... { tag: "sdk-v1.6.0" }
```

So both sides agreed with each other and neither agreed with the repo. A fake cannot catch a contract mismatch when it defines both ends of the contract. The doc comment on `selectTaggedRelease` cited `sdk-v1.6.0` as its example too, which made the wrong prefix look load-bearing.

## 3. The dependency bump

`@nimbus-dev/sdk` 1.31.0 to **1.32.0** — nimbus-sdk#265, additive.

Both `packages/gateway` and `packages/cli` were bumped, and both were necessary: `resolvedFromBunLock` takes the **minimum** across the hoisted entry and every workspace-scoped copy, so bumping gateway alone merely moved gateway to a nested 1.32.0 while cli's `^1.19.0` kept the hoisted copy at 1.31.0 — leaving the edge stale. A partial bump would have looked done and changed nothing.

Note that `bun update @nimbus-dev/sdk` is the wrong tool at the root of a workspace repo: it adds the package to the **root** `package.json` as a new direct dependency rather than bumping the workspace that declares it. The ranges are edited in the workspace manifests instead.

Sibling PRs for the other three edges: nimbus-agent/nimbus-vscode#124 and nimbus-agent/nimbus-client#83.

## Verification

Proved with the gate's own output rather than by inspection — running `bun scripts/structure-audit/check-release-staleness.ts` on this branch, `sdk:publish` no longer reports a manifest error, so the pattern now resolves `typescript-v1.32.0`.

- New `stale` arm **red-proved** by reverting `evaluatePublishEdge` to its old unconditional `indeterminate`: exactly one test fails, and it is the new one.
- `bun run preflight:fast` — **33 gates green**
- `bun test packages/gateway` — 16,391 pass, 42 skip, 0 fail
- `bun test packages/cli/src` — 2,614 pass, 0 fail
- `bun test scripts` — 1,701 pass, 27 skip, 0 fail

One local red herring worth recording: `bun run typecheck` failed on `packages/cli/src/mcp/adapter.ts` with a zod type mismatch that reproduced even on stashed-main, while CI was green on all three OSes. It was stale `node_modules` left by the update-and-revert churn, cleared by `bun install --force` — not a real error, and not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xDbS7PwHNDzLxDkaaH8o4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the CLI and gateway packages to use SDK version 1.32.0.
  * Updated SDK release tag recognition to follow the current TypeScript release format.

* **Bug Fixes**
  * Improved release-staleness checks by distinguishing unavailable release information from a readable release list with no matching release.
  * Reports now provide clearer status details when a package manifest is outdated.

* **Tests**
  * Added coverage for release-list read failures, missing matching releases, and warning-only scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->