### PR TITLE
docs: correct "exactly one status check gates the merge" — there are ten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,35 @@ not here. Where the Gateway also carries per-connector sync/indexing logic, a fe
 ### CI gating
 
 PRs run the Ubuntu `pr-quality` set **and** `pr-quality-cross-platform` — one macOS leg and one
-Windows leg. Pushes run the full 3-OS matrix. Exactly one status check gates the merge:
-**`PR quality — required gates`**, an `if: always()` aggregator that `needs:` every other PR job —
-so adding or renaming a gate never needs a ruleset edit, and a red leg reds the aggregator.
+Windows leg. Pushes run the full 3-OS matrix.
+
+**TEN status checks gate the merge, not one.** The _General_ ruleset (14784377) requires all of:
+`PR quality — required gates`, `Dependency audit`, `Trivy vulnerability scan`, `Gitleaks secret
+scan`, `Gateway audit JSON + connector.remove vault restore`, `Cargo audit (Tauri)`, `Cargo deny
+(licenses + advisories + bans)`, `Analyze (javascript-typescript)`, `Analyze (rust)`, and `cla`.
+Only the FIRST is an aggregator: `PR quality — required gates` is an `if: always()` job that
+`needs:` every other job in the PR-quality workflow, so adding or renaming a gate **inside that
+workflow** never needs a ruleset edit, and a red leg there reds the aggregator. The other nine come
+from separate workflows (Security, CodeQL, CLA) and are named in the ruleset individually — adding
+one there IS a ruleset edit.
+
+This sentence read "exactly one status check gates the merge" until 2026-09-09, and the error is
+the kind that costs a merge: on #1475 the Dependency audit and Trivy checks were red, this file
+said they could not be blocking, and the ruleset disagreed. Both are required, both were genuinely
+blocking, and neither was the PR's fault — they had gone red repo-wide overnight on newly published
+advisories, the same sha having passed hours earlier. **When a check is red and this file says it
+should not matter, re-derive the list from the ruleset** (`gh api
+repos/nimbus-agent/Nimbus/rulesets/14784377`) rather than trusting the prose.
+
+**A failing step HIDES every later step in the same job.** Both of these jobs are step sequences,
+and a red one reports only its first failure — so "one gate is red" routinely means several are,
+serialised one CI round-trip apart. `Dependency audit` runs `bun audit` → `audit:advisories` →
+`audit:js-licenses`, and on #1475 each fix revealed the next, three pushes for what looked like one
+problem. `Unit + Coverage` runs `audit:coverage-floor` → `audit:coverage-scopes` → the SonarQube
+gate, and a floor failure means the scopes gate **never executed at all** — it is not passing, it
+is unmeasured. Before pushing a fix for any red job, read its whole step list
+(`gh api repos/nimbus-agent/Nimbus/actions/jobs/<id> --jq '.steps[] | "\(.conclusion) \(.name)"'`)
+and run the later steps locally too.
 
 **The PR cross-platform legs run the same test PATHS as the push matrix** —
 `bun test packages/gateway packages/cli scripts`, whole-repo and in ONE

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -137,9 +137,35 @@ not here. Where the Gateway also carries per-connector sync/indexing logic, a fe
 ### CI gating
 
 PRs run the Ubuntu `pr-quality` set **and** `pr-quality-cross-platform` — one macOS leg and one
