### PR TITLE
feat(http): GET /v1/metrics/stats — the bucketed DORA series, plus the change-failure-rate attribution fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,9 +35,11 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   in the index, readable, and ignored. Every bucket `nimbus stats` printed already had the hole.
   **The route is PUBLIC**, beside `/v1/metrics/dora` and `/v1/preflight/deploy` — a decision, and
   deliberately the OPPOSITE of `GET /v1/services/resolve` below, with both reasons recorded at
-  their `HTTP_ROUTE_AUTH` entries. It is the same data, over the same config, for the same
-  service, at a different resolution, and `/v1/metrics/dora`'s own `since` already lets a caller
-  walk nested windows, so the series reaches nothing new; scoping it while the scalar beside it
+  their `HTTP_ROUTE_AUTH` entries. It is the same config and the same service at a different
+  resolution, and `/v1/metrics/dora`'s own `since` already lets a caller walk nested windows, so
+  the series reaches nothing new. Its metric SET is wider than that route's — `pr-merges` and
+  `incidents-opened` have no scalar equivalent — but both merely count `item` rows the public
+  `GET /v1/items` already serves unaggregated; scoping it while the scalar beside it
   stayed public would be a seam no caller could explain. `services/resolve` is scoped for the
   opposite reason — it CLAIMS narrowness, and a public mount would have let N cheap calls rebuild
   the grouping it exists not to expose. Public also means published: `HTTP_ROUTES` plus a `paths:`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,52 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-09-11 — `GET /v1/metrics/stats`, and the change-failure-rate attribution hole it
+  made worth fixing.** Two things, landing together because the design argued they must: a route
+  over `computeStatsSeries` (already shipped behind `nimbus stats`, with no HTTP surface), and a
+  correctness fix to `changeFailureRate` without which the series would publish a metric known to
+  read systematically low.
+  **The fix first, because it changes numbers that already ship.** `changeFailureRate` selected
+  its incident candidates through `selectResolvedIncidents`, which bounds on `i.modified_at` — for
+  a resolved incident, effectively RESOLUTION time — while the attribution loop compares
+  `opened_at_ms`. An incident opened inside the window moments after a deploy but resolved after
+  the window's upper edge was never a candidate, and its deploy was reported CLEAN. Not a corner
+  case: `mttr` exists precisely because resolution lag runs to hours and days. The obvious fix —
+  widen the lookup by `incidentWindowMinutes` — does NOT work, because the widening would be in
+  resolution time; the COLUMN had to change. New `selectAttributionIncidents` selects on
+  `opened_at_ms` over `[start, until + incidentWindowMinutes]`; `selectResolvedIncidents` is
+  untouched and still serves `mttr`, where windowing on resolution time is correct. The deploy
+  selection is deliberately NOT widened — `deploys.length` is the denominator. The `synced_at`
+  fallback is dropped for attribution: that is our INDEXING time, so it blamed whichever deploy
+  happened to precede the moment we indexed the row. **One existing test asserted that fallback as
+  intended behaviour and is rewritten to the new contract rather than deleted.** KNOWN RESIDUAL,
+  disclosed not fixed: `status = 'resolved'` is still required, so a still-burning incident is
+  invisible at any bound and a historical rate under-reports for that second, independent reason.
+  **This matters far more for a series than for the scalar it also corrects:** a
+  `/v1/metrics/dora` window has one upper edge, `now`, where the incident genuinely has not
+  happened yet; a series has N upper edges and every one is in the past, with the incident sitting
+  in the index, readable, and ignored. Every bucket `nimbus stats` printed already had the hole.
+  **The route is PUBLIC**, beside `/v1/metrics/dora` and `/v1/preflight/deploy` — a decision, and
+  deliberately the OPPOSITE of `GET /v1/services/resolve` below, with both reasons recorded at
+  their `HTTP_ROUTE_AUTH` entries. It is the same data, over the same config, for the same
+  service, at a different resolution, and `/v1/metrics/dora`'s own `since` already lets a caller
+  walk nested windows, so the series reaches nothing new; scoping it while the scalar beside it
+  stayed public would be a seam no caller could explain. `services/resolve` is scoped for the
+  opposite reason — it CLAIMS narrowness, and a public mount would have let N cheap calls rebuild
+  the grouping it exists not to expose. Public also means published: `HTTP_ROUTES` plus a `paths:`
+  entry in `openapi/v1.yaml` (`StatsSeries` + `StatsPoint` schemas), which `audit:openapi-drift`
+  enforces as a pair.
+  Params mirror the IPC one-for-one (`service`, `metric`, `window_ms`, `bucket_ms`), snake_case
+  and integer milliseconds — the CLI parses `--window 90d` at its own edge. An **unknown service
+  is refused (400), not answered softly**, unlike `/v1/metrics/dora`: a series whose bucket count
+  and unit depend on config it does not have has nothing honest to place-hold, and N empty buckets
+  read as thin data rather than a typo. A malformed `nimbus.toml` answers `500 config_unreadable`
+  with **no config value echoed** — the same answer `GET /v1/services/resolve` gives, as the design
+  asked. That differs from `/v1/metrics/dora` beside it, which still 500s with the parser's message
+  intact; pre-existing, out of scope, and named so the difference reads as deliberate.
+  No migration, no invariant, no new egress class.
+  Design: [`2026-09-11-metrics-series-route-design.md`](./superpowers/specs/2026-09-11-metrics-series-route-design.md).
+
 - **2026-09-11 — `GET /v1/services/resolve`: repo-URN-to-service resolution, answering the
   proposal merged hours earlier.** A browser client sitting on a repository knows the repository
   and nothing else; the two routes that would tell its reader anything — `GET /v1/metrics/dora`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -3243,7 +3243,7 @@ nimbus serve --port 7474        # Default port: 7474
 | `GET /v1/items` | List indexed items (supports `service`, `type`, `since`, `until`, `limit` query params) |
 | `GET /v1/items/:id` | Get a single item by ID |
 | `GET /v1/metrics/dora` | DORA metrics for a service (supports `service`, `since` query params) |
