### PR TITLE
docs(spec): propose GET /v1/items/resolve-ids — an item id back to its reference

### DIFF
--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
@@ -3,8 +3,8 @@
 **Date:** 2026-09-07  
 **Reviewer:** Antigravity (AI Coding Assistant)  
 **Status:** Approved with Notes  
-**Target Plan:** [`2026-09-07-items-resolve-ids.md`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/plans/2026-09-07-items-resolve-ids.md)  
-**Design Spec:** [`../specs/2026-09-07-items-resolve-ids-design.md`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md)  
+**Target Plan:** [`2026-09-07-items-resolve-ids.md`](./2026-09-07-items-resolve-ids.md)  
+**Design Spec:** [`../specs/2026-09-07-items-resolve-ids-design.md`](../specs/2026-09-07-items-resolve-ids-design.md)  
 
 ---
 
@@ -33,11 +33,11 @@
 
 ## 1. Summary of Review
 
-The proposal and implementation plan for [`GET /v1/items/resolve-ids`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/plans/2026-09-07-items-resolve-ids.md) are clean, minimal, and fully compliant with gateway architectural and security invariants:
+The proposal and implementation plan for [`GET /v1/items/resolve-ids`](./2026-09-07-items-resolve-ids.md) are clean, minimal, and fully compliant with gateway architectural and security invariants:
 
 1. **Security & Scoping:** Reuses the existing `resolve` scope under bearer authentication; avoids public unauthenticated exposure; does not append to the egress ledger (pure local index read); enforces fail-closed behavior on missing or legacy scopes.
 2. **Safe Disclosure Boundary:** Strict field-by-field projection (`id`, `service`, `type`, `title`, `url`, `modified_at`), preventing leakage of `body`, `metadata`, `author_id`, or `external_id`.
