### PR TITLE
docs(spec): propose GET /v1/services — repo-to-service resolution for clients

### DIFF
--- a/docs/superpowers/specs/2026-09-11-services-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design-review.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-11  
 **Reviewer:** Claude Opus 5 (AI Coding Assistant)  
-**Status:** Review Complete — sound as a proposal. All four corrections are applied: C3.1–C3.4, plus R4.1 (the alternative-shape section promoted ahead of the mount question — it was §6 when this review was written and is **§5** in the spec now, with the mount decision at §6), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion. A later PR review added a fifth, **C5 — repository-to-service cardinality**, now answered in the spec at §5.1, and a sixth, **C6 — the resolver entry point for a repository-only query**, answered in the second half of that same section.  
+**Status:** Review Complete — sound as a proposal. All four corrections are applied: C3.1–C3.4, plus R4.1 (the alternative-shape section promoted ahead of the mount question — it was §6 when this review was written and is **§5** in the spec now, with the mount decision at §6), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion. A later PR review added a fifth, **C5 — repository-to-service cardinality**, now answered in the spec at §5.1, and a sixth, **C6 — the resolver entry point for a repository-only query**. C6 is **raised and scoped, not answered, and deliberately so**: §5.1's second half shows that neither existing matcher takes a bare URN and names what each way out costs, and §11 Q1 now carries the choice itself. Selecting an entry point here would be the consumer settling the gateway's own matching — the same reason C5's cardinality question was answered by *citing* the existing rule rather than by proposing a new one.  
 **Target Spec:** [`2026-09-11-services-route-design.md`](./2026-09-11-services-route-design.md)  
 **Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
 **Related Routes:** `GET /v1/metrics/dora`, `GET /v1/preflight/deploy`, `POST /v1/deployments`, `GET /v1/items/resolve-file`, `GET /v1/items/resolve-ids`  
@@ -229,7 +229,10 @@ more than its size suggests.
 - **Auth.** Option A: reachable with no bearer, and present in `HTTP_ROUTE_AUTH` (C3.1).
   Option B: 403 for a `LEGACY_SCOPES` token, `404 services_disabled` with no clips vault.
 - **Resolve form, if that is the shape that lands.** A repository-only
-  `repo=circleci:…` query, pinned against whichever entry point §5.1's second half
+  `repo=circleci:…` query, pinned against whichever entry point §11 Q1's second half
   settles on — the two available matchers disagree about exactly this provider, so the
   answer has to be asserted rather than inherited from whichever one the handler happens
-  to call. Pair it with the multi-claimant case §5.1 already asks for.
+  to call. If the chosen entry point is the item-shaped resolver, the `excluded` →
+  `service | null` projection needs its own case: a repo a config *does* claim, whose
+  deployment environment the gate excludes, must not be indistinguishable from a repo no
+  config claims at all. Pair both with the multi-claimant case §5.1 already asks for.

--- a/docs/superpowers/specs/2026-09-11-services-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design-review.md
@@ -13,12 +13,13 @@
 > **This is a review note, not guidance. Where it disagrees with the design
 > spec, the spec wins.**
 >
-> **Section numbers below are the spec's numbering AS REVIEWED**, before R4.1 was
-> applied. The alternative-shape section was **§6** then and is **§5** now; the
-> mount decision moved from §5 to §6. They are deliberately not renumbered: R4.1
-> is the correction "move §6 ahead of §5", which becomes incoherent if rewritten
-> to the numbering it produced. Read a `§` here as "in the spec as it stood on
-> 2026-09-11", and follow the status line above for where a section lives now.
+> **Every `§` below points at the spec as it stands now.** R4.1 was applied, and
+> it swapped two sections: the alternative-shape/matcher discussion was §6 when
+> this review was written and is **§5** now, while the mount decision moved from
+> §5 to **§6**. The references here have been updated to match, so a reader can
+> follow any one of them without holding a second numbering in their head. R4.1
+> itself is restated in the past tense for the same reason — the instruction
+> "move §6 ahead of §5" cannot survive its own application unedited.
 >
 > It is committed because this repo keeps review notes beside their specs, and
 > it is pruned when the feature ships — or when the proposal is declined.
@@ -31,7 +32,7 @@ services and the repo URNs each claims — so a browser that knows it is looking
 
 **Verdict: ready to open with the four corrections in §3 applied.** It argues a real gap,
 it declines to decide the question it does not own (mount point and scope), it names the
-cheaper alternative shape against its own ask (§6), and it states the do-nothing baseline
+cheaper alternative shape against its own ask (§5), and it states the do-nothing baseline
 as an acceptable outcome (§10). The disclosure analysis in §4 is the strongest part of the
 document and is, as far as this review can establish, correct.
 
@@ -45,7 +46,7 @@ hold:
 | `checkServiceAllowlist` returns `known_services: known.slice(0, 25)` in a 400, after `recordRejection` | `packages/gateway/src/ipc/http-write-routes.ts` |
 | `buildServiceIdentityResolver` matches `metadata.repo` / `.project` / `.jobName` against parsed URNs | `packages/gateway/src/metrics/service-identity.ts` |
 | `dispatchReadOnlyDataGet` is "no bearer gate, never fall through"; `/v1/connectors`, `/v1/metrics/dora`, `/v1/preflight/deploy` live in it | `packages/gateway/src/ipc/http-server.ts` |
-| `handleItemsResolveFile`'s comment, quoted in §5, is verbatim | `packages/gateway/src/ipc/http-server.ts` |
+| `handleItemsResolveFile`'s comment, quoted in §6, is verbatim | `packages/gateway/src/ipc/http-server.ts` |
 | Three `resolve` reads + four `egress` reads mounted inline in `tryBearerAuthedGet`, which runs before the public dispatcher | `packages/gateway/src/ipc/http-server.ts` |
 | `unconfiguredEnvelope` answers an unknown service with `gap: "unknown_service"` on all three checks | `packages/gateway/src/ipc/preflight-rpc.ts` |
 | `GET /v1/items` is `{ kind: "public" }` and its projection includes `metadata` | `packages/gateway/src/ipc/http-route-auth.ts`, `packages/gateway/src/index/item-list-query.ts` |
@@ -72,9 +73,9 @@ enumeration that costs one request total — and the same distinction is why
 promoting it from a trailing sentence to its own short paragraph, because a reviewer who
 is going to object will object there.
 
-**The question is properly left open.** §5 states the constraint that kills the third
+**The question is properly left open.** §6 states the constraint that kills the third
 option, lays out two coherent ones, declines to pick, and §11 asks. That is the right
-register for a consumer proposing against a contract it does not own. §5's one request —
+register for a consumer proposing against a contract it does not own. §6's one request —
 that whichever choice is made be stated in the route's own comment — is the correct thing
 to ask for, and the only thing asked for.
 
@@ -82,7 +83,7 @@ to ask for, and the only thing asked for.
 
 ### C3.1 — Option A also needs an `HTTP_ROUTE_AUTH` entry (factual)
 
-§5's Option A costs list names `HTTP_ROUTES` and a `paths:` entry in
+§6's Option A costs list names `HTTP_ROUTES` and a `paths:` entry in
 `packages/gateway/openapi/v1.yaml`, and names `HTTP_ROUTE_AUTH` only under Option B. That
 is wrong. The table's own header states it is **total over the surface**:
 
@@ -119,9 +120,9 @@ Two sub-questions the spec should raise, not answer:
 This belongs in §4 as well as §7: the honest-disclosure section currently reasons only
 about the success body.
 
-### C3.3 — §6 names the wrong matcher for the CircleCI behaviour (factual)
+### C3.3 — §5 names the wrong matcher for the CircleCI behaviour (factual)
 
-§6 says `repoMetadataMatchesUrn` is provider-specific and that "CircleCI matches on an
+§5 says `repoMetadataMatchesUrn` is provider-specific and that "CircleCI matches on an
 external id the resolver's item shape does not even carry". `repoMetadataMatchesUrn`
 returns `false` for `circleci` — it never matches. The external-id branch lives in
 `repoLikeMatchesUrn` in `packages/gateway/src/metrics/dora.ts`, and
