### PR TITLE
docs(spec): propose an HTTP route for the bucketed DORA series

### DIFF
--- a/docs/superpowers/specs/2026-09-11-metrics-series-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-metrics-series-route-design-review.md
@@ -1,0 +1,256 @@
+# Design Review: `until` on `GET /v1/metrics/dora` — making a disjoint window expressible
+
+**Date:** 2026-09-11  
+**Reviewer:** Claude Opus 5 (AI Coding Assistant)  
+**Status:** Review Complete — needs changes; the ordering of the ask should be reconsidered. **Addressed:** the spec now leads with the stats route per §2, keeps `until_ms` as its §6 fallback, and was renamed to match.  
+**Target Spec:** [`2026-09-11-metrics-series-route-design.md`](./2026-09-11-metrics-series-route-design.md) — reviewed under its original title, *`until` on `GET /v1/metrics/dora` — making a disjoint window expressible*  
+**Slot:** HTTP Client Surfaces / Web Clipper (`nimbus-web-clipper` integration)  
+**Related Surfaces:** `metrics.dora`, `metrics.stats`, `GET /v1/metrics/dora`, `nimbus metrics dora`, `nimbus stats`  
+**Sibling Proposal:** `GET /v1/services` — [#1489](https://github.com/nimbus-agent/Nimbus/pull/1489)
+
+---
+
+> **This is a review note, not guidance. Where it disagrees with the design
+> spec, the spec wins.**
+>
+> One disagreement is deliberate and is the reason this note exists: **§5's
+> proposed fix does not close the hole §5 identifies.** Extending the incident
+> lookup past the upper bound by `incidentWindowMinutes` is insufficient,
+> because `selectResolvedIncidents` windows on *resolution* time, not on the
+> `opened` timestamp attribution actually compares. See C3.2.
+>
+> It is committed because this repo keeps review notes beside their specs, and
+> it is pruned when the feature ships — or when the proposal is declined.
+
+## 1. Executive Summary
+
+The spec proposes one optional parameter, `until_ms`, moving the upper bound of the DORA
+window off `now` so three calls describe three consecutive periods instead of three nested
+ones. It is additive, back-compatible, needs no new route, scope or re-pairing, and the
+client ships without it today.
+
+**Verdict: needs changes.** Not because the ask is wrong — the gap is real and precisely
+stated — but because of two things:
+
+1. **§5's fix is wrong in a way that matters.** It correctly finds that `until` would ship
+   a knowably wrong `change_failure_rate`, then prescribes a widening that does not fix it.
+   A maintainer who implements §5 as written would believe the hole is closed. (C3.2.)
+2. **The alternative in §7 is probably the better primary ask.** `metrics.stats` already
+   computes the series the consumer wants; §2 of this note argues it should lead, with
+   `until` as the secondary — and names the one thing that argument must *not* claim.
+
+Claims checked against the branch point. The load-bearing ones hold:
+
+| Claim | Verified |
+| --- | --- |
+| `handleMetricsDora` reads only `service` and `since`; `requireDoraParams` accepts only those two | `packages/gateway/src/ipc/http-server.ts`, `packages/gateway/src/ipc/metrics-rpc.ts` |
+| `parseSinceToMs` yields a **duration**; grammar `\d+(d\|h)`, 1..365; errors are `MetricsRpcError(-32602)` mapped to 400 | `packages/gateway/src/ipc/metrics-rpc.ts` |
+| Every calculator is `(db, cfg, nowMs, sinceMs)` and binds `nowMs - sinceMs, nowMs`; queries are two-sided | `packages/gateway/src/metrics/dora.ts` |
+| `computeDoraMetrics` derives `computed_at` from the same `nowMs` it binds as the upper bound — the double duty §3 names | `packages/gateway/src/metrics/dora.ts` |
+| `computeStatsSeries` calls `splitBuckets(untilMs, windowMs, bucketMs)` and evaluates each bucket against a sub-window ending in the past | `packages/gateway/src/metrics/stats.ts` |
+| The comment quoted in §3 ("binding `nowMs` to the bucket's end…") is verbatim | `packages/gateway/src/metrics/stats.ts` |
+| `StatsSeries` publishes `window: { since_ms, until_ms }`, both absolute; `DoraMetricsResult.since_ms` is a duration | `packages/gateway/src/metrics/stats.ts`, `packages/gateway/src/metrics/dora.ts` |
+| `MAX_BUCKETS = 400` | `packages/gateway/src/metrics/stats-buckets.ts` |
+| `metrics.stats` refuses an unconfigured service where `metrics.dora` answers softly — and the dispatcher documents the asymmetry | `packages/gateway/src/ipc/metrics-rpc.ts` |
+| `/v1/metrics/dora` is the only `/v1/metrics` route on the HTTP server; `metrics.stats` has none | `packages/gateway/src/ipc/http-server.ts` |
+| `/v1/metrics/dora` is `{ kind: "public" }`, is in `HTTP_ROUTES`, and has a `paths:` entry in the schema | `packages/gateway/src/ipc/http-route-auth.ts`, `packages/gateway/src/ipc/http-routes.ts`, `packages/gateway/openapi/v1.yaml` |
+| `GET /v1/items` accepts camelCase `sinceMs` / `untilMs` beside a relative `since` | `packages/gateway/src/ipc/http-server.ts` |
+| `nimbus metrics dora` takes `--since` and has no `--until` | `packages/cli/src/commands/metrics.ts` |
+| The named tests exist and are both in `test:coverage:metrics` | `packages/gateway/test/integration/http/metrics-dora-route.test.ts`, `packages/gateway/test/unit/metrics/` |
+| The `modified_at` skew and the dora.ts follow-up are documented for `nimbus stats`, quoted verbatim | `docs/cli-reference.md` |
+
+## 2. Should This Lead With `GET /v1/metrics/stats` Instead?
+
+**Yes — with one correction that the stats argument must not be allowed to make.**
+
+The consumer's actual requirement is a *series*. `computeStatsSeries` produces exactly
+that, disjoint, gap-annotated per bucket, capped at 400 buckets, over the same service
+config — and `StatsSeries` already carries the absolute `window: { since_ms, until_ms }`
+vocabulary the DORA envelope is missing. It has no HTTP route. Three arguments for putting
+it first:
+
+- **Round trips.** A twelve-bucket trend is twelve `until` calls. Through a stats route it
+  is one call per metric — four, for the four DORA metrics — and the spec's "in **one** call
+  instead of N" overstates only by that factor (C3.5), not in direction.
+- **Who owns the arithmetic.** With `until`, bucket boundaries are computed in a browser.
+  §7's own reason for rejecting a relative `until` — that N calls each anchored to their own
+  `Date.now()` do not tile exactly — is evidence *against* client-side series assembly in
+  general, not merely against the relative form. `splitBuckets` already solves the tiling
+  problem, including the deliberate choice to let the oldest bucket absorb the remainder so
+  the freshest one is complete. That decision should not be re-derived per consumer.
+- **Vocabulary.** A stats route lands with `window.since_ms` / `until_ms` already absolute
+  and already shipped, which dissolves §4's naming collision instead of adding to it.
+
+**The correction.** A stats-first argument must not claim stats avoids §5's accuracy
+problem. It does not. `computeStatsSeries` binds `nowMs` to each bucket's end and calls the
+same four calculators, so **every bucket has the same upper-edge attribution hole**, and
+`nimbus stats` ships it today. That is the unifying point both proposals are circling: the
+defect is in `dora.ts`'s window-bounded attribution, not in any wire shape, and it is
+already on the wire via the CLI. Whichever route lands, the fix is the same fix.
+
+**Recommended restructure.** Lead with "expose the series the gateway already computes",
+keep `until` as the narrower fallback for the scalar question ("the same metric for last
+quarter"), and move the honesty section so it governs both — because it does. The spec's
+three reasons for ordering it second are all real and all small: a new route is a mount
+decision, stats refuses an unconfigured service, and `until` is independently useful. None
+of them outweighs "the gateway already computes the thing the consumer is asking to
+approximate". The error-story objection in particular is a paragraph of design, not a
+reason to reorder a proposal.
+
+This is a judgement call, not a defect. §7 does name stats as "the strongest alternative by
+some distance" and offers to close this proposal unbuilt in its favour, which is honest.
+The recommendation is to make that the headline rather than the last section.
+
+## 3. Corrections Before This Opens
+
+### C3.1 — "Three of the four metrics window on `item.modified_at`" is wrong (factual)
+
+**All four do.** `selectDeploys`, the PR query inside `leadTimeForChanges`, and
+`selectResolvedIncidents` each bind `modified_at >= ? AND modified_at <= ?`, and every DORA
+metric is built from those three selections.
+
+The "three" in `docs/cli-reference.md` is counting something else — the metrics that read
+**pr and incident** rows, where `modified_at` is a last-touch timestamp rather than an event
+time:
+
+> The four wrapped DORA metrics call the existing calculators unchanged, which also inherits
+> their `item.modified_at` windowing — last touch, not event time, for the `pr` and
+> `incident` rows three of them read
+
+Deployment rows are windowed on `modified_at` too; they simply suffer less from it. Restate
+as: all four window on `modified_at`; for the three that read `pr` / `incident` rows, that
+is last touch rather than event time. This matters because the sentence is addressed to the
+people who own `dora.ts` and will be read as a claim about their code.
+
+### C3.2 — §5's proposed fix does not close §5's hole (material)
+
+The mechanism §5 describes is real, and worse than stated. Verified in
+`packages/gateway/src/metrics/dora.ts`:
+
+- `selectResolvedIncidents` selects `pagerduty` / `incident` rows bound by
+  `i.modified_at >= ? AND i.modified_at <= ?`, then keeps only rows whose
+  `metadata.status === "resolved"`, and sets `resolved: r.modified_at`. So the window is
+  applied to the **resolution** time.
+- Attribution compares `inc.opened` — taken from `metadata.opened_at_ms`, falling back to
+  `synced_at` — against each in-window deploy, looking back `incidentWindowMinutes`.
+
+The consequence: the parameter the window filters on is not the parameter attribution reads.
+§5 prescribes extending the incident lookup past the upper bound by `incidentWindowMinutes`.
+That is sized against the *opened*-time gap, but the filter is on *resolution* time. An
+incident opened one minute before `until` may resolve days later — `mttr` exists precisely
+because resolution lag is measured in hours to days — and such an incident falls outside a
+lookup widened by sixty minutes, so the deploy is still reported clean.
+
+The fix that actually closes it is to select attribution candidates by
+`json_extract(i.metadata, '$.opened_at_ms')` rather than by `modified_at`, over
+`[start, until + incidentWindowMinutes]`. A second consequence falls out of the same
+reading and should be stated: because `status === "resolved"` is required, an incident that
+is **still burning** is invisible at any bound, so a historical `change_failure_rate` under-
+reports for that reason as well. (`computeStatsSeries`'s own `discloseUntimedIncidents` seam
+exists for a neighbouring version of this problem, which is a useful precedent to cite.)
+
+Also delete, or qualify, the parenthetical "(and deploy)". Widening the **deploy** selection
+changes `deploys.length`, which is the denominator. The next clause does say the denominator
+stays the requested window, but the parenthetical is what an implementer will copy.
+
+### C3.3 — §5 states the consequence too softly for what it found (judgement)
+
+Asked directly: **no, §5 is not strong enough**, and the reason is structural rather than
+rhetorical. Three fixes, in order of value:
+
+1. **Promote it.** It arrives as "a second, sharper edge case" beneath the `modified_at`
+   discussion. It is the more serious of the two: the `modified_at` skew is an accepted,
+   documented cost inherited from `nimbus stats`, while this is a *new* wrong number that
+   the parameter would introduce.
+2. **Say what changes about the edge count.** Today there is one upper edge, it is `now`,
+   and the incident genuinely has not happened yet — unavoidable, and the spec says so. A
+   series has N upper edges and every one of them is in the past, where the incident is
+   sitting in the index and is avoidable. The defect rate goes from "one boundary you cannot
+   fix" to "every boundary, all fixable". That sentence is missing and it is the whole
+   argument.
+3. **Make §5 agree with §9.** Open question 3 already takes the position that the widening
+   should land with the parameter. §5 says it "belongs with this change, not after it" and
+   then hands the decision back. Pick one register. This review's position matches Q3's:
+   `until` should not ship without it, and the spec is entitled to say so — a consumer may
+   decline to consume a number it knows to be wrong, which is a statement about the client's
+   own honesty rules rather than a demand on the gateway.
+
+### C3.4 — `since_ms` is not on the preflight envelope (precision)
+
+§4's parameter-naming paragraph reads "`target_ref`, `max_findings`, `since_ms` on the
+sibling preflight route and in this envelope". `target_ref` and `max_findings` are
+preflight's; `since_ms` is this envelope's only — the preflight result's required fields are
+`service`, `target_ref`, `computed_at`, `verdict`, `checks`. The sentence is defensible if
+parsed carefully and misleading if read at speed. Split it.
+
+### C3.5 — "the series in **one** call instead of N" (precision)
+
+`computeStatsSeries` takes a single `metric`. Four DORA metrics is four calls, not one. The
+comparison is still decisive — four versus one-per-bucket — so state it as four.
+
+## 4. Endorsements
+
+- **§3's `nowMs` double-duty finding is correct and important.** `computeDoraMetrics` uses
+  the same `nowMs` for the query's upper bound and for `computed_at`. Threading `untilMs`
+  separately, as the spec insists, is the difference between a cacheable historical answer
+  and one indistinguishable from a fresh computation. Keep this paragraph exactly as it is.
+- **§4's naming-collision analysis is correct**, and the three options are the three
+  options. Recommend option 2 (a nested absolute `window`, top-level `since_ms` left alone),
+  for a reason the spec cannot know it has: if a stats route lands, option 2 is the only one
+  that leaves the two envelopes speaking the same language.
+- **Accepting a future `until_ms`** rather than 400-ing a client whose clock is seconds
+  ahead is right, and the justification given (no row has a `modified_at` beyond now) is the
+  correct one.
+- **§7's rejection of client-side trend arithmetic** is correct and worth keeping verbatim:
+  `lead_time_for_changes` and `mttr` are medians, and medians do not decompose across
+  subtracted windows.
+
+## 5. Invariants & Gates
+
+1. **I13.** Correct — a query parameter on a public GET does not touch
+   `WRITE_ROUTE_ALLOWLIST`.
+2. **OpenAPI drift.** Correct and load-bearing: `/v1/metrics/dora` is in both `HTTP_ROUTES`
+   and the schema, so the parameter and the new response field must land in
+   `packages/gateway/openapi/v1.yaml` in the same commit or `audit:openapi-drift` fails.
+3. **`HTTP_ROUTE_AUTH`.** Unchanged, correctly — the route already has its `{ kind: "public" }`
+   entry. (Contrast the sibling proposal, which needs a new one under either option.)
+4. **Egress / schema.** Correct: local index read, no ledger row, no migration.
+5. **A gate the spec does not name.** A malformed `nimbus.toml` throws out of
+   `loadNimbusServiceConfigsFromConfigDir`, and `handleMetricsDora` catches only
+   `MetricsRpcError` — so that throw is already a 500 on this route today. Not introduced by
+   this parameter, but a reviewer touching `handleMetricsDora` will see it, and the sibling
+   proposal raises the same seam.
+
+## 6. Read as a Proposal
+
+A maintainer reading cold gets the problem (nested windows cannot express a trend), the
+shape (one optional parameter, absent means today), and what happens on a no (§6: the page
+ships three nested windows and refuses to draw a line between them). Nothing is asked for
+that the client does not need — `until_ms` on the request and `until_ms` on the response,
+where the second exists so a cached answer can say which window it describes.
+
+Tone is peer throughout, and §5 is the strongest evidence of it: the spec spends its longest
+section arguing against its own parameter's readiness. That is the right instinct and the
+reason C3.2 and C3.3 are framed as making that section *do its job*, not as softening it.
+
+The one structural weakness is §7. Burying the alternative the gateway may well prefer at
+the end of the document is not dishonest — it is argued fairly and the offer to close this
+proposal unbuilt is explicit — but it asks the reviewer to read to the end to find the
+question they most need to answer. See §2.
+
+## 7. Testing Strategy, If It Is Built
+
+- **The parameter is wired, not accepted and dropped.** A historical window whose result
+  differs from the same-length window ending now — the spec names this and it is the right
+  assertion.
+- **Absent means today.** The existing route test's expectations must pass unchanged with no
+  `until_ms`, byte for byte.
+- **`computed_at` is not `until_ms`.** A response for a window ending a month ago carries a
+  `computed_at` of wall-clock now. This is the test that proves §3's separation held.
+- **The attribution edge (C3.2).** A fixture with a deploy five minutes before `until_ms`
+  and an incident opened ten minutes after it, resolved three days later: the deploy counts
+  as failed. This single case is what distinguishes the correct fix from the widening §5
+  currently prescribes, which would still report it clean.
+- **Bounds.** Non-integer and non-positive `until_ms` are 400s; a future `until_ms` is a 200
+  equivalent to the no-parameter answer.
+- **Schema.** `audit:openapi-drift` green with the parameter and the new field documented.

--- a/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
@@ -1,0 +1,470 @@
+# `GET /v1/metrics/stats` — putting the series the gateway already computes on the wire
+
+> **Status:** proposal. No code in this branch — this is the contract, argued
+> before it is built, per the satellite-repo convention that the gateway owns
+> the wire and consumers propose against it (#1464 established the shape).
+>
+> **Proposed by:** the browser client (`nimbus-web-clipper`), whose DORA page is
+> designed and ships either way — without this it shows three nested windows and
+> deliberately refuses to draw a line between them.
+>
+> **Not a blocker.** The primary ask adds no computation: `computeStatsSeries`
+> already exists, is already shipped behind `nimbus stats`, and has no HTTP
+> route.
+>
+> **Supersedes an earlier draft** that led with an `until_ms` parameter on
+> `GET /v1/metrics/dora`. That parameter survives here as §6, the fallback, for
+> the reason §5 gives.
+
+## 1. What this is
+
+The consumer wants a **time series**: one value per period, periods disjoint, so
+a line between them means something. The gateway already computes exactly that,
+for exactly the four DORA metrics, over exactly the same service config — and
+the only way to reach it is the CLI.
+
+```text
+GET /v1/metrics/stats?service=payment-service&metric=mttr&window_ms=7776000000&bucket_ms=604800000
+```
+
+```json
+{
+  "metric": "mttr",
+  "service": "payment-service",
+  "window": { "since_ms": 1749081600000, "until_ms": 1756857600000 },
+  "bucket_ms": 604800000,
+  "points": [
+    { "start_ms": 1749081600000, "end_ms": 1749686400000,
+      "value": 5400, "unit": "seconds_median", "sample": 4, "gap": null }
+  ]
+}
+```
+
+That is `StatsSeries` (`packages/gateway/src/metrics/stats.ts`) verbatim. The
+ask is a route, not a computation.
+
+## 2. The concrete gap
+
+`GET /v1/metrics/dora` takes `service` and `since` and nothing else.
+`handleMetricsDora` (`packages/gateway/src/ipc/http-server.ts`) reads exactly
+those two; `requireDoraParams` (`packages/gateway/src/ipc/metrics-rpc.ts`)
+accepts exactly those two. `parseSinceToMs` turns `since` into a **duration**,
+and every calculator in `packages/gateway/src/metrics/dora.ts` is
+`(db, cfg, nowMs, sinceMs)` binding the pair `nowMs - sinceMs, nowMs`.
+
+So every window ends at the same instant. `7d`, `30d` and `90d` are **nested** —
+the first is a subset of the second, which is a subset of the third. Disjoint
+periods are not expressible at any combination of parameters, and a client that
+plots three nested windows as a line draws a slope that means nothing.
+
+Meanwhile:
+
+- `computeStatsSeries` produces disjoint buckets, each one gap-annotated,
+  wrapping the same four DORA calculators plus two event-timed counters.
+- `splitBuckets` (`packages/gateway/src/metrics/stats-buckets.ts`) owns the
+  tiling, including `MAX_BUCKETS = 400` and a decision a consumer should not be
+  re-deriving: the **first** bucket absorbs the remainder so the **last** one
+  ends exactly at `untilMs`, because "the freshest point must be complete, and a
+  short bucket is honest only if it is the oldest one".
+- `StatsSeries` already publishes `window: { since_ms, until_ms }`, **both
+  absolute**, which is the vocabulary the DORA envelope lacks.
+- `metrics.stats` is an IPC method with a CLI (`nimbus stats <metric>
+  --service <id> [--window 90d] [--bucket 1w]`) and **no HTTP route**.
+  `/v1/metrics/dora` is the only `/v1/metrics` route the server serves.
+
+The gap is therefore not "the gateway cannot answer this". It is "the answer is
+reachable from a terminal and not from a browser".
+
+## 3. Why this is the right ask, and the earlier draft was not
+
+An earlier version of this document asked for an `until_ms` parameter on
+`GET /v1/metrics/dora` so a client could issue N calls and assemble a series
+itself. That is asking for the wrong thing, for three reasons.
+
+**Round trips.** A twelve-bucket trend is twelve `until_ms` calls per metric.
+Through a stats route it is **one call per metric — four**, for the four DORA
+metrics, because `computeStatsSeries` takes a single `metric`. Four versus
+forty-eight is decisive; four versus one is the honest way to state it.
+
+**Who owns the tiling.** With `until_ms`, bucket boundaries are computed in a
+browser. The argument the earlier draft used to reject a *relative* `until` —
+that N calls each anchored to their own `Date.now()` on the gateway do not tile
+exactly — is evidence against client-side series assembly in general, not merely
+against one spelling of the parameter. `splitBuckets` already solved this,
+remainder decision and all. A second consumer re-deriving it will get the
+remainder on the wrong end.
+
+**Vocabulary.** A stats route arrives with `window.since_ms` / `until_ms`
+already absolute and already shipped. The `until_ms` route adds an absolute
+field next to a `since_ms` that is a duration (§6), which is a naming problem
+this proposal would rather not create.
+
+## 4. Proposed contract
+
+### Request
+
+`GET /v1/metrics/stats`, mirroring the IPC params one-for-one.
+
+| parameter | required | notes |
+| --- | --- | --- |
+| `service` | yes | 1..64 chars, as `metrics.dora` already enforces |
+| `metric` | yes | one of `STATS_METRIC_IDS` |
+| `window_ms` | yes | integer ms — `requireStatsParams`'s own name |
+| `bucket_ms` | yes | integer ms |
+
+Snake_case matches both the IPC params and the response fields, and
+`StatsPoint`'s own comment is explicit that one method must not mix conventions.
+
+The consumer would rather send `window_ms` / `bucket_ms` as integers than a
+`90d` / `1w` duration string: the CLI parses durations at its own edge
+(`nimbus stats --window 90d`) and the IPC layer takes milliseconds, so
+millisecond params keep the HTTP route on the same side of that line as the IPC
+it wraps. If the gateway prefers duration strings for symmetry with `since`,
+the client will send either.
+
+### Response
+
+`StatsSeries`, unchanged, field for field. No new type, no projection decision,
+and the consumer already has a parser shape for `value` / `unit` / `sample` /
+`gap` because `DoraMetricValue` carries the same four.
+
+`StatsGap` is `DoraGap` plus `github_only_merge_data` and
+`incidents_missing_opened_at`. The client renders whatever gap it is handed and
+prints an unrecognised one rather than dropping the point.
+
+### The error story is the one real design question
+
+`metrics.stats` **refuses** an unconfigured service:
+
+```text
+-32602  unknown service 'payments' — add [metrics.dora.payments] or
+        [ci.service.payments] to nimbus.toml
+```
+
+`metrics.dora` **answers softly** with `unconfiguredEnvelope` and
+`gap: "unknown_service"`. The dispatcher documents the asymmetry deliberately:
+`dora` has four fixed slots it can place-hold, `stats` has a series whose bucket
+count and unit depend on config it does not have, so there is nothing honest to
+place-hold and a typo'd service must say so rather than render 13 empty buckets
+that look like thin data.
+
+That reasoning is right and this proposal does not ask to change it. It does
+have to name two consequences:
+
+1. **The consumer's service-binding validation leans on the soft answer.** It
+   validates a typed service id by calling `GET /v1/preflight/deploy` and
+   refusing an id that reports `unknown_service`. It will keep using preflight
+   for that; it does not need stats to be soft. No change requested.
+2. **Under a public mount, that refusal message is a disclosure channel.** It
+   embeds the service id the caller supplied — which is their own input, so it
+   discloses nothing — but the same handler must also decide what it says when
+   `nimbus.toml` fails to *parse*, where the messages embed the owner's config
+   values. The sibling proposal
+   (`GET /v1/services`, proposed in [#1489](https://github.com/nimbus-agent/Nimbus/pull/1489))
+   raises the identical seam in its §7, and both routes should answer it the
+   same way.
+
+### Bucket-shape errors
+
+`splitBuckets` throws `StatsBucketError` for a non-positive `window_ms` /
+`bucket_ms`, for `bucket_ms > window_ms`, and for more than `MAX_BUCKETS = 400`
+buckets. `dispatchMetricsRpc` already maps that to `MetricsRpcError(-32602)`,
+which `handleMetricsDora`'s existing pattern turns into a 400 with the message
+intact. The messages are actionable ("widen the bucket or narrow the window")
+and should reach the client verbatim. This is the whole error surface; nothing
+new is needed.
+
+### Mount and scope — the gateway's call
+
+The consistent answer is **public, in `dispatchReadOnlyDataGet`**, beside
+`/v1/metrics/dora` and `/v1/preflight/deploy`: it is the same data, over the
+same config, for the same service, at a different resolution. Scoping the series
+while the scalar stays public would be a strange seam.
+
+That answer is not this document's to give. It carries the same costs the
+sibling spec spells out — an `HTTP_ROUTE_AUTH` entry (the table is **total**
+over the surface, so a public route needs `{ kind: "public" }` there or the
+completeness test fails), an `HTTP_ROUTES` entry, and a `paths:` entry in
+`packages/gateway/openapi/v1.yaml`, which `audit:openapi-drift` enforces as a
+pair. The OpenAPI entry means the public mount also publishes the route in a
+schema other tools generate clients from; that is a longer-lived commitment than
+a handler.
+
+### The series still ends at now, and that is correct
+
+`dispatchMetricsRpc` binds `computeStatsSeries`'s `untilMs` to `nowMs`. This
+proposal does not ask to change that. A trend that ends at the present is what a
+trend is for, and leaving the anchor alone keeps the route's surface to four
+parameters.
+
+## 5. The accuracy defect — live today, and not introduced by either ask
+
+This section governs both §4 and §6, because the defect is in `dora.ts`'s
+window-bounded attribution rather than in any wire shape. It is stated here in
+full because it is the most useful thing in this document for the people who own
+that code, and because a consumer asking for a series should say plainly what
+the series will and will not be worth.
+
+### All four metrics window on `item.modified_at`
+
+Not three. `selectDeploys`, the PR query inside `leadTimeForChanges`, and
+`selectResolvedIncidents` each bind `modified_at >= ? AND modified_at <= ?`, and
+every DORA metric is built from those three selections.
+
+The "three" in `docs/cli-reference.md` is counting something narrower — the
+metrics that read `pr` and `incident` rows, where `modified_at` is a *last
+touch* timestamp rather than an event time:
+
+> The four wrapped DORA metrics call the existing calculators unchanged, which
+> also inherits their `item.modified_at` windowing — last touch, not event time,
+> for the `pr` and `incident` rows three of them read
+
+Deployment rows are windowed on `modified_at` too; they simply suffer less from
+it. Stated precisely because the sentence is addressed to the people who own
+`dora.ts` and will be read as a claim about their code.
+
+For a window ending at *now*, last-touch windowing inflates the recent window.
+For a series it does worse: a recently-touched old row is pulled out of the
+period it belongs to and into the present one, which is the shape of a fake
+trend. This is a documented, accepted cost that `nimbus stats` already carries.
+
+### The attribution hole, and why the obvious fix does not close it
+
+`changeFailureRate` attributes an incident to a deploy only when both fall
+inside the window, then looks back `incidentWindowMinutes`. A deploy near the
+window's upper edge whose incident opens after that edge is counted as a
+**success**.
+
+The obvious fix — widen the incident lookup past the upper bound by
+`incidentWindowMinutes` — **does not work**, and an implementer who applied it
+would believe the hole was closed. The reason is that the column the window
+filters on is not the column attribution reads:
+
+- `selectResolvedIncidents` bounds on `i.modified_at`, keeps only rows whose
+  `metadata.status === "resolved"`, and sets `resolved: r.modified_at`. The
+  window is applied to **resolution** time.
+- The attribution loop compares `inc.opened` — `metadata.opened_at_ms`, falling
+  back to `synced_at` — against each in-window deploy.
+
+An incident opened one minute before the upper bound may resolve days later;
+`mttr` exists precisely because resolution lag is measured in hours to days. A
+lookup widened by sixty minutes of *resolution* time does not reach it, and the
+deploy is still reported clean.
+
+**The fix that closes it** is to select attribution candidates by
+`json_extract(i.metadata, '$.opened_at_ms')` rather than by `modified_at`, over
+`[start, until + incidentWindowMinutes]`.
+
+Two riders:
+
+- **Do not widen the deploy selection.** `deploys.length` is the denominator;
+  widening it changes the number the metric reports. Only the incident lookup
+  moves.
+- **A still-burning incident is invisible at any bound**, because
+  `status === "resolved"` is required. So a historical `change_failure_rate`
+  under-reports for a second, independent reason. `computeStatsSeries`'s
+  `discloseUntimedIncidents` seam exists for a neighbouring version of this
+  problem — a series-level probe that reports what the buckets could not see —
+  and is the precedent for disclosing this one.
+
+### What changes when a series goes on the wire
+
+**Nothing about the defect. Everything about how often it fires.**
+
+Today `GET /v1/metrics/dora` has exactly one upper edge, it is `now`, and the
+incident genuinely has not happened yet. That is unavoidable and no reasonable
+contract avoids it.
+
+A series has N upper edges and **every one of them is in the past**, where the
+incident is sitting in the index, readable, and being ignored. The defect rate
+goes from "one boundary nobody can fix" to "every boundary, all fixable".
+
+And this is not hypothetical or future: `computeStatsSeries` binds `nowMs` to
+each bucket's end and calls the same four calculators, so **every bucket
+`nimbus stats` prints today already has this hole**. Putting the series on HTTP
+does not introduce the defect. It widens its audience.
+
+### The consumer's position
+
+The correction should land with whichever route lands. This is a statement about
+the client's own honesty rules rather than a demand: a page that refuses to draw
+a slope between overlapping windows is not going to draw a
+`change_failure_rate` line it knows to be systematically low. Without the
+correction the consumer would ship the series with that metric suppressed or
+caveated, which is a worse outcome than shipping it correct.
+
+Whether the disclosure belongs on the wire — a new `DoraGap` member, additive to
+a closed union two repos consume — or only in documentation is the gateway's
+call. The client prints whatever gap it is handed, so either works.
+
+## 6. The fallback: `until_ms` on `GET /v1/metrics/dora`
+
+If a new route is not wanted, one optional parameter on the existing public one
+makes disjoint windows expressible, and the client assembles the series itself.
+This is the narrower ask and it remains independently useful — "the same metric
+for last quarter" is a scalar question, not a series one.
+
+### Shape
+
+`until_ms` — optional, absolute epoch milliseconds. Absent means `now`, which is
+today's behaviour exactly, so every existing caller is unaffected. `since` keeps
+its grammar (`\d+(d|h)`, 1..365) and its meaning as a **duration**, now measured
+back from `until_ms`.
+
+The response gains `until_ms` so a cached answer can say which window it
+describes.
+
+### `nowMs` is doing double duty and must be split
+
+`computeDoraMetrics` derives `computed_at` from the same `nowMs` it binds as the
+query's upper bound. Threading `untilMs` separately is not tidiness: it is the
+difference between a historical answer that is cacheable and one
+indistinguishable from a fresh computation. `computed_at` stays wall-clock now.
+
+### The naming collision, which is why this is the fallback
+
+`DoraMetricsResult.since_ms` is a **duration** (it is `sinceMs`, the parsed
+window length). `StatsSeries.window.since_ms` is an **absolute timestamp**.
+Adding an absolute `until_ms` beside a duration `since_ms` puts two meanings
+behind one `_ms` suffix, in an envelope whose sibling already uses the other
+meaning. Three ways out:
+
+1. Add `until_ms` and leave `since_ms` alone. Smallest change, permanent
+   oddity.
+2. Add a nested `window: { since_ms, until_ms }`, both absolute, mirroring
+   `StatsSeries`, leaving the top-level `since_ms` as the duration it has always
+   been. Redundant, but every field is unambiguous — and if the §4 route ever
+   lands, this is the only option that leaves the two envelopes speaking the
+   same language. **Recommended.**
+3. Rename `since_ms`. Breaking; not worth a major.
+
+For the record on naming precedent: `target_ref` and `max_findings` are the
+*preflight* route's parameters; `since_ms` is this envelope's own field and is
+not on the preflight result at all, whose fields are `service`, `target_ref`,
+`computed_at`, `verdict` and `checks`. Snake_case is still the recommendation —
+`StatsSeries` uses it — but the surface is already mixed: `GET /v1/items` takes
+camelCase `sinceMs` / `untilMs` beside a relative `since`.
+
+### Validation
+
+| condition | status | body |
+| --- | --- | --- |
+| `until_ms` not an integer | 400 | `{ "error": "until_ms must be integer milliseconds" }` |
+| `until_ms` <= 0 | 400 | same shape |
+
+A **future** `until_ms` is accepted, not refused: it degrades to today's
+behaviour (no row has a `modified_at` beyond now), and a client whose clock runs
+a few seconds ahead of the gateway's should not get a 400 for it. Errors stay
+`MetricsRpcError(-32602)` mapped to 400, as `since` already does.
+
+### Costs
+
+No new route, no new scope, no re-pairing — `/v1/metrics/dora` is already
+`{ kind: "public" }` and this does not ask to change that, so its
+`HTTP_ROUTE_AUTH` entry is unchanged (the one place this ask is cheaper than
+§4). The parameter and the response field must land in
+`packages/gateway/openapi/v1.yaml` in the same commit or `audit:openapi-drift`
+fails.
+
+And §5 applies here too — more sharply, because a client assembling N windows
+hits N upper edges with no `splitBuckets` to at least make them consistent.
+
+### Does the IPC verb move too?
+
+`metrics.dora` is an IPC method before it is an HTTP route, and `nimbus metrics
+dora` takes `--since` with no `--until`. Adding the parameter on HTTP only would
+make the CLI the weaker surface for the first time; `docs/cli-reference.md`
+would need the flag in the same change. The consumer has no stake. Recorded
+because a reviewer will ask.
+
+## 7. What the client does without either
+
+Ships, and says less.
+
+The DORA page renders the four metrics across three nested windows (7d / 30d /
+90d) side by side, each column labelled as a window **ending now**, as three
+independent concurrent GETs through `Promise.allSettled` so one slow or failing
+window does not discard two good answers. It deliberately **does not draw a
+line** between them, because a slope between overlapping windows would assert
+change over time that the data does not contain.
+
+That is still directional and still useful — a change-failure rate worse over 7
+days than over 90 is a real statement about the recent past. It is simply not a
+series. The day either ask lands, the page draws one, the same way the client
+adopted `resolve-file` (#1447) and `resolve-ids` (#1465): probe, and use it if
+it answers.
+
+## 8. Alternatives considered
+
+**Have the client compute a trend from nested windows.** Subtracting a 30-day
+window from a 90-day one to recover days 31–90 is arithmetic that works for a
+count and fails for a median or a ratio — `lead_time_for_changes` and `mttr` are
+medians, and medians do not decompose across subtracted windows. It would also
+invent a `sample` the gateway never reported. Rejected: a metrics page whose
+numbers are derived rather than measured is exactly the failure mode the
+consumer's honesty rules exist to prevent.
+
+**Express the fallback's `until` as a relative age (`until=30d`).** Keeps the
+route in one vocabulary and avoids the client computing epochs at all. Rejected
+as the primary spelling because a series built from N concurrent calls, each
+anchored to its own `Date.now()` on the gateway, does not tile exactly. An
+absolute `until_ms` makes window *k*'s end and window *k+1*'s start the same
+integer by construction. Both could be accepted, as `GET /v1/items` already
+accepts both forms for `since`.
+
+**Expose `metrics.stats` only over the existing IPC/Tauri surface and let the
+browser go without.** Coherent, and it is the status quo. Rejected as the thing
+being proposed against: the browser speaks HTTP and not IPC, which is the same
+reason the egress reads needed routes (#1319) over primitives that had shipped
+as IPC verbs.
+
+**Add `until_ms` to the stats route too**, so a series can end in the past.
+Deliberately not asked for. It is a fifth parameter for a case no consumer has,
+and §5 means a past-anchored series compounds the attribution hole rather than
+merely inheriting it.
+
+## 9. Compliance checklist
+
+- **No new computation.** `computeStatsSeries`, `splitBuckets` and the four
+  calculators are untouched by §4. The route is the ask.
+- **Route auth table.** `HTTP_ROUTE_AUTH` is total over the surface; §4 needs an
+  entry whichever mount is chosen. §6 needs none — the route already has one.
+- **OpenAPI.** §4 adds `HTTP_ROUTES` + a `paths:` entry; §6 adds a parameter and
+  a response field to the existing entry. `audit:openapi-drift` enforces both.
+- **Not a write.** I13 governs HTTP write routes via `WRITE_ROUTE_ALLOWLIST`;
+  a GET stays off it. Named because "new HTTP route" is the trigger a reviewer
+  reaches for I13 on.
+- **Not egress.** Local index read, no provider request, no ledger row.
+- **No schema change, no migration.** The columns and indexes already carry both
+  bounds.
+- **Tests.** `packages/gateway/test/integration/http/metrics-dora-route.test.ts`
+  and `packages/gateway/test/unit/metrics/` are both in the
+  `test:coverage:metrics` gate; a stats route test belongs beside the first as
+  `metrics-stats-route.test.ts`. Three assertions carry the weight:
+  - **Absent means today.** The existing dora route test passes unchanged with
+    no `until_ms`, byte for byte.
+  - **`computed_at` is not `until_ms`.** A response for a window ending a month
+    ago carries a wall-clock-now `computed_at` — the test that proves §6's
+    separation held.
+  - **The attribution edge (§5).** A deploy five minutes before a bucket's end,
+    an incident opened ten minutes after it and resolved three days later: the
+    deploy counts as **failed**. This single fixture distinguishes the correct
+    fix from the widening that does not work, which would still report it clean.
+
+## 10. Open questions for the gateway
+
+1. The series route (§4), the `until_ms` parameter (§6), both, or neither? The
+   consumer's order of preference is as written.
+2. Mount and scope for §4 — public beside `/v1/metrics/dora` is the consistent
+   answer, but it is the gateway's to give, and it publishes the route in
+   `openapi/v1.yaml`.
+3. `window_ms` / `bucket_ms` as integers, or duration strings like `since`? §4.
+4. **Does §5's correction land with whichever route lands?** The consumer's
+   position is yes — and note the defect is live in `nimbus stats` today, so
+   this question outlives this proposal either way.
+5. Should the still-burning-incident and `modified_at` caveats be disclosed on
+   the wire (a new `DoraGap` / `StatsGap` member), or only in documentation? §5.
+6. If §6: which of the three answers to the `since_ms` collision? Option 2 is
+   recommended, and is the only one that survives §4 landing later.
+7. If §6: does `metrics.dora` the IPC verb, and `nimbus metrics dora --until`,
+   move in the same change?


### PR DESCRIPTION
## Summary

Proposes exposing the **bucketed DORA series** the gateway already computes — `computeStatsSeries` / `metrics.stats` — over HTTP, with `until_ms` on `GET /v1/metrics/dora` as the named fallback. **Design only, no implementation**, in the shape of #1464.

Sibling proposal: `GET /v1/services` — #1489. Neither is a blocker; the client ships and works without both.

## The ask started out wrong, and the spec says so

The original draft proposed adding `until` to `GET /v1/metrics/dora`, because every window that route answers ends at *now* — 7d/30d/90d are **nested**, sharing an end point, not consecutive, so a disjoint series is not expressible and a consumer cannot honestly draw a trend.

Reviewing it against your source changed the ask. `computeStatsSeries` already walks `splitBuckets(untilMs, windowMs, bucketMs)` and evaluates the DORA metrics per bucket, with `window.since_ms` / `until_ms` already absolute. **The series exists; it has no HTTP route.** Asking for a new parameter on a different route, when an existing computation answers the question, is the worse request — so the spec now leads with the stats route and keeps `until_ms` as the fallback for the case where you would rather not expose stats.

## The part we think matters most

While establishing that, we found what looks like a live attribution defect, and it is **not** something either proposal would introduce:

`changeFailureRate` selects deploys and incidents over the same window, but `selectResolvedIncidents` bounds on `modified_at` — *resolution* time — while attribution compares against `inc.opened` (`dora.ts:347`). An incident that opens inside a window and resolves after it falls out of the selection, so its deploy is reported clean.

Today the upper bound is always *now*, which makes this a single edge nobody hits. Under a series it becomes **one edge per bucket** — and `computeStatsSeries` binds `nowMs` to each bucket's end, so `nimbus stats` has this now.

Our first attempt at a fix was also wrong: widening by `incidentWindowMinutes` does not work, because it widens the *resolution* bound while attribution reads *opened*. The spec's §5 proposes selecting on `opened_at_ms` instead. We would rather hand you a defect we found honestly, with a first fix that turned out to be wrong and why, than a clean-looking proposal that quietly ships a metric wrong at every boundary.

This is your call to make in whichever register you prefer — the spec frames it as a condition of shipping a series, not a demand.

## What it leaves to you

Mounting and scoping, response shape, whether the IPC verb changes, and whether the attribution correction lands with a route or separately. The spec records what we established from source and flags where we are guessing.

## If you say no

The consumer renders three nested windows side by side, each labelled as ending now — directional and honest, without implying a trend the contract cannot back. That is already shipped and documented in the client's `architecture.md` as a property of the route, so a "no" costs us nothing but a nicer page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdWmqLJUG2mXevhr31o9dG