-| `GET /v1/metrics/stats` | One DORA-family metric as a bucketed time series — the same data as `/v1/metrics/dora` at a different resolution (`service`, `metric`, `window_ms`, `bucket_ms`; at most 400 buckets). Buckets are disjoint, so a line between points is meaningful; an unknown service is **refused** rather than answered softly, because a series has nothing honest to place-hold |
+| `GET /v1/metrics/stats` | One DORA-family or related operational metric as a bucketed time series, over the same service config as `/v1/metrics/dora` at a different resolution (`service`, `metric`, `window_ms`, `bucket_ms`; all positive, at most 400 buckets). Its metric set is **wider** than that route's: the same four DORA metrics plus `pr-merges` and `incidents-opened`. Buckets are disjoint, so a line between points is meaningful; an unknown service is **refused** rather than answered softly, because a series has nothing honest to place-hold |
 | `GET /v1/openapi.json` | Machine-readable OpenAPI 3.1 schema for this API |
 | `GET /v1/people` | List people graph entries |
 | `GET /v1/people/:id` | Get a single person record |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -3243,6 +3243,7 @@ nimbus serve --port 7474        # Default port: 7474
 | `GET /v1/items` | List indexed items (supports `service`, `type`, `since`, `until`, `limit` query params) |
 | `GET /v1/items/:id` | Get a single item by ID |
 | `GET /v1/metrics/dora` | DORA metrics for a service (supports `service`, `since` query params) |
+| `GET /v1/metrics/stats` | One DORA-family metric as a bucketed time series — the same data as `/v1/metrics/dora` at a different resolution (`service`, `metric`, `window_ms`, `bucket_ms`; at most 400 buckets). Buckets are disjoint, so a line between points is meaningful; an unknown service is **refused** rather than answered softly, because a series has nothing honest to place-hold |
 | `GET /v1/openapi.json` | Machine-readable OpenAPI 3.1 schema for this API |
 | `GET /v1/people` | List people graph entries |
 | `GET /v1/people/:id` | Get a single person record |

--- a/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
@@ -1,6 +1,24 @@
 # `GET /v1/metrics/stats` — putting the series the gateway already computes on the wire
 
-> **Status:** proposal. No code in this branch — this is the contract, argued
+> **Status: ANSWERED — the §4 route shipped 2026-09-11, together with §5's
+> correction.** This document is kept as the argument, not as a description of
+> the surface; where it and the code disagree, the code is right and
+> `docs/CHANGELOG.md` records why. What landed: `GET /v1/metrics/stats`, PUBLIC
+> in `dispatchReadOnlyDataGet` (§4's "Mount and scope" answered as it
+> recommended), returning `StatsSeries` unchanged; and §5's attribution fix, as
+> `selectAttributionIncidents` in `metrics/dora.ts`.
+>
+> **The disclosure question §5 left open was answered by documentation, not by
+> the wire.** No new `DoraGap`/`StatsGap` member was added — the union is
+> consumed by two other repos, and the residual it would announce (a
+> still-burning incident is invisible because `status = 'resolved'` is required)
+> is recorded in `selectAttributionIncidents`' own comment and in the CHANGELOG
+> instead. That residual is NOT fixed; only the window-column defect is.
+>
+> **§6's `until_ms` fallback did NOT ship** and was not needed, since §4 landed.
+> It stays as a live alternative if the anchor ever has to move.
+>
+> Originally filed as: proposal, no code in the branch — the contract argued
 > before it is built, per the satellite-repo convention that the gateway owns
 > the wire and consumers propose against it (#1464 established the shape).
 >

--- a/packages/gateway/openapi/v1.yaml
+++ b/packages/gateway/openapi/v1.yaml
@@ -232,6 +232,61 @@ paths:
         "400":
           description: Bad request (missing/invalid service, malformed since).
 
+  /v1/metrics/stats:
+    get:
+      operationId: getMetricsStatsSeries
+      summary: One DORA-family metric as a bucketed time series
+      description: >
+        The same metrics as /v1/metrics/dora, over the same service config, at a different
+        resolution: one value per disjoint bucket, so a line between points is meaningful.
+        Buckets end at the present. Millisecond params mirror the IPC method this wraps;
+        duration strings are parsed at the CLI's edge, not here.
+      parameters:
+        - in: query
+          name: service
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: metric
+          required: true
+          schema:
+            type: string
+            enum:
+              [
+                deployment-frequency,
+                lead-time,
+                change-failure-rate,
+                mttr,
+                pr-merges,
+                incidents-opened,
+              ]
+        - in: query
+          name: window_ms
+          required: true
+          schema:
+            type: integer
+          description: Total span of the series, in milliseconds.
+        - in: query
+          name: bucket_ms
+          required: true
+          schema:
+            type: integer
+          description: Width of one bucket, in milliseconds. At most 400 buckets per series.
+      responses:
+        "200":
+          description: The bucketed series.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatsSeries"
+        "400":
+          description: >
+            Missing or invalid params, an unknown service, or an unusable bucket shape
+            (non-positive bounds, bucket wider than the window, or over 400 buckets).
+        "500":
+          description: nimbus.toml could not be parsed. The body names no config value.
+
   /v1/preflight/deploy:
     get:
       operationId: getDeployPreflight
@@ -324,6 +379,51 @@ components:
               low_sample,
               approximate_lead_time,
               mixed_source,
+            ]
+    StatsSeries:
+      type: object
+      required: [metric, service, window, bucket_ms, points]
+      properties:
+        metric: { type: string }
+        service: { type: string }
+        window:
+          type: object
+          required: [since_ms, until_ms]
+          properties:
+            since_ms: { type: integer }
+            until_ms: { type: integer }
+        bucket_ms: { type: integer }
+        points:
+          type: array
+          items: { $ref: "#/components/schemas/StatsPoint" }
+    StatsPoint:
+      type: object
+      required: [start_ms, end_ms, value, unit, sample, gap]
+      properties:
+        start_ms: { type: integer }
+        end_ms: { type: integer }
+        value:
+          type: number
+          nullable: true
+        unit: { type: string }
+        sample: { type: integer }
+        gap:
+          nullable: true
+          type: string
+          # Mirrors `StatsGap` in src/metrics/stats.ts: every `DoraGap` member above, plus the
+          # two this surface adds. A client should render an unrecognised value rather than
+          # drop the point — the union is open in practice, since a gap is a disclosure.
+          enum:
+            [
+              unknown_service,
+              no_pagerduty_mapping,
+              no_repos,
+              no_deployment_data,
+              low_sample,
+              approximate_lead_time,
+              mixed_source,
+              github_only_merge_data,
+              incidents_missing_opened_at,
             ]
     DeployPreflightResult:
       type: object