@@ -132,7 +133,7 @@ The correction **strengthens** the argument it was making. There are two matcher
 already disagree with each other about one provider, and a client doing string equality
 against a URN list would be a third. "A client cannot see the matcher" becomes "there is
 no single matcher to see" — which is the best reason in the document to prefer the resolve
-form of §6 over the list form.
+form of §5 over the list form.
 
 ### C3.4 — "whole item rows" overstates `GET /v1/items` (precision)
 
@@ -143,13 +144,18 @@ load-bearing claim — `metadata.repo` is readable unauthenticated — survives 
 
 ## 4. Recommendations (non-blocking)
 
-### R4.1 — Move §6 ahead of §5
+### R4.1 — Put the alternative shape ahead of the mount decision (applied)
+
+*As written: "move §6 ahead of §5". Applied, which is why those two numbers now mean the
+opposite of what they meant here — the alternative shape is §5 and the mount decision is
+§6. Restated below in the numbering the spec actually has.*
 
 The resolve form is argued on two grounds, and the second one (the matching rules stay on
 the gateway side) is independent of the disclosure debate and, after C3.3, stronger than
-the spec realises. A reviewer who reads §5 first spends their attention on a mount decision
-for a shape §6 may talk them out of. §11's Q3 already ranks the questions in the better
-order; the body should match it.
+the spec realises. A reviewer who reads the mount decision first spends their attention on
+a choice the alternative shape may talk them out of. The spec's §11 already ranks the
+questions in the better order — the list-versus-resolve question is now Q1, ahead of the
+two mount questions, which apply only to the list form — and the body should match it.
 
 ### R4.2 — Name the mount gate under Option B
 

