### PR TITLE
fix(metrics): stop requiring a resolved status to attribute a change failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,9 +26,16 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
   selection is deliberately NOT widened — `deploys.length` is the denominator. The `synced_at`
   fallback is dropped for attribution: that is our INDEXING time, so it blamed whichever deploy
   happened to precede the moment we indexed the row. **One existing test asserted that fallback as
-  intended behaviour and is rewritten to the new contract rather than deleted.** KNOWN RESIDUAL,
-  disclosed not fixed: `status = 'resolved'` is still required, so a still-burning incident is
-  invisible at any bound and a historical rate under-reports for that second, independent reason.
+  intended behaviour and is rewritten to the new contract rather than deleted.**
+  **The `status = 'resolved'` predicate is dropped too** — recorded here as a known residual when
+  this first shipped, and closed hours later in the same day rather than disclosed. It exists for
+  MTTR, which needs a resolution timestamp to compute a duration; attribution reads only `opened`,
+  so inheriting it answered a question CFR is not asking. While it stood, a deploy that caused an
+  outage read CLEAN for as long as the outage was still burning, and the metric silently depended
+  on sync freshness — a resolved incident whose row has not been re-synced still reads `triggered`
+  locally. `stats.ts`'s `incidentsOpened`, which asks the same shape of question, never had the
+  predicate and is the precedent. **`change_failure_rate` can only move UP as a result**, never
+  down. MTTR is untouched and keeps the filter, now pinned by its own divergence test.
   **This matters far more for a series than for the scalar it also corrects:** a
   `/v1/metrics/dora` window has one upper edge, `now`, where the incident genuinely has not
   happened yet; a series has N upper edges and every one is in the past, with the incident sitting