--- a/packages/gateway/openapi/v1.yaml
+++ b/packages/gateway/openapi/v1.yaml
@@ -237,10 +237,11 @@ paths:
       operationId: getMetricsStatsSeries
       summary: One DORA-family metric as a bucketed time series
       description: >
-        The same metrics as /v1/metrics/dora, over the same service config, at a different
-        resolution: one value per disjoint bucket, so a line between points is meaningful.
-        Buckets end at the present. Millisecond params mirror the IPC method this wraps;
-        duration strings are parsed at the CLI's edge, not here.
+        DORA-family and related operational metrics over the same service config, one value per
+        disjoint bucket, so a line between points is meaningful. The metric set is WIDER than
+        /v1/metrics/dora's: the same four DORA metrics, plus pr-merges and incidents-opened,
+        which that route does not return. Buckets end at the present. Millisecond params mirror
+        the IPC method this wraps; duration strings are parsed at the CLI's edge, not here.
       parameters:
         - in: query
           name: service
@@ -266,13 +267,17 @@ paths:
           required: true
           schema:
             type: integer
-          description: Total span of the series, in milliseconds.
+            minimum: 1
+          description: Total span of the series, in milliseconds. Must be positive.
         - in: query
           name: bucket_ms
           required: true
           schema:
             type: integer
-          description: Width of one bucket, in milliseconds. At most 400 buckets per series.
+            minimum: 1
+          description: >
+            Width of one bucket, in milliseconds. Must be positive, must not exceed window_ms,
+            and must not yield more than 400 buckets.
       responses:
         "200":
           description: The bucketed series.

--- a/packages/gateway/src/ipc/http-route-auth.ts
+++ b/packages/gateway/src/ipc/http-route-auth.ts
@@ -54,6 +54,12 @@ export const HTTP_ROUTE_AUTH: Readonly<Record<string, RouteAuth>> = Object.freez
   "GET /v1/people/*": { kind: "public" },
   "GET /v1/audit": { kind: "public" },
   "GET /v1/metrics/dora": { kind: "public" },
+  // The same four metrics as the line above, over the same config, for the same service, at a
+  // different resolution — so it inherits that route's mount rather than choosing a new one.
+  // Scoping the series while the scalar beside it stays public would be a seam no caller could
+  // explain, and `/v1/metrics/dora`'s own `since` already lets a caller walk nested windows.
+  // Contrast `GET /v1/services/resolve` below, which is scoped for the opposite reason.
+  "GET /v1/metrics/stats": { kind: "public" },
   "GET /v1/preflight/deploy": { kind: "public" },
   "GET /v1/openapi.json": { kind: "public" },
 

--- a/packages/gateway/src/ipc/http-route-auth.ts
+++ b/packages/gateway/src/ipc/http-route-auth.ts
@@ -54,8 +54,11 @@ export const HTTP_ROUTE_AUTH: Readonly<Record<string, RouteAuth>> = Object.freez
   "GET /v1/people/*": { kind: "public" },
   "GET /v1/audit": { kind: "public" },
   "GET /v1/metrics/dora": { kind: "public" },
-  // The same four metrics as the line above, over the same config, for the same service, at a
-  // different resolution — so it inherits that route's mount rather than choosing a new one.
+  // The same config and the same service as the line above, at a different resolution — so it
+  // inherits that route's mount rather than choosing a new one. Its metric set is WIDER, not
+  // identical: the four DORA metrics plus `pr-merges` and `incidents-opened`. That widens what
+  // is public, but not what is REACHABLE — both extras count rows in `item` that `GET /v1/items`
+  // already serves publicly and unaggregated.
   // Scoping the series while the scalar beside it stays public would be a seam no caller could
   // explain, and `/v1/metrics/dora`'s own `since` already lets a caller walk nested windows.
   // Contrast `GET /v1/services/resolve` below, which is scoped for the opposite reason.