--- a/docs/superpowers/specs/2026-09-11-services-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design-review.md
@@ -1,0 +1,217 @@
+# Design Review: `GET /v1/services` — the configured services, and the repos they claim
+
+**Date:** 2026-09-11  
+**Reviewer:** Claude Opus 5 (AI Coding Assistant)  
+**Status:** Review Complete — sound as a proposal; four corrections before it opens. **Addressed:** C3.1–C3.4 applied, plus R4.1 (§6 promoted ahead of the mount question), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion.  
+**Target Spec:** [`2026-09-11-services-route-design.md`](./2026-09-11-services-route-design.md)  
+**Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
+**Related Routes:** `GET /v1/metrics/dora`, `GET /v1/preflight/deploy`, `POST /v1/deployments`, `GET /v1/items/resolve-file`, `GET /v1/items/resolve-ids`  
+**Precedent:** [`2026-09-07-items-resolve-ids-design.md`](./2026-09-07-items-resolve-ids-design.md) — spec-only proposal, no implementation
+
+---
+
+> **This is a review note, not guidance. Where it disagrees with the design
+> spec, the spec wins.**
+>
+> It is committed because this repo keeps review notes beside their specs, and
+> it is pruned when the feature ships — or when the proposal is declined.
+
+## 1. Executive Summary
+
+The spec proposes one read — the configured `[metrics.dora.<id>]` / `[ci.service.<id>]`
+services and the repo URNs each claims — so a browser that knows it is looking at
+`github:acme/payments-api` can call the two routes that are scoped by service id.
+
+**Verdict: ready to open with the four corrections in §3 applied.** It argues a real gap,
+it declines to decide the question it does not own (mount point and scope), it names the
+cheaper alternative shape against its own ask (§6), and it states the do-nothing baseline
+as an acceptable outcome (§10). The disclosure analysis in §4 is the strongest part of the
+document and is, as far as this review can establish, correct.
+
+Every code claim in the spec was checked against the branch point. The load-bearing ones
+hold:
+
+| Claim | Verified |
+| --- | --- |
+| `resolveKnownServices` is `Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys())`, `[]` when no config dir | `packages/gateway/src/ipc/http-server.ts` |
+| Passed into `resolveWriteRouteDeps` as `knownServices`; exactly one non-test consumer | `http-server.ts`, `packages/gateway/src/ipc/http-write-routes.ts` |
+| `checkServiceAllowlist` returns `known_services: known.slice(0, 25)` in a 400, after `recordRejection` | `packages/gateway/src/ipc/http-write-routes.ts` |
+| `buildServiceIdentityResolver` matches `metadata.repo` / `.project` / `.jobName` against parsed URNs | `packages/gateway/src/metrics/service-identity.ts` |
+| `dispatchReadOnlyDataGet` is "no bearer gate, never fall through"; `/v1/connectors`, `/v1/metrics/dora`, `/v1/preflight/deploy` live in it | `packages/gateway/src/ipc/http-server.ts` |
+| `handleItemsResolveFile`'s comment, quoted in §5, is verbatim | `packages/gateway/src/ipc/http-server.ts` |
+| Three `resolve` reads + four `egress` reads mounted inline in `tryBearerAuthedGet`, which runs before the public dispatcher | `packages/gateway/src/ipc/http-server.ts` |
+| `unconfiguredEnvelope` answers an unknown service with `gap: "unknown_service"` on all three checks | `packages/gateway/src/ipc/preflight-rpc.ts` |
+| `GET /v1/items` is `{ kind: "public" }` and its projection includes `metadata` | `packages/gateway/src/ipc/http-route-auth.ts`, `packages/gateway/src/index/item-list-query.ts` |
+| `ServiceConfig`'s six extra fields, named in §7, exist exactly as listed | `packages/gateway/src/metrics/dora-config.ts` |
+| `LEGACY_SCOPES = ["clip", "briefs"]`; scopes changed in place by `nimbus clip scopes <label> --set <scopes>` | `packages/gateway/src/clips/api-scopes.ts` |
+| `[ci.service.*]` and `[metrics.dora.*]` merge into one `Map`, stderr warning on collision, CI wins | `packages/gateway/src/config/nimbus-toml.ts` |
+| `resolve-file` and `resolve-ids` both pin their wire key set in a test | `packages/gateway/test/integration/http/items-resolve-file-route.test.ts`, `packages/gateway/test/integration/http/items-resolve-ids-route.test.ts` |
+| Inline reads signal absence with `404 { "error": "<surface>_disabled" }` | `packages/gateway/src/ipc/http-server.ts` |
+
+## 2. Is the disclosure reasoning sound, and is the question properly left open?
+
+**Sound, with one qualification the spec already half-states.**
+
+The three-part argument in §4 checks out. Service ids are probe-confirmable without a
+bearer, because both `metrics/dora` and `preflight/deploy` are public and answer an
+unconfigured id *softly* rather than with a refusal. Repo names are readable without a
+bearer, because `GET /v1/items` projects `metadata`. Neither discloses the grouping, and
+the spec says so plainly instead of arguing that the new route discloses nothing.
+
+The qualification: the spec calls bulk-vs-probe "a second, smaller point". It is smaller,
+but it is the difference between an oracle that costs one request per guessed id and an
+enumeration that costs one request total — and the same distinction is why
+`known_services` is capped at 25 in a 400 body rather than returned whole. Recommend
+promoting it from a trailing sentence to its own short paragraph, because a reviewer who
+is going to object will object there.
+
+**The question is properly left open.** §5 states the constraint that kills the third
+option, lays out two coherent ones, declines to pick, and §11 asks. That is the right
+register for a consumer proposing against a contract it does not own. §5's one request —
+that whichever choice is made be stated in the route's own comment — is the correct thing
+to ask for, and the only thing asked for.
+
+## 3. Corrections Before This Opens
+
+### C3.1 — Option A also needs an `HTTP_ROUTE_AUTH` entry (factual)
+
+§5's Option A costs list names `HTTP_ROUTES` and a `paths:` entry in
+`packages/gateway/openapi/v1.yaml`, and names `HTTP_ROUTE_AUTH` only under Option B. That
+is wrong. The table's own header states it is **total over the surface**:
+
+> TOTAL over the surface, including the routes that are deliberately unauthenticated. See
+> the completeness test: a new route with no entry here fails the suite rather than
+> inheriting whatever the surrounding code happens to do.
+
+A public `/v1/services` needs `"GET /v1/services": { kind: "public" }` or the suite goes
+red. Both options cost an entry; only the *value* differs. Fix the sentence — a costs list
+that undercounts the option the author did not pick reads as a thumb on the scale.
+
+### C3.2 — The error table omits the throw (material)
+
+§7's error table covers "no config dir wired" and "`nimbus.toml` absent", both 200 with an
+empty list, and that matches `loadNimbusServiceConfigsFromConfigDir`. It omits the third
+case: **a malformed `nimbus.toml` throws.** `materializeOneServiceConfig`
+(`packages/gateway/src/config/service-config-toml.ts`) throws on a missing `repos`, an
+out-of-range `incident_window_minutes`, an invalid `deploy_environments` entry, or an empty
+table id. Existing consumers know this and wrap it — `packages/gateway/src/ipc/agents-rpc.ts`
+degrades rather than throws, and `packages/gateway/src/platform/assemble.ts` try/catches for
+exactly this reason.
+
+`handleMetricsDora` does **not** wrap it, so a malformed config already 500s
+`GET /v1/metrics/dora` today. That is a pre-existing condition, not this proposal's fault,
+but a new route must state which behaviour it chooses rather than inherit one by accident.
+Two sub-questions the spec should raise, not answer:
+
+- Degrade to an empty list (matching `agents-rpc.ts`), or surface the parse error?
+- If the error surfaces, **under Option A the message is public.** The throw strings embed
+  the service id and the offending value — `[metrics.dora.payments].deploy_environments
+  entry 'staging-eu' is invalid` — which discloses config content to an unauthenticated
+  caller through a channel the disclosure analysis in §4 never considers.
+
+This belongs in §4 as well as §7: the honest-disclosure section currently reasons only
+about the success body.
+
+### C3.3 — §6 names the wrong matcher for the CircleCI behaviour (factual)
+
+§6 says `repoMetadataMatchesUrn` is provider-specific and that "CircleCI matches on an
+external id the resolver's item shape does not even carry". `repoMetadataMatchesUrn`
+returns `false` for `circleci` — it never matches. The external-id branch lives in
+`repoLikeMatchesUrn` in `packages/gateway/src/metrics/dora.ts`, and
+`service-identity.ts`'s own comment says so: it "Mirrors `repoLikeMatchesUrn` in
+`metrics/dora.ts`, minus its `circleci` external-id branch".
+
+The correction **strengthens** the argument it was making. There are two matchers, they
+already disagree with each other about one provider, and a client doing string equality
+against a URN list would be a third. "A client cannot see the matcher" becomes "there is
+no single matcher to see" — which is the best reason in the document to prefer the resolve
+form of §6 over the list form.
+
+### C3.4 — "whole item rows" overstates `GET /v1/items` (precision)
+
+§4 says `GET /v1/items` "returns whole item rows including `metadata`". It returns a
+thirteen-column projection (`buildItemListSql`): `body_preview`, not `body`. The
+load-bearing claim — `metadata.repo` is readable unauthenticated — survives intact. Say
+"projects `metadata`" and the sentence is both shorter and true.
+
+## 4. Recommendations (non-blocking)
+
+### R4.1 — Move §6 ahead of §5
+
+The resolve form is argued on two grounds, and the second one (the matching rules stay on
+the gateway side) is independent of the disclosure debate and, after C3.3, stronger than
+the spec realises. A reviewer who reads §5 first spends their attention on a mount decision
+for a shape §6 may talk them out of. §11's Q3 already ranks the questions in the better
+order; the body should match it.
+
+### R4.2 — Name the mount gate under Option B
+
+Option B inherits the inline reads' capability signal, and with it their ambiguity: the
+gate is the **clips vault**, so a gateway that has the route but no paired-client surface
+answers `404 services_disabled`, which the client reads as "this gateway is older than the
+route". Every inline read carries this and none of them says so. One sentence closes it.
+
+### R4.3 — `deployWorkflowPattern` is a `RegExp`, which sharpens §7
+
+§7 argues against spreading `ServiceConfig` because two of its fields are more sensitive
+than the repo list. There is a second, quieter reason: `deployWorkflowPattern` is a
+`RegExp`, which `JSON.stringify` renders as `{}`. A spread would therefore *look* harmless
+in a test fixture while shipping `pagerdutyServices` and `deployEnvironments` beside it.
+Worth one clause — it is exactly the kind of thing a key-pinning test exists to catch.
+
+### R4.4 — `id` is a rename, not a projection
+
+The proposed wire entry is `{ id, repos }`; the type's field is `serviceId`. The spec's
+"field by field, never a spread" already forces the handler to do this correctly, but the
+pinning test should be described as pinning the **wire** key set, so nobody reads
+`["id", "repos"]` as a claim about `ServiceConfig`.
+
+## 5. Security & Invariants Audit
+
+1. **I13 (write-route allowlist).** Correctly identified as the wrong invariant, and
+   correctly named anyway because "new HTTP route" is the trigger a reviewer reaches for it
+   on. A GET stays off `WRITE_ROUTE_ALLOWLIST`.
+2. **Egress.** No provider request, no ledger row — the same narrowing
+   `packages/gateway/src/egress/egress-coverage.ts` already applies to the three `resolve`
+   reads. If Option B lands, that file's local-index-read list should gain this route, as it
+   did for `resolve-file` and `resolve-ids`.
+3. **I6 (loopback).** Untouched. The route reads a local file and answers on `127.0.0.1`.
+4. **Scope escalation.** Reusing `resolve` grants the route to every token that already
+   holds it — including tokens paired for `resolve-file` alone. That is the spec's own
+   framing ("no re-pairing"), and it is a cost as well as a convenience: a reviewer choosing
+   `resolve` is choosing to widen three existing tokens' reach. A new `services` scope is
+   absent from `LEGACY_SCOPES` by construction and grants nothing retroactively.
+5. **Error-path disclosure.** See C3.2. Under Option A this is the only unexamined channel.
+
+## 6. Read as a Proposal
+
+A maintainer reading cold gets the problem (a browser cannot learn the one parameter both
+service-scoped routes require), the shape (one read, two fields, built field by field), and
+what happens on a no (§10: the client keeps its local binding, which already works).
+Nothing is asked for that the client does not use: the response carries `id` and `repos`
+and the consumer needs both — `repos` to match its recognised scope, `id` to pass on.
+`repos: []` for a configured-but-empty service is justified by `DoraGap`'s existing
+`no_repos` member rather than by consumer preference, which is the right way to justify a
+wire decision in someone else's repo.
+
+Tone is peer, not demand: the ask is bounded, the alternative that would replace it is
+argued for rather than against, and the do-nothing outcome is stated as acceptable in the
+first three lines and again in §10. The one place it slips is the costs list in C3.1, where
+the option the author did not pick is undercounted — which is why that correction matters
+more than its size suggests.
+
+## 7. Testing Strategy, If It Is Built
+
+- **Wire-shape pinning.** `Object.keys(body.services[0]).sort()` equals `["id", "repos"]`,
+  as the resolve-ids route test does for its own projection. This is the test that keeps a
+  later `ServiceConfig` field from leaking.
+- **Ordering.** Sorted by `id`, asserted against a fixture whose `nimbus.toml` declares
+  `[ci.service.*]` before `[metrics.dora.*]`, so insertion order and sorted order differ.
+- **Empty vs absent.** A configured service with `repos = []` appears with `"repos": []`; a
+  gateway with no `nimbus.toml` answers 200 with an empty list, not 404.
+- **Malformed config.** Whatever C3.2 resolves, assert it — and under Option A assert the
+  response body does not echo the offending config value.
+- **Collision.** `[ci.service.web]` and `[metrics.dora.web]` both present: one entry, the CI
+  one, matching `loadNimbusServiceConfigsFromConfigDir`'s documented precedence.
+- **Auth.** Option A: reachable with no bearer, and present in `HTTP_ROUTE_AUTH` (C3.1).
+  Option B: 403 for a `LEGACY_SCOPES` token, `404 services_disabled` with no clips vault.