--- a/docs/superpowers/specs/2026-09-11-metrics-series-route-design-review.md
+++ b/docs/superpowers/specs/2026-09-11-metrics-series-route-design-review.md
@@ -149,6 +149,14 @@ is **still burning** is invisible at any bound, so a historical `change_failure_
 reports for that reason as well. (`computeStatsSeries`'s own `discloseUntimedIncidents` seam
 exists for a neighbouring version of this problem, which is a useful precedent to cite.)
 
+> **Both halves are now FIXED, 2026-09-11 — the second one was not disclosed, it was closed.**
+> The window-column defect shipped as `selectAttributionIncidents`; the `status === "resolved"`
+> half was dropped hours later. The `discloseUntimedIncidents` precedent cited above turned out
+> to be the wrong model for it: that seam exists because an untimestamped row *cannot* be placed
+> in any bucket, so disclosure is the only honest answer. A still-burning incident can be placed
+> perfectly well — it has an `opened_at_ms` — so there was nothing to disclose, only a filter
+> that belonged to MTTR and had been inherited by a metric that never reads `resolved`.
+
 Also delete, or qualify, the parenthetical "(and deploy)". Widening the **deploy** selection
 changes `deploys.length`, which is the denominator. The next clause does say the denominator
 stays the requested window, but the parenthetical is what an implementer will copy.

--- a/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
+++ b/docs/superpowers/specs/2026-09-11-metrics-series-route-design.md
@@ -8,12 +8,14 @@
 > recommended), returning `StatsSeries` unchanged; and §5's attribution fix, as
 > `selectAttributionIncidents` in `metrics/dora.ts`.
 >
-> **The disclosure question §5 left open was answered by documentation, not by
-> the wire.** No new `DoraGap`/`StatsGap` member was added — the union is
-> consumed by two other repos, and the residual it would announce (a
-> still-burning incident is invisible because `status = 'resolved'` is required)
-> is recorded in `selectAttributionIncidents`' own comment and in the CHANGELOG
-> instead. That residual is NOT fixed; only the window-column defect is.
+> **The disclosure question §5 left open was answered by FIXING the thing it
+> would have disclosed.** No new `DoraGap`/`StatsGap` member was added, and none
+> is needed: the residual it would have announced — a still-burning incident
+> being invisible because `status = 'resolved'` was required — was itself closed
+> shortly after this route shipped. The predicate is gone from
+> `selectAttributionIncidents`, so there is nothing left to disclose. §5's two
+> options turned out to be alternatives rather than complements, and the cheaper
+> one was the fix.
 >
 > **§6's `until_ms` fallback did NOT ship** and was not needed, since §4 landed.
 > It stays as a live alternative if the anchor ever has to move.
@@ -285,6 +287,15 @@ Two riders:
   problem — a series-level probe that reports what the buckets could not see —
   and is the precedent for disclosing this one.
 
+  > **RESOLVED 2026-09-11, and not by disclosing it.** The predicate was dropped
+  > instead. It belongs to MTTR, which needs a resolution timestamp to compute a
+  > duration; attribution reads only `opened`, so the filter answered a question
+  > this metric does not ask — and `stats.ts`'s `incidentsOpened`, which asks the
+  > same shape of question, never carried it. It also made the metric depend on
+  > something nobody chose: a resolved incident whose row has not been re-synced
+  > still reads `triggered` locally, so the answer moved with sync freshness.
+  > `change_failure_rate` can therefore only move UP; MTTR is untouched.
+
 ### What changes when a series goes on the wire
 
 **Nothing about the defect. Everything about how often it fires.**
@@ -480,8 +491,12 @@ merely inheriting it.
 4. **Does §5's correction land with whichever route lands?** The consumer's
    position is yes — and note the defect is live in `nimbus stats` today, so
    this question outlives this proposal either way.
-5. Should the still-burning-incident and `modified_at` caveats be disclosed on
-   the wire (a new `DoraGap` / `StatsGap` member), or only in documentation? §5.
+5. **ANSWERED: neither — both were fixed instead.** The `modified_at` caveat
+   was the window-column defect the route shipped with, and the
+   still-burning-incident caveat was closed hours later by dropping the
+   `resolved` predicate. No `DoraGap` / `StatsGap` member was added, and none is
+   needed. Originally: should the still-burning-incident and `modified_at`
+   caveats be disclosed on the wire, or only in documentation? §5.
 6. If §6: which of the three answers to the `since_ms` collision? Option 2 is
    recommended, and is the only one that survives §4 landing later.
 7. If §6: does `metrics.dora` the IPC verb, and `nimbus metrics dora --until`,

--- a/packages/gateway/src/metrics/dora.test.ts
+++ b/packages/gateway/src/metrics/dora.test.ts
@@ -798,20 +798,61 @@ describe("changeFailureRate", () => {
     expect(result.gap).toBe("low_sample");
   });
 
-  test("incident without resolved status is excluded", () => {
+  // BEHAVIOUR CHANGED, deliberately. This asserted `0` until the `resolved` predicate was
+  // dropped: a deploy that caused an outage was reported CLEAN for as long as the outage was
+  // still burning, and only became a change failure once somebody closed the ticket. Whether an
+  // incident has been fixed says nothing about whether a deploy caused it — `resolved` is
+  // MTTR's requirement, inherited here from a shared helper and never CFR's own.
+  test("attributes a still-burning incident, which resolution status does not bear on", () => {
     const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
     const deployAt = NOW - 2 * ONE_DAY;
     insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
     insertCiRun(db, "github_actions", "Deploy main", NOW - ONE_DAY, "org/repo");
     insertCiRun(db, "github_actions", "Deploy main", NOW - 3 * ONE_DAY, "org/repo");
-    // Active incident (not resolved)
     insertItem(db, "pagerduty", "incident", "Active Incident", NOW - ONE_DAY - 100_000, {
       status: "acknowledged",
       pagerduty_service_id: "pd-svc-1",
       opened_at_ms: deployAt + 1_000_000,
     });
     const result = changeFailureRate(db, cfg, NOW, SINCE);
-    expect(result.value).toBe(0);
+    // One of three deploys blamed — and the value proves it is the RIGHT one, since a wrong
+    // attribution would give the same ratio only by coincidence at this sample size.
+    expect(result.value).toBeCloseTo(1 / 3, 10);
+    expect(result.sample).toBe(3);
+  });
+
+  test("attributes a triggered incident too, not only an acknowledged one", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - 2 * ONE_DAY;
+    insertCiRun(db, "github_actions", "Deploy main", deployAt, "org/repo");
+    insertItem(db, "pagerduty", "incident", "Firing", NOW - ONE_DAY, {
+      status: "triggered",
+      pagerduty_service_id: "pd-svc-1",
+      opened_at_ms: deployAt + 600_000,
+    });
+    expect(changeFailureRate(db, cfg, NOW, SINCE).value).toBe(1);
+  });
+
+  // The reason this is more than a corner case. A resolved incident whose row we have not
+  // re-synced still reads `triggered` here, so while status gated attribution, CFR silently
+  // depended on how fresh the PagerDuty sync happened to be — which nobody chose.
+  test("does not depend on sync freshness: same answer whatever the stored status", () => {
+    const cfg = baseConfig({ deployEnvironments: [], pagerdutyServices: ["pd-svc-1"] });
+    const deployAt = NOW - 2 * ONE_DAY;
+    const values: (number | null)[] = [];
+    for (const status of ["triggered", "acknowledged", "resolved"]) {
+      const fresh = freshDb();
+      resetSeq();
+      insertCiRun(fresh, "github_actions", "Deploy main", deployAt, "org/repo");
+      insertItem(fresh, "pagerduty", "incident", "Incident", NOW - ONE_DAY, {
+        status,
+        pagerduty_service_id: "pd-svc-1",
+        opened_at_ms: deployAt + 600_000,
+      });
+      values.push(changeFailureRate(fresh, cfg, NOW, SINCE).value);
+      fresh.close();
+    }
+    expect(values).toEqual([1, 1, 1]);
   });
 
   // BEHAVIOUR CHANGED, deliberately. This test asserted the opposite until 2026-09-11: an
@@ -860,6 +901,24 @@ describe("mttr", () => {
   });
   afterEach(() => {
     db.close();
+  });
+
+  // The divergence guard. `changeFailureRate` deliberately attributes a still-burning incident,
+  // because resolution status says nothing about whether a deploy caused one. MTTR is the
+  // opposite case and must keep its `resolved` filter: it measures time-to-RESTORE, so an
+  // unresolved incident has no duration to contribute and counting one would report a recovery
+  // that has not happened. Nothing pinned this until the two selectors were split, which is
+  // exactly when it became possible to break by accident.
+  test("ignores a still-burning incident, unlike changeFailureRate", () => {
+    const cfg = baseConfig({ pagerdutyServices: ["pd-svc-1"] });
+    insertItem(db, "pagerduty", "incident", "Still burning", NOW - ONE_DAY, {
+      status: "acknowledged",
+      pagerduty_service_id: "pd-svc-1",
+      opened_at_ms: NOW - 2 * ONE_DAY,
+    });
+    const result = mttr(db, cfg, NOW, SINCE);
+    expect(result.value).toBeNull();
+    expect(result.sample).toBe(0);
   });
 
   test("returns no_pagerduty_mapping when pagerdutyServices is empty", () => {

--- a/packages/gateway/src/metrics/dora.ts
+++ b/packages/gateway/src/metrics/dora.ts
@@ -352,11 +352,16 @@ type AttributionIncident = {
  *
  * `json_valid` guards every `json_extract`, which RAISES on malformed JSON in this position.
  *
- * KNOWN RESIDUAL, unchanged here and disclosed rather than fixed: `status = 'resolved'` is still
- * required, so an incident that is still burning is invisible to attribution at any bound, and a
- * historical `change_failure_rate` under-reports for that second, independent reason. Dropping
- * the predicate would close it and would also raise reported failure rates, which is a separate
- * decision from this one.
+ * There is deliberately NO `status = 'resolved'` predicate, which is the second half of the same
+ * defect and was closed a step later. `selectResolvedIncidents` requires it because MTTR needs a
+ * resolution timestamp to compute a duration; attribution reads only `opened`, so inheriting that
+ * filter answered a question this function is not asking. While it stood, a deploy that caused an
+ * outage was reported CLEAN for as long as the outage was still burning, and became a change
+ * failure only once somebody closed the ticket. Worse, it made the metric depend on something
+ * nobody chose: a resolved incident whose row has not been re-synced still reads `triggered` here,
+ * so the answer moved with how fresh the PagerDuty sync happened to be. `stats.ts`'s
+ * `incidentsOpened` — which asks the same shape of question, what opened in this window — has no
+ * status predicate either, and is the precedent.
  */
 function selectAttributionIncidents(
   db: Database,
@@ -375,7 +380,6 @@ function selectAttributionIncidents(
          AND i.type = 'incident'
          AND json_valid(i.metadata)
          AND json_extract(i.metadata, '$.pagerduty_service_id') IN (${placeholders})
-         AND json_extract(i.metadata, '$.status') = 'resolved'
          AND json_extract(i.metadata, '$.opened_at_ms') >= ?
          AND json_extract(i.metadata, '$.opened_at_ms') <= ?`,
     )