--- a/packages/gateway/src/ipc/http-routes.test.ts
+++ b/packages/gateway/src/ipc/http-routes.test.ts
@@ -12,6 +12,7 @@ describe("HTTP_ROUTES", () => {
       "GET /v1/items",
       "GET /v1/items/{id}",
       "GET /v1/metrics/dora",
+      "GET /v1/metrics/stats",
       "GET /v1/openapi.json",
       "GET /v1/people",
       "GET /v1/people/{id}",

--- a/packages/gateway/src/ipc/http-routes.ts
+++ b/packages/gateway/src/ipc/http-routes.ts
@@ -29,6 +29,7 @@ export const HTTP_ROUTES: readonly HttpRoute[] = Object.freeze([
   { method: "GET", path: "/v1/items" },
   { method: "GET", path: "/v1/items/{id}" },
   { method: "GET", path: "/v1/metrics/dora" },
+  { method: "GET", path: "/v1/metrics/stats" },
   { method: "GET", path: "/v1/openapi.json" },
   { method: "GET", path: "/v1/people" },
   { method: "GET", path: "/v1/people/{id}" },

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -281,6 +281,106 @@ function handleOpenApiJson(): Response {
   });
 }
 
+/**
+ * GET /v1/metrics/stats — one DORA-family metric as a bucketed TIME SERIES.
+ *
+ * PUBLIC, beside `/v1/metrics/dora` and `/v1/preflight/deploy`. That is a decision and not an
+ * inheritance, and it lands the opposite way from `GET /v1/services/resolve`, which is scoped —
+ * so the difference is worth stating, because the next proposal will copy one of them:
+ *
+ *   - It is the same data, over the same config, for the same service, at a different
+ *     resolution. `/v1/metrics/dora` already answers all four of these metrics publicly for an
+ *     arbitrary `since` window, so a caller can already walk nested windows and difference them.
+ *     This route makes that cheaper and disjoint; it does not reach anything new.
+ *   - Scoping the series while the scalar beside it stays public would be a seam no caller could
+ *     explain, and the client that needs it is the same unauthenticated reader.
+ *
+ * `/v1/services/resolve` is scoped for the opposite reason: it CLAIMS narrowness (one repo the
+ * caller already named), and a public mount would have let N cheap calls rebuild the whole
+ * service-to-repo grouping it exists not to expose.
+ *
+ * Public therefore also means published: `HTTP_ROUTES` plus a `paths:` entry in
+ * `openapi/v1.yaml`, which `audit:openapi-drift` enforces as a pair.
+ *
+ * Appends NO egress row — it reads the local index and the owner's config, and makes no
+ * outbound request (the `http` narrowing in `egress/egress-coverage.ts`).
+ */
+async function handleMetricsStats(
+  url: URL,
+  db: Database,
+  opts: ReadOnlyHttpServerOptions,
+): Promise<Response> {
+  // Params mirror the IPC one-for-one, snake_case included: the CLI parses `--window 90d` at its
+  // own edge and the IPC layer takes milliseconds, so integer ms keeps this route on the same
+  // side of that line as the method it wraps. `requireStatsParams` does the real validation and
+  // its messages are actionable, so bare presence is all that is checked here.
+  const service = url.searchParams.get("service");
+  if (service === null || service === "") {
+    return json({ error: "missing required query param: service" }, 400);
+  }
+  const metric = url.searchParams.get("metric");
+  if (metric === null || metric === "") {
+    return json({ error: "missing required query param: metric" }, 400);
+  }
+  const windowMs = url.searchParams.get("window_ms");
+  const bucketMs = url.searchParams.get("bucket_ms");
+  if (windowMs === null || bucketMs === null) {
+    return json({ error: "missing required query params: window_ms, bucket_ms" }, 400);
+  }
+  let loaded: Map<string, ServiceConfig>;
+  try {
+    loaded =
+      opts.configDir === undefined
+        ? new Map()
+        : loadNimbusServiceConfigsFromConfigDir(opts.configDir);
+  } catch {
+    // Loaded HERE rather than inside the dispatcher's `loadConfig` thunk, so a malformed
+    // `nimbus.toml` is caught rather than escaping as a 500 with the parser's message intact —
+    // which is what `/v1/metrics/dora` beside it still does today. Those messages embed the
+    // service id AND the offending config value, and on a PUBLIC route that is readable by any
+    // local process on the machine. Same answer as `GET /v1/services/resolve` gives, deliberately:
+    // the design asked that both routes answer this seam the same way.
+    //
+    // Not a fix for the sibling route. That is pre-existing and out of scope here; it is named so
+    // the next reader knows the two differ on purpose rather than by oversight.
+    return json({ error: "config_unreadable" }, 500);
+  }
+  let out: Awaited<ReturnType<typeof dispatchMetricsRpc>>;
+  try {
+    out = await dispatchMetricsRpc(
+      "metrics.stats",
+      {
+        service,
+        metric,
+        // `requireStatsParams` demands real integers (`Number.isInteger`), so the query
+        // string's values must be converted here — but deliberately NOT validated here.
+        // `Number("abc")` is `NaN`, which fails that check and produces the dispatcher's own
+        // message naming both params; a second, blander rejection at this layer would only
+        // shadow it. `Number("")` is 0, which the bucket-shape check refuses as non-positive.
+        window_ms: Number(windowMs),
+        bucket_ms: Number(bucketMs),
+      },
+      {
+        db,
+        loadConfig: () => loaded,
+        ...(opts.nowMs === undefined ? {} : { nowMs: opts.nowMs }),
+      },
+    );
+  } catch (e) {
+    if (e instanceof MetricsRpcError) {
+      // Covers the unknown-service refusal AND every `StatsBucketError` the dispatcher already
+      // maps here — non-positive or inverted bounds, and the MAX_BUCKETS ceiling. Those messages
+      // are actionable ("widen the bucket or narrow the window") and reach the client verbatim.
+      return json({ error: e.message }, 400);
+    }
+    throw e;
+  }
+  if (out.kind === "miss") {
+    throw new Error("metrics.stats dispatcher returned miss");
+  }
+  return json(out.value);
+}
+
 async function handleMetricsDora(
   url: URL,
   db: Database,
@@ -472,6 +572,9 @@ function dispatchReadOnlyDataGet(
   }
   if (path === "/v1/metrics/dora") {
     return handleMetricsDora(url, db, opts);
+  }
+  if (path === "/v1/metrics/stats") {
+    return handleMetricsStats(url, db, opts);
   }
   if (path === "/v1/preflight/deploy") {
     return handleDeployPreflight(url, db, opts);

--- a/packages/gateway/src/ipc/http-server.ts
+++ b/packages/gateway/src/ipc/http-server.ts
@@ -288,10 +288,12 @@ function handleOpenApiJson(): Response {
  * inheritance, and it lands the opposite way from `GET /v1/services/resolve`, which is scoped —
  * so the difference is worth stating, because the next proposal will copy one of them:
  *
- *   - It is the same data, over the same config, for the same service, at a different
- *     resolution. `/v1/metrics/dora` already answers all four of these metrics publicly for an
- *     arbitrary `since` window, so a caller can already walk nested windows and difference them.
- *     This route makes that cheaper and disjoint; it does not reach anything new.
+ *   - It is the same config and the same service at a different resolution. `/v1/metrics/dora`
+ *     already answers the four DORA metrics publicly over an arbitrary `since`, so a caller can
+ *     already walk nested windows and difference them; this route makes that cheaper and
+ *     disjoint. Its metric set is WIDER than that route's — `pr-merges` and `incidents-opened`
+ *     have no scalar equivalent — but neither reaches anything new either: both count rows in
+ *     `item` that the public `GET /v1/items` already serves unaggregated.
  *   - Scoping the series while the scalar beside it stays public would be a seam no caller could
  *     explain, and the client that needs it is the same unauthenticated reader.
  *
@@ -323,9 +325,15 @@ async function handleMetricsStats(
     return json({ error: "missing required query param: metric" }, 400);
   }
   const windowMs = url.searchParams.get("window_ms");
+  if (windowMs === null) {
+    return json({ error: "missing required query param: window_ms" }, 400);
+  }
+  // Checked SEPARATELY from `window_ms`, not as one combined `||`. A combined check names both
+  // params whatever the caller omitted, so someone who sent `window_ms` and forgot `bucket_ms`
+  // is told `window_ms` is missing too — and then goes looking at the one param they got right.
   const bucketMs = url.searchParams.get("bucket_ms");
-  if (windowMs === null || bucketMs === null) {
-    return json({ error: "missing required query params: window_ms, bucket_ms" }, 400);
+  if (bucketMs === null) {
+    return json({ error: "missing required query param: bucket_ms" }, 400);
   }
   let loaded: Map<string, ServiceConfig>;
   try {

--- a/packages/gateway/src/metrics/dora.test.ts
+++ b/packages/gateway/src/metrics/dora.test.ts
@@ -687,6 +687,68 @@ describe("changeFailureRate", () => {
     expect(result.sample).toBe(3);
   });
 
+  // The attribution hole (metrics-series design § 5). `selectResolvedIncidents` windows on
+  // `modified_at` — RESOLUTION time for a resolved incident — while attribution compares
+  // `opened_at_ms`. An incident opened inside the window right after a deploy, but resolved
+  // after the window's upper edge, was therefore never even a candidate, and its deploy was
+  // reported CLEAN. `mttr` exists because resolution lag runs to days, so this is the normal
+  // case near any upper edge, not a corner.
+  test("counts an incident opened in-window but resolved after the upper edge", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - 30 * 60_000; // 30 min before the upper edge
+    insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
+    // Opened 10 min after the deploy (inside the 60-min incident window, and inside the
+    // metric window); resolved THREE DAYS after the upper edge, so `modified_at` is far
+    // outside [NOW - SINCE, NOW].
+    insertIncident(db, "pd-svc-1", NOW + 3 * ONE_DAY, deployAt + 600_000);
+    const result = changeFailureRate(db, cfg, NOW, SINCE);
+    expect(result.value).toBe(1);
+    expect(result.sample).toBe(1);
+  });
+
+  // The rider the design names: only the INCIDENT lookup widens. `deploys.length` is the
+  // denominator, so widening the deploy selection would change the number the metric reports.
+  test("does not widen the deploy denominator past the upper edge", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    insertCiRun(db, "github_actions", "Deploy main", NOW - ONE_DAY, "org/repo");
+    insertCiRun(db, "github_actions", "Deploy main", NOW + ONE_DAY, "org/repo"); // future
+    const result = changeFailureRate(db, cfg, NOW, SINCE);
+    expect(result.sample).toBe(1);
+  });
+
+  // An incident opened AFTER the upper edge can still belong to an in-window deploy, if it
+  // opened within `incidentWindowMinutes` of it — which is why the candidate window extends
+  // past the edge by exactly that much, and no further.
+  test("attributes an incident opened just past the edge, within the incident window", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - 10 * 60_000; // 10 min before the edge
+    insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
+    insertIncident(db, "pd-svc-1", NOW + ONE_DAY, NOW + 20 * 60_000); // 30 min after deploy
+    expect(changeFailureRate(db, cfg, NOW, SINCE).value).toBe(1);
+  });
+
+  test("ignores an incident opened beyond the incident window past the edge", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - 10 * 60_000;
+    insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
+    // Opened 2h after the deploy — outside the 60-min incident window.
+    insertIncident(db, "pd-svc-1", NOW + ONE_DAY, NOW + 110 * 60_000);
+    expect(changeFailureRate(db, cfg, NOW, SINCE).value).toBe(0);
+  });
+
+  test("survives an incident row whose metadata is not valid JSON", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - ONE_DAY;
+    insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
+    db.run(
+      `INSERT INTO item (id, service, type, external_id, title, modified_at, metadata, synced_at)
+       VALUES ('bad-json', 'pagerduty', 'incident', 'ext-bad', 'Incident', ?, '{not json', ?)`,
+      [NOW - ONE_DAY, NOW - ONE_DAY],
+    );
+    insertIncident(db, "pd-svc-1", NOW - ONE_DAY + 700_000, deployAt + 600_000);
+    expect(changeFailureRate(db, cfg, NOW, SINCE).value).toBe(1);
+  });
+
   test("attributes incident to the most-recent deploy before the incident", () => {
     const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
     const deployAt1 = NOW - 3 * ONE_DAY;
@@ -752,7 +814,13 @@ describe("changeFailureRate", () => {
     expect(result.value).toBe(0);
   });
 
-  test("incident with no opened_at_ms falls back to synced_at", () => {
+  // BEHAVIOUR CHANGED, deliberately. This test asserted the opposite until 2026-09-11: an
+  // incident carrying no `opened_at_ms` was attributed via its `synced_at`. That is our INDEXING
+  // time, so it blamed whichever deploy happened to precede the moment we happened to index the
+  // row — a number with no relationship to what occurred. Such an incident is now excluded from
+  // attribution, matching the rule `stats.ts`'s `incidentsOpened` already states. Three deploys,
+  // so the assertion also proves no OTHER deploy inherits the blame.
+  test("incident with no opened_at_ms is excluded rather than attributed via synced_at", () => {
     const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
     const deployAt = NOW - 2 * ONE_DAY;
     insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
@@ -775,8 +843,9 @@ describe("changeFailureRate", () => {
       ],
     );
     const result = changeFailureRate(db, cfg, NOW, SINCE);
-    // synced_at = deployAt + 30min → within window → attributed
-    expect(result.value).toBeGreaterThan(0);
+    // synced_at = deployAt + 30min, which the old fallback treated as the open time.
+    expect(result.value).toBe(0);
+    expect(result.sample).toBe(3);
   });
 });
 

--- a/packages/gateway/src/metrics/dora.ts
+++ b/packages/gateway/src/metrics/dora.ts
@@ -319,6 +319,76 @@ function selectResolvedIncidents(
   return out;
 }
 
+type AttributionIncident = {
+  opened: number;
+};
+
+/**
+ * Incidents that could be ATTRIBUTED to a deploy inside `[startMs, endMs]`.
+ *
+ * Deliberately NOT `selectResolvedIncidents`, which is correct for `mttr` and wrong here, for
+ * one reason: **the column it windows on is not the column attribution reads.** It bounds on
+ * `i.modified_at` — for a resolved incident, effectively RESOLUTION time — while the
+ * attribution loop compares `opened_at_ms`. An incident opened inside the window moments after
+ * a deploy, but resolved after the window's upper edge, was therefore never a candidate and its
+ * deploy was reported CLEAN. That is not a corner case: `mttr` exists precisely because
+ * resolution lag runs to hours and days, so it is the normal shape near any upper edge.
+ *
+ * It matters far more for a SERIES than for the single scalar this originally served. A
+ * `GET /v1/metrics/dora` window has exactly one upper edge, `now`, where the incident genuinely
+ * has not happened yet and no contract can do better. A series has N upper edges and every one
+ * of them is in the past, with the incident sitting in the index, readable, and ignored.
+ *
+ * Two bounds, both deliberate:
+ *  - The upper bound extends past `endMs` by `incidentWindowMs` and no further, because a deploy
+ *    just inside the edge can still be blamed for an incident opening just outside it. The
+ *    DEPLOY selection is NOT widened to match — `deploys.length` is the denominator, so widening
+ *    it would change the number the metric reports rather than correct it.
+ *  - There is no `synced_at` fallback. `selectResolvedIncidents` has one, and it is indefensible
+ *    for attribution specifically: `synced_at` is our INDEXING time, so falling back to it blames
+ *    whichever deploy happened to precede the moment we happened to index the row. An incident
+ *    with no real opened timestamp is excluded from attribution instead, matching the rule
+ *    `stats.ts`'s `incidentsOpened` already states for the same reason.
+ *
+ * `json_valid` guards every `json_extract`, which RAISES on malformed JSON in this position.
+ *
+ * KNOWN RESIDUAL, unchanged here and disclosed rather than fixed: `status = 'resolved'` is still
+ * required, so an incident that is still burning is invisible to attribution at any bound, and a
+ * historical `change_failure_rate` under-reports for that second, independent reason. Dropping
+ * the predicate would close it and would also raise reported failure rates, which is a separate
+ * decision from this one.
+ */
+function selectAttributionIncidents(
+  db: Database,
+  cfg: ServiceConfig,
+  startMs: number,
+  endMs: number,
+  incidentWindowMs: number,
+): AttributionIncident[] {
+  if (cfg.pagerdutyServices.length === 0) return [];
+  const placeholders = cfg.pagerdutyServices.map(() => "?").join(",");
+  const rows = db
+    .query(
+      `SELECT json_extract(i.metadata, '$.opened_at_ms') AS opened
+       FROM item i
+       WHERE i.service = 'pagerduty'
+         AND i.type = 'incident'
+         AND json_valid(i.metadata)
+         AND json_extract(i.metadata, '$.pagerduty_service_id') IN (${placeholders})
+         AND json_extract(i.metadata, '$.status') = 'resolved'
+         AND json_extract(i.metadata, '$.opened_at_ms') >= ?
+         AND json_extract(i.metadata, '$.opened_at_ms') <= ?`,
+    )
+    .all(...cfg.pagerdutyServices, startMs, endMs + incidentWindowMs) as { opened: unknown }[];
+  const out: AttributionIncident[] = [];
+  for (const r of rows) {
+    // Re-checked in TypeScript rather than trusted from SQL: `opened_at_ms` is connector-written
+    // metadata, and a string there would compare by SQLite's type ordering rather than numerically.
+    if (typeof r.opened === "number") out.push({ opened: r.opened });
+  }
+  return out;
+}
+
 export function changeFailureRate(
   db: Database,
   cfg: ServiceConfig,
@@ -335,8 +405,8 @@ export function changeFailureRate(
   if (cfg.pagerdutyServices.length === 0) {
     return { value: null, unit: "ratio", sample: deploys.length, gap: "no_pagerduty_mapping" };
   }
-  const incidents = selectResolvedIncidents(db, cfg, nowMs, sinceMs);
   const windowMs = cfg.incidentWindowMinutes * 60_000;
+  const incidents = selectAttributionIncidents(db, cfg, nowMs - sinceMs, nowMs, windowMs);
   const sortedDeploys = deploys
     .map((d) => ({ id: d.id, t: d.modified_at }))
     .sort((a, b) => a.t - b.t);

--- a/packages/gateway/test/integration/http/metrics-stats-route.test.ts
+++ b/packages/gateway/test/integration/http/metrics-stats-route.test.ts
@@ -161,18 +161,31 @@ describe("GET /v1/metrics/stats", () => {
     expect(((await res.json()) as { error: string }).error).toContain("nope");
   });
 
-  it("refuses each missing required param by name", async () => {
+  it("refuses each missing required param, naming ONLY the one that is missing", async () => {
     await start(VALID_TOML);
-    const cases: readonly [string, string][] = [
+    // The negative half is the point. `window_ms` and `bucket_ms` were originally checked with
+    // one combined `||` whose message named BOTH, so a caller who omitted only `bucket_ms` was
+    // told `window_ms` was missing too. A `toContain(named)` assertion passes against that
+    // message for every case — it is a test that cannot fail. Asserting the OTHER params are
+    // absent from the message is what catches it.
+    const all = ["service", "metric", "window_ms", "bucket_ms"] as const;
+    const cases: readonly [string, (typeof all)[number]][] = [
       [`metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`, "service"],
       [`service=payment-service&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`, "metric"],
       [`service=payment-service&metric=mttr&bucket_ms=${7 * DAY}`, "window_ms"],
       [`service=payment-service&metric=mttr&window_ms=${14 * DAY}`, "bucket_ms"],
     ];
-    for (const [query, named] of cases) {
+    for (const [query, missing] of cases) {
       const res = await get(query);
       expect(res.status).toBe(400);
-      expect(((await res.json()) as { error: string }).error).toContain(named);
+      const { error } = (await res.json()) as { error: string };
+      expect(error).toContain(missing);
+      for (const other of all) {
+        if (other === missing) continue;
+        // No name in this set is a substring of another, so plain containment is a sound
+        // negative check.
+        expect(error).not.toContain(other);
+      }
     }
   });
 

--- a/packages/gateway/test/integration/http/metrics-stats-route.test.ts
+++ b/packages/gateway/test/integration/http/metrics-stats-route.test.ts
@@ -1,0 +1,229 @@
+/**
+ * End-to-end tests for `GET /v1/metrics/stats` — one DORA-family metric as a bucketed time
+ * series, so a client can draw a line rather than three overlapping windows.
+ *
+ * Sibling of `metrics-dora-route.test.ts`: same fixture, same public mount, same config seam.
+ * Design: `docs/superpowers/specs/2026-09-11-metrics-series-route-design.md`.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CURRENT_SCHEMA_VERSION } from "../../../src/index/local-index.ts";
+import { startReadOnlyHttpServer } from "../../../src/ipc/http-server.ts";
+import {
+  FIXTURE_NOW_MS,
+  seedPaymentServiceFixture,
+} from "../../fixtures/dora/payment-service/seed.ts";
+import { seedDbFile } from "../../helpers/migrated-db-seed.ts";
+
+const DAY = 86_400_000;
+
+type StatsPoint = {
+  start_ms: number;
+  end_ms: number;
+  value: number | null;
+  unit: string;
+  sample: number;
+  gap: string | null;
+};
+type StatsBody = {
+  metric: string;
+  service: string;
+  window: { since_ms: number; until_ms: number };
+  bucket_ms: number;
+  points: StatsPoint[];
+};
+
+const VALID_TOML = `[metrics.dora.payment-service]
+repos = ["github:nimbus-agent/payments", "gitlab:nimbus-agent/payments", "jenkins:payment-service/deploy-prod"]
+pagerduty_services = ["P12ABCD"]
+`;
+
+describe("GET /v1/metrics/stats", () => {
+  let dir: string;
+  let handle: ReturnType<typeof startReadOnlyHttpServer> | undefined;
+  let port: number;
+
+  async function start(toml: string): Promise<void> {
+    const dbPath = join(dir, "nimbus.db");
+    seedDbFile(dbPath, CURRENT_SCHEMA_VERSION);
+    const db = new Database(dbPath);
+    await seedPaymentServiceFixture(db);
+    db.close();
+    writeFileSync(join(dir, "nimbus.toml"), toml);
+    handle = startReadOnlyHttpServer(dbPath, 0, {
+      configDir: dir,
+      nowMs: () => FIXTURE_NOW_MS,
+    });
+    port = handle.port;
+  }
+
+  function get(query: string): Promise<Response> {
+    return fetch(`http://127.0.0.1:${port}/v1/metrics/stats?${query}`);
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "nimbus-stats-http-"));
+  });
+
+  afterEach(() => {
+    handle?.stop();
+    handle = undefined;
+    try {
+      // maxRetries: 0 / retryDelay: 0 — see metrics-dora-route.test.ts (#972, #973).
+      rmSync(dir, { recursive: true, force: true, maxRetries: 0, retryDelay: 0 });
+    } catch {
+      /* non-fatal */
+    }
+  });
+
+  it("returns disjoint buckets covering the requested window", async () => {
+    await start(VALID_TOML);
+    const res = await get(
+      `service=payment-service&metric=deployment-frequency&window_ms=${28 * DAY}&bucket_ms=${7 * DAY}`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StatsBody;
+    expect(body.metric).toBe("deployment-frequency");
+    expect(body.service).toBe("payment-service");
+    expect(body.bucket_ms).toBe(7 * DAY);
+    expect(body.points).toHaveLength(4);
+    // Disjoint and contiguous is the whole point of the route — a client draws a line across
+    // these, which a nested-window series could not support.
+    for (let i = 1; i < body.points.length; i += 1) {
+      expect(body.points[i]?.start_ms).toBe(body.points[i - 1]?.end_ms as number);
+    }
+    expect(body.points[0]?.start_ms).toBe(body.window.since_ms);
+    expect(body.points[body.points.length - 1]?.end_ms).toBe(body.window.until_ms);
+    expect(body.window.until_ms - body.window.since_ms).toBe(28 * DAY);
+  });
+
+  it("pins the wire key set of the series and of a point", async () => {
+    await start(VALID_TOML);
+    const body = (await (
+      await get(`service=payment-service&metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`)
+    ).json()) as StatsBody;
+    expect(Object.keys(body).sort()).toEqual([
+      "bucket_ms",
+      "metric",
+      "points",
+      "service",
+      "window",
+    ]);
+    expect(Object.keys(body.points[0] as object).sort()).toEqual([
+      "end_ms",
+      "gap",
+      "sample",
+      "start_ms",
+      "unit",
+      "value",
+    ]);
+  });
+
+  it("serves every metric id the enum advertises", async () => {
+    await start(VALID_TOML);
+    for (const metric of [
+      "deployment-frequency",
+      "lead-time",
+      "change-failure-rate",
+      "mttr",
+      "pr-merges",
+      "incidents-opened",
+    ]) {
+      const res = await get(
+        `service=payment-service&metric=${metric}&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`,
+      );
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as StatsBody).metric).toBe(metric);
+    }
+  });
+
+  it("is reachable with no bearer token", async () => {
+    await start(VALID_TOML);
+    // Public by decision, beside /v1/metrics/dora. Asserted rather than assumed, because the
+    // sibling GET /v1/services/resolve deliberately lands the other way.
+    const res = await get(
+      `service=payment-service&metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses an unknown service rather than rendering empty buckets", async () => {
+    await start(VALID_TOML);
+    // Deliberately unlike /v1/metrics/dora, which answers softly with `unknown_service`: a
+    // series whose bucket count and unit depend on config it does not have has nothing honest
+    // to place-hold, and N empty buckets look like thin data rather than a typo.
+    const res = await get(`service=nope&metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("nope");
+  });
+
+  it("refuses each missing required param by name", async () => {
+    await start(VALID_TOML);
+    const cases: readonly [string, string][] = [
+      [`metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`, "service"],
+      [`service=payment-service&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`, "metric"],
+      [`service=payment-service&metric=mttr&bucket_ms=${7 * DAY}`, "window_ms"],
+      [`service=payment-service&metric=mttr&window_ms=${14 * DAY}`, "bucket_ms"],
+    ];
+    for (const [query, named] of cases) {
+      const res = await get(query);
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toContain(named);
+    }
+  });
+
+  it("refuses an unknown metric and names the valid ids", async () => {
+    await start(VALID_TOML);
+    const res = await get(
+      `service=payment-service&metric=uptime&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("deployment-frequency");
+  });
+
+  it("refuses a non-integer window as a bad param, not a server error", async () => {
+    await start(VALID_TOML);
+    // Number("abc") is NaN, which requireStatsParams rejects with its own message. The handler
+    // deliberately does not pre-validate, so this proves the conversion reaches that check.
+    const res = await get(`service=payment-service&metric=mttr&window_ms=abc&bucket_ms=${7 * DAY}`);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("integer milliseconds");
+  });
+
+  it("refuses an unusable bucket shape with an actionable message", async () => {
+    await start(VALID_TOML);
+    // A bucket wider than the window, and a series over the 400-bucket ceiling.
+    const wide = await get(
+      `service=payment-service&metric=mttr&window_ms=${DAY}&bucket_ms=${7 * DAY}`,
+    );
+    expect(wide.status).toBe(400);
+    const tooMany = await get(
+      `service=payment-service&metric=mttr&window_ms=${500 * DAY}&bucket_ms=${DAY}`,
+    );
+    expect(tooMany.status).toBe(400);
+    expect(((await tooMany.json()) as { error: string }).error.length).toBeGreaterThan(0);
+  });
+
+  it("surfaces a malformed nimbus.toml without echoing any config value", async () => {
+    await start(`[metrics.dora.super-secret-service]
+repos = ["github:nimbus-agent/payments"]
+deploy_environments = ["staging-EU!"]
+`);
+    const res = await get(
+      `service=payment-service&metric=mttr&window_ms=${14 * DAY}&bucket_ms=${7 * DAY}`,
+    );
+    // 500 rather than a degraded empty series: a series of empty buckets would read as "no
+    // data" when the truth is "your config does not parse".
+    expect(res.status).toBe(500);
+    const raw = await res.text();
+    expect(JSON.parse(raw)).toEqual({ error: "config_unreadable" });
+    // The parser's own message embeds the service id AND the offending value, and this route
+    // is PUBLIC — so neither may cross the wire.
+    expect(raw).not.toContain("super-secret-service");
+    expect(raw).not.toContain("staging-EU");
+  });
+});


### PR DESCRIPTION
Answers [#1490](https://github.com/nimbus-agent/Nimbus/pull/1490), merged this morning. Two commits, landing together because the design argues they must.

```text
GET /v1/metrics/stats?service=payment-service&metric=mttr&window_ms=7776000000&bucket_ms=604800000
→ { "metric": "mttr", "service": "…", "window": {…}, "bucket_ms": …, "points": [ … ] }
```

## 1. The attribution fix, first — it changes numbers that already ship

`changeFailureRate` selected its incident candidates through `selectResolvedIncidents`, which bounds on `i.modified_at` — for a resolved incident, effectively **resolution** time — while the attribution loop compares `opened_at_ms`. An incident opened inside the window moments after a deploy, but resolved after the window's upper edge, was never a candidate, and its deploy was reported **clean**.

Not a corner case: `mttr` exists precisely because resolution lag runs to hours and days, so this is the normal shape near any upper edge.

The obvious fix — widen the lookup by `incidentWindowMinutes` — **does not work**, and an implementer applying it would believe the hole closed: the widening would be in resolution time, and an incident opened a minute before the edge may resolve days later. The column had to change, not the bound. So `selectAttributionIncidents` selects on `opened_at_ms` over `[start, until + incidentWindowMinutes]`. `selectResolvedIncidents` is untouched and still serves `mttr`, where windowing on resolution time is correct — that is why this is a second function, not an edit to the shared one.

Two bounds, both deliberate and both tested: the **deploy selection is not widened** (`deploys.length` is the denominator, so widening it would change the number rather than correct it), and the upper bound extends past the edge by exactly `incidentWindowMinutes` and no further.

It also drops the `synced_at` fallback for attribution — that is our *indexing* time, so it blamed whichever deploy happened to precede the moment we indexed the row. **One existing test asserted that fallback as intended behaviour; it is rewritten to the new contract rather than deleted**, and keeps its three-deploy setup so it also proves no other deploy inherits the blame.

**Known residual, disclosed rather than fixed:** `status = 'resolved'` is still required, so a still-burning incident is invisible to attribution at any bound and a historical rate under-reports for that second, independent reason. Dropping that predicate would close it *and* raise reported failure rates — a separate decision, and I did not take it unilaterally.

**Why it matters more for a series:** a `/v1/metrics/dora` window has one upper edge, `now`, where the incident genuinely has not happened yet and no contract can do better. A series has N upper edges and every one is in the past, with the incident sitting in the index, readable, and ignored. Every bucket `nimbus stats` printed already had this hole.

## 2. The route

**Public**, beside `/v1/metrics/dora` — a decision, and deliberately the **opposite** of `GET /v1/services/resolve` from an hour ago. Both reasons now sit at their `HTTP_ROUTE_AUTH` entries, because the next proposal will copy one:

- *stats* is the same data, same config, same service, different resolution. `/v1/metrics/dora`'s own `since` already lets a caller walk nested windows and difference them, so the series reaches nothing new. Scoping it while the scalar beside it stayed public would be a seam no caller could explain.
- *services/resolve* is scoped because it **claims** narrowness, and a public mount would have let N cheap calls rebuild the grouping it exists not to expose.

Public also means published: `HTTP_ROUTES` + a `paths:` entry with `StatsSeries`/`StatsPoint` schemas, which `audit:openapi-drift` enforces as a pair.

Two error decisions, both the design's open questions:

- **Unknown service is refused (400), not answered softly** as `/v1/metrics/dora` does. A series whose bucket count and unit depend on config it lacks has nothing honest to place-hold, and N empty buckets read as thin data rather than a typo. The client's binding validation leans on *preflight*'s soft answer and is unaffected.
- **Malformed `nimbus.toml` → `500 config_unreadable`, echoing no config value** — the same answer `/v1/services/resolve` gives, as the design asked. Config is loaded in the handler rather than the dispatcher's thunk so the parser's message cannot escape. `/v1/metrics/dora` beside it still 500s with that message intact: pre-existing, out of scope, and named in the comment so the difference reads as deliberate.

## Verification

- The attribution fix was written **test-first**: 6 new cases, 4 red before the change, and the 2 that passed from the start are the over-correction guards (denominator not widened; nothing attributed beyond the incident window).
- `audit:openapi-drift` **red-proved** by deleting the `HTTP_ROUTES` entry — it fails with `schema_without_handler`.
- 10 integration tests against the real seeded fixture: buckets disjoint, contiguous and spanning the window exactly; wire key sets of series and point pinned; every advertised metric id served; reachable with no bearer; malformed-config body contains neither the service id nor the offending value.
- 2365 tests green across `ipc`/`metrics`/`test/integration/http`/`test/integration/metrics`; `bun run preflight:fast` green.

**No disclosure added to the wire.** The design left open whether the still-burning residual should become a new `DoraGap`/`StatsGap` member; I did not add one — that union is consumed by two other repos, and documentation carries the residual instead. Easy to add later if you want it on the wire.

No migration, no invariant, no new egress class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHGHyesmwAiDZEDrZBTYu1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `GET /v1/metrics/stats` endpoint for bucketed metric time series.
  * Added support for four DORA metrics plus `pr-merges` and `incidents-opened`.
  * Added validation for service, metric, time-window, and bucket parameters, with sanitized configuration errors.

* **Bug Fixes**
  * Corrected change-failure-rate attribution to use incident opening times while preserving existing MTTR behavior.

* **Documentation**
  * Updated API and changelog documentation with the expanded metric set and parameter requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->