--- a/docs/superpowers/specs/2026-09-11-services-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design-review.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-11  
 **Reviewer:** Claude Opus 5 (AI Coding Assistant)  
-**Status:** Review Complete — sound as a proposal; four corrections before it opens. **Addressed:** C3.1–C3.4 applied, plus R4.1 (§6 promoted ahead of the mount question), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion.  
+**Status:** Review Complete — sound as a proposal. All four corrections are applied: C3.1–C3.4, plus R4.1 (the alternative-shape section promoted ahead of the mount question — it was §6 when this review was written and is **§5** in the spec now, with the mount decision at §6), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion. A later PR review added a fifth, **C5 — repository-to-service cardinality**, now answered in the spec at §5.1.  
 **Target Spec:** [`2026-09-11-services-route-design.md`](./2026-09-11-services-route-design.md)  
 **Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
 **Related Routes:** `GET /v1/metrics/dora`, `GET /v1/preflight/deploy`, `POST /v1/deployments`, `GET /v1/items/resolve-file`, `GET /v1/items/resolve-ids`  
@@ -12,6 +12,13 @@
 
 > **This is a review note, not guidance. Where it disagrees with the design
 > spec, the spec wins.**
+>
+> **Section numbers below are the spec's numbering AS REVIEWED**, before R4.1 was
+> applied. The alternative-shape section was **§6** then and is **§5** now; the
+> mount decision moved from §5 to §6. They are deliberately not renumbered: R4.1
+> is the correction "move §6 ahead of §5", which becomes incoherent if rewritten
+> to the numbering it produced. Read a `§` here as "in the spec as it stood on
+> 2026-09-11", and follow the status line above for where a section lives now.
 >
 > It is committed because this repo keeps review notes beside their specs, and
 > it is pruned when the feature ships — or when the proposal is declined.

--- a/docs/superpowers/specs/2026-09-11-services-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design-review.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-11  
 **Reviewer:** Claude Opus 5 (AI Coding Assistant)  
-**Status:** Review Complete — sound as a proposal. All four corrections are applied: C3.1–C3.4, plus R4.1 (the alternative-shape section promoted ahead of the mount question — it was §6 when this review was written and is **§5** in the spec now, with the mount decision at §6), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion. A later PR review added a fifth, **C5 — repository-to-service cardinality**, now answered in the spec at §5.1.  
+**Status:** Review Complete — sound as a proposal. All four corrections are applied: C3.1–C3.4, plus R4.1 (the alternative-shape section promoted ahead of the mount question — it was §6 when this review was written and is **§5** in the spec now, with the mount decision at §6), R4.2, R4.3, R4.4 and §2's bulk-vs-probe promotion. A later PR review added a fifth, **C5 — repository-to-service cardinality**, now answered in the spec at §5.1, and a sixth, **C6 — the resolver entry point for a repository-only query**, answered in the second half of that same section.  
 **Target Spec:** [`2026-09-11-services-route-design.md`](./2026-09-11-services-route-design.md)  
 **Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
 **Related Routes:** `GET /v1/metrics/dora`, `GET /v1/preflight/deploy`, `POST /v1/deployments`, `GET /v1/items/resolve-file`, `GET /v1/items/resolve-ids`  
@@ -228,3 +228,8 @@ more than its size suggests.
   one, matching `loadNimbusServiceConfigsFromConfigDir`'s documented precedence.
 - **Auth.** Option A: reachable with no bearer, and present in `HTTP_ROUTE_AUTH` (C3.1).
   Option B: 403 for a `LEGACY_SCOPES` token, `404 services_disabled` with no clips vault.
+- **Resolve form, if that is the shape that lands.** A repository-only
+  `repo=circleci:…` query, pinned against whichever entry point §5.1's second half
+  settles on — the two available matchers disagree about exactly this provider, so the
+  answer has to be asserted rather than inherited from whichever one the handler happens
+  to call. Pair it with the multi-claimant case §5.1 already asks for.

--- a/docs/superpowers/specs/2026-09-11-services-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design.md
@@ -211,7 +211,34 @@ That has two consequences for this proposal, and the second is the open one:
    deploy against one service while the metrics behind it belong to another. The
    resolve form's whole argument in §5 is that the matching rules stay on the
    gateway side; a second precedence rule here would be the third matcher that
-   argument exists to prevent. Reuse the existing index.
+   argument exists to prevent. Reuse the gateway's own binding rather than
+   inventing a second one.
+
+   **Which entry point that is, this proposal deliberately leaves to Q1 — but
+   it is not a free choice, because neither existing matcher takes the shape a
+   resolve route is handed.** `buildServiceIdentityResolver` resolves a
+   `ServiceIdentityItem` — `{ service, type, metadata }`, an *indexed item* —
+   whereas `GET /v1/services/resolve?repo=…` is handed a bare URN and has no
+   item to match. Answering it means either synthesising a metadata record to
+   feed the item-shaped matcher, or adding a URN-to-URN entry point beside it,
+   and both have consequences worth naming before either is picked:
+
+   - **Synthesising** inherits `repoMetadataMatchesUrn`'s
+     `case "circleci": return false`, so `repo=circleci:…` answers `null` for a
+     service that `repoLikeMatchesUrn` *would* have matched on its
+     `externalId`. It also forces a choice of `type`, which is load-bearing:
+     the resolver returns `bound` outright for a non-`deployment` item but runs
+     the `deployEnvironments` gate for a `deployment` one, so the synthesised
+     type decides the answer. Its three-way `bound` / `excluded` / `unknown`
+     result has no natural projection onto `service | null` either — `excluded`
+     means a config *did* claim the repo, which is not `null` in any useful
+     sense.
+   - **A URN-to-URN entry point** sidesteps all of that, and is the third
+     matcher §5 warns about unless it becomes the one the other two are
+     refactored onto.
+
+   So the CircleCI answer is a decision, not a default, and the resolve form's
+   viability partly rests on it.
 
 2. **Whether the route DISCLOSES the ambiguity is still open, and is a real
    choice.** Returning a bare `{ "service": "payment-service" }` is honest about
@@ -509,7 +536,8 @@ too sensitive for either mount, this is the outcome and the consumer is fine.
    services do?** §5.1. Three answers, and the third is the gateway's to prefer
    if it wants it:
    - **Resolve as the gateway already does** (first claimant wins,
-     `service-identity.ts:36-44`) and stay silent about the contest.
+     `packages/gateway/src/metrics/service-identity.ts:36-44`) and stay silent
+     about the contest.
    - **Resolve the same way and disclose the candidates.** The consumer's
      recommendation, for the reason §5.1 gives.
    - **Reject duplicate claims at config-validation time**, as the PR review

--- a/docs/superpowers/specs/2026-09-11-services-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design.md
@@ -523,6 +523,19 @@ too sensitive for either mount, this is the outcome and the consumer is fine.
    provider-specific matching on the gateway side, and there is no single
    matcher for a client to copy even if it wanted to. This is the question to
    answer first, because the next two only apply to the list form.
+
+   **If the resolve form is chosen, it carries a second decision that is not
+   optional** (§5.1): which entry point answers a repository-only query, given
+   that neither existing matcher takes a bare URN. Choosing to synthesise an
+   item for `buildServiceIdentityResolver` settles two things by side effect
+   that should be settled deliberately — whether `repo=circleci:…` answers
+   `null` (it would, via `repoMetadataMatchesUrn`'s `circleci` arm, for a
+   service `repoLikeMatchesUrn` would have matched), and how the resolver's
+   three-way `bound` / `excluded` / `unknown` projects onto `service | null`
+   (`excluded` is not `null` in any useful sense). Choosing a URN-to-URN entry
+   point avoids both but is a third matcher unless the other two are refactored
+   onto it. The consumer has no preference here and could not implement either;
+   it is named so that the choice is made rather than fallen into.
 2. Public (Option A) or scoped (Option B)? §6 — and note Option A publishes the
    route in `openapi/v1.yaml`, which is a longer-lived commitment than the
    handler.