-3. **URL Selection & Fallback Logic:** Selects `COALESCE(url, canonical_url) AS url`, prioritizing the bare `url` column (matching [`resolveItemByUrl`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.ts#L58)) while falling back to `canonical_url` only when `url` is null to maximize linkability.
+3. **URL Selection & Fallback Logic:** Selects `COALESCE(url, canonical_url) AS url`, prioritizing the bare `url` column (matching [`resolveItemByUrl`](../../../packages/gateway/src/index/resolve-by-url.ts#L58)) while falling back to `canonical_url` only when `url` is null to maximize linkability.
 4. **Resilience & DoS Mitigation:** Bounded batching (`RESOLVE_IDS_MAX_BATCH = 100`) with raw query parameter counting before trimming/de-duplication, refusing over-cap requests (`400 too_many_ids`) rather than silently dropping links.
 
 Below are specific technical nuances and recommendations to observe during implementation.
@@ -56,7 +56,7 @@ Below are specific technical nuances and recommendations to observe during imple
   applySchema(db); // replace with whatever resolve-by-url.test.ts calls
   ```
 
-- **Context:** [`packages/gateway/src/index/resolve-by-url.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.test.ts#L7-L8) uses a lightweight custom DDL:
+- **Context:** [`packages/gateway/src/index/resolve-by-url.test.ts`](../../../packages/gateway/src/index/resolve-by-url.test.ts#L7-L8) uses a lightweight custom DDL:
 
   ```ts
   db.exec(`CREATE TABLE item (id TEXT PRIMARY KEY, service TEXT, type TEXT, title TEXT,
@@ -65,19 +65,19 @@ Below are specific technical nuances and recommendations to observe during imple
 
   Note that `resolve-by-url.test.ts` did not declare `canonical_url`.
 - **Correction:** Because `resolveItemsByIds` executes `SELECT id, service, type, title, COALESCE(url, canonical_url) AS url, modified_at FROM item`, copying `resolve-by-url.test.ts`'s DDL verbatim will cause SQLite to fail with `no such column: canonical_url`.
-- **Fix:** In `resolve-ids.test.ts`, ensure the in-memory test table explicitly includes `canonical_url TEXT`, or import [`UNIFIED_ITEM_V3_SCHEMA_SQL`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/unified-item-v3-sql.ts#L16-L31) from `packages/gateway/src/index/unified-item-v3-sql.ts`.
+- **Fix:** In `resolve-ids.test.ts`, ensure the in-memory test table explicitly includes `canonical_url TEXT`, or import [`UNIFIED_ITEM_V3_SCHEMA_SQL`](../../../packages/gateway/src/index/unified-item-v3-sql.ts#L16-L31) from `packages/gateway/src/index/unified-item-v3-sql.ts`.
 
 ---
 
 ### F2.2: Test Scanner Ordering Coupling in Task 2 vs Task 3
 
-- **Context:** [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts#L101-L114) includes the anti-stale test:
+- **Context:** [`packages/gateway/src/ipc/http-route-auth.test.ts`](../../../packages/gateway/src/ipc/http-route-auth.test.ts#L101-L114) includes the anti-stale test:
 
   ```ts
   test("no table entry is a route that no longer exists", async () => { ... });
   ```
 
-  This scanner checks that every entry in `HTTP_ROUTE_AUTH` matches a string literal in [`http-server.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts).
+  This scanner checks that every entry in `HTTP_ROUTE_AUTH` matches a string literal in [`http-server.ts`](../../../packages/gateway/src/ipc/http-server.ts).
 - **Observation:** Adding `[ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" }` in Task 2 *before* mounting `if (url.pathname === "/v1/items/resolve-ids")` in Task 3 will cause `http-route-auth.test.ts` to fail because the route literal is not yet found in `http-server.ts`.
 - **Guidance:** Task 2 and Task 3 are closely coupled by design. Implementers should combine Task 2 and Task 3 edits into a single logical step/commit to keep CI and pre-commit test runs cleanly green.
 
@@ -86,8 +86,8 @@ Below are specific technical nuances and recommendations to observe during imple
 ### F2.3: Two-Tier Batch Cap Enforcement
 
 - **Assessment:** The plan employs a layered defense for the 100-item batch cap:
-  1. **HTTP Layer ([`handleItemsResolveIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts)):** Inspects `url.searchParams.getAll("id").length > RESOLVE_IDS_MAX_BATCH` immediately, protecting the server against expensive parameter parsing and set construction when flooded with duplicate parameters.
-  2. **Lookup Layer ([`resolveItemsByIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-ids.ts)):** Asserts `unique.length > RESOLVE_IDS_MAX_BATCH`, preventing unbounded dynamic parameter lists in SQLite queries.
+  1. **HTTP Layer ([`handleItemsResolveIds`](../../../packages/gateway/src/ipc/http-server.ts)):** Inspects `url.searchParams.getAll("id").length > RESOLVE_IDS_MAX_BATCH` immediately, protecting the server against expensive parameter parsing and set construction when flooded with duplicate parameters.
+  2. **Lookup Layer (`resolveItemsByIds`, in the `packages/gateway/src/index/resolve-ids.ts` Task 1 creates):** Asserts `unique.length > RESOLVE_IDS_MAX_BATCH`, preventing unbounded dynamic parameter lists in SQLite queries.
 - **Verdict:** This separation of concerns is robust and prevents algorithmic complexity attacks on the query parser.
 
 ---
@@ -96,7 +96,7 @@ Below are specific technical nuances and recommendations to observe during imple
 
 ### S2.1: Parity Unit Tests in `http-route-auth.test.ts`
 
-- **Suggestion:** In [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts), add explicit scope assertions for `ROUTE_KEY_ITEMS_RESOLVE_IDS` alongside the existing tests for `ROUTE_KEY_ITEMS_RESOLVE`:
+- **Suggestion:** In [`packages/gateway/src/ipc/http-route-auth.test.ts`](../../../packages/gateway/src/ipc/http-route-auth.test.ts), add explicit scope assertions for `ROUTE_KEY_ITEMS_RESOLVE_IDS` alongside the existing tests for `ROUTE_KEY_ITEMS_RESOLVE`:
 
   ```ts
   test("the resolve-ids route requires the resolve scope", () => {
@@ -117,7 +117,7 @@ Below are specific technical nuances and recommendations to observe during imple
   expect(ledgerRows()).toBe(before);
   ```
 
-- **Note:** Checking the delta across the request rather than `=== 0` avoids flakiness if boot-time markers or background migrations append ledger records. This matches the convention established in [`items-resolve-file-route.test.ts:335`](file:///C:/gitrep/Nimbus/packages/gateway/test/integration/http/items-resolve-file-route.test.ts#L335).
+- **Note:** Checking the delta across the request rather than `=== 0` avoids flakiness if boot-time markers or background migrations append ledger records. This matches the convention established in [`items-resolve-file-route.test.ts:335`](../../../packages/gateway/test/integration/http/items-resolve-file-route.test.ts#L335).
 
 ---
 

--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
@@ -8,6 +8,29 @@
 
 ---
 
+> **This is a review note, not guidance. Where it disagrees with the design
+> spec, the spec wins.**
+>
+> Every recommendation here was adjudicated in
+> [`../specs/2026-09-07-items-resolve-ids-design.md`](../specs/2026-09-07-items-resolve-ids-design.md)
+> §11 and in the plan's own disposition section. Three were accepted, one was
+> accepted with the fix inverted, and the rest are assessments. **Do not
+> implement from this file.**
+>
+> Two disagreements are deliberate and worth naming, because a reader who copied
+> the snippets below would ship the wrong behaviour:
+>
+> - **§2's SQL recommends `COALESCE(canonical_url, url)`** — canonical first.
+>   The spec requires the opposite: the bare `url`, falling back to
+>   `canonical_url` only when `url` is null, because the sibling route selects
+>   the bare column and this response claims to be that projection.
+> - **§2 offers `ORDER BY modified_at DESC, id ASC` as an alternative** to
+>   `ORDER BY id`. The spec picks `ORDER BY id`, singular — two deterministic
+>   orders are still two different wire responses.
+>
+> It is committed because this repo keeps review notes beside their specs, and
+> it is pruned when the feature ships.
+
 ## 1. Summary of Review
 
 The proposal and implementation plan for [`GET /v1/items/resolve-ids`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/plans/2026-09-07-items-resolve-ids.md) are clean, minimal, and fully compliant with gateway architectural and security invariants:
@@ -25,7 +48,7 @@ Below are specific technical nuances and recommendations to observe during imple
 
 ### F2.1: SQLite Seed Schema in Unit Tests (`canonical_url` column)
 
-* **Issue:** In Task 1 Step 1, the test setup notes:
+- **Issue:** In Task 1 Step 1, the test setup notes:
 
   ```ts
   // Use the project's real schema application, exactly as resolve-by-url.test.ts does —
@@ -33,7 +56,7 @@ Below are specific technical nuances and recommendations to observe during imple
   applySchema(db); // replace with whatever resolve-by-url.test.ts calls
   ```
 
-* **Context:** [`packages/gateway/src/index/resolve-by-url.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.test.ts#L7-L8) uses a lightweight custom DDL:
+- **Context:** [`packages/gateway/src/index/resolve-by-url.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.test.ts#L7-L8) uses a lightweight custom DDL:
 
   ```ts
   db.exec(`CREATE TABLE item (id TEXT PRIMARY KEY, service TEXT, type TEXT, title TEXT,
@@ -41,31 +64,31 @@ Below are specific technical nuances and recommendations to observe during imple
   ```
 
   Note that `resolve-by-url.test.ts` did not declare `canonical_url`.
-* **Correction:** Because `resolveItemsByIds` executes `SELECT id, service, type, title, COALESCE(url, canonical_url) AS url, modified_at FROM item`, copying `resolve-by-url.test.ts`'s DDL verbatim will cause SQLite to fail with `no such column: canonical_url`.
-* **Fix:** In `resolve-ids.test.ts`, ensure the in-memory test table explicitly includes `canonical_url TEXT`, or import [`UNIFIED_ITEM_V3_SCHEMA_SQL`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/unified-item-v3-sql.ts#L16-L31) from `packages/gateway/src/index/unified-item-v3-sql.ts`.
+- **Correction:** Because `resolveItemsByIds` executes `SELECT id, service, type, title, COALESCE(url, canonical_url) AS url, modified_at FROM item`, copying `resolve-by-url.test.ts`'s DDL verbatim will cause SQLite to fail with `no such column: canonical_url`.
+- **Fix:** In `resolve-ids.test.ts`, ensure the in-memory test table explicitly includes `canonical_url TEXT`, or import [`UNIFIED_ITEM_V3_SCHEMA_SQL`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/unified-item-v3-sql.ts#L16-L31) from `packages/gateway/src/index/unified-item-v3-sql.ts`.
 
 ---
 
 ### F2.2: Test Scanner Ordering Coupling in Task 2 vs Task 3
 
-* **Context:** [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts#L101-L114) includes the anti-stale test:
+- **Context:** [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts#L101-L114) includes the anti-stale test:
 
   ```ts
   test("no table entry is a route that no longer exists", async () => { ... });
   ```
 
   This scanner checks that every entry in `HTTP_ROUTE_AUTH` matches a string literal in [`http-server.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts).
-* **Observation:** Adding `[ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" }` in Task 2 *before* mounting `if (url.pathname === "/v1/items/resolve-ids")` in Task 3 will cause `http-route-auth.test.ts` to fail because the route literal is not yet found in `http-server.ts`.
-* **Guidance:** Task 2 and Task 3 are closely coupled by design. Implementers should combine Task 2 and Task 3 edits into a single logical step/commit to keep CI and pre-commit test runs cleanly green.
+- **Observation:** Adding `[ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" }` in Task 2 *before* mounting `if (url.pathname === "/v1/items/resolve-ids")` in Task 3 will cause `http-route-auth.test.ts` to fail because the route literal is not yet found in `http-server.ts`.
+- **Guidance:** Task 2 and Task 3 are closely coupled by design. Implementers should combine Task 2 and Task 3 edits into a single logical step/commit to keep CI and pre-commit test runs cleanly green.
 
 ---
 
 ### F2.3: Two-Tier Batch Cap Enforcement
 
-* **Assessment:** The plan employs a layered defense for the 100-item batch cap:
+- **Assessment:** The plan employs a layered defense for the 100-item batch cap:
   1. **HTTP Layer ([`handleItemsResolveIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts)):** Inspects `url.searchParams.getAll("id").length > RESOLVE_IDS_MAX_BATCH` immediately, protecting the server against expensive parameter parsing and set construction when flooded with duplicate parameters.
   2. **Lookup Layer ([`resolveItemsByIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-ids.ts)):** Asserts `unique.length > RESOLVE_IDS_MAX_BATCH`, preventing unbounded dynamic parameter lists in SQLite queries.
-* **Verdict:** This separation of concerns is robust and prevents algorithmic complexity attacks on the query parser.
+- **Verdict:** This separation of concerns is robust and prevents algorithmic complexity attacks on the query parser.
 
 ---
 
@@ -73,7 +96,7 @@ Below are specific technical nuances and recommendations to observe during imple
 
 ### S2.1: Parity Unit Tests in `http-route-auth.test.ts`
 
-* **Suggestion:** In [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts), add explicit scope assertions for `ROUTE_KEY_ITEMS_RESOLVE_IDS` alongside the existing tests for `ROUTE_KEY_ITEMS_RESOLVE`:
+- **Suggestion:** In [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts), add explicit scope assertions for `ROUTE_KEY_ITEMS_RESOLVE_IDS` alongside the existing tests for `ROUTE_KEY_ITEMS_RESOLVE`:
 
   ```ts
   test("the resolve-ids route requires the resolve scope", () => {
@@ -84,7 +107,7 @@ Below are specific technical nuances and recommendations to observe during imple
 
 ### S2.2: Egress Ledger Delta Assertion in Integration Tests
 
-* **Assessment:** Task 4 Step 1 specifies testing that the route appends no egress ledger rows:
+- **Assessment:** Task 4 Step 1 specifies testing that the route appends no egress ledger rows:
 
   ```ts
   const ledgerRows = (): number =>
@@ -94,7 +117,7 @@ Below are specific technical nuances and recommendations to observe during imple
   expect(ledgerRows()).toBe(before);
   ```
 
-* **Note:** Checking the delta across the request rather than `=== 0` avoids flakiness if boot-time markers or background migrations append ledger records. This matches the convention established in [`items-resolve-file-route.test.ts:335`](file:///C:/gitrep/Nimbus/packages/gateway/test/integration/http/items-resolve-file-route.test.ts#L335).
+- **Note:** Checking the delta across the request rather than `=== 0` avoids flakiness if boot-time markers or background migrations append ledger records. This matches the convention established in [`items-resolve-file-route.test.ts:335`](file:///C:/gitrep/Nimbus/packages/gateway/test/integration/http/items-resolve-file-route.test.ts#L335).
 
 ---
 

--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids-review.md
@@ -1,0 +1,105 @@
+# Implementation Plan Review: `GET /v1/items/resolve-ids`
+
+**Date:** 2026-09-07  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Approved with Notes  
+**Target Plan:** [`2026-09-07-items-resolve-ids.md`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/plans/2026-09-07-items-resolve-ids.md)  
+**Design Spec:** [`../specs/2026-09-07-items-resolve-ids-design.md`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md)  
+
+---
+
+## 1. Summary of Review
+
+The proposal and implementation plan for [`GET /v1/items/resolve-ids`](file:///C:/gitrep/Nimbus/.claude/worktrees/items-resolve-ids/docs/superpowers/plans/2026-09-07-items-resolve-ids.md) are clean, minimal, and fully compliant with gateway architectural and security invariants:
+
+1. **Security & Scoping:** Reuses the existing `resolve` scope under bearer authentication; avoids public unauthenticated exposure; does not append to the egress ledger (pure local index read); enforces fail-closed behavior on missing or legacy scopes.
+2. **Safe Disclosure Boundary:** Strict field-by-field projection (`id`, `service`, `type`, `title`, `url`, `modified_at`), preventing leakage of `body`, `metadata`, `author_id`, or `external_id`.
+3. **URL Selection & Fallback Logic:** Selects `COALESCE(url, canonical_url) AS url`, prioritizing the bare `url` column (matching [`resolveItemByUrl`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.ts#L58)) while falling back to `canonical_url` only when `url` is null to maximize linkability.
+4. **Resilience & DoS Mitigation:** Bounded batching (`RESOLVE_IDS_MAX_BATCH = 100`) with raw query parameter counting before trimming/de-duplication, refusing over-cap requests (`400 too_many_ids`) rather than silently dropping links.
+
+Below are specific technical nuances and recommendations to observe during implementation.
+
+---
+
+## 2. Critical Findings & Technical Corrections
+
+### F2.1: SQLite Seed Schema in Unit Tests (`canonical_url` column)
+
+* **Issue:** In Task 1 Step 1, the test setup notes:
+
+  ```ts
+  // Use the project's real schema application, exactly as resolve-by-url.test.ts does —
+  // a hand-written CREATE TABLE here would drift from the migrations.
+  applySchema(db); // replace with whatever resolve-by-url.test.ts calls
+  ```
+
+* **Context:** [`packages/gateway/src/index/resolve-by-url.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-by-url.test.ts#L7-L8) uses a lightweight custom DDL:
+
+  ```ts
+  db.exec(`CREATE TABLE item (id TEXT PRIMARY KEY, service TEXT, type TEXT, title TEXT,
+    url TEXT, resolve_key TEXT, modified_at INTEGER)`);
+  ```
+
+  Note that `resolve-by-url.test.ts` did not declare `canonical_url`.
+* **Correction:** Because `resolveItemsByIds` executes `SELECT id, service, type, title, COALESCE(url, canonical_url) AS url, modified_at FROM item`, copying `resolve-by-url.test.ts`'s DDL verbatim will cause SQLite to fail with `no such column: canonical_url`.
+* **Fix:** In `resolve-ids.test.ts`, ensure the in-memory test table explicitly includes `canonical_url TEXT`, or import [`UNIFIED_ITEM_V3_SCHEMA_SQL`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/unified-item-v3-sql.ts#L16-L31) from `packages/gateway/src/index/unified-item-v3-sql.ts`.
+
+---
+
+### F2.2: Test Scanner Ordering Coupling in Task 2 vs Task 3
+
+* **Context:** [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts#L101-L114) includes the anti-stale test:
+
+  ```ts
+  test("no table entry is a route that no longer exists", async () => { ... });
+  ```
+
+  This scanner checks that every entry in `HTTP_ROUTE_AUTH` matches a string literal in [`http-server.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts).
+* **Observation:** Adding `[ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" }` in Task 2 *before* mounting `if (url.pathname === "/v1/items/resolve-ids")` in Task 3 will cause `http-route-auth.test.ts` to fail because the route literal is not yet found in `http-server.ts`.
+* **Guidance:** Task 2 and Task 3 are closely coupled by design. Implementers should combine Task 2 and Task 3 edits into a single logical step/commit to keep CI and pre-commit test runs cleanly green.
+
+---
+
+### F2.3: Two-Tier Batch Cap Enforcement
+
+* **Assessment:** The plan employs a layered defense for the 100-item batch cap:
+  1. **HTTP Layer ([`handleItemsResolveIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-server.ts)):** Inspects `url.searchParams.getAll("id").length > RESOLVE_IDS_MAX_BATCH` immediately, protecting the server against expensive parameter parsing and set construction when flooded with duplicate parameters.
+  2. **Lookup Layer ([`resolveItemsByIds`](file:///C:/gitrep/Nimbus/packages/gateway/src/index/resolve-ids.ts)):** Asserts `unique.length > RESOLVE_IDS_MAX_BATCH`, preventing unbounded dynamic parameter lists in SQLite queries.
+* **Verdict:** This separation of concerns is robust and prevents algorithmic complexity attacks on the query parser.
+
+---
+
+## 3. Improvements & Observations
+
+### S2.1: Parity Unit Tests in `http-route-auth.test.ts`
+
+* **Suggestion:** In [`packages/gateway/src/ipc/http-route-auth.test.ts`](file:///C:/gitrep/Nimbus/packages/gateway/src/ipc/http-route-auth.test.ts), add explicit scope assertions for `ROUTE_KEY_ITEMS_RESOLVE_IDS` alongside the existing tests for `ROUTE_KEY_ITEMS_RESOLVE`:
+
+  ```ts
+  test("the resolve-ids route requires the resolve scope", () => {
+    expect(HTTP_ROUTE_AUTH[ROUTE_KEY_ITEMS_RESOLVE_IDS]).toEqual({ kind: "clip", scope: "resolve" });
+    expect(clipScopeFor(ROUTE_KEY_ITEMS_RESOLVE_IDS)).toBe("resolve");
+  });
+  ```
+
+### S2.2: Egress Ledger Delta Assertion in Integration Tests
+
+* **Assessment:** Task 4 Step 1 specifies testing that the route appends no egress ledger rows:
+
+  ```ts
+  const ledgerRows = (): number =>
+    (db.query("SELECT COUNT(*) AS n FROM egress_ledger").get() as { n: number }).n;
+  const before = ledgerRows();
+  await fetch(...);
+  expect(ledgerRows()).toBe(before);
+  ```
+
+* **Note:** Checking the delta across the request rather than `=== 0` avoids flakiness if boot-time markers or background migrations append ledger records. This matches the convention established in [`items-resolve-file-route.test.ts:335`](file:///C:/gitrep/Nimbus/packages/gateway/test/integration/http/items-resolve-file-route.test.ts#L335).
+
+---
+
+## 4. Summary of Recommended Plan Actions
+
+1. In Task 1 Step 1, explicitly specify `canonical_url TEXT` in the test database schema definition.
+2. Note that Tasks 2 and 3 should be tested and committed together to satisfy `http-route-auth.test.ts`'s route literal scanner.
+3. Proceed with implementation as outlined.

--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
@@ -20,6 +20,7 @@
 - **`RESOLVE_IDS_MAX_BATCH = 100`.** Not 5 — that is `RESOLVE_CANDIDATE_CAP`, whose *rationale* this borrows and whose *magnitude* would refuse `catchup` on its ordinary path (`PER_SERVICE_QUOTA = 50` per service, `packages/gateway/src/agents/catchup.ts:12`).
 - **Over the cap: refuse `400 { "error": "too_many_ids" }`.** Never clamp — silently dropping ids means silently dropping links.
 - **Count RAW `?id=` parameters before de-duplicating.** A post-dedup check is cheap for a caller sending fifty thousand copies of one id and not for the gateway.
+- **A count is not a size.** `item.id` is unbounded `TEXT`, so 100 ids can be 3 KB of query string or 12 KB. The client chunks by ~1,800 bytes as well as by count (spec §5); the route refuses an over-budget query string where it sees one, but an over-long URL may be rejected before any handler runs — that limit is the client's to respect.
 - **Response fields, exactly:** `id`, `service`, `type`, `title`, `url`, `modified_at`. Never `body`, `body_preview`, `metadata`, `author_id`, `external_id`, `synced_at`.
 - **`url` selection:** the bare `url` column, matching `resolve-by-url.ts:58` — **except** fall back to `canonical_url` where `url` is null. This is the opposite precedence from `resolve_key`, deliberately (spec §4).
 - **`url` stays nullable** all the way to the response. Never substitute, never omit the row because of it.
@@ -423,6 +424,10 @@ test("discloses exactly six fields", () => {
 });
 test("400 missing_id when no id parameter is given", /* also: only blank ids */);
 test("400 too_many_ids above the cap", /* RESOLVE_IDS_MAX_BATCH + 1 raw params */);
+test("400 too_many_ids on repeated ids above the cap", () => {
+  // The raw count is what is checked, so 101 copies of ONE id must be refused —
+  // de-duplicating first would let this through with a single-row answer.
+});
 test("403 for a token without the resolve scope", /* LEGACY_SCOPES */);
 test("404 resolve_disabled when the clips surface is unmounted", /* startServerWithoutClipsVault */);
 test("404 fires before auth", /* unmounted server + a bad token still 404s, not 401 */);

--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
@@ -1,0 +1,483 @@
+# `GET /v1/items/resolve-ids` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **This plan is conditional on the contract being accepted.** The spec it
+> implements is a proposal; the gateway owns the wire and may change the shape or
+> decline it. Nothing here presumes approval — it exists so the cost of saying
+> yes is visible alongside the ask, and so nobody has to re-derive the surface.
+
+**Goal:** Serve one bearer-authed read that maps indexed item ids back to the references they came from, so a client holding an agent brief can turn an item id into a link.
+
+**Architecture:** A pure lookup module beside `resolve-by-url.ts` doing one parameterised `IN (…)` query with an exact projection, plus a handler mounted inline in the bearer-authed GET family. No schema change, no new scope, no egress row, no OpenAPI entry.
+
+**Tech Stack:** TypeScript strict, Bun, `bun:sqlite`, Biome, `bun test`.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md` — read §4 (contract), §5 (the three argued decisions), §6 (what this is not) and §8 (compliance) before starting.
+
+## Global Constraints
+
+- **`RESOLVE_IDS_MAX_BATCH = 100`.** Not 5 — that is `RESOLVE_CANDIDATE_CAP`, whose *rationale* this borrows and whose *magnitude* would refuse `catchup` on its ordinary path (`PER_SERVICE_QUOTA = 50` per service, `packages/gateway/src/agents/catchup.ts:12`).
+- **Over the cap: refuse `400 { "error": "too_many_ids" }`.** Never clamp — silently dropping ids means silently dropping links.
+- **Count RAW `?id=` parameters before de-duplicating.** A post-dedup check is cheap for a caller sending fifty thousand copies of one id and not for the gateway.
+- **Response fields, exactly:** `id`, `service`, `type`, `title`, `url`, `modified_at`. Never `body`, `body_preview`, `metadata`, `author_id`, `external_id`, `synced_at`.
+- **`url` selection:** the bare `url` column, matching `resolve-by-url.ts:58` — **except** fall back to `canonical_url` where `url` is null. This is the opposite precedence from `resolve_key`, deliberately (spec §4).
+- **`url` stays nullable** all the way to the response. Never substitute, never omit the row because of it.
+- **An unindexed id is ABSENT from `items`** — not an error, not a null entry. Absent and `url: null` are different facts.
+- **404 `{ "error": "resolve_disabled" }` fires BEFORE the auth check** when the clips surface is unmounted. This is the capability signal a client probes; a 500 would turn a quiet degradation into a visible error.
+- **Bind every id as a parameter.** Never interpolate into the `IN (…)` list.
+- **No egress row.** No outbound request of any kind; no federation arm, now or later.
+- **No `any`;** external data is `unknown` narrowed by a guard. Biome must pass with `--error-on-warnings`.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `packages/gateway/src/index/resolve-ids.ts` — the lookup and its exact projection. Beside `resolve-by-url.ts` because it is the same kind of thing: a read over `item` that answers a resolution question, with no HTTP knowledge.
+- `packages/gateway/src/index/resolve-ids.test.ts` — unit tests over a real in-memory database, matching how `resolve-by-url.test.ts` tests its sibling.
+- `packages/gateway/test/integration/http/items-resolve-ids-route.test.ts` — the route's end-to-end tests, beside `items-resolve-route.test.ts` and `items-resolve-file-route.test.ts`.
+
+**Modify:**
+
+- `packages/gateway/src/ipc/http-route-auth.ts` — the route-key constant, the `HTTP_ROUTE_AUTH` entry, the `ClipReadRouteKey` union member (`:154-165`).
+- `packages/gateway/src/ipc/http-server.ts` — the handler beside `handleItemsResolveFile` (`:672`), and one mount line in the bearer-authed GET dispatcher (`:1146-1148`).
+- `packages/gateway/src/egress/egress-coverage.ts:80-88` — re-point the "newest of them" sentence.
+- `docs/CHANGELOG.md`, `docs/architecture.md`.
+
+**Not touched, deliberately:** no migration, no `HTTP_ROUTES` / OpenAPI entry, no `WRITE_ROUTE_ALLOWLIST` (this is a read), no new scope.
+
+---
+
+### Task 1: The lookup module
+
+**Files:**
+
+- Create: `packages/gateway/src/index/resolve-ids.ts`
+- Test: `packages/gateway/src/index/resolve-ids.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Database` from `bun:sqlite`; the `item` table.
+- Produces: `RESOLVE_IDS_MAX_BATCH: 100`, `type ResolvedItemRef`, `resolveItemsByIds(db: Database, ids: readonly string[]): ResolvedItemRef[]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Read `packages/gateway/src/index/resolve-by-url.test.ts` first and reuse its database-seeding idiom rather than inventing one.
+
+```ts
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { RESOLVE_IDS_MAX_BATCH, resolveItemsByIds } from "./resolve-ids.ts";
+
+function seed(): Database {
+  const db = new Database(":memory:");
+  // Use the project's real schema application, exactly as resolve-by-url.test.ts does —
+  // a hand-written CREATE TABLE here would drift from the migrations.
+  applySchema(db); // replace with whatever resolve-by-url.test.ts calls
+  const insert = (row: Record<string, unknown>) => { /* per that file's helper */ };
+  insert({ id: "github:acme/web#1", service: "github", type: "pull_request",
+           title: "Auth rewrite", url: "https://example.test/pr/1",
+           canonical_url: null, modified_at: 1_700_000_000_000 });
+  insert({ id: "jira:PLAT-9", service: "jira", type: "issue",
+           title: "Latency", url: null, canonical_url: null,
+           modified_at: 1_700_000_000_001 });
+  insert({ id: "nimbus:brief-7", service: "nimbus", type: "research_brief",
+           title: "A saved brief", url: null,
+           canonical_url: "https://example.test/canon/7",
+           modified_at: 1_700_000_000_002 });
+  return db;
+}
+
+describe("resolveItemsByIds", () => {
+  test("returns the exact six-field projection and nothing else", () => {
+    const [row] = resolveItemsByIds(seed(), ["github:acme/web#1"]);
+    expect(Object.keys(row ?? {}).sort()).toEqual([
+      "id", "modified_at", "service", "title", "type", "url",
+    ]);
+    expect(row?.url).toBe("https://example.test/pr/1");
+  });
+
+  test("omits ids the index does not hold, without erroring", () => {
+    const rows = resolveItemsByIds(seed(), ["github:acme/web#1", "github:nope#404"]);
+    expect(rows.map((r) => r.id)).toEqual(["github:acme/web#1"]);
+  });
+
+  test("keeps url null when the row has neither url nor canonical_url", () => {
+    const [row] = resolveItemsByIds(seed(), ["jira:PLAT-9"]);
+    // Null must survive to the caller: the client renders the title as plain
+    // text. Substituting anything here would fabricate a reference.
+    expect(row?.url).toBeNull();
+  });
+
+  test("falls back to canonical_url only when url is null", () => {
+    const [row] = resolveItemsByIds(seed(), ["nimbus:brief-7"]);
+    expect(row?.url).toBe("https://example.test/canon/7");
+  });
+
+  test("prefers url over canonical_url when both exist", () => {
+    const db = seed();
+    db.query("UPDATE item SET canonical_url = ? WHERE id = ?")
+      .run("https://example.test/canon/1", "github:acme/web#1");
+    const [row] = resolveItemsByIds(db, ["github:acme/web#1"]);
+    // The sibling route returns the bare `url` column; matching it matters more
+    // than matching resolve_key's canonical-first derivation. Spec §4.
+    expect(row?.url).toBe("https://example.test/pr/1");
+  });
+
+  test("de-duplicates repeated ids into one row", () => {
+    const rows = resolveItemsByIds(seed(), ["jira:PLAT-9", "jira:PLAT-9", "jira:PLAT-9"]);
+    expect(rows).toHaveLength(1);
+  });
+
+  test("returns an empty array for an empty id list", () => {
+    expect(resolveItemsByIds(seed(), [])).toEqual([]);
+  });
+
+  test("orders deterministically by id", () => {
+    const rows = resolveItemsByIds(seed(), ["nimbus:brief-7", "github:acme/web#1", "jira:PLAT-9"]);
+    expect(rows.map((r) => r.id)).toEqual([...rows.map((r) => r.id)].sort());
+  });
+
+  test("throws above the batch cap rather than truncating", () => {
+    const ids = Array.from({ length: RESOLVE_IDS_MAX_BATCH + 1 }, (_, i) => `x:${i}`);
+    expect(() => resolveItemsByIds(seed(), ids)).toThrow();
+  });
+
+  test("treats an id containing SQL syntax as data, not as SQL", () => {
+    const rows = resolveItemsByIds(seed(), ["github:acme/web#1'); DROP TABLE item; --"]);
+    expect(rows).toEqual([]);
+    // The table is still there.
+    expect(resolveItemsByIds(seed(), ["jira:PLAT-9"])).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bun test packages/gateway/src/index/resolve-ids.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+import type { Database } from "bun:sqlite";
+
+/**
+ * The most ids one call may name.
+ *
+ * `RESOLVE_CANDIDATE_CAP` (resolve-by-url.ts) is the precedent for HAVING a cap:
+ * an uncapped list turns a `resolve`-scoped token into a bulk index read. Its
+ * magnitude is not the precedent. That cap is 5, sized for a disambiguation menu
+ * a human reads; this route answers a machine holding an agent brief, and
+ * `catchup` alone admits PER_SERVICE_QUOTA = 50 items PER SERVICE across several
+ * sections. A cap near 5 would refuse the largest consumer on its ordinary path.
+ *
+ * 100 clears a dense brief, sits three orders of magnitude under SQLite's
+ * bind-parameter ceiling, and stays well inside any URL-length limit.
+ */
+export const RESOLVE_IDS_MAX_BATCH = 100;
+
+/**
+ * What a resolved id discloses: `ResolveCandidate` plus `modified_at`, which is
+ * exactly what `GET /v1/items/resolve`'s `found` arm already returns. Never a
+ * body, never `metadata`, never `author_id` — this is a resolver; reading is
+ * `GET /v1/items/{id}`.
+ */
+export type ResolvedItemRef = {
+  readonly id: string;
+  readonly service: string;
+  readonly type: string;
+  readonly title: string;
+  readonly url: string | null;
+  readonly modified_at: number;
+};
+
+/**
+ * Map item ids to their references. Ids the index does not hold are ABSENT from
+ * the result — not null entries. "Not indexed" and "indexed with no source URL"
+ * are different facts and a caller renders them differently.
+ *
+ * Throws above `RESOLVE_IDS_MAX_BATCH`; the HTTP layer turns that into a 400
+ * rather than clamping, because silently dropping ids drops links.
+ */
+export function resolveItemsByIds(db: Database, ids: readonly string[]): ResolvedItemRef[] {
+  const unique = [...new Set(ids)];
+  if (unique.length > RESOLVE_IDS_MAX_BATCH) {
+    throw new Error(`resolveItemsByIds: ${unique.length} ids exceeds ${RESOLVE_IDS_MAX_BATCH}`);
+  }
+  if (unique.length === 0) {
+    return [];
+  }
+  const placeholders = unique.map(() => "?").join(", ");
+  // `COALESCE(url, canonical_url)` — url FIRST. The sibling route selects the
+  // bare `url` column, and this response claims to be that projection; the
+  // fallback only fires where the sibling would have returned null anyway, so no
+  // caller ever sees a different URL for the same row. This is deliberately the
+  // opposite order from `resolve_key`, which is canonical-first because it
+  // exists to make two spellings match rather than to be clicked.
+  //
+  // Every id is BOUND, never interpolated.
+  const rows = db
+    .query(
+      `SELECT id, service, type, title, COALESCE(url, canonical_url) AS url, modified_at
+         FROM item
+        WHERE id IN (${placeholders})
+        ORDER BY id`,
+    )
+    .all(...unique) as ResolvedItemRef[];
+  return rows;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test packages/gateway/src/index/resolve-ids.test.ts && bun run lint && bun run typecheck`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/index/resolve-ids.ts packages/gateway/src/index/resolve-ids.test.ts
+git commit -m "feat(index): resolve item ids back to their references"
+```
+
+---
+
+### Task 2: Route auth wiring
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/http-route-auth.ts` (constants near `:22-23`, `HTTP_ROUTE_AUTH` near `:80`, `ClipReadRouteKey` at `:154-165`)
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: `ROUTE_KEY_ITEMS_RESOLVE_IDS = "GET /v1/items/resolve-ids"`, its `{ kind: "clip", scope: "resolve" }` entry, and its union member.
+
+> **Three completeness tests enforce this**, so a route added without its table
+> entry fails the suite rather than failing open. That is the point of doing this
+> as its own task: it is the safety wiring, and it should be reviewable alone.
+
+- [ ] **Step 1: Add the constant, the entry, and the union member**
+
+Beside the existing route keys:
+
+```ts
+export const ROUTE_KEY_ITEMS_RESOLVE_IDS = "GET /v1/items/resolve-ids";
+```
+
+In `HTTP_ROUTE_AUTH`, beside `ROUTE_KEY_ITEMS_RESOLVE_FILE`:
+
+```ts
+  // Maps indexed item ids back to their references. Same `resolve` scope as the two reads
+  // above and for the same reason: it reads, it runs nothing, and it appends NO egress row.
+  [ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" },
+```
+
+And in the union (`:154-165`), which exists so passing a raw request path to `enforceClipScope` is a compile error rather than a runtime fail-open:
+
+```ts
+  | typeof ROUTE_KEY_ITEMS_RESOLVE_IDS
+```
+
+- [ ] **Step 2: Run the route-auth suite**
+
+Run: `bun test packages/gateway/src/ipc/http-route-auth.test.ts`
+Expected: PASS. Note the scanner also fails if a table entry exists for a route no handler serves — so at this point the entry is present and Task 3 adds the literal it scans for. If the suite objects to an entry without a route, do Tasks 2 and 3 as one commit rather than fighting it, and say so in your report.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/src/ipc/http-route-auth.ts
+git commit -m "feat(http): scope resolve-ids under the existing resolve scope"
+```
+
+---
+
+### Task 3: The handler and its mount
+
+**Files:**
+
+- Modify: `packages/gateway/src/ipc/http-server.ts` (handler beside `handleItemsResolveFile` at `:672`; mount at `:1146-1148`)
+
+**Interfaces:**
+
+- Consumes: `resolveItemsByIds`, `RESOLVE_IDS_MAX_BATCH` (Task 1); `ROUTE_KEY_ITEMS_RESOLVE_IDS` (Task 2); the existing `requireScopedClipToken` and `json` helpers.
+- Produces: the served route.
+
+- [ ] **Step 1: Add the handler**
+
+Mirror `handleItemsResolveFile` (`:672`) closely — it is the newest sibling and the shape reviewers expect:
+
+```ts
+async function handleItemsResolveIds(
+  req: Request,
+  url: URL,
+  db: Database,
+  opts: ReadOnlyHttpServerOptions,
+): Promise<Response> {
+  const clipsVault = opts.clipsVault;
+  if (clipsVault === undefined) {
+    // Before the auth check, and load-bearing: a client reads this 404 as "gateway older than
+    // the route" and withholds its links silently. A 500 would turn a correct, quiet
+    // degradation into a visible error on every gateway that does not mount the clips surface.
+    return json({ error: "resolve_disabled" }, 404);
+  }
+  const auth = await requireScopedClipToken(req, clipsVault, ROUTE_KEY_ITEMS_RESOLVE_IDS);
+  if (!auth.ok) return auth.response;
+
+  // RAW count first, before trimming and before de-duplicating: checking after the set is built
+  // would let a caller send fifty thousand copies of one id and pay only the parse cost.
+  const raw = url.searchParams.getAll("id");
+  if (raw.length > RESOLVE_IDS_MAX_BATCH) {
+    return json({ error: "too_many_ids" }, 400);
+  }
+  const ids = raw.map((id) => id.trim()).filter((id) => id !== "");
+  if (ids.length === 0) {
+    return json({ error: "missing_id" }, 400);
+  }
+
+  // Field by field, never a spread and never a destructured rest: `item` carries `body`,
+  // `metadata` and `author_id`, and this route is reachable by any holder of a clip token. A
+  // column added to the row type later cannot leak here unnamed.
+  const items = resolveItemsByIds(db, ids).map((row) => ({
+    id: row.id,
+    service: row.service,
+    type: row.type,
+    title: row.title,
+    url: row.url,
+    modified_at: row.modified_at,
+  }));
+  return json({ items });
+}
+```
+
+- [ ] **Step 2: Mount it inline in the bearer-authed GET dispatcher**
+
+Beside the two existing resolve mounts (`:1146-1148`):
+
+```ts
+  if (url.pathname === "/v1/items/resolve-ids") {
+    return await handleItemsResolveIds(req, url, db, opts);
+  }
+```
+
+**A flat `url.pathname ===` comparison, not a regex** — `http-route-auth.test.ts` source-scans for route literals and separately pins the count of regex-routed GETs, so a regex form needs extra bookkeeping for nothing.
+
+**Never in `dispatchReadOnlyDataGet`** — that table's `"/v1/items/*"` entry is `{ kind: "public" }` with no bearer gate, so routing through it would serve scoped output to any local process.
+
+- [ ] **Step 3: Run the route-auth and server suites**
+
+Run: `bun test packages/gateway/src/ipc/ && bun run typecheck && bun run lint`
+Expected: PASS, including the three completeness tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/gateway/src/ipc/http-server.ts
+git commit -m "feat(http): serve GET /v1/items/resolve-ids"
+```
+
+---
+
+### Task 4: Route integration tests
+
+**Files:**
+
+- Create: `packages/gateway/test/integration/http/items-resolve-ids-route.test.ts`
+
+**Interfaces:**
+
+- Consumes: `startServerWithClipToken`, `startServerWithoutClipsVault` from `packages/gateway/src/ipc/http-api-test-server.ts`; `LEGACY_SCOPES` from `packages/gateway/src/clips/api-scopes.ts`.
+
+- [ ] **Step 1: Write the tests**
+
+Read `items-resolve-file-route.test.ts` first and match its harness use and header-comment style.
+
+```ts
+/**
+ * End-to-end tests for `GET /v1/items/resolve-ids` — the reverse lookup a client uses to turn the
+ * item ids inside an agent brief into links. Sibling of `items-resolve-route.test.ts`: same
+ * harness, same inline-bearer-read seam, same `resolve` scope.
+ */
+```
+
+Cover, at minimum:
+
+```ts
+test("resolves several ids in one call", /* 200, items in id order */);
+test("omits an id the index does not hold", /* the known one comes back, the unknown does not */);
+test("discloses exactly six fields", () => {
+  // The disclosure guard. A column added to `item` later cannot reach the wire unnamed.
+  expect(Object.keys(body.items[0]).sort()).toEqual([
+    "id", "modified_at", "service", "title", "type", "url",
+  ]);
+});
+test("400 missing_id when no id parameter is given", /* also: only blank ids */);
+test("400 too_many_ids above the cap", /* RESOLVE_IDS_MAX_BATCH + 1 raw params */);
+test("403 for a token without the resolve scope", /* LEGACY_SCOPES */);
+test("404 resolve_disabled when the clips surface is unmounted", /* startServerWithoutClipsVault */);
+test("404 fires before auth", /* unmounted server + a bad token still 404s, not 401 */);
+test("appends no egress row", () => {
+  // A COUNT delta across the call, not an inspection — the claim is "this route never appends",
+  // and only a delta actually tests it.
+});
+```
+
+- [ ] **Step 2: Run them**
+
+Run: `bun test packages/gateway/test/integration/http/items-resolve-ids-route.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/gateway/test/integration/http/items-resolve-ids-route.test.ts
+git commit -m "test(http): pin resolve-ids' disclosure, caps and capability signal"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+
+- Modify: `packages/gateway/src/egress/egress-coverage.ts:80-88`, `docs/CHANGELOG.md`, `docs/architecture.md`
+
+- [ ] **Step 1: Re-point the egress-coverage comment**
+
+That comment names `GET /v1/items/resolve-file` as "the newest of them and the one most likely to be mistaken for egress". `resolve-ids` is now the newest. Add it to the list of reads that hand index rows to a local process and append **no** row, and move the "newest" sentence — it takes item ids from an external caller and answers entirely from the local index, with no outbound request at all.
+
+- [ ] **Step 2: Add the changelog entry**
+
+`docs/CHANGELOG.md`, matching the surrounding entries' voice. State the three things a reader needs: it is `resolve`-scoped so no re-pairing is needed; route presence is the capability signal so there is no version floor; and an id the index does not hold is absent from the response rather than null.
+
+- [ ] **Step 3: Note the route in the architecture doc**
+
+Wherever `docs/architecture.md` describes the clip-scoped read surface, add this route beside `resolve` and `resolve-file` — including that it is the only one of the three that takes a *list*, and the cap that bounds it.
+
+- [ ] **Step 4: Run the docs gates**
+
+Run: `bun run lint:markdown && bun run audit:doc-refs`
+Expected: both clean. **These are the gates most likely to fail a docs-only change** — markdownlint enforces labelled fences and blank lines around headings and lists, and the doc-reference audit requires every cited path to resolve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/gateway/src/egress/egress-coverage.ts docs/CHANGELOG.md docs/architecture.md
+git commit -m "docs: record resolve-ids as a local read that appends no egress"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §4's request shape → Task 3; its response and the six fields → Tasks 1, 3, 4. The URL-column divergence → Task 1's two dedicated tests. Absent-vs-null → Task 1 and Task 4. §4's error table → Task 3, each pinned in Task 4. §5's batching, cap, raw-count-first and ordering → Tasks 1 and 3, pinned in both suites. §5's flat-path and never-in-the-public-table rules → Task 3 Step 2. §6's "not egress" → Task 4's ledger delta and Task 5 Step 1. §7's rollout → Task 4's two 404 tests. §8's compliance list → Tasks 2, 3, 4.
+
+**Deliberately absent:** no migration task (no schema change), no OpenAPI task (this route stays off `HTTP_ROUTES`, like every clip-scoped bearer read), no scope task (`resolve` already exists, so no re-pairing).
+
+**Type consistency.** `resolveItemsByIds(db, ids)` returns `ResolvedItemRef[]` in Task 1 and is consumed under that name in Task 3. `RESOLVE_IDS_MAX_BATCH` is defined once in Task 1 and imported by Task 3 rather than re-declared. `ROUTE_KEY_ITEMS_RESOLVE_IDS` is introduced in Task 2 and used in Task 3. The six-field key set is written identically in Task 1's projection test and Task 4's disclosure guard.
+
+**Known adjustments an implementer should expect.** Task 1's test seeding is written against `resolve-by-url.test.ts`'s helper, which must be read rather than assumed — the placeholder `applySchema`/`insert` names in Step 1 are explicitly marked to be replaced with whatever that file actually uses. Task 2 may not be independently green if the route-auth scanner rejects a table entry with no matching handler literal; the step says to fold Tasks 2 and 3 into one commit if so, rather than working around the scanner.

--- a/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
+++ b/docs/superpowers/plans/2026-09-07-items-resolve-ids.md
@@ -64,19 +64,33 @@
 
 - [ ] **Step 1: Write the failing tests**
 
-Read `packages/gateway/src/index/resolve-by-url.test.ts` first and reuse its database-seeding idiom rather than inventing one.
+`resolve-by-url.test.ts` is the sibling to match, and it seeds with a **hand-written lightweight DDL** naming only the columns under test — not the real schema. Follow that idiom, but **it must declare `canonical_url`**, which the sibling omits because it never reads it. `resolveItemsByIds` selects `COALESCE(url, canonical_url)`, so copying the sibling's DDL verbatim fails with `no such column: canonical_url`.
+
+(Importing the real schema from `packages/gateway/src/index/unified-item-v3-sql.ts` is the alternative. Either is defensible; the lightweight form matches the neighbour and keeps the fixture readable.)
 
 ```ts
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { RESOLVE_IDS_MAX_BATCH, resolveItemsByIds } from "./resolve-ids.ts";
 
+type Row = {
+  id: string; service: string; type: string; title: string;
+  url: string | null; canonical_url: string | null; modified_at: number;
+};
+
 function seed(): Database {
   const db = new Database(":memory:");
-  // Use the project's real schema application, exactly as resolve-by-url.test.ts does —
-  // a hand-written CREATE TABLE here would drift from the migrations.
-  applySchema(db); // replace with whatever resolve-by-url.test.ts calls
-  const insert = (row: Record<string, unknown>) => { /* per that file's helper */ };
+  // Lightweight DDL in the sibling's style — every column this module reads, plus
+  // `canonical_url`, which the sibling has no reason to declare and this one does.
+  db.exec(`CREATE TABLE item (id TEXT PRIMARY KEY, service TEXT, type TEXT, title TEXT,
+    url TEXT, canonical_url TEXT, modified_at INTEGER)`);
+  const insert = (r: Row) =>
+    db
+      .query(
+        `INSERT INTO item (id, service, type, title, url, canonical_url, modified_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(r.id, r.service, r.type, r.title, r.url, r.canonical_url, r.modified_at);
   insert({ id: "github:acme/web#1", service: "github", type: "pull_request",
            title: "Auth rewrite", url: "https://example.test/pr/1",
            canonical_url: null, modified_at: 1_700_000_000_000 });
@@ -245,20 +259,26 @@ git commit -m "feat(index): resolve item ids back to their references"
 
 ---
 
-### Task 2: Route auth wiring
+### Task 2: Route auth, the handler, and its mount
 
 **Files:**
 
 - Modify: `packages/gateway/src/ipc/http-route-auth.ts` (constants near `:22-23`, `HTTP_ROUTE_AUTH` near `:80`, `ClipReadRouteKey` at `:154-165`)
+- Modify: `packages/gateway/src/ipc/http-server.ts` (handler beside `handleItemsResolveFile` at `:672`; mount at `:1146-1148`)
+- Test: `packages/gateway/src/ipc/http-route-auth.test.ts`
 
 **Interfaces:**
 
-- Consumes: nothing from Task 1.
-- Produces: `ROUTE_KEY_ITEMS_RESOLVE_IDS = "GET /v1/items/resolve-ids"`, its `{ kind: "clip", scope: "resolve" }` entry, and its union member.
+- Consumes: `resolveItemsByIds`, `RESOLVE_IDS_MAX_BATCH` (Task 1); the existing `requireScopedClipToken` and `json` helpers.
+- Produces: `ROUTE_KEY_ITEMS_RESOLVE_IDS = "GET /v1/items/resolve-ids"`, its `{ kind: "clip", scope: "resolve" }` entry, its `ClipReadRouteKey` union member, and the served route.
 
-> **Three completeness tests enforce this**, so a route added without its table
-> entry fails the suite rather than failing open. That is the point of doing this
-> as its own task: it is the safety wiring, and it should be reviewable alone.
+> **The auth entry and the mount cannot be separate commits, and this is not a
+> style preference.** `http-route-auth.test.ts`'s *"no table entry is a route
+> that no longer exists"* test source-scans `http-server.ts` for route literals
+> and reports any `HTTP_ROUTE_AUTH` key whose path it cannot find. Adding the
+> table entry without the mount puts this route in that `stale` list and the
+> suite goes red. An earlier draft of this plan split them and hedged about it;
+> the scanner settles it.
 
 - [ ] **Step 1: Add the constant, the entry, and the union member**
 
@@ -282,32 +302,7 @@ And in the union (`:154-165`), which exists so passing a raw request path to `en
   | typeof ROUTE_KEY_ITEMS_RESOLVE_IDS
 ```
 
-- [ ] **Step 2: Run the route-auth suite**
-
-Run: `bun test packages/gateway/src/ipc/http-route-auth.test.ts`
-Expected: PASS. Note the scanner also fails if a table entry exists for a route no handler serves — so at this point the entry is present and Task 3 adds the literal it scans for. If the suite objects to an entry without a route, do Tasks 2 and 3 as one commit rather than fighting it, and say so in your report.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add packages/gateway/src/ipc/http-route-auth.ts
-git commit -m "feat(http): scope resolve-ids under the existing resolve scope"
-```
-
----
-
-### Task 3: The handler and its mount
-
-**Files:**
-
-- Modify: `packages/gateway/src/ipc/http-server.ts` (handler beside `handleItemsResolveFile` at `:672`; mount at `:1146-1148`)
-
-**Interfaces:**
-
-- Consumes: `resolveItemsByIds`, `RESOLVE_IDS_MAX_BATCH` (Task 1); `ROUTE_KEY_ITEMS_RESOLVE_IDS` (Task 2); the existing `requireScopedClipToken` and `json` helpers.
-- Produces: the served route.
-
-- [ ] **Step 1: Add the handler**
+- [ ] **Step 2: Add the handler**
 
 Mirror `handleItemsResolveFile` (`:672`) closely — it is the newest sibling and the shape reviewers expect:
 
@@ -354,7 +349,7 @@ async function handleItemsResolveIds(
 }
 ```
 
-- [ ] **Step 2: Mount it inline in the bearer-authed GET dispatcher**
+- [ ] **Step 3: Mount it inline in the bearer-authed GET dispatcher**
 
 Beside the two existing resolve mounts (`:1146-1148`):
 
@@ -368,21 +363,32 @@ Beside the two existing resolve mounts (`:1146-1148`):
 
 **Never in `dispatchReadOnlyDataGet`** — that table's `"/v1/items/*"` entry is `{ kind: "public" }` with no bearer gate, so routing through it would serve scoped output to any local process.
 
-- [ ] **Step 3: Run the route-auth and server suites**
+- [ ] **Step 4: Add the scope parity assertion**
+
+`http-route-auth.test.ts` already asserts the scope for its neighbours; add the matching one so this route's scope is pinned by name rather than only by the completeness scan:
+
+```ts
+  test("the resolve-ids route requires the resolve scope", () => {
+    expect(HTTP_ROUTE_AUTH[ROUTE_KEY_ITEMS_RESOLVE_IDS]).toEqual({ kind: "clip", scope: "resolve" });
+    expect(clipScopeFor(ROUTE_KEY_ITEMS_RESOLVE_IDS)).toBe("resolve");
+  });
+```
+
+- [ ] **Step 5: Run the ipc suite**
 
 Run: `bun test packages/gateway/src/ipc/ && bun run typecheck && bun run lint`
-Expected: PASS, including the three completeness tests.
+Expected: PASS, including all three completeness tests. A `stale` failure here means the mount in Step 3 is missing or its literal does not match the table key exactly.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add packages/gateway/src/ipc/http-server.ts
-git commit -m "feat(http): serve GET /v1/items/resolve-ids"
+git add packages/gateway/src/ipc/http-route-auth.ts packages/gateway/src/ipc/http-server.ts packages/gateway/src/ipc/http-route-auth.test.ts
+git commit -m "feat(http): serve GET /v1/items/resolve-ids under the resolve scope"
 ```
 
 ---
 
-### Task 4: Route integration tests
+### Task 3: Route integration tests
 
 **Files:**
 
@@ -440,7 +446,7 @@ git commit -m "test(http): pin resolve-ids' disclosure, caps and capability sign
 
 ---
 
-### Task 5: Documentation
+### Task 4: Documentation
 
 **Files:**
 
@@ -474,10 +480,53 @@ git commit -m "docs: record resolve-ids as a local read that appends no egress"
 
 ## Self-Review
 
-**Spec coverage.** §4's request shape → Task 3; its response and the six fields → Tasks 1, 3, 4. The URL-column divergence → Task 1's two dedicated tests. Absent-vs-null → Task 1 and Task 4. §4's error table → Task 3, each pinned in Task 4. §5's batching, cap, raw-count-first and ordering → Tasks 1 and 3, pinned in both suites. §5's flat-path and never-in-the-public-table rules → Task 3 Step 2. §6's "not egress" → Task 4's ledger delta and Task 5 Step 1. §7's rollout → Task 4's two 404 tests. §8's compliance list → Tasks 2, 3, 4.
+**Spec coverage.** §4's request shape → Task 2; its response and the six fields → Tasks 1, 2, 3. The URL-column divergence → Task 1's two dedicated tests. Absent-vs-null → Tasks 1 and 3. §4's error table → Task 2, each pinned in Task 3. §5's batching, cap, raw-count-first and ordering → Tasks 1 and 2, pinned in both suites. §5's flat-path and never-in-the-public-table rules → Task 2 Step 3. §6's "not egress" → Task 3's ledger delta and Task 4 Step 1. §7's rollout → Task 3's two 404 tests. §8's compliance list → Tasks 2 and 3.
 
 **Deliberately absent:** no migration task (no schema change), no OpenAPI task (this route stays off `HTTP_ROUTES`, like every clip-scoped bearer read), no scope task (`resolve` already exists, so no re-pairing).
 
 **Type consistency.** `resolveItemsByIds(db, ids)` returns `ResolvedItemRef[]` in Task 1 and is consumed under that name in Task 3. `RESOLVE_IDS_MAX_BATCH` is defined once in Task 1 and imported by Task 3 rather than re-declared. `ROUTE_KEY_ITEMS_RESOLVE_IDS` is introduced in Task 2 and used in Task 3. The six-field key set is written identically in Task 1's projection test and Task 4's disclosure guard.
 
-**Known adjustments an implementer should expect.** Task 1's test seeding is written against `resolve-by-url.test.ts`'s helper, which must be read rather than assumed — the placeholder `applySchema`/`insert` names in Step 1 are explicitly marked to be replaced with whatever that file actually uses. Task 2 may not be independently green if the route-auth scanner rejects a table entry with no matching handler literal; the step says to fold Tasks 2 and 3 into one commit if so, rather than working around the scanner.
+**Known adjustments an implementer should expect.** Task 1's seeding DDL is written out in full rather than deferred to the sibling's helper, because the sibling's DDL omits `canonical_url` and copying it would fail on this module's `COALESCE`. The three `stats`-free row shapes are transcribed from the real `item` table; if a column has since been renamed, the schema is the authority and the plan is wrong.
+
+**One task boundary is set by a test, not by taste.** The route-auth entry and the handler mount are a single task because `http-route-auth.test.ts`'s stale-entry scanner reports any `HTTP_ROUTE_AUTH` key whose path literal is absent from `http-server.ts` — so an auth-only commit is red by construction, and a task that cannot be green alone is not a task.
+
+## Review disposition
+
+Reviewed against
+[`2026-09-07-items-resolve-ids-review.md`](./2026-09-07-items-resolve-ids-review.md).
+Each finding was checked against the gateway source before being accepted.
+
+**Accepted — both were real defects.**
+
+| finding | verified against | resolution |
+| --- | --- | --- |
+| F2.1 the seeding DDL lacks `canonical_url` | `resolve-by-url.test.ts:6-8` — a hand-written `CREATE TABLE item (…)` with no `canonical_url` | Task 1 Step 1 now writes the DDL out in full, `canonical_url` included, and names the schema constant as the alternative |
+| F2.2 the auth entry cannot ship without the mount | `http-route-auth.test.ts:101-114` — the stale-entry scanner reports any `HTTP_ROUTE_AUTH` key whose path literal is absent from `http-server.ts` | Tasks 2 and 3 **merged into one**; the plan is four tasks now |
+
+**F2.1 caught a false statement, not just a gap.** The draft told the
+implementer to seed "exactly as `resolve-by-url.test.ts` does" and described that
+file as applying the real schema. It does not — it hand-writes a lightweight
+DDL naming only the columns it reads, and `canonical_url` is not among them.
+Following the instruction as written would have produced `no such column:
+canonical_url` on this module's `COALESCE`.
+
+**F2.2 was hedged where it should have been decided.** The draft said to fold
+the two tasks together "if the suite objects". The scanner does not object
+conditionally — an auth-only commit is red by construction, so a task that
+cannot be green alone is not a task. Merged rather than annotated.
+
+**Accepted as an addition.**
+
+- **S2.1** — a named scope assertion for the new route, beside the ones its
+  neighbours already have. Added as Task 2 Step 4. The completeness scan proves
+  an entry *exists*; this proves it says `resolve`.
+
+**Noted, no change.**
+
+- **S2.2** confirms the egress assertion should be a count *delta* rather than
+  `=== 0`, and points at `items-resolve-file-route.test.ts:335` as the
+  precedent. The plan already specified a delta, and says why — this is a
+  confirmation, and a welcome one.
+- **F2.3** is an assessment of the two-tier cap rather than a finding. The
+  layering it describes — a raw-count refusal at the HTTP layer and a throw in
+  the lookup — is what the plan already specifies.

--- a/docs/superpowers/specs/2026-09-07-items-resolve-ids-design-review.md
+++ b/docs/superpowers/specs/2026-09-07-items-resolve-ids-design-review.md
@@ -1,0 +1,214 @@
+# Design Review: `GET /v1/items/resolve-ids`
+
+**Date:** 2026-09-07  
+**Reviewer:** Antigravity (AI Coding Assistant)  
+**Status:** Review Complete  
+**Target Spec:** [`2026-09-07-items-resolve-ids-design.md`](./2026-09-07-items-resolve-ids-design.md)  
+**Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
+**Related Routes:** `GET /v1/items/resolve`, `GET /v1/items/resolve-file`, `POST /v1/items/fetch`
+
+---
+
+## 1. Executive Summary
+
+The target specification proposes a clean, necessary reverse-lookup endpoint (`GET /v1/items/resolve-ids`) to map indexed item IDs back to reference metadata (`id`, `service`, `type`, `title`, `url`, `modified_at`). This fills a critical capability gap for the browser client (`nimbus-web-clipper`), which currently renders dead-text titles for findings in four agent lanes (`expert`, `impact`, `catchup`, `why`).
+
+Key strengths of the proposed design:
+
+1. **Reduced Disclosure Security Posture (§ 3):** Requiring the `resolve` bearer scope and projecting only 6 metadata fields (excluding `body`, `metadata`, `author_id`, and `external_id`) provides strictly less disclosure than the existing unauthenticated `GET /v1/items/{id}` public route.
+2. **Batched Arity (§ 5):** Supporting multi-ID resolution in a single round trip eliminates $N$ sequential HTTP polls on active agent views.
+3. **Capability Signal via 404 (§ 7):** Treating route presence (404 on unmounted or older gateways) as the capability gate allows client-side graceful degradation without brittle version floors.
+4. **Zero Egress & Zero Mutation (§ 6):** Pure read from local SQLite; appends no egress ledger rows and makes zero outbound network calls.
+
+Below are architectural refinements, resolutions to open questions, and concrete implementation guidance.
+
+---
+
+## 2. Open Questions & Architectural Refinements
+
+### Q2.1: Defining the Batch Cap Constant (`RESOLVE_IDS_MAX_BATCH`)
+
+- **Context:**
+  - § 5 proposes refusing requests with `400 { "error": "too_many_ids" }` when exceeding a cap, citing `RESOLVE_CANDIDATE_CAP` (5 in `resolve-by-url.ts`).
+  - However, for reverse ID resolution, agent briefs regularly return 20 to 50 findings (e.g. `CatchupBrief` with `PER_SERVICE_QUOTA = 50`). A cap of 5 or 10 would cause legitimate agent brief resolutions to fail.
+- **Recommendation:**
+  - Define and export an explicit constant:
+
+    ```ts
+    export const RESOLVE_IDS_MAX_BATCH = 100;
+    ```
+
+  - `100` comfortably accommodates even dense briefs while remaining well within SQLite parameter binding limits (default `SQLITE_LIMIT_VARIABLE_NUMBER = 32766`) and HTTP URL query length ceilings.
+  - If the client collects $>100$ IDs across multiple sections, the client should chunk requests in batches of $\le 100$.
+
+---
+
+### Q2.2: Parameter Parsing, Counting, and Query-String DoS Prevention
+
+- **Context:**
+  - In URL query parsing, a malicious or buggy client could submit thousands of repeated `?id=...` parameters, causing excessive CPU/memory consumption during string parsing and deduplication.
+- **Recommendation:**
+  - Extract IDs via `url.searchParams.getAll("id")`.
+  - Validate bounds in three strict steps:
+    1. **Raw Parameter Bound:** If `rawIds.length > RESOLVE_IDS_MAX_BATCH`, immediately refuse with `400 { "error": "too_many_ids" }`.
+    2. **Blank Filter:** Trim IDs and discard empty strings (`id.trim() === ""`).
+    3. **Missing ID Guard:** If filtered array is empty, refuse with `400 { "error": "missing_id" }`.
+    4. **Deduplication:** Convert to unique set (`[...new Set(filteredIds)]`) before SQL parameter binding.
+
+---
+
+### Q2.3: Deterministic Ordering of the Returned `items` Array
+
+- **Context:**
+  - § 4 specifies returning `{ "items": [...] }`.
+  - SQLite `WHERE id IN (?, ?)` does not guarantee preservation of input parameter order.
+- **Recommendation:**
+  - Order SQL results deterministically by `ORDER BY id ASC` (or `ORDER BY modified_at DESC, id ASC`).
+  - Deterministic ordering ensures stable JSON wire responses and deterministic testing across platforms.
+  - The client matches returned items by `item.id` via map/dictionary lookup rather than positional indexing.
+
+---
+
+### Q2.4: URL Precedence & SQL Query Construction
+
+- **Context:**
+  - The `item` table contains both `url` and `canonical_url` columns (both nullable).
+  - § 4 specifies returning canonical URL over raw URL.
+- **Recommendation:**
+  - Use `COALESCE(canonical_url, url)` directly in the SQL projection:
+
+    ```sql
+    SELECT id, service, type, title,
+           COALESCE(canonical_url, url) AS url,
+           modified_at
+      FROM item
+     WHERE id IN (${placeholders})
+     ORDER BY id ASC;
+    ```
+
+  - This avoids fetching extra columns into memory and applies the exact canonicalization precedence at the database layer.
+
+---
+
+## 3. Module Architecture & File Layout
+
+To maintain modularity and isolation, the implementation should be structured as follows:
+
+```text
+packages/gateway/src/
+├── index/
+│   ├── resolve-by-id.ts          # Core SQL lookup and projection logic
+│   └── resolve-by-id.test.ts     # Unit tests for query, deduplication, and bounds
+├── ipc/
+│   ├── http-route-auth.ts        # Add ROUTE_KEY_ITEMS_RESOLVE_IDS & scope binding
+│   ├── http-route-auth.test.ts   # Verify route scanning & auth completeness
+│   └── http-server.ts            # Wire handleItemsResolveIds in tryBearerAuthedGet
+```
+
+### 3.1 Type Definitions (`packages/gateway/src/index/resolve-by-id.ts`)
+
+```ts
+import type { Database } from "bun:sqlite";
+
+export const RESOLVE_IDS_MAX_BATCH = 100;
+
+export interface ResolvedItemRef {
+  readonly id: string;
+  readonly service: string;
+  readonly type: string;
+  readonly title: string;
+  readonly url: string | null;
+  readonly modified_at: number;
+}
+
+export function resolveItemsByIds(
+  db: Database,
+  ids: readonly string[],
+): ResolvedItemRef[] {
+  if (ids.length === 0) return [];
+  const uniqueIds = Array.from(new Set(ids));
+  if (uniqueIds.length > RESOLVE_IDS_MAX_BATCH) {
+    throw new Error(`resolveItemsByIds: batch size exceeds limit of ${RESOLVE_IDS_MAX_BATCH}`);
+  }
+
+  const placeholders = uniqueIds.map(() => "?").join(", ");
+  const sql = `
+    SELECT id, service, type, title,
+           COALESCE(canonical_url, url) AS url,
+           modified_at
+      FROM item
+     WHERE id IN (${placeholders})
+     ORDER BY id ASC
+  `;
+
+  const rows = db.query(sql).all(...uniqueIds) as Array<{
+    id: string;
+    service: string;
+    type: string;
+    title: string;
+    url: string | null;
+    modified_at: number;
+  }>;
+
+  // Exact projection: prevent internal table row leaks
+  return rows.map((r) => ({
+    id: r.id,
+    service: r.service,
+    type: r.type,
+    title: r.title,
+    url: r.url,
+    modified_at: r.modified_at,
+  }));
+}
+```
+
+### 3.2 HTTP Route & Auth Integration (`packages/gateway/src/ipc/http-route-auth.ts`)
+
+```ts
+export const ROUTE_KEY_ITEMS_RESOLVE_IDS = "GET /v1/items/resolve-ids";
+
+export const HTTP_ROUTE_AUTH = Object.freeze({
+  // ...
+  [ROUTE_KEY_ITEMS_RESOLVE_IDS]: { kind: "clip", scope: "resolve" },
+});
+
+export type ClipReadRouteKey =
+  // ...
+  | typeof ROUTE_KEY_ITEMS_RESOLVE_IDS;
+```
+
+---
+
+## 4. Security & Invariants Audit
+
+1. **Invariant I13 (Write Route Allowlist):** `GET /v1/items/resolve-ids` is a read-only endpoint, correctly staying off `WRITE_ROUTE_ALLOWLIST` and mounted in `tryBearerAuthedGet`.
+2. **Invariant I29 / Egress Ledger:** No egress row is appended. `egress/egress-coverage.ts` documentation should be updated to list `GET /v1/items/resolve-ids` alongside `resolve` and `resolve-file` as local index reads that emit zero ledger rows.
+3. **Scope Partitioning (`resolve` vs `fetch`):** A token with `resolve` scope can read metadata for existing indexed items, but cannot trigger remote provider requests (`POST /v1/items/fetch`).
+4. **Exact Field Projection:** The handler constructs returned objects explicitly (`id`, `service`, `type`, `title`, `url`, `modified_at`), ensuring internal SQLite columns (`body`, `metadata`, `author_id`, `synced_at`) never leak over the wire.
+
+---
+
+## 5. Comprehensive Testing Strategy
+
+### 5.1 Unit Tests (`packages/gateway/src/index/resolve-by-id.test.ts`)
+
+- **Single ID hit:** Returns exact 6-field projection.
+- **Multiple IDs hit:** Returns all matched items.
+- **Partial hit:** Missing IDs omitted from `items` array without error.
+- **URL fallback:** `canonical_url` prioritized over `url`; null when both absent.
+- **Deduplication:** Duplicate input IDs query SQLite once and return single object.
+- **Batch cap:** Throws when input array exceeds `RESOLVE_IDS_MAX_BATCH`.
+
+### 5.2 HTTP Route & Auth Tests (`packages/gateway/src/ipc/http-route-auth.test.ts`)
+
+- `HTTP_ROUTE_AUTH` scanner verifies `GET /v1/items/resolve-ids` is present and mapped to `{ kind: "clip", scope: "resolve" }`.
+- Token without `resolve` scope receives `403 { "error": "insufficient_scope" }`.
+- Legacy token (`clip`, `briefs`) receives 403.
+- Unmounted clips vault receives `404 { "error": "resolve_disabled" }`.
+
+### 5.3 HTTP Integration Tests (`packages/gateway/src/ipc/http-server.test.ts`)
+
+- `GET /v1/items/resolve-ids` with valid token $\to$ `200 { "items": [...] }`.
+- `GET /v1/items/resolve-ids` with no `id` query params $\to$ `400 { "error": "missing_id" }`.
+- `GET /v1/items/resolve-ids` with $>100$ `id` query params $\to$ `400 { "error": "too_many_ids" }`.
+- Exact key set assertion: `Object.keys(body.items[0]).sort()` strictly equals `["id", "modified_at", "service", "title", "type", "url"]`.

--- a/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
+++ b/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
@@ -1,0 +1,275 @@
+# `GET /v1/items/resolve-ids` — turning an item id back into a reference
+
+> **Status:** proposal. No code in this branch — this is the contract, argued
+> before it is built, per the satellite-repo convention that the gateway owns
+> the wire and consumers propose against it.
+>
+> **Proposed by:** the browser client (`nimbus-web-clipper`), which is blocked
+> on it for four of its seven agent lanes.
+
+## 1. What this is
+
+One bearer-authed read that maps **indexed item ids to the references they came
+from**:
+
+```text
+GET /v1/items/resolve-ids?id=github:acme/web%23482&id=jira:PLAT-91
+```
+
+It is the inverse of `GET /v1/items/resolve`, which maps a URL to an item. That
+direction has existed since the clip surface shipped. This one has not, and its
+absence is now load-bearing for a shipped feature.
+
+## 2. The concrete gap
+
+Every agent brief the browser renders is a typed object, and several of them
+name other indexed items — but by **id only**, with no URL:
+
+| finding | the id it carries | URL? |
+| --- | --- | --- |
+| `ExpertFinding.evidence[].itemId` | the PR, issue or commit that evidences someone's expertise | none |
+| `ImpactFinding.affectedItemId` | the thing that breaks if this change lands | none |
+| `CatchupItem.itemId` | each item that changed while you were away | none |
+
+The browser now renders these briefs as structure rather than prose (phase C8 in
+`nimbus-web-clipper`; `why`, `glossary` and `decisions` shipped in v0.6.0 and
+the release after it). Those three lanes carry real URLs in their findings, so
+their entries are clickable. **The four remaining lanes carry ids only**, so a
+reader gets a list of titles that look like links, are not, and cannot be made
+into links by any client-side means — `GET /v1/items/resolve` goes URL → item,
+and nothing goes the other way.
+
+The client-side slice that renders those four lanes is designed and waiting. It
+ships either way; with this route it ships with references, without it a title
+is a dead end.
+
+## 3. Why this is narrower than what the gateway already serves
+
+The reflexive objection to an id-keyed read is that it is an enumeration oracle:
+a caller could confirm which items exist by asking.
+
+**That is already true, unauthenticated, with far more disclosure.**
+`packages/gateway/src/ipc/http-route-auth.ts:48-49`:
+
+```ts
+  "GET /v1/items": { kind: "public" },
+  "GET /v1/items/*": { kind: "public" },
+```
+
+`GET /v1/items/{id}` is `{ kind: "public" }` — no bearer gate at all — and its
+handler returns the **entire row**, including `body`, `metadata` and
+`author_id`. Any local process can already resolve an arbitrary item id to its
+URL *and* its body today.
+
+This proposal is therefore **strictly less disclosure than the status quo**: a
+`resolve`-scoped token, six named fields, no body, no metadata, no author. The
+only thing it adds is arity — asking about several ids in one round trip instead
+of one at a time.
+
+That is the whole security argument, and it should be stated first in review so
+the discussion is about arity rather than about disclosure.
+
+## 4. Proposed contract
+
+### Request
+
+`GET /v1/items/resolve-ids`, with `id` repeated once per item — the same shape
+as the existing repeated `?service=` parameter on `GET /v1/items`.
+
+Bearer-authed under the **existing `resolve` scope**, for the same reason
+`resolve-file` is: it reads, it runs nothing, and it appends no egress row.
+
+### Response
+
+```json
+{
+  "items": [
+    {
+      "id": "github:acme/web#482",
+      "service": "github",
+      "type": "pull_request",
+      "title": "Rewrite the auth middleware",
+      "url": "https://github.com/acme/web/pull/482",
+      "modified_at": 1757203200000
+    }
+  ]
+}
+```
+
+Field-for-field this is `ResolveCandidate` plus `modified_at` — exactly the
+projection `GET /v1/items/resolve`'s `found` arm already returns
+(`packages/gateway/src/index/resolve-by-url.ts`). That is deliberate: the
+browser already has the type, the parser and the renderer for this shape, so
+consuming it costs a call site rather than a new model.
+
+**An id that is not indexed is simply absent from `items`.** It is not an error
+and not a null entry. Absent and `url: null` are different facts and the client
+renders them differently: absent means "the index does not hold this", `url:
+null` means "it does, and it has no source URL". Collapsing them would make a
+missing item indistinguishable from a URL-less one.
+
+### `url` is nullable, and must stay nullable
+
+Both URL columns on `item` are nullable and many item types genuinely have
+none — derived items, brief saves, glossary projections. The SDK already made
+this exact call for `WhyItemSubject.url`, and its reasoning applies verbatim: a
+non-null type "would force it to substitute the URL it was *asked* with for the
+one the item *has*, which is a fabricated field inside a subject."
+
+Where both `url` and `canonical_url` exist, return the same precedence the row's
+own `resolve_key` is derived from — canonical over raw — rather than inventing a
+second rule.
+
+### Errors
+
+| condition | status | body |
+| --- | --- | --- |
+| clips surface unmounted | 404 | `{ "error": "resolve_disabled" }` |
+| no `id` parameter, or all blank | 400 | `{ "error": "missing_id" }` |
+| more ids than the cap | 400 | `{ "error": "too_many_ids" }` |
+| token lacks `resolve` | 403 | the standard scope-gap body |
+
+The 404 is the capability signal (§7) and must come **before** the auth check,
+matching `resolve-file` — a client reads it as "gateway older than the route"
+and withholds its links silently. A 500 there would turn a correct quiet
+degradation into a visible error.
+
+## 5. Design decisions
+
+### It has to be batched
+
+A single findings payload routinely names a dozen or more ids — a `catchup`
+brief with several populated sections can name many more. One round trip per id,
+over a panel that is already polling, is the wrong shape. No route on the surface
+accepts multiple ids today, so this is a new arity; it is not a new *kind* of
+input, since `POST /v1/clips/related` already takes a browser-supplied item id.
+
+De-duplicate before binding, join back by id, and bind every value as a
+parameter — never interpolate ids into the `IN (…)` list.
+
+### The cap, and refusing rather than truncating
+
+`RESOLVE_CANDIDATE_CAP`'s rationale (`resolve-by-url.ts`) is the precedent and
+the reason:
+
+> Candidate lists are capped: rung 3 trims path segments and can match broadly,
+> so an uncapped list would turn a mis-trimmed URL into a bulk index read over a
+> `resolve`-scoped token.
+
+A `?id=` list is that risk in a more direct form, so it takes a cap. SQLite's
+bind-parameter ceiling is not the binding constraint; the token scope is.
+
+**Over the cap, refuse with 400 rather than clamping.** The repo has both
+postures — `parsePositiveInt` clamps a `limit`, `nimbus media allow-remote`
+refuses above 500 — and refusal is right here. Silently dropping ids means
+silently dropping *links*: the reader sees some references and not others, with
+nothing to say why. A caller over the cap has a bug and should hear about it.
+
+Note this differs from `resolve`'s over-cap behaviour, which returns an empty
+candidate list plus `truncated: true` because "a truncated choice menu implies
+the right answer is among those shown when it may not be." An id-keyed map has
+no implied ranking, so that argument does not transfer; the honest failure here
+is a refusal.
+
+### A flat path, not a regex
+
+Match `url.pathname === "/v1/items/resolve-ids"` and pass ids as query
+parameters. `http-route-auth.test.ts` source-scans `http-server.ts` for route
+literals and additionally pins the count of regex-routed GETs, so a path-embedded
+id (`/v1/items/resolve-ids/{id}`) would need an explicit `REGEX_ROUTED_GET`
+entry. The flat form stays inside the `tryBearerAuthedGet` family the existing
+test server already harnesses, and costs nothing.
+
+### Mounted inline, never in the public GET table
+
+The `"GET /v1/items/*"` entry is `{ kind: "public" }` with no bearer gate, so
+routing this through `dispatchReadOnlyDataGet` would serve scoped output to any
+local process. It mounts inline in `tryBearerAuthedGet`, exactly as
+`resolve-file` does and for the same stated reason.
+
+### The response is written field by field
+
+Never a spread and never a destructured rest, matching `resolve-file`'s handler:
+a field added later to the internal row type cannot then leak here unnamed. The
+integration test pins `Object.keys(body.items[0]).sort()` to an exact set.
+
+## 6. What this is not
+
+- **Not a body read.** No `body`, no `body_preview`, no `metadata`, no
+  `author_id`, no `external_id`. `resolve`'s own note applies — it is a
+  resolver; reading is `GET /v1/items/{id}`.
+- **Not a federation surface.** It reads the local `item` table and must never
+  grow an outbound peer arm. The reasoning behind the invariant that keeps a
+  browser-reachable *file* question local applies unchanged to a
+  browser-reachable *item* question: any holder of that token could otherwise
+  turn a question about one item into outbound peer calls, from a client whose
+  entire premise is that it talks to loopback and nothing else. If that is ever
+  wanted it is a new decision with its own gate, not a relaxation of this one.
+- **Not egress.** No provider request, no ledger row. The
+  `egress-coverage.ts` comment that names the newest such route by name should
+  be re-pointed at this one when it lands.
+- **Not a schema change.** No migration, no new column, no new index — `item.id`
+  is the primary key.
+- **Not an OpenAPI addition.** Like every other clip-scoped bearer read, it stays
+  off `HTTP_ROUTES`.
+
+## 7. Rollout
+
+**Route presence is the capability signal. There is no version floor.**
+
+This follows `resolve-file` exactly: the client probes, reads a 404 as "this
+gateway does not have it", and withholds the links silently. A floor constant
+would have to be raised by hand on every future change; presence cannot drift.
+
+The `resolve` scope already exists, so **no re-pairing**. A browser paired before
+scopes existed holds the legacy set and gets a 403 naming the fix, repairable in
+place with `nimbus clip scopes` — the same story as every other scoped read.
+
+## 8. Compliance checklist
+
+- **Token verification.** Routes through the standard scoped-clip-token path;
+  never a hand-rolled scope check.
+- **Route auth table.** A new `ROUTE_KEY_*` constant, an entry
+  `{ kind: "clip", scope: "resolve" }`, and a member added to the read-route
+  union — the union exists so passing a raw request path is a compile error
+  rather than a runtime fail-open. Three completeness tests enforce this.
+- **Parameter binding.** Placeholders built from the array length, every value
+  bound; no interpolation.
+- **Egress ledger.** No row appended, asserted by a count delta in the
+  integration test rather than by inspection.
+- **Disclosure guard.** An exact-key-set assertion on the response, so a widened
+  internal row cannot leak.
+- **The unmounted branch.** A test that the 404 fires before auth.
+
+## 9. Alternatives considered
+
+**Have the client call `GET /v1/items/{id}` per id.** It is public, it already
+returns the URL, and it needs no new route. Rejected: it returns the entire row
+including `body` and `metadata` to a client that wants six fields, it is
+unauthenticated where the rest of the browser's surface is scoped, it is one
+round trip per reference, and it is not part of the clip contract the client is
+built against. Using it would be the client reaching around its own boundary.
+
+**Put URLs into the agent briefs themselves.** Arguably the tidier fix — the
+agents have the rows in hand. Rejected as the larger change: it alters what
+several agents *return*, which is a three-repo chain through the SDK's published
+brief types, and it inflates every brief with data most consumers do not render.
+A reverse lookup is additive and consumers opt in.
+
+**Return a map keyed by id rather than an array.** Marginally more convenient
+for the client, but item ids contain characters that make them awkward object
+keys, and the array form matches the projection the neighbouring resolve route
+already returns. The client joins by id either way.
+
+## 10. What the client does with it
+
+For the record, so the shape is judged against a real consumer rather than in
+the abstract. On a resolved agent lane the browser already holds the typed
+brief; it collects the ids its renderer would otherwise print as dead text,
+issues one `resolve-ids` call, and renders each as a link where the response
+carries a URL — falling back to plain text where it does not, which is the
+existing rule for every reference it renders.
+
+It is one call per lane expansion, bounded by the cap, on a surface that is
+already polling. No new destination: the browser's only network target remains
+the gateway on loopback.

--- a/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
+++ b/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
@@ -198,10 +198,38 @@ which is right for a disambiguation menu a human reads and hopeless here:
 brief. A cap anywhere near 5 would refuse the single largest consumer on its
 ordinary path — a caps-are-good instinct producing a route that does not work.
 
-**100** clears a dense `catchup` brief with room, sits three orders of magnitude
-under the bind ceiling, and stays well inside any URL-length limit. A client
-holding more than that chunks; the client is the one that knows which references
-are worth resolving.
+**100** clears a dense `catchup` brief with room and sits three orders of
+magnitude under the bind ceiling. A client holding more than that chunks; the
+client is the one that knows which references are worth resolving.
+
+### A count is not a size, and the size limit is not ours to enforce
+
+`item.id` is unconstrained `TEXT` — `"<service>:<externalId>"` where the external
+id is connector-defined. A GitHub PR id is around twenty characters; a deep
+GitLab subgroup path is several times that. So **100 ids does not bound the
+request**: at 30 bytes per `&id=` pair the query string is ~3 KB, and at 120
+bytes per pair it is past 12 KB.
+
+That matters more than an ordinary cap, because **the gateway may never see an
+over-long request**. A URL past the server's own line limit is refused before any
+handler runs, so the client gets a transport error rather than the honest
+`too_many_ids` this route would otherwise return. A limit the route cannot
+enforce is a limit the client has to respect.
+
+The contract therefore states both, and says which one binds:
+
+- **Never more than `RESOLVE_IDS_MAX_BATCH` ids** — the route enforces this and
+  returns `400 { "error": "too_many_ids" }`.
+- **Never more than ~1,800 bytes of query string.** The client chunks by
+  whichever limit is reached first. 1,800 is chosen to sit under the ~2,000-byte
+  length that is safe on every server and proxy, rather than under the ~8,000
+  many allow — this is a loopback call where an extra round trip costs almost
+  nothing, and a request that dies in the socket costs a debugging session.
+
+The route should also refuse a query string over a stated byte budget where it
+does see one, so a client that ignores the guidance gets a 400 rather than a
+truncated answer. But the byte rule is guidance the client owns, and the spec
+says so rather than implying the gateway can police it.
 
 **Over the cap, refuse with 400 rather than clamping.** The repo has both
 postures — `parsePositiveInt` clamps a `limit`, `nimbus media allow-remote`

--- a/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
+++ b/docs/superpowers/specs/2026-09-07-items-resolve-ids-design.md
@@ -102,6 +102,26 @@ projection `GET /v1/items/resolve`'s `found` arm already returns
 browser already has the type, the parser and the renderer for this shape, so
 consuming it costs a call site rather than a new model.
 
+### Which URL column, and one deliberate divergence
+
+The sibling route selects the bare `url` column
+(`packages/gateway/src/index/resolve-by-url.ts:58`), not a coalesce. This route
+matches it — a response that claimed to be the same projection while quietly
+applying different precedence would be worse than an honest difference.
+
+The one divergence: **when `url` is null and `canonical_url` is not, return
+`canonical_url`.** A reference the reader can follow beats no reference, and the
+fallback only ever fires where the sibling would have returned null anyway, so
+no caller sees a *different* URL for the same row — only a URL where it would
+otherwise have had none.
+
+Note this is the opposite precedence from the row's own `resolve_key`, which is
+derived canonical-first. That is correct: `resolve_key` exists to make two
+spellings of the same address match, so it wants the normalized form. This field
+exists to be clicked, so it wants the address the provider actually published.
+Flagged explicitly because it is the one place a reviewer may reasonably prefer
+strict parity with the sibling instead.
+
 **An id that is not indexed is simply absent from `items`.** It is not an error
 and not a null entry. Absent and `url: null` are different facts and the client
 renders them differently: absent means "the index does not hold this", `url:
@@ -116,9 +136,9 @@ this exact call for `WhyItemSubject.url`, and its reasoning applies verbatim: a
 non-null type "would force it to substitute the URL it was *asked* with for the
 one the item *has*, which is a fabricated field inside a subject."
 
-Where both `url` and `canonical_url` exist, return the same precedence the row's
-own `resolve_key` is derived from — canonical over raw — rather than inventing a
-second rule.
+`null` therefore survives all the way to the reader, who sees the title as plain
+text rather than a link — the same rule the browser already applies to every
+reference it renders.
 
 ### Errors
 
@@ -126,7 +146,7 @@ second rule.
 | --- | --- | --- |
 | clips surface unmounted | 404 | `{ "error": "resolve_disabled" }` |
 | no `id` parameter, or all blank | 400 | `{ "error": "missing_id" }` |
-| more ids than the cap | 400 | `{ "error": "too_many_ids" }` |
+| more than `RESOLVE_IDS_MAX_BATCH` raw ids | 400 | `{ "error": "too_many_ids" }` |
 | token lacks `resolve` | 403 | the standard scope-gap body |
 
 The 404 is the capability signal (§7) and must come **before** the auth check,
@@ -147,17 +167,41 @@ input, since `POST /v1/clips/related` already takes a browser-supplied item id.
 De-duplicate before binding, join back by id, and bind every value as a
 parameter — never interpolate ids into the `IN (…)` list.
 
-### The cap, and refusing rather than truncating
+**Count the raw parameters before de-duplicating.** Checking the cap after
+de-duplication would let a caller send fifty thousand copies of one id and pay
+only the parsing and set-building cost — cheap for them, not for the gateway.
+The order is: read `getAll("id")`, refuse if the *raw* count is over the cap,
+then trim and drop blanks, then refuse as `missing_id` if nothing survives, then
+de-duplicate.
 
-`RESOLVE_CANDIDATE_CAP`'s rationale (`resolve-by-url.ts`) is the precedent and
-the reason:
+**Return the rows in a deterministic order** (`ORDER BY id`). `IN (…)` does not
+preserve parameter order, and callers join by id rather than by position, so
+ordering carries no meaning — which is exactly why it should be stable rather
+than incidental, so a wire response is reproducible in tests across platforms.
+
+### The cap: `RESOLVE_IDS_MAX_BATCH = 100`
+
+`RESOLVE_CANDIDATE_CAP`'s rationale (`resolve-by-url.ts`) is why there is a cap
+at all:
 
 > Candidate lists are capped: rung 3 trims path segments and can match broadly,
 > so an uncapped list would turn a mis-trimmed URL into a bulk index read over a
 > `resolve`-scoped token.
 
-A `?id=` list is that risk in a more direct form, so it takes a cap. SQLite's
-bind-parameter ceiling is not the binding constraint; the token scope is.
+A `?id=` list is that risk in a more direct form. SQLite's bind-parameter
+ceiling (32,766) is not the binding constraint; the token scope is.
+
+**Borrow that rationale, not its magnitude.** `RESOLVE_CANDIDATE_CAP` is **5**,
+which is right for a disambiguation menu a human reads and hopeless here:
+`catchup` alone admits up to `PER_SERVICE_QUOTA = 50` items **per service**
+(`packages/gateway/src/agents/catchup.ts:12`), across several sections in one
+brief. A cap anywhere near 5 would refuse the single largest consumer on its
+ordinary path — a caps-are-good instinct producing a route that does not work.
+
+**100** clears a dense `catchup` brief with room, sits three orders of magnitude
+under the bind ceiling, and stays well inside any URL-length limit. A client
+holding more than that chunks; the client is the one that knows which references
+are worth resolving.
 
 **Over the cap, refuse with 400 rather than clamping.** The repo has both
 postures — `parsePositiveInt` clamps a `limit`, `nimbus media allow-remote`
@@ -229,6 +273,12 @@ place with `nimbus clip scopes` — the same story as every other scoped read.
 
 - **Token verification.** Routes through the standard scoped-clip-token path;
   never a hand-rolled scope check.
+- **I13 does not apply, and that is the point.** I13 governs HTTP *write* routes
+  (`WRITE_ROUTE_ALLOWLIST` + bearer auth, `docs/SECURITY-INVARIANTS.md`). This is
+  a read: it stays off that allowlist and mounts in the bearer-authed GET family
+  instead. Named here because "new HTTP route" is the trigger a reviewer will
+  reach for I13 on, and the answer is that it is the wrong invariant for this
+  one.
 - **Route auth table.** A new `ROUTE_KEY_*` constant, an entry
   `{ kind: "clip", scope: "resolve" }`, and a member added to the read-route
   union — the union exists so passing a raw request path is a compile error
@@ -240,6 +290,11 @@ place with `nimbus clip scopes` — the same story as every other scoped read.
 - **Disclosure guard.** An exact-key-set assertion on the response, so a widened
   internal row cannot leak.
 - **The unmounted branch.** A test that the 404 fires before auth.
+
+The integration test belongs beside its siblings as
+`packages/gateway/test/integration/http/items-resolve-ids-route.test.ts` —
+`items-resolve-route.test.ts` and `items-resolve-file-route.test.ts` are already
+there, and #1447 established the shape.
 
 ## 9. Alternatives considered
 
@@ -273,3 +328,56 @@ existing rule for every reference it renders.
 It is one call per lane expansion, bounded by the cap, on a surface that is
 already polling. No new destination: the browser's only network target remains
 the gateway on loopback.
+
+## 11. Review disposition
+
+Reviewed against
+[`2026-09-07-items-resolve-ids-design-review.md`](./2026-09-07-items-resolve-ids-design-review.md).
+Each finding was checked against the gateway source before being accepted.
+
+**Accepted.**
+
+| finding | verified against | resolution |
+| --- | --- | --- |
+| Q2.1 the cap must clear a real brief | `catchup.ts:12` — `PER_SERVICE_QUOTA = 50` per service | §5 now names `RESOLVE_IDS_MAX_BATCH = 100` and separates the precedent's *rationale* from its magnitude |
+| Q2.2 count raw parameters before de-duplicating | — (reasoning, not a code claim) | §5: the four-step order, with the reason a post-dedup check is cheap for the caller and not for the gateway |
+| Q2.3 deterministic ordering | `IN (…)` does not preserve parameter order | §5: `ORDER BY id`, framed as reproducibility rather than meaning |
+| Q2.4 concrete URL selection | `resolve-by-url.ts:58` | §4 — but with the precedence **inverted**, see below |
+| I13 is the write-route invariant | `docs/SECURITY-INVARIANTS.md:242` | §8: named as the invariant a reviewer will reach for and why it does not apply |
+
+**Q2.1 is the one that mattered.** The original draft cited
+`RESOLVE_CANDIDATE_CAP` as "the precedent" without naming a number. That cap is
+**5**. A reader taking the precedent for a magnitude would have shipped a route
+that refuses `catchup` — the single largest consumer — on its ordinary path. The
+draft was not wrong so much as silent in a place where silence reads as guidance.
+
+**Accepted problem, opposite fix.**
+
+- **Q2.4 recommended `COALESCE(canonical_url, url)`** — canonical first, matching
+  how the row's `resolve_key` is derived. Rejected in that direction, on evidence
+  the review did not check: `resolve-by-url.ts:58` selects the **bare `url`
+  column**, so canonical-first would have made this response semantically
+  different from the sibling projection it claims to be field-for-field. The
+  original draft made the same error, in prose. §4 now matches the sibling and
+  falls back to `canonical_url` **only when `url` is null** — the fallback fires
+  exactly where the sibling would have returned nothing, so no caller ever sees a
+  different URL for the same row. `resolve_key` wants the normalized form because
+  it exists to make two spellings match; this field wants the published address
+  because it exists to be clicked.
+
+**Declined.**
+
+- **§3's module layout and implementation code.** This document is a contract
+  proposal, and its own header says no code lands in this branch. The gateway
+  owns the wire and its implementation; a consumer that arrives with the module
+  already written has pre-empted the decision it came to ask for. The
+  *behavioural* requirements that code encoded — the cap, the parse order, the
+  ordering, the exact projection — are captured above as contract, which is the
+  part a consumer legitimately has an opinion about.
+
+**Noted.**
+
+- The review's §5.3 places the integration test at
+  `packages/gateway/src/ipc/http-server.test.ts`. That file does exist, but the
+  per-route convention is `test/integration/http/<route>-route.test.ts`, where
+  both resolve siblings already live. §8 now says so.


### PR DESCRIPTION
## Summary

**Contract proposal only — no implementation in this branch.** A design doc asking for one new bearer-authed read, `GET /v1/items/resolve-ids`, which maps indexed item ids back to the references they came from. It is the inverse of `GET /v1/items/resolve`, which has mapped URL → item since the clip surface shipped.

**Why it is needed now.** The browser client renders agent briefs as structure rather than prose (phase C8 in `nimbus-web-clipper`; `why`, `glossary` and `decisions` shipped in v0.6.0 and the release after). Several findings name other indexed items **by id with no URL** — `ExpertFinding.evidence[].itemId`, `ImpactFinding.affectedItemId`, `CatchupItem.itemId`. So four of the browser's seven lanes render titles that look like references, are not, and cannot be made into references by any client-side means. The client slice that renders those lanes is designed and ships either way; with this route it ships with links instead of dead text.

## The argument that should lead review

The reflexive objection to an id-keyed read is that it is an enumeration oracle. **That door is already open, wider, and unauthenticated** — `packages/gateway/src/ipc/http-route-auth.ts:48-49`:

```ts
  "GET /v1/items": { kind: "public" },
  "GET /v1/items/*": { kind: "public" },
```

`GET /v1/items/{id}` has no bearer gate at all and returns the entire row, including `body`, `metadata` and `author_id`. This proposal is a `resolve`-scoped read of six named fields — no body, no metadata, no author. **Strictly less disclosure than the status quo.** The only thing it adds is arity.

So the discussion worth having is about arity and cost, not about disclosure.

## Shape

Follows #1447 (`resolve-file`) deliberately, so there is nothing novel to adjudicate:

- Existing **`resolve` scope** — it reads, it runs nothing, no egress row, **no re-pairing**.
- **No version floor.** Route presence is the capability signal, probed via the 404 that fires before auth when the clips surface is unmounted. A floor constant has to be raised by hand forever; presence cannot drift.
- **No schema change, no migration, no OpenAPI entry** — `item.id` is already the primary key, and this stays off `HTTP_ROUTES` like every other clip-scoped bearer read.
- Response is `ResolveCandidate` + `modified_at` **verbatim**, so the client already has the type, the parser and the renderer.

## Three decisions argued rather than assumed

Each is a place a reviewer will reach for a precedent that does not quite transfer, so §5 argues them explicitly:

1. **`RESOLVE_IDS_MAX_BATCH = 100`, borrowing `RESOLVE_CANDIDATE_CAP`'s rationale but not its magnitude.** That cap is 5 — right for a disambiguation menu a human reads, hopeless here, since `catchup` alone admits `PER_SERVICE_QUOTA = 50` items *per service* (`packages/gateway/src/agents/catchup.ts:12`) across several sections in one brief. A cap near 5 would refuse the largest consumer on its ordinary path.
2. **Refuse over the cap rather than clamp.** The repo has both postures. Silently dropping ids here means silently dropping *links* — the reader sees some references and not others with nothing to say why. Note `resolve`'s own "empty list plus `truncated: true`" posture rests on a truncated menu implying the right answer is among those shown; an id map has no ranking, so that argument does not transfer.
3. **An unindexed id is absent from the response, not null.** "Not in the index" and "indexed, no source URL" are different facts a client renders differently.

## One divergence from the sibling, flagged deliberately

The response returns the bare `url` column, matching `resolve-by-url.ts:58` — **with one exception**: where `url` is null and `canonical_url` is not, it returns `canonical_url`. The fallback fires exactly where the sibling would have returned nothing, so no caller ever sees a *different* URL for the same row — only a URL where it would otherwise have had none.

This is the **opposite** precedence from the row's own `resolve_key`, which is canonical-first, and that is intentional: `resolve_key` exists to make two spellings of an address match, so it wants the normalized form; this field exists to be clicked, so it wants the address the provider published. Called out because it is the one place a reviewer may reasonably prefer strict parity instead.

## Alternatives considered (§9)

- **Have the client call the public `GET /v1/items/{id}` per id.** Rejected: far more data than it needs, unauthenticated where the rest of its surface is scoped, one round trip per reference, and outside the clip contract the client is built against — it would be reaching around its own boundary.
- **Put URLs into the agent briefs themselves.** Arguably tidier, since the agents hold the rows. Rejected as the larger change: it alters what agents *return*, which is a three-repo chain through the SDK's published brief types, and inflates every brief with data most consumers do not render.

## Related Issue

<!-- No tracking issue yet — happy to open one if you'd like this triaged that way. -->

## Type of Change

- [x] Documentation only

## Non-Negotiables Checklist

- [x] `bun run typecheck` passes with zero errors — unaffected, no source changed
- [x] `bun run lint` passes (Biome) — unaffected, no source changed
- [x] All existing tests pass (`bun test`) — unaffected, no source changed
- [x] New behaviour is covered by tests — n/a, no behaviour in this branch
- [x] No `any` types introduced
- [x] No credentials, tokens, or secret values appear in logs, IPC messages, config, or test fixtures
- [x] Platform-specific code is behind the `PlatformServices` abstraction — n/a
- [x] The HITL consent gate has not been weakened, bypassed, or made configurable
- [x] Does not touch `docs/README.md`

## Testing

Docs-only, so the gates that apply are the docs gates, both run in the worktree:

- `bun run lint:markdown` — 171 files, **0 issues** (clean at baseline too, so the delta is this branch's)
- `bun run audit:doc-refs` — **1464 refs across 81 docs, all resolve**

## Notes for Reviewers

**The proposal was reviewed and amended before this PR opened**; §11 records the disposition. Two findings changed the contract — the batch cap above, and the URL column, where both the original draft *and* the review had it backwards until `resolve-by-url.ts:58` was actually read. A review recommendation to include the module layout and implementation code was **declined**: the gateway owns its implementation, and a consumer arriving with the code already written has pre-empted the decision it came to ask for. The behavioural requirements that code encoded are captured as contract instead.

If the shape is acceptable, I am happy to implement it — or to hand it over, since the client half is independent and ships either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StU1MQg9BjZzthYFue7TPr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a batched endpoint for resolving item IDs into reference metadata, including service, type, title, URL, and modification time.
  - Supports up to 100 IDs per request, removes duplicates, preserves deterministic ordering, and omits unknown IDs.
  - Added scoped authorization for the endpoint.

- **Documentation**
  - Documented request validation, response behavior, URL fallback rules, authorization, and integration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->