### PR DESCRIPTION
Closes the residual [#1493](https://github.com/nimbus-agent/Nimbus/pull/1493) disclosed rather than fixed. One line removed from `selectAttributionIncidents`:

```sql
AND json_extract(i.metadata, '$.status') = 'resolved'
```

## Why it was wrong

Pure inheritance. That predicate exists for **MTTR**, which needs a resolution timestamp to compute a duration. Attribution reads only `opened`, so carrying it over answered a question `change_failure_rate` does not ask.

The codebase already disagreed with it: `stats.ts`'s `incidentsOpened` asks the same *shape* of question — what opened in this window — and its `incidentScopeSql` has no status predicate at all.

Two things were wrong while it stood, and the second is what makes this more than a corner case:

1. **A deploy that caused an outage read CLEAN while the outage was still burning**, and became a change failure only once somebody closed the ticket. Whether an incident has been fixed says nothing about whether a deploy caused it.
2. **The metric silently depended on sync freshness.** A resolved incident whose row we have not re-synced still reads `triggered` locally, so the answer moved with how recently the PagerDuty connector last ran — which nobody chose.

## What changes

`change_failure_rate` can only move **up**, never down. Users may see it rise; that is the metric becoming correct, not a regression. Recorded in the CHANGELOG in those words.

**MTTR is untouched** and keeps its filter — it measures time-to-restore, so an unresolved incident has no duration to contribute.

## The divergence is now deliberate, so it is pinned

Splitting the two selectors made it possible to break MTTR by accident, and **nothing pinned that before**. Added: `mttr > ignores a still-burning incident, unlike changeFailureRate`.

## Verification

- Written **test-first**: 3 new CFR cases, all red before the change.
- **Both directions red-proved.** Restoring the predicate fails exactly the three new CFR tests; removing MTTR's filter fails exactly the new divergence guard. Neither mutation disturbs the other's tests.
- One existing test (`"incident without resolved status is excluded"`) asserted the old behaviour and is **rewritten to the new contract rather than deleted**, keeping its three-deploy setup so the ratio proves the *right* deploy is blamed.
- 2368 tests green across `metrics`/`ipc`/`test/integration/{metrics,http}`; `preflight:fast` green.

## Docs corrected at every restatement

Not just the nearest one — the claim had been stated in five places: the CHANGELOG entry recording it as a known residual, the design spec's status block, its §5 bullet, its §11 Q5 open question, and the **review companion's C3.2**.

That last one is worth a look: it had cited `discloseUntimedIncidents` as the precedent for *disclosing* this. That turned out to be the wrong model, and the note now says so — that seam exists because an untimestamped row **cannot** be bucketed, so disclosure is the only honest answer available. A still-burning incident has an `opened_at_ms` and buckets perfectly well, so there was nothing to disclose, only a filter that belonged to another metric.

No migration, no invariant, no new egress class, no wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHGHyesmwAiDZEDrZBTYu1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Change failure rate (CFR) attribution now includes incidents based on their opening time, regardless of whether they are acknowledged, triggered, or resolved.
  * Ongoing incidents can now contribute to CFR, including when synchronization is stale.
  * Incidents without an opening timestamp remain excluded from attribution.
  * Mean time to recovery (MTTR) continues to exclude unresolved incidents.

* **Documentation**
  * Updated metric documentation and release records to reflect the corrected attribution behavior.

* **Tests**
  * Added coverage for active incidents, stale synchronization, missing timestamps, and MTTR regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->