--- a/docs/superpowers/specs/2026-09-11-services-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design.md
@@ -184,18 +184,24 @@ Raised in PR review: the resolve form returns a single `service`, and the client
 feeds that id straight into `preflight/deploy` — so "which service" is not a
 cosmetic question, and this document did not answer it.
 
-**Nothing rejects an overlapping claim at config load.** Two `[[metrics.dora.*]]`
-entries may both list `github:acme/payments-api`, and no validation refuses it.
+**Nothing rejects an overlapping claim at config load.** Two `[metrics.dora.<id>]`
+blocks may both list `github:acme/payments-api`, and no validation refuses it.
 So the ambiguity is reachable, not theoretical.
 
-**But the behaviour is not undefined — it is already implemented and shipped.**
-`metrics/service-identity.ts`'s `indexAmbiguousBindings` precomputes, from the
-configs alone, every binding key claimed by more than one service. For such a key
-it takes `claimants[0]` — **first claimant wins** — and records an
-`AmbiguousBindingWarning` carrying both `chosenServiceId` and the full
-`candidateServiceIds`. `reportAmbiguityIfBound` then emits it at most once, and
-only for a resolution that actually bound, precisely so a warning never asserts a
-`chosenServiceId` for a resolve that returned nothing.
+**But the behaviour is not undefined — it is already decided, implemented and
+shipped**, at `packages/gateway/src/metrics/service-identity.ts:36-44`:
+
+> M-2: reported when two `ServiceConfig`s both claim the same binding key — the
+> resolver still picks deterministically (first by config-map iteration order,
+> same as before), this only makes the ambiguity observable.
+
+`indexAmbiguousBindings` precomputes, from the configs alone, every binding key
+claimed by more than one service. For such a key it takes `claimants[0]` —
+**first claimant wins** — and records an `AmbiguousBindingWarning` carrying both
+`chosenServiceId` and the full `candidateServiceIds`. `reportAmbiguityIfBound`
+then emits it at most once, and only for a resolution that actually bound,
+precisely so a warning never asserts a `chosenServiceId` for a resolve that
+returned nothing.
 
 That has two consequences for this proposal, and the second is the open one:
 
