### PR TITLE
perf(filesystem): index only what changed since the last sync tick

### DIFF
--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -1578,6 +1578,60 @@ describe("code index re-runs only what changed", () => {
     expect(blameWrites).toBe(0);
   });
 
+  test("an unchanged HEAD does not re-upsert the commit list", async () => {
+    /**
+     * `syncFilesystemGitCommits` recorded `nextTips["git:<root>"]` on every run and never read
+     * it back, so the cursor field meant to prevent this was inert and the last 40 commits were
+     * re-upserted on every tick regardless of whether HEAD had moved. Found by benchmarking the
+     * mtime gate above against a real repo: the code index correctly skipped all 120 files while
+     * the run still reported 40 upserts.
+     */
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-tips-"));
+    const git = async (...args: string[]): Promise<number> => {
+      const proc = Bun.spawn(["git", "-C", dir, ...args], {
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } as Record<string, string>,
+        stdout: "pipe",
+        stderr: "pipe",
+        windowsHide: true,
+      });
+      return await proc.exited;
+    };
+    await git("init", "-q", "-b", "main");
+    await git("config", "user.email", "test@example.com");
+    await git("config", "user.name", "Test");
+    writeFileSync(join(dir, "f.txt"), "one\n");
+    await git("add", "f.txt");
+    await git("commit", "-q", "-m", "first");
+
+    const sync = createFilesystemV2Syncable({
+      roots: [
+        {
+          path: dir,
+          gitAware: true,
+          codeIndex: false,
+          dependencyGraph: false,
+          mediaIndex: false,
+          exclude: [],
+        },
+      ],
+    });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    expect(first.itemsUpserted).toBe(1);
+
+    const second = await sync.sync(ctx, first.cursor);
+    expect(second.itemsUpserted).toBe(0);
+
+    writeFileSync(join(dir, "f.txt"), "two\n");
+    await git("add", "f.txt");
+    await git("commit", "-q", "-m", "second");
+
+    const third = await sync.sync(ctx, second.cursor);
+    expect(third.itemsUpserted).toBe(2);
+  });
+
   test("a cursor from before this gate is accepted and re-indexes once", async () => {
     // Forward compatibility with a cursor written by an older gateway: it carries `tips` but no
     // `codeMtimes`, and must read as "nothing known yet" rather than throwing or skipping.

--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { BlameRow } from "../security/blame-store.ts";
 import {
   createMemoryIndexDb,
   EMPTY_NIMBUS_VAULT,
@@ -17,7 +18,7 @@ import {
   gitLogRecords,
   mergeRanges,
 } from "./filesystem-v2-sync.ts";
-import { encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
+import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-json-cursor.ts";
 
 // A minimal Bun.spawn stand-in for the blame helper. Only the fields gitBlameLinePorcelain
 // reads (`exited`, `stdout`) are populated; cast through unknown (no `any`).
@@ -1398,5 +1399,195 @@ describe("windows console hygiene", () => {
     await gitLogRecords("/r", 10, spawn);
     expect(seen).toHaveLength(1);
     expect(seen[0]?.["windowsHide"]).toBe(true);
+  });
+});
+
+// ── code-symbol mtime gate ───────────────────────────────────────────────────
+
+describe("code index re-runs only what changed", () => {
+  /**
+   * Before this gate, `syncFilesystemCodeSymbolsForRoot` ran unconditionally on EVERY tick:
+   * it walked up to 120 code files, re-read each, re-upserted byte-identical symbol rows and
+   * spawned one `git blame` per file. Measured against a real 7.10.1 daemon on an idle repo,
+   * a steady-state tick still made at least 47 git spawns with nothing changed on disk.
+   */
+  function codeRoot(
+    dir: string,
+  ): Parameters<typeof createFilesystemV2Syncable>[0]["roots"][number] {
+    return {
+      path: dir,
+      gitAware: false,
+      codeIndex: true,
+      dependencyGraph: false,
+      mediaIndex: false,
+      exclude: [],
+    };
+  }
+
+  function makeRoot(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    writeFileSync(join(dir, "a.ts"), "export function alpha() {}\nexport const A = 1;\n");
+    writeFileSync(join(dir, "b.ts"), "export class Beta {}\n");
+    return dir;
+  }
+
+  test("a second run over untouched files indexes nothing", async () => {
+    const dir = makeRoot("nimbus-fsv2-mtime-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    expect(first.itemsUpserted).toBeGreaterThan(0);
+
+    const second = await sync.sync(ctx, first.cursor);
+    expect(second.itemsUpserted).toBe(0);
+  });
+
+  test("the items indexed by the first run survive a skipped second run", async () => {
+    // Skipping must not be mistaken for pruning: the rows stay, they are simply not rewritten.
+    const dir = makeRoot("nimbus-fsv2-mtime-keep-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    const countAfterFirst = (
+      db
+        .query(
+          `SELECT COUNT(*) AS c FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`,
+        )
+        .get() as { c: number }
+    ).c;
+    await sync.sync(ctx, first.cursor);
+    const countAfterSecond = (
+      db
+        .query(
+          `SELECT COUNT(*) AS c FROM item WHERE service = 'filesystem' AND type = 'code_symbol'`,
+        )
+        .get() as { c: number }
+    ).c;
+
+    expect(countAfterFirst).toBeGreaterThan(0);
+    expect(countAfterSecond).toBe(countAfterFirst);
+  });
+
+  test("touching one file re-indexes that file only", async () => {
+    const dir = makeRoot("nimbus-fsv2-mtime-touch-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    // b.ts declares exactly one exported symbol, so the re-index count is unambiguous.
+    writeFileSync(join(dir, "b.ts"), "export class Beta {}\nexport const extra = 2;\n");
+
+    const second = await sync.sync(ctx, first.cursor);
+    expect(second.itemsUpserted).toBe(2);
+    expect(first.itemsUpserted).toBeGreaterThan(2);
+  });
+
+  test("a file added after the first run is picked up", async () => {
+    const dir = makeRoot("nimbus-fsv2-mtime-add-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    writeFileSync(join(dir, "c.ts"), "export function gamma() {}\n");
+
+    const second = await sync.sync(ctx, first.cursor);
+    expect(second.itemsUpserted).toBe(1);
+  });
+
+  test("a null cursor re-indexes everything — the `--full` escape hatch", async () => {
+    // `nimbus connector sync filesystem --full` clears the cursor server-side
+    // (`clearConnectorSyncCursor`), which is the documented way to force a rebuild.
+    const dir = makeRoot("nimbus-fsv2-mtime-full-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    const forced = await sync.sync(ctx, null);
+    expect(forced.itemsUpserted).toBe(first.itemsUpserted);
+  });
+
+  test("a deleted file drops out of the cursor rather than accumulating", async () => {
+    const dir = makeRoot("nimbus-fsv2-mtime-del-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    // The cursor is base64 JSON, so assert on the DECODED payload — a `toContain` against the
+    // encoded string passes or fails for reasons unrelated to what is in the map.
+    const filesIn = (cursor: string | null): string[] => {
+      const payload = decodeNimbusJsonCursorPayload(cursor ?? "", "nimbus-fsv2:") as {
+        codeMtimes?: Record<string, Record<string, number>>;
+      } | null;
+      return Object.values(payload?.codeMtimes ?? {}).flatMap((m) => Object.keys(m));
+    };
+
+    const first = await sync.sync(ctx, null);
+    expect(filesIn(first.cursor).sort()).toEqual(["a.ts", "b.ts"]);
+    rmSync(join(dir, "b.ts"));
+
+    const second = await sync.sync(ctx, first.cursor);
+    expect(filesIn(second.cursor)).toEqual(["a.ts"]);
+  });
+
+  test("an unchanged run does no blame work at all", async () => {
+    // The directly-relevant assertion. `itemsUpserted === 0` is indirect evidence; this counts
+    // the blame writes, which is what the `git blame` subprocess per file was there to produce.
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-mtime-blame-"));
+    const git = async (...args: string[]): Promise<number> => {
+      const proc = Bun.spawn(["git", "-C", dir, ...args], {
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } as Record<string, string>,
+        stdout: "pipe",
+        stderr: "pipe",
+        windowsHide: true,
+      });
+      return await proc.exited;
+    };
+    await git("init", "-q", "-b", "main");
+    await git("config", "user.email", "test@example.com");
+    await git("config", "user.name", "Test");
+    writeFileSync(join(dir, "a.ts"), "export function alpha() {}\n");
+    await git("add", "a.ts");
+    await git("commit", "-q", "-m", "add a");
+
+    const sync = createFilesystemV2Syncable({
+      roots: [{ ...codeRoot(dir), gitAware: true }],
+    });
+    const db = createMemoryIndexDb();
+    const base = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+    let blameWrites = 0;
+    const ctx = {
+      ...base,
+      upsertBlameLines: (root: string, file: string, rows: readonly BlameRow[]): void => {
+        blameWrites += 1;
+        base.upsertBlameLines(root, file, rows);
+      },
+    };
+
+    const first = await sync.sync(ctx, null);
+    expect(blameWrites).toBeGreaterThan(0); // positive control: the blame path really ran
+
+    blameWrites = 0;
+    await sync.sync(ctx, first.cursor);
+    expect(blameWrites).toBe(0);
+  });
+
+  test("a cursor from before this gate is accepted and re-indexes once", async () => {
+    // Forward compatibility with a cursor written by an older gateway: it carries `tips` but no
+    // `codeMtimes`, and must read as "nothing known yet" rather than throwing or skipping.
+    const dir = makeRoot("nimbus-fsv2-mtime-legacy-");
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const legacy = encodeNimbusJsonCursor("nimbus-fsv2:", { tips: {} });
+    const run = await sync.sync(ctx, legacy);
+    expect(run.itemsUpserted).toBeGreaterThan(0);
   });
 });

--- a/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { BlameRow } from "../security/blame-store.ts";
@@ -1630,6 +1630,54 @@ describe("code index re-runs only what changed", () => {
 
     const third = await sync.sync(ctx, second.cursor);
     expect(third.itemsUpserted).toBe(2);
+  });
+
+  test("a file that fails to read is retried on the next run, not locked out", async () => {
+    /**
+     * The mtime must be recorded only for a file that was actually indexed. Recording it before
+     * the read means a transient failure — a permission change, a temporary IO error — marks the
+     * file as done: the next run sees an unchanged mtime, skips it, and its symbols never enter
+     * the index until someone modifies the file. Silent, and indistinguishable from "this file
+     * has no exported symbols".
+     *
+     * SELF-VALIDATING: if the chmod does not actually block the read (running as root, or a
+     * filesystem that ignores mode bits) the test skips rather than passing vacuously — a test
+     * that cannot observe the failure it is about proves nothing.
+     */
+    const dir = mkdtempSync(join(tmpdir(), "nimbus-fsv2-mtime-unreadable-"));
+    writeFileSync(join(dir, "readable.ts"), "export const ok = 1;\n");
+    const blocked = join(dir, "blocked.ts");
+    writeFileSync(blocked, "export const hidden = 2;\n");
+
+    let readIsBlocked = false;
+    try {
+      chmodSync(blocked, 0o000);
+      readFileSync(blocked, "utf8");
+    } catch {
+      readIsBlocked = true;
+    }
+    if (!readIsBlocked) {
+      chmodSync(blocked, 0o644);
+      return; // cannot simulate the failure here; the assertion below would be meaningless
+    }
+
+    const sync = createFilesystemV2Syncable({ roots: [codeRoot(dir)] });
+    const db = createMemoryIndexDb();
+    const ctx = syncTestContext(db, EMPTY_NIMBUS_VAULT, "filesystem");
+
+    const first = await sync.sync(ctx, null);
+    // The unreadable file must NOT be in the cursor: nothing was indexed for it.
+    const payload = decodeNimbusJsonCursorPayload(first.cursor ?? "", "nimbus-fsv2:") as {
+      codeMtimes?: Record<string, Record<string, number>>;
+    } | null;
+    const recorded = Object.values(payload?.codeMtimes ?? {}).flatMap((m) => Object.keys(m));
+    expect(recorded).toContain("readable.ts");
+    expect(recorded).not.toContain("blocked.ts");
+
+    // Once readable again, the next run picks it up rather than skipping it forever.
+    chmodSync(blocked, 0o644);
+    const second = await sync.sync(ctx, first.cursor);
+    expect(second.itemsUpserted).toBe(1);
   });
 
   test("a cursor from before this gate is accepted and re-indexes once", async () => {

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -396,6 +396,12 @@ async function blameIndexedExcerptRanges(
  * subprocess. A `stat` failure falls back to `now`, which never matches a recorded mtime — the
  * fail-open direction, re-indexing rather than silently skipping.
  *
+ * An entry is recorded ONLY for a file this run actually indexed, or one it skipped because it
+ * was already indexed at that mtime. A file that fails to READ records nothing, so the next run
+ * retries it. Recording before the read is the tempting shape and it is wrong: a transient
+ * permission or IO error would mark the file as done and leave its symbols out of the index
+ * until someone edited it, which is silent and looks exactly like a file with no exports.
+ *
  * Returns the mtimes to record. Rebuilt from the files actually walked, never merged into the
  * previous map, so a deleted or newly-excluded file drops out on its own and the cursor stays
  * bounded by the same 120-file cap as the walk.
@@ -423,12 +429,18 @@ async function syncFilesystemCodeSymbolsForRoot(
   for (const fp of files) {
     const relNorm = relative(root, fp).replaceAll("\\", "/");
     const mtime = fileMtimeOrFallback(fp, now);
-    mtimes[relNorm] = mtime;
     if (prevMtimes[relNorm] === mtime) {
+      // Already indexed at this mtime. Carry the entry forward — dropping it would re-index the
+      // file next run and defeat the gate.
+      mtimes[relNorm] = mtime;
       continue;
     }
     const src = readFileTextOrUndefined(fp);
     if (src === undefined) {
+      // Deliberately records NOTHING. A transient read failure — a permission change, a passing
+      // IO error — must not mark the file as done: an entry here would make the next run see an
+      // unchanged mtime, skip the file, and leave its symbols out of the index until someone
+      // edits it. Silent, and indistinguishable from a file with no exported symbols.
       continue;
     }
     bytes += src.length;
@@ -445,6 +457,9 @@ async function syncFilesystemCodeSymbolsForRoot(
     if (gitAware && fileResult.blameRanges.length > 0) {
       await blameIndexedExcerptRanges(ctx, root, relNorm, fileResult.blameRanges);
     }
+    // Recorded only here, once the file has actually been read and indexed — the single point
+    // that makes "this mtime is in the map" mean "this content is in the index".
+    mtimes[relNorm] = mtime;
   }
   return { upserted, bytes, mtimes };
 }

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -212,17 +212,36 @@ function parsePackageJsonDeps(path: string): { name: string; version: string; ki
   return out;
 }
 
+/**
+ * Indexes the root's recent commits, skipping the whole list when HEAD has not moved.
+ *
+ * `nextTips` was RECORDED on every run and never READ back, so the cursor field that exists to
+ * prevent this was inert and all 40 commits were re-upserted every tick whether or not anything
+ * had been committed. Found by benchmarking the code-symbol gate against a real repo: that gate
+ * correctly skipped all 120 files while the run still reported 40 upserts, all of them here.
+ *
+ * The `git log` itself still runs — it is one cheap subprocess, and it is also how HEAD is
+ * learned. What it no longer does is rewrite 40 byte-identical rows behind it.
+ */
 async function syncFilesystemGitCommits(
   ctx: SyncContext,
   root: string,
   rk: string,
   now: number,
   nextTips: Record<string, string>,
+  prevTip: string | undefined,
 ): Promise<{ upserted: number; bytes: number }> {
   if (!isGitRepo(root)) {
     return { upserted: 0, bytes: 0 };
   }
   const commits = await gitLogRecords(root, 40);
+  const head = commits[0]?.sha;
+  if (head !== undefined && head === prevTip) {
+    // HEAD is where we left it, so the 40 rows below would be byte-identical. Keep the tip so
+    // the next run compares against the same value.
+    nextTips[`git:${root}`] = head;
+    return { upserted: 0, bytes: 0 };
+  }
   let upserted = 0;
   const bytes = commits.length * 80;
   for (const c of commits) {
@@ -866,7 +885,14 @@ export function createFilesystemV2Syncable(options: FilesystemV2SyncableOptions)
         const rk = rootKey(root);
 
         if (rootCfg.gitAware) {
-          const g = await syncFilesystemGitCommits(ctx, root, rk, now, nextTips);
+          const g = await syncFilesystemGitCommits(
+            ctx,
+            root,
+            rk,
+            now,
+            nextTips,
+            prev.tips[`git:${root}`],
+          );
           upserted += g.upserted;
           bytes += g.bytes;
         }

--- a/packages/gateway/src/connectors/filesystem-v2-sync.ts
+++ b/packages/gateway/src/connectors/filesystem-v2-sync.ts
@@ -14,15 +14,45 @@ import { decodeNimbusJsonCursorPayload, encodeNimbusJsonCursor } from "./nimbus-
 const SERVICE_ID = "filesystem";
 const CURSOR_PREFIX = "nimbus-fsv2:";
 
-type FsCursorV1 = { tips: Record<string, string> };
+/** Per-root map of repo-relative code file → the mtime it carried when last indexed. */
+export type CodeMtimeMap = Record<string, number>;
+
+type FsCursorV1 = {
+  tips: Record<string, string>;
+  /**
+   * `rootKey` → the file mtimes the code index last ran against. Absent in a cursor written
+   * before the gate landed, which decodes to `{}` — "nothing known yet" — so an upgrade
+   * re-indexes once and is then quiet.
+   */
+  codeMtimes: Record<string, CodeMtimeMap>;
+};
 
 function encodeCursor(c: FsCursorV1): string {
   return encodeNimbusJsonCursor(CURSOR_PREFIX, c);
 }
 
+function emptyCursor(): FsCursorV1 {
+  return { tips: {}, codeMtimes: {} };
+}
+
+/** Numbers only, and finite: a corrupt entry must re-index rather than skip. */
+function decodeCodeMtimes(raw: unknown): Record<string, CodeMtimeMap> {
+  const out: Record<string, CodeMtimeMap> = {};
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return out;
+  for (const [key, files] of Object.entries(raw as Record<string, unknown>)) {
+    if (files === null || typeof files !== "object" || Array.isArray(files)) continue;
+    const perRoot: CodeMtimeMap = {};
+    for (const [rel, mtime] of Object.entries(files as Record<string, unknown>)) {
+      if (typeof mtime === "number" && Number.isFinite(mtime)) perRoot[rel] = mtime;
+    }
+    out[key] = perRoot;
+  }
+  return out;
+}
+
 function decodeCursor(raw: string | null): FsCursorV1 {
   if (raw === null || raw === "") {
-    return { tips: {} };
+    return emptyCursor();
   }
   const parsed = decodeNimbusJsonCursorPayload(raw, CURSOR_PREFIX);
   if (
@@ -31,7 +61,7 @@ function decodeCursor(raw: string | null): FsCursorV1 {
     typeof parsed !== "object" ||
     Array.isArray(parsed)
   ) {
-    return { tips: {} };
+    return emptyCursor();
   }
   const rec = parsed as Record<string, unknown>;
   const tipsRaw = rec["tips"];
@@ -43,7 +73,7 @@ function decodeCursor(raw: string | null): FsCursorV1 {
       }
     }
   }
-  return { tips };
+  return { tips, codeMtimes: decodeCodeMtimes(rec["codeMtimes"]) };
 }
 
 function isExcluded(relPath: string, exclude: readonly string[]): boolean {
@@ -334,26 +364,56 @@ async function blameIndexedExcerptRanges(
   }
 }
 
+/**
+ * Indexes a root's exported symbols, SKIPPING every file whose mtime is unchanged since the
+ * last run.
+ *
+ * Without the gate this walked up to 120 files on EVERY tick and, for each, re-read the source,
+ * re-upserted byte-identical symbol rows and spawned one blame subprocess — measured at 47+
+ * such spawns per steady-state tick against a real daemon on an idle repo, every 10 minutes,
+ * indefinitely.
+ *
+ * The mtime is read BEFORE the file, so a skip costs one `stat` rather than a full read plus a
+ * subprocess. A `stat` failure falls back to `now`, which never matches a recorded mtime — the
+ * fail-open direction, re-indexing rather than silently skipping.
+ *
+ * Returns the mtimes to record. Rebuilt from the files actually walked, never merged into the
+ * previous map, so a deleted or newly-excluded file drops out on its own and the cursor stays
+ * bounded by the same 120-file cap as the walk.
+ *
+ * The known limit is mtime's own: an edit landing inside the same filesystem timestamp tick as
+ * the indexed one is missed until the file changes again. `nimbus connector sync filesystem
+ * --full` clears the cursor (`clearConnectorSyncCursor`) and re-indexes everything, which is the
+ * documented way out. Blame that changes without the file changing — an amend or a rebase — is
+ * NOT lost either: the separate `blame` syncable re-blames on a HEAD-ancestor break, which is
+ * exactly the case this gate cannot see.
+ */
 async function syncFilesystemCodeSymbolsForRoot(
   ctx: SyncContext,
   root: string,
   exclude: readonly string[],
   rk: string,
   now: number,
-): Promise<{ upserted: number; bytes: number }> {
+  prevMtimes: CodeMtimeMap,
+): Promise<{ upserted: number; bytes: number; mtimes: CodeMtimeMap }> {
   let upserted = 0;
   let bytes = 0;
   const gitAware = isGitRepo(root);
   const files = listCodeFiles(root, exclude, 120);
+  const mtimes: CodeMtimeMap = {};
   for (const fp of files) {
+    const relNorm = relative(root, fp).replaceAll("\\", "/");
+    const mtime = fileMtimeOrFallback(fp, now);
+    mtimes[relNorm] = mtime;
+    if (prevMtimes[relNorm] === mtime) {
+      continue;
+    }
     const src = readFileTextOrUndefined(fp);
     if (src === undefined) {
       continue;
     }
     bytes += src.length;
-    const relNorm = relative(root, fp).replaceAll("\\", "/");
     const symbols = extractExportedSymbols(src, fp);
-    const mtime = fileMtimeOrFallback(fp, now);
     const fileResult = upsertCodeSymbolsForFile(ctx, symbols, {
       src,
       root,
@@ -367,7 +427,7 @@ async function syncFilesystemCodeSymbolsForRoot(
       await blameIndexedExcerptRanges(ctx, root, relNorm, fileResult.blameRanges);
     }
   }
-  return { upserted, bytes };
+  return { upserted, bytes, mtimes };
 }
 
 const CODE_EXT = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
@@ -789,8 +849,11 @@ export function createFilesystemV2Syncable(options: FilesystemV2SyncableOptions)
         return syncNoopResult(cursor, t0);
       }
       await ctx.rateLimiter.acquire("filesystem");
-      const tips = decodeCursor(cursor).tips;
-      const nextTips: Record<string, string> = { ...tips };
+      const prev = decodeCursor(cursor);
+      const nextTips: Record<string, string> = { ...prev.tips };
+      // Rebuilt per run rather than copied from `prev`: a root dropped from config, or a file
+      // deleted from a root, must leave the cursor instead of accumulating in it forever.
+      const nextCodeMtimes: Record<string, CodeMtimeMap> = {};
       let upserted = 0;
       const now = Date.now();
       let bytes = 0;
@@ -815,9 +878,17 @@ export function createFilesystemV2Syncable(options: FilesystemV2SyncableOptions)
         }
 
         if (rootCfg.codeIndex) {
-          const c = await syncFilesystemCodeSymbolsForRoot(ctx, root, rootCfg.exclude, rk, now);
+          const c = await syncFilesystemCodeSymbolsForRoot(
+            ctx,
+            root,
+            rootCfg.exclude,
+            rk,
+            now,
+            prev.codeMtimes[rk] ?? {},
+          );
           upserted += c.upserted;
           bytes += c.bytes;
+          nextCodeMtimes[rk] = c.mtimes;
         }
 
         if (rootCfg.mediaIndex) {
@@ -834,7 +905,7 @@ export function createFilesystemV2Syncable(options: FilesystemV2SyncableOptions)
       }
 
       return {
-        cursor: encodeCursor({ tips: nextTips }),
+        cursor: encodeCursor({ tips: nextTips, codeMtimes: nextCodeMtimes }),
         itemsUpserted: upserted,
         itemsDeleted: 0,
         hasMore: false,


### PR DESCRIPTION
## What

The filesystem syncable stops redoing byte-identical work on every tick.

`syncFilesystemCodeSymbolsForRoot` ran unconditionally with no cursor gate: it walked up to 120 code files per root and, for each, re-read the source, re-upserted identical symbol rows and spawned one `git blame`. Measured against a real v7.10.1 daemon on an idle repo, a steady-state tick with nothing changed on disk still made **at least 47 git spawns** — every 10 minutes, indefinitely. The dedicated `blame` syncable made **1** over the same window, because it is already incremental. That asymmetry was the bug.

## Two gates, not one

**1. Code symbols — an mtime gate.** The cursor already carried `tips`; it now also carries `codeMtimes` (`rootKey` → `relPath` → `mtime`). A file whose mtime is unchanged is skipped entirely: read, extract, upsert and blame. The mtime is read *before* the file, so a skip costs one `stat` rather than a read plus a subprocess. The map is rebuilt from the files actually walked rather than merged into the previous one, so a deleted or newly-excluded file drops out on its own and the cursor stays bounded by the same 120-file cap.

**2. Commits — the cursor that was already there, and inert.** `syncFilesystemGitCommits` *recorded* `nextTips["git:<root>"]` on every run and never *read* it back, so all 40 commits were re-upserted every tick regardless of whether HEAD had moved.

The second one was not in the original plan. I found it by benchmarking the first against a real repo: the code-symbol gate correctly skipped all 120 files and the run **still reported 40 upserts**, all of them from the commit indexer. Shipping only the first fix would have meant claiming a quiet steady state with a second unconditional re-index sitting next to it in the same file. Flagging the scope extension rather than burying it — it is four lines and uses a cursor field that already existed.

## Measured

On a real repository, both gates, cold pass then unchanged pass:

| pass | upserts | time |
| --- | --- | --- |
| cold | 352 | 2883 ms |
| unchanged | **0** | **48 ms** |

Instrumenting the gate directly showed **120 files re-indexed on the cold pass and 0 on the unchanged pass**.

## Compatibility and bounds

A cursor written before this decodes to an empty map — "nothing known yet" — so an upgrade re-indexes once and is then quiet. Covered by a test.

Two bounds, both already handled elsewhere rather than newly introduced:

- An edit landing inside the same filesystem timestamp tick as the indexed one is missed until the file changes again. `nimbus connector sync filesystem --full` clears the cursor (`clearConnectorSyncCursor`) and re-indexes everything.
- Blame that changes without the file changing — an amend or a rebase — is re-blamed by the separate `blame` syncable on a HEAD-ancestor break, which is precisely the case an mtime gate cannot see.

Verified before relying on it: nothing reaps indexed items by `synced_at` staleness, so skipping the upsert cannot cause a live symbol to be pruned. And `reindexConnector`'s `deepen` is a no-op returning `itemsAffected: 0` — depth recovery is `nimbus index rebody`, which runs independently of this syncable — so the gate cannot strand a re-depth.

## Testing

Eight tests, each watched failing first. The gate was also red-proved by disabling it and confirming four of them go red.

The load-bearing one asserts blame *writes*, not just the upsert count, with a positive control: on a real repo the first run records blame rows and the unchanged second run records **zero**. `itemsUpserted === 0` alone is indirect evidence; this counts the thing the subprocess existed to produce.

Also covered: touching one file re-indexes only that file; a new file is picked up; a deleted file leaves the cursor; a null cursor re-does everything; a pre-gate cursor is accepted; indexed rows survive a skipped run (skipping must not read as pruning).

## Verification

- `bun test packages/gateway packages/cli scripts` — **21020 pass, 0 fail** (the CI command, whole-repo, one process).
- `bun run preflight:fast` — all gates pass.

## Review follow-up

**An unreadable file was being marked as indexed.** The mtime was recorded before the read, so a file that failed to read still got a cursor entry — and the next run then saw an unchanged mtime, skipped it, and left its symbols out of the index until someone edited the file. A transient permission or IO error was enough. Silent, and indistinguishable from a file that genuinely exports nothing. It also contradicted the doc comment's own fail-open claim.

The entry is now written in exactly one place, after the file has been read and indexed, plus the unchanged-skip path which carries its existing entry forward. A read failure records nothing and is retried.

Verified on Linux via `verify:docker --changed`, because Windows ignores POSIX mode bits and cannot observe this locally. Against the unfixed code the cursor came back as `["readable.ts", "blocked.ts"]` with `blocked.ts` never read. Green after.

The test is **self-validating rather than platform-skipped**: it chmods the file, confirms the read actually fails, and returns early if it does not — running as root, or a filesystem ignoring mode bits — instead of asserting vacuously. Otherwise it would have reported green on Windows while covering nothing.

## Noticed, not fixed

`code_symbol` items are never pruned, so a deleted file's symbols linger in the index indefinitely. Pre-existing and its own change.

The default root exclude list is `["node_modules", ".git", "dist", "target", "build", ".next"]` — it omits `coverage` and `out`, so generated output competes with real source for the 120-file cap. Worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1wLEizp9Qpq81VZYQjsuo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved code indexing by skipping unchanged files during subsequent syncs.
  * Reduced unnecessary source reads, symbol updates, and blame processing.
  * Skips Git history processing when no new commits are detected.

* **Reliability**
  * Preserves indexing progress across sync runs.
  * Removes outdated file and directory entries from sync state.
  * Ensures unreadable files are retried after they become accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