-Windows leg. Pushes run the full 3-OS matrix. Exactly one status check gates the merge:
-**`PR quality — required gates`**, an `if: always()` aggregator that `needs:` every other PR job —
-so adding or renaming a gate never needs a ruleset edit, and a red leg reds the aggregator.
+Windows leg. Pushes run the full 3-OS matrix.
+
+**TEN status checks gate the merge, not one.** The _General_ ruleset (14784377) requires all of:
+`PR quality — required gates`, `Dependency audit`, `Trivy vulnerability scan`, `Gitleaks secret
+scan`, `Gateway audit JSON + connector.remove vault restore`, `Cargo audit (Tauri)`, `Cargo deny
+(licenses + advisories + bans)`, `Analyze (javascript-typescript)`, `Analyze (rust)`, and `cla`.
+Only the FIRST is an aggregator: `PR quality — required gates` is an `if: always()` job that
+`needs:` every other job in the PR-quality workflow, so adding or renaming a gate **inside that
+workflow** never needs a ruleset edit, and a red leg there reds the aggregator. The other nine come
+from separate workflows (Security, CodeQL, CLA) and are named in the ruleset individually — adding
+one there IS a ruleset edit.
+
+This sentence read "exactly one status check gates the merge" until 2026-09-09, and the error is
+the kind that costs a merge: on #1475 the Dependency audit and Trivy checks were red, this file
+said they could not be blocking, and the ruleset disagreed. Both are required, both were genuinely
+blocking, and neither was the PR's fault — they had gone red repo-wide overnight on newly published
+advisories, the same sha having passed hours earlier. **When a check is red and this file says it
+should not matter, re-derive the list from the ruleset** (`gh api
+repos/nimbus-agent/Nimbus/rulesets/14784377`) rather than trusting the prose.
+
+**A failing step HIDES every later step in the same job.** Both of these jobs are step sequences,
+and a red one reports only its first failure — so "one gate is red" routinely means several are,
+serialised one CI round-trip apart. `Dependency audit` runs `bun audit` → `audit:advisories` →
+`audit:js-licenses`, and on #1475 each fix revealed the next, three pushes for what looked like one
+problem. `Unit + Coverage` runs `audit:coverage-floor` → `audit:coverage-scopes` → the SonarQube
+gate, and a floor failure means the scopes gate **never executed at all** — it is not passing, it
+is unmeasured. Before pushing a fix for any red job, read its whole step list
+(`gh api repos/nimbus-agent/Nimbus/actions/jobs/<id> --jq '.steps[] | "\(.conclusion) \(.name)"'`)
+and run the later steps locally too.
 
 **The PR cross-platform legs run the same test PATHS as the push matrix** —
 `bun test packages/gateway packages/cli scripts`, whole-repo and in ONE


### PR DESCRIPTION
CLAUDE.md and GEMINI.md both stated that `PR quality — required gates` is the only status check gating a merge. The _General_ ruleset (14784377) requires **ten**.

## Why this is worth a PR

The error is the kind that costs a merge rather than a pedantic one. On #1475, `Dependency audit` and `Trivy vulnerability scan` were red, this file said they could not be blocking, and the ruleset disagreed — both were required and genuinely blocking.

Neither was that PR's fault, which is what made the wrong prose actively dangerous: three advisories were published overnight, and the *same sha* on `main` passed the Security workflow at `2026-09-08T18:19Z` and failed it at `2026-09-09T07:05Z`. Anyone trusting this file would have concluded the red belonged to someone else and waited.

## What changed

The true half is kept — the aggregator really does mean a gate added **inside** the PR-quality workflow needs no ruleset edit. The other nine come from separate workflows (Security, CodeQL, CLA), are named individually, and adding one there **is** a ruleset edit.

Re-derive rather than trust the prose:

```
gh api repos/nimbus-agent/Nimbus/rulesets/14784377 \
  --jq ".rules[] | select(.type==\"required_status_checks\") | .parameters.required_status_checks[].context"
```

## Second paragraph: a failing step hides every later step in the same job

Found the expensive way in the same session. Both required jobs are step sequences that report only their first failure, so "one gate is red" routinely means several are, serialised one CI round-trip apart:

| Job | Steps | Cost on #1475 |
|---|---|---|
| `Dependency audit` | `bun audit` → `audit:advisories` → `audit:js-licenses` | each fix revealed the next — **three pushes** |
| `Unit + Coverage` | `audit:coverage-floor` → `audit:coverage-scopes` → SonarQube gate | a floor failure meant **scopes never executed at all** |

That second one is the more dangerous shape: an unmeasured gate reads as green to anyone scanning the job list. `audit:coverage-scopes` had never run against #1475 in either direction until the floor was fixed.

## Type of Change

- [x] Documentation only

## Non-Negotiables Checklist

- [x] Mirrors kept byte-identical, per CLAUDE.md's own rule for these two files (verified with `diff`)
- [x] No code, no behaviour change
- [x] Both documented commands were RUN before being written down — a doc citing a dead command is the trap this repo already tracks

## Testing

Green: `lint:markdown` (0 issues), `audit:doc-refs` (1479 refs across 81 docs, all resolve), `audit:status-drift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PrC9o6EhyDeeHLK6PCh1M