@@ -222,9 +228,25 @@ That has two consequences for this proposal, and the second is the open one:
    ```
 
    The gateway already computes every value in that second shape; not returning
-   them is a decision to withhold, not an absence of data. **Recommended:** return
-   them, on the same reasoning `nimbus prove` applies to its own scope label — a
-   consumer that cannot see a qualification cannot account for it.
+   them is a decision to withhold, not an absence of data.
+
+   **Recommended: return them — and this is a consumer need rather than a
+   preference.** The whole design of the client feature behind this proposal is
+   that it must never silently answer about the wrong service. Its deploy
+   verdict is a claim about *this* repository; answering it from a service the
+   user never chose, with nothing on the wire to say a second service also
+   claimed the repo, is exactly the defect that cost a fix round during the
+   client's own implementation. Being handed one arbitrary id with no ambiguity
+   signal would reintroduce it at the contract level, where the client cannot
+   detect it at all.
+
+   Worth saying plainly, because it bounds the ask: **the client's fallback does
+   not have this problem.** Its local binding is per repository and the user
+   typed the service id explicitly, so there is no ambiguity to disclose. The
+   candidates matter precisely when the gateway resolves *for* the client —
+   which is the case this route exists to create. The gateway may reasonably
+   decide a warning on stderr is disclosure enough; the consumer's position is
+   only that a browser never sees stderr.
 
 **For the list form**, the same question appears as: does a repo URN appear under
 every service that claims it, or only under the winner? It should appear under
@@ -483,7 +505,24 @@ too sensitive for either mount, this is the outcome and the consumer is fine.
 4. What does the route do when `nimbus.toml` does not parse — degrade to an
    empty list, or surface the error? §7. Under Option A the message is public
    and embeds config values.
-5. Should `[ci.service.<id>]` and `[metrics.dora.<id>]` services be
+5. **Repository-to-service cardinality — what should one repo claimed by two
+   services do?** §5.1. Three answers, and the third is the gateway's to prefer
+   if it wants it:
+   - **Resolve as the gateway already does** (first claimant wins,
+     `service-identity.ts:36-44`) and stay silent about the contest.
+   - **Resolve the same way and disclose the candidates.** The consumer's
+     recommendation, for the reason §5.1 gives.
+   - **Reject duplicate claims at config-validation time**, as the PR review
+     offered as its first option. This is a legitimate answer and it is not the
+     consumer's call: it makes the ambiguity unrepresentable rather than
+     disclosed, at the cost of turning a config that loads today into one that
+     does not. If it is chosen, the route needs no ambiguity field at all and
+     `indexAmbiguousBindings` becomes dead code — which is a reason to prefer
+     it, not an objection to it.
+
+   Whichever is chosen needs a test for the multi-claimant case; there is none
+   today because there is no route.
+6. Should `[ci.service.<id>]` and `[metrics.dora.<id>]` services be
    distinguishable in the response? They are merged into one `Map` today, with a
    stderr warning on collision, and the consumer does not care — but a future
    one might.

--- a/docs/superpowers/specs/2026-09-11-services-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design.md
@@ -1,0 +1,431 @@
+# `GET /v1/services` — the configured services, and the repos they claim
+
+> **Status:** proposal. No code in this branch — this is the contract, argued
+> before it is built, per the satellite-repo convention that the gateway owns
+> the wire and consumers propose against it (#1464 established the shape).
+>
+> **Proposed by:** the browser client (`nimbus-web-clipper`), which shipped its
+> deploy-readiness surface without it and carries a per-repository hand-binding
+> in its place.
+>
+> **Not a blocker.** The consumer is in production today. This proposal removes
+> a gesture and a drift risk; it does not unblock anything.
+
+## 1. What this is
+
+One read that answers "which Nimbus services are configured, and which
+repositories does each one claim":
+
+```text
+GET /v1/services
+```
+
+```json
+{
+  "services": [
+    {
+      "id": "payment-service",
+      "repos": ["github:acme/payments-api", "jenkins:platform/payments"]
+    },
+    { "id": "web", "repos": ["github:acme/web"] }
+  ]
+}
+```
+
+A **service** here is a `[metrics.dora.<id>]` or `[ci.service.<id>]` block in
+the owner's `nimbus.toml`, carrying `repos = [...]` as provider URNs. It is the
+unit `GET /v1/metrics/dora` and `GET /v1/preflight/deploy` are both scoped by —
+both take `service` as a required query parameter — and it is the one input to
+those routes that a browser has no way to obtain.
+
+## 2. The concrete gap
+
+The gateway holds the repo → service map internally and builds it on demand:
+
+- `buildServiceIdentityResolver` (`packages/gateway/src/metrics/service-identity.ts`)
+  resolves an indexed item to its service id, matching `metadata.repo` /
+  `metadata.project` / `metadata.jobName` against each `ServiceConfig`'s parsed
+  repo URNs.
+- `resolveKnownServices` (`packages/gateway/src/ipc/http-server.ts`) already
+  assembles the plain id list —
+  `Array.from(loadNimbusServiceConfigsFromConfigDir(cfgDir).keys())`.
+
+Neither reaches HTTP. `resolveKnownServices` is passed into
+`resolveWriteRouteDeps` and consumed at exactly one call site,
+`checkServiceAllowlist` in `http-write-routes.ts`, which uses it to refuse an
+unknown `service` on `POST /v1/deployments` — and returns
+`known_services: known.slice(0, 25)` in that 400 body. So the list is already
+**enumerable over HTTP**, but only to a holder of the deployment token, and only
+by deliberately failing a write.
+
+A browser sitting on `github.com/acme/payments-api` knows the repository. It
+cannot learn that the repository is `payment-service`, so it cannot call either
+of the two routes that would tell the reader anything.
+
+## 3. What the client does today, and will keep doing
+
+The consumer ships a **locally-stored binding**. The user types a service id
+once per repository; the client stores `{ product, scope, serviceId }` keyed by
+`product:scope`, and validates the typed id by asking
+`GET /v1/preflight/deploy` — an id no config claims comes back as a normal
+envelope with `gap: "unknown_service"` on all three checks
+(`unconfiguredEnvelope`, `packages/gateway/src/ipc/preflight-rpc.ts`), so the
+client refuses to save it. That path needed no new route and no new scope, and
+it works.
+
+Two things are wrong with it, and neither is fatal:
+
+- **It is a gesture per repository.** A reader who works across fifteen repos
+  binds fifteen times, and a colleague who installs the extension binds them
+  all again.
+- **It can drift.** The binding is a copy of a fact the gateway owns. Rename a
+  service in `nimbus.toml` and every browser that bound the old id keeps sending
+  it; the reader sees `unknown_service` and has to work out that the config
+  moved under them.
+
+With this route, repo → service resolves with no gesture, and the local binding
+survives as an **override** — still needed for a repository the config does not
+claim, and for Jenkins, where the client's own scope key is a job path rather
+than anything URN-shaped. So the fallback is not wasted work either way.
+
+## 4. What this discloses, honestly
+
+This is the part worth arguing, because the answer is not "nothing".
+
+**Service ids are already reachable, unauthenticated, one at a time.** Both
+`GET /v1/metrics/dora` and `GET /v1/preflight/deploy` are `{ kind: "public" }`
+in `HTTP_ROUTE_AUTH`, and both answer an unconfigured service *softly* rather
+than refusing — a fixed envelope whose gap is `unknown_service`. Any local
+process can therefore already confirm whether a guessed service id exists, and
+`known_services` in the deployment-write 400 already enumerates them for one
+credential.
+
+**Repository names are also already public**, via a wider route than this one.
+`GET /v1/items` is `{ kind: "public" }` and its projection includes `metadata`
+— thirteen columns, `body_preview` rather than `body` (`buildItemListSql`,
+`packages/gateway/src/index/item-list-query.ts`) — so `metadata.repo` for every
+indexed forge item is readable by any local process today.
+
+**What is genuinely new is the grouping.** Neither of the above exposes *which
+repositories the owner filed under which service name*. That map is a curated
+statement about how the owner's estate is organised — closer to configuration
+than to index content — and it is the thing a reviewer should weigh.
+
+**And the difference between an oracle and an enumeration is not a footnote.**
+The probe that exists today costs one request per *guessed* id, against an id
+space the caller has to invent. This route costs one request for the whole list.
+That distinction is presumably why `checkServiceAllowlist` caps its own
+disclosure at `known_services: known.slice(0, 25)` rather than returning the
+list whole — in a body that already requires the deployment token. A reviewer
+inclined to object will object here, so it is stated as its own point rather
+than as a trailing clause.
+
+**There is a fourth channel, and it is the error path.** A malformed
+`nimbus.toml` throws out of `loadNimbusServiceConfigsFromConfigDir`, and those
+messages embed the service id *and* the offending value — verbatim from
+`packages/gateway/src/config/service-config-toml.ts`:
+
+```text
+[metrics.dora.payments].deploy_environments entry 'staging-eu' is invalid: must match /^[a-z0-9][a-z0-9._-]*$/
+```
+
+Under a public mount that string is readable by any local process. So the
+disclosure question is not only about the success body, and this route must
+decide deliberately what it says when the config does not parse — see §7's
+error table, which raises it rather than answering it.
+
+## 5. An alternative shape worth weighing first
+
+Placed before the mount question, because it may dissolve it.
+
+A narrower route answers the client's actual question without enumerating
+anything:
+
+```text
+GET /v1/services/resolve?repo=github:acme/payments-api
+→ { "service": "payment-service" }   // or { "service": null }
+```
+
+This is strictly less disclosure — one answer about one repository the caller
+already named — and it has a second advantage that is independent of the
+disclosure debate and is the stronger of the two: **the matching rules stay on
+the gateway side.**
+
+There is no single matcher for a client to copy. There are **two**, and they
+already disagree about one provider:
+
+- `repoLikeMatchesUrn` (`packages/gateway/src/metrics/dora.ts`) takes an
+  `externalId` alongside the metadata, and its `circleci` arm is
+  `externalId.includes(urn.providerId)`.
+- `repoMetadataMatchesUrn` (`packages/gateway/src/metrics/service-identity.ts`)
+  has no external id in its item shape, so its `circleci` arm returns `false` —
+  it never matches. Its own comment says so: it "Mirrors `repoLikeMatchesUrn` in
+  `metrics/dora.ts`, minus its `circleci` external-id branch".
+
+Both also treat GitLab specially (`metadata.project` *or* `metadata.repo`). A
+client doing string equality against a URN list would be a **third** matcher,
+written by someone who can see neither of the first two. A resolve form cannot
+drift from the gateway's own matching, because it *is* the gateway's own
+matching.
+
+What it loses: a service picker. The consumer's DORA page wants to offer the
+reader a list of services to look at, not only to identify the one repository
+in front of them.
+
+Both shapes are compatible — the resolve form could land first and the list form
+later, or the list form could carry enough for the client to do its own
+matching. Named here so the reviewer sees that "list every service" is a choice
+and not the only way to close the gap, and placed first because a mount decision
+for the list form is wasted attention if the resolve form is the one that lands.
+
+## 6. Where it mounts, and under what scope — the gateway's call
+
+**This document does not decide this.** It states the two coherent options and
+the constraint that rules out a third, and leaves the choice to the repo that
+owns the contract.
+
+### The constraint
+
+`dispatchReadOnlyDataGet`'s table is **public by construction** — its own
+comment says "no bearer gate, never fall through" — and the three `resolve`
+reads plus the four egress reads are mounted inline in `tryBearerAuthedGet`
+*precisely because* routing scoped output through that table would serve it to
+any local process on the machine. `handleItemsResolveFile` states it directly:
+
+> the "/v1/items/\*" entry in dispatchReadOnlyDataGet's table is PUBLIC, so
+> routing this through it would serve the reader's indexed-file set to any local
+> process on the machine.
+
+So the mount point is not a detail that follows the decision — it **is** the
+decision. There is no "mount it in the read-only table but scope it" option.
+
+### Option A — public, in `dispatchReadOnlyDataGet`
+
+Beside `/v1/connectors` and the two routes it exists to feed. Consistent with
+them: a client that can already call `preflight/deploy` unauthenticated would
+otherwise need a token to learn what to pass it, which is an odd seam.
+
+Costs: an `HTTP_ROUTE_AUTH` entry — `"GET /v1/services": { kind: "public" }` —
+because that table is **total over the surface** by its own header and a route
+with no entry fails the completeness test rather than inheriting whatever the
+surrounding code does; plus `HTTP_ROUTES` and a `paths:` entry in
+`packages/gateway/openapi/v1.yaml`, which `audit:openapi-drift` enforces as a
+pair. Both options cost an auth entry; only its *value* differs.
+
+And one cost that is easy to miss because it is not a code change: **Option A
+bundles "public" with "documented forever".** `HTTP_ROUTES` is the OpenAPI
+source of truth, so the public mount publishes this route in
+`openapi/v1.yaml` — a schema other tools generate clients from. Un-publishing it
+later is a different kind of change from deleting a handler. The scoped reads
+stay off that list precisely because they are not part of the published surface.
+
+Plus the grouping from §4, and §4's error-path channel, become readable by any
+local process.
+
+### Option B — bearer-authed, inline in `tryBearerAuthedGet`
+
+A `ROUTE_KEY_SERVICES_LIST` constant, an `HTTP_ROUTE_AUTH` entry, a member on
+the `ClipReadRouteKey` union, and the same `404 { "error": "..._disabled" }`
+before the auth check that every other inline read uses as its capability
+signal. Stays off `HTTP_ROUTES` like every other clip-scoped read.
+
+**Name the gate, because the inline reads do not.** What that 404 actually
+tests is `opts.clipsVault === undefined` — the *clips surface*, not this route.
+So a gateway new enough to have the route but with no paired-client surface
+mounted answers `404 services_disabled`, and a client reads it as "this gateway
+is older than the route". Every existing inline read carries that ambiguity and
+none of them says so out loud. The consequence is benign here — both readings
+lead the client to the same fallback — but it should be written in the route's
+comment rather than rediscovered.
+
+Then: which scope?
+
+- **Reuse `resolve`.** It reads, it runs nothing, it appends no egress row —
+  the same three sentences `resolve-file` and `resolve-ids` are mounted on. It
+  is also a *resolution*: repo coordinate in, identity out. No re-pairing for
+  any token that already holds `resolve`.
+- **A new `services` scope.** Cleanest separation, and a token in the wild gains
+  nothing. Costs an `API_SCOPES` entry, deliberate absence from `LEGACY_SCOPES`,
+  and an owner gesture — `nimbus clip scopes <label> --set <scopes>`, in place,
+  no re-pairing.
+
+The consumer has no preference and will read whichever it is given. It does ask
+that the choice be **stated in the route's own comment**, because the next
+proposal will copy it.
+
+## 7. Proposed contract, if the list form is chosen
+
+### Request
+
+`GET /v1/services`. No parameters.
+
+### Response
+
+```json
+{
+  "services": [
+    { "id": "payment-service", "repos": ["github:acme/payments-api"] }
+  ]
+}
+```
+
+Field by field, never a spread of `ServiceConfig`. That type also carries
+`pagerdutyServices`, `deployWorkflowPattern`, `incidentWindowMinutes`,
+`excludePrLabels`, `deployEnvironments` and `severityP1Aliases` — **none of
+which any consumer needs**, and two of which (the PagerDuty service ids and the
+deploy-environment names) are materially more sensitive than the repo list.
+
+A spread would also *look* clean while leaking: `deployWorkflowPattern` is a
+`RegExp`, which `JSON.stringify` renders as `{}`, so a test fixture eyeballed by
+a human would show a harmless empty object sitting beside the two fields that
+actually matter. That is exactly the failure a key-pinning test exists to catch.
+
+A test should therefore pin `Object.keys()` on a service entry to exactly
+`["id", "repos"]`. Note this pins the **wire** key set, not `ServiceConfig`'s:
+`id` is a rename of `serviceId`, so the two are deliberately not the same
+vocabulary and nobody should read the assertion as a claim about the internal
+type. `resolve-ids` and `resolve-file` both set this precedent and both have
+such a test.
+
+`repos` is each `ParsedDoraRepoUrn` rendered back to its wire form,
+`` `${provider}:${providerId}` `` — the same rendering
+`indexAmbiguousBindings` already uses internally for its binding keys, and the
+same string the owner wrote in `nimbus.toml`.
+
+**A service with no repos is present with `"repos": []`.** It is a configured
+service; `no_repos` is a real and separately-reported state in `DoraGap`, and
+collapsing it into absence would make a mis-configured service look like a
+missing one.
+
+**Order is `ORDER BY id`-equivalent** (sort the ids). The underlying `Map` has
+`[metrics.dora.*]` insertion order followed by `[ci.service.*]`, which is
+incidental; a stable order makes a response reproducible in tests across
+platforms.
+
+### Errors
+
+| condition | status | body |
+| --- | --- | --- |
+| no config dir wired | 200 | `{ "services": [] }` |
+| `nimbus.toml` absent | 200 | `{ "services": [] }` |
+| **`nimbus.toml` malformed** | **the gateway's call — see below** | |
+| (Option B only) surface unmounted | 404 | `{ "error": "services_disabled" }` |
+| (Option B only) token lacks the scope | 403 | the standard scope-gap body |
+
+The empty-list cases are deliberately **200, not 404**: `resolveKnownServices`
+already returns `[]` for an unwired config dir, and
+`loadNimbusServiceConfigsFromConfigDir` returns an empty `Map` when
+`nimbus.toml` does not exist. "No services are configured" is an answer, and the
+client renders it as one — a prompt to configure a service, not an error. Under
+Option B the 404 keeps its distinct meaning: *this gateway is older than the
+route*, which is the capability signal.
+
+#### The malformed-config row is a real decision, not an omission
+
+`loadNimbusServiceConfigsFromConfigDir` **throws** on a config that does not
+parse. `materializeOneServiceConfig` and its helpers
+(`packages/gateway/src/config/service-config-toml.ts`) throw on a missing
+`repos`, an `incident_window_minutes` outside 1..1440, an invalid
+`deploy_environments` entry, an unparseable `deploy_workflow_pattern`, an
+unknown key, or an empty table id.
+
+The existing callers know this and disagree about what to do:
+
+- `packages/gateway/src/ipc/agents-rpc.ts` degrades rather than throwing.
+- `packages/gateway/src/platform/assemble.ts` try/catches at startup for
+  precisely this reason.
+- `handleMetricsDora` does **not** wrap it — it catches only `MetricsRpcError` —
+  so a malformed `nimbus.toml` already turns `GET /v1/metrics/dora` into a 500
+  today. Pre-existing, and not this proposal's to fix; named because a new route
+  must choose rather than inherit a behaviour by accident.
+
+Two sub-questions, raised and deliberately not answered:
+
+1. **Degrade to an empty list, or surface the parse error?** Degrading matches
+   `agents-rpc.ts` and keeps the route's contract simple; surfacing it is the
+   only way a reader learns their config is broken from the surface they are
+   actually looking at.
+2. **If it surfaces, what may the body say?** Under Option A the message is
+   public, and these messages embed the service id and the offending value (§4).
+   A body that names only *that* parsing failed, with the detail going to stderr
+   where the owner already reads it, is the shape that keeps the disclosure
+   analysis in §4 true.
+
+### Caching and cost
+
+`loadNimbusServiceConfigsFromConfigDir` reads and parses `nimbus.toml` on every
+call; the existing callers accept that, and this route can too. Worth noting
+because it is a file read on a public route under Option A — a reviewer may want
+a cheap guard there that the internal callers do not need.
+
+## 8. What this is not
+
+- **Not a version floor.** Route presence is the capability signal, as with
+  `resolve-file` and `resolve-ids`. The consumer probes, reads a 404 as "this
+  gateway does not have it", and falls back to §3's local binding silently.
+- **Not egress.** It reads a local file. No provider request, no ledger row —
+  the same narrowing `packages/gateway/src/egress/egress-coverage.ts` already
+  applies to the three `resolve` reads. Under Option B that file's
+  local-index-read list should gain this route, as it did for `resolve-file`
+  and `resolve-ids`.
+- **Not a write.** I13 governs HTTP *write* routes via
+  `WRITE_ROUTE_ALLOWLIST`; this stays off it. Named because "new HTTP route" is
+  the trigger a reviewer reaches for I13 on, and it is the wrong invariant here.
+- **Not a schema change.** No table, no migration — the source is `nimbus.toml`.
+- **Not a config *write* surface.** The client never proposes a service. Editing
+  `nimbus.toml` stays an owner gesture on the machine.
+
+## 9. What the client does with it
+
+For the record, so the shape is judged against a real consumer.
+
+On a recognised pull-request or build page the extension derives a repo-level
+scope from its recognition registry (`owner/repo` on the three forges, a job
+path on Jenkins). With this route it reads the service list once, matches its
+scope against the URN list, and calls `preflight/deploy` with the id it found —
+no bind form, no gesture. Where nothing matches, the existing bind form appears
+exactly as it does today, and a stored binding continues to win over the
+gateway's answer, because a reader who typed an id meant it.
+
+It is one call per session, cached; the browser's only network destination
+remains the gateway on loopback.
+
+## 10. Alternatives considered
+
+**Let the client call `POST /v1/deployments` with a junk service and read
+`known_services` out of the 400.** It is the only path that exists today.
+Rejected without hesitation: it requires the deployment token, which a browser
+must never hold, it is a write on the I13 surface, and it obtains data by
+deliberately failing a request that records a rejection. Named only because it
+demonstrates the list is already considered disclosable to *some* credential.
+
+**Have the client infer the service from `GET /v1/items`.** The public item rows
+carry `metadata.repo`, and deployment rows carry `nimbus_service_id`. A client
+could in principle mine the correlation. Rejected: it reconstructs a config fact
+from data by inference, it is wrong whenever a service has no recent deployment,
+and it reads far more of the index than a direct answer would.
+
+**Keep the local binding and do nothing.** The honest baseline, and the reason
+this is a proposal rather than a bug report. It costs a gesture per repository
+and carries a drift the user has to diagnose. If the grouping in §4 is judged
+too sensitive for either mount, this is the outcome and the consumer is fine.
+
+## 11. Open questions for the gateway
+
+1. List form, resolve form, or both? §5 — the resolve form keeps the
+   provider-specific matching on the gateway side, and there is no single
+   matcher for a client to copy even if it wanted to. This is the question to
+   answer first, because the next two only apply to the list form.
+2. Public (Option A) or scoped (Option B)? §6 — and note Option A publishes the
+   route in `openapi/v1.yaml`, which is a longer-lived commitment than the
+   handler.
+3. If scoped: reuse `resolve`, or a new `services` scope? §6. Reusing `resolve`
+   widens the reach of every token that already holds it, including tokens
+   paired for `resolve-file` alone; a new scope grants nothing retroactively.
+4. What does the route do when `nimbus.toml` does not parse — degrade to an
+   empty list, or surface the error? §7. Under Option A the message is public
+   and embeds config values.
+5. Should `[ci.service.<id>]` and `[metrics.dora.<id>]` services be
+   distinguishable in the response? They are merged into one `Map` today, with a
+   stderr warning on collision, and the consumer does not care — but a future
+   one might.

--- a/docs/superpowers/specs/2026-09-11-services-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-services-route-design.md
@@ -178,6 +178,64 @@ matching. Named here so the reviewer sees that "list every service" is a choice
 and not the only way to close the gap, and placed first because a mount decision
 for the list form is wasted attention if the resolve form is the one that lands.
 
+### 5.1 One repo can be claimed by several services, and the gateway already decided what happens
+
+Raised in PR review: the resolve form returns a single `service`, and the client
+feeds that id straight into `preflight/deploy` — so "which service" is not a
+cosmetic question, and this document did not answer it.
+
+**Nothing rejects an overlapping claim at config load.** Two `[[metrics.dora.*]]`
+entries may both list `github:acme/payments-api`, and no validation refuses it.
+So the ambiguity is reachable, not theoretical.
+
+**But the behaviour is not undefined — it is already implemented and shipped.**
+`metrics/service-identity.ts`'s `indexAmbiguousBindings` precomputes, from the
+configs alone, every binding key claimed by more than one service. For such a key
+it takes `claimants[0]` — **first claimant wins** — and records an
+`AmbiguousBindingWarning` carrying both `chosenServiceId` and the full
+`candidateServiceIds`. `reportAmbiguityIfBound` then emits it at most once, and
+only for a resolution that actually bound, precisely so a warning never asserts a
+`chosenServiceId` for a resolve that returned nothing.
+
+That has two consequences for this proposal, and the second is the open one:
+
+1. **This route must not invent a precedence rule.** A route that picked, say,
+   the alphabetically-first service would disagree with the binding the rest of
+   the DORA pipeline already made for the same repo, and the client would gate a
+   deploy against one service while the metrics behind it belong to another. The
+   resolve form's whole argument in §5 is that the matching rules stay on the
+   gateway side; a second precedence rule here would be the third matcher that
+   argument exists to prevent. Reuse the existing index.
+
+2. **Whether the route DISCLOSES the ambiguity is still open, and is a real
+   choice.** Returning a bare `{ "service": "payment-service" }` is honest about
+   the binding and silent about its being contested — the caller cannot tell a
+   sole claim from a coin-toss among three, and it is about to gate a deployment
+   on the answer. Adding the candidates the warning already carries costs one
+   field:
+
+   ```text
+   GET /v1/services/resolve?repo=github:acme/payments-api
+   → { "service": "payment-service", "ambiguous": false }
+   → { "service": "payment-service", "ambiguous": true,
+       "candidates": ["payment-service", "billing-service"] }
+   ```
+
+   The gateway already computes every value in that second shape; not returning
+   them is a decision to withhold, not an absence of data. **Recommended:** return
+   them, on the same reasoning `nimbus prove` applies to its own scope label — a
+   consumer that cannot see a qualification cannot account for it.
+
+**For the list form**, the same question appears as: does a repo URN appear under
+every service that claims it, or only under the winner? It should appear under
+each — the list form's purpose is for the client to see the configuration, and a
+list that silently drops the losing claimant hides exactly the misconfiguration a
+reader would want to find.
+
+**Whichever shape lands needs a test for the contract chosen**, including the
+multi-claimant case. There is no such test today because there is no such route;
+this paragraph exists so that "no test" is a known cost rather than an oversight.
+
 ## 6. Where it mounts, and under what scope — the gateway's call
 
 **This document does not decide this.** It states the two coherent options and


### PR DESCRIPTION
## Summary

Proposes `GET /v1/services` — a read over the service ids in `[metrics.dora.*]` / `[ci.service.*]` and the repo URNs bound to them. **Design only, no implementation**, following the shape of #1464.

**This is not a blocker.** The consumer already ships and works without it; the proposal is about removing a gesture, not unblocking a feature.

## Why a client wants it

The `nimbus-web-clipper` extension just shipped a deploy-readiness panel that calls `GET /v1/preflight/deploy`. That route needs a `service`, and the client has no way to learn which service a repository is: a service is a `[metrics.dora.<id>]` block carrying `repos = [...]`, and while the gateway holds the reverse map internally (`buildServiceIdentityResolver`) and assembles `knownServices` (`resolveKnownServices`), both are reachable only from the I13 write dispatcher. No GET exposes either.

So the client stores a **local binding**: the user types a service id once per repository, seeded with a guess, and it is validated by asking preflight — an id the gateway does not know comes back reporting `unknown_service` on every check, so an unknown id is refused rather than saved. That works. It costs a gesture per repo, and it can drift from `nimbus.toml` when a service is renamed.

With this read, repo→service resolves with no gesture, and the local binding survives as an override for repos the config does not claim.

## What the spec settles, and what it leaves to you

Settled by reading the source: where the config is already loaded, what `resolveKnownServices` already returns, that `HTTP_ROUTE_AUTH` is total over the surface so **either** mounting option needs an entry there, and that `loadNimbusServiceConfigsFromConfigDir` **throws** on a malformed `nimbus.toml` — a path whose message would be public under the public-table option and can embed config values.

Left open, deliberately, because they are yours to decide:

- **Public table or scoped.** `dispatchReadOnlyDataGet` is public by construction, which is exactly why `handleItemsResolve` and its siblings mount separately. Service *ids* are already probe-confirmable unauthenticated via preflight, and repo *names* already appear in `GET /v1/items`' projection — so the new disclosure is the **grouping**, not the values. Whether that warrants a scope is a judgment about your threat model, not ours.
- Whether the IPC verb gains a matching shape.
- Response shape details, naming, and pagination.

## If you say no

The client keeps its local binding and nothing regresses. A "no" with a reason is genuinely useful to us — it tells the next surface not to ask again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdWmqLJUG2mXevhr31o9dG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a proposal for a `GET /v1/services` endpoint listing configured service IDs and repository URNs.
  - Documented authentication, scopes, OpenAPI exposure, disclosure, caching, malformed configuration handling, and client fallback behavior.
  - Expanded service-resolution coverage for repository-only queries, CircleCI behavior, matcher incompatibilities, overlapping bindings, first-claimant handling, response shapes, and unresolved contract questions.
  - Updated the design review to scope C6 as unresolved and expand testing guidance for item-shaped resolver exclusions, repository queries, and multiple claimants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->