### PR TITLE
fix(platform): bundle a full SQLite with the macOS build so semantic search works without Homebrew

### DIFF
--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -37,7 +37,7 @@ runs:
     #
     # THIS BUILDS THE LIBRARY THE RELEASE SHIPS, rather than installing Homebrew's. That is the
     # point: `scripts/build-sqlite-darwin.ts` produces the same bytes the macOS `.pkg` and archives
-    # carry (#1505), so the 54 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the
+    # carry (#1505), so the 68 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the
     # artifact users get. `brew install sqlite` tested one library and shipped another.
     #
     # THE POSTURE CHANGED FROM NON-FATAL TO FATAL when it did, and the earlier reasoning no longer

--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -23,46 +23,60 @@ runs:
       with:
         bun-version: ${{ inputs.bun-version }}
 
-    # macOS ONLY, and required for sqlite-vec to load at all (issue #1029).
+    # macOS ONLY, and required for sqlite-vec to load at all (issues #1029, #1505).
     #
     # Bun links Apple's system libsqlite3 on macOS for the throughput, and that build has
     # extension loading COMPILED OUT — so `db.loadExtension()` fails until
     # `Database.setCustomSQLite()` points the process at a vanilla build.
-    # `packages/gateway/src/platform/sqlite-runtime.ts` makes that call and looks for the library
-    # at the Homebrew `opt/` prefixes; this step is what puts one there.
+    # `packages/gateway/src/platform/sqlite-runtime.ts` makes that call and resolves the library
+    # beside the executable first, then at the Homebrew `opt/` prefixes.
     #
     # Lives in the shared setup action rather than in each macOS job, for the same reason
     # `ensureFullSqlite()` is called at every entry point rather than the three someone thought
     # of: a leg that misses it looks fine and silently skips every vec-dependent test.
     #
-    # Deliberately NOT fatal. The authoritative gate is the canary in
-    # `packages/gateway/src/connectors/reindex-vector-erasure.test.ts`, which fails the run on
-    # every CI platform where sqlite-vec did not load — so a brew hiccup here surfaces as a real
-    # test failure with a real message, and cannot red a release build (this action is shared with
-    # release.yml, which needs no SQLite extension at all).
-    - name: macOS — Ensure a full SQLite build (sqlite-vec needs one)
+    # THIS BUILDS THE LIBRARY THE RELEASE SHIPS, rather than installing Homebrew's. That is the
+    # point: `scripts/build-sqlite-darwin.ts` produces the same bytes the macOS `.pkg` and archives
+    # carry (#1505), so the 54 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the
+    # artifact users get. `brew install sqlite` tested one library and shipped another.
+    #
+    # THE POSTURE CHANGED FROM NON-FATAL TO FATAL when it did, and the earlier reasoning no longer
+    # applies. It used to be tolerant because a brew hiccup was cosmetic — the canary in
+    # `packages/gateway/src/connectors/reindex-vector-erasure.test.ts` was the authoritative gate,
+    # and this action is shared with release.yml, which then needed no SQLite extension at all. Both
+    # halves are now false: the library is a PAYLOAD COMPONENT of the macOS package, so a release
+    # that could not build it must not proceed to publish one silently missing it; and a tolerant
+    # failure here would leave `NIMBUS_SQLITE_PATH` unset, the resolver would fall through to
+    # whatever Homebrew build the runner image happens to carry, and the suite would go green
+    # against a library we do not ship. That is the silent divergence this step exists to remove.
+    - name: macOS — Cache the bundled SQLite build
+      if: runner.os == 'macOS'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/nimbus-sqlite
+        # Keyed on the BUILD SCRIPT, not on a version string: the pinned release, the compile flags
+        # and the deployment target all live in that one file, so any change to what the library IS
+        # misses the cache. A key naming only the version would serve a stale dylib after a flag
+        # change — the exact failure the flag tests exist to prevent.
+        key: nimbus-sqlite-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/build-sqlite-darwin.ts') }}
+
+    - name: macOS — Build the full SQLite the release ships (sqlite-vec needs one)
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        set -uo pipefail
-        found=""
-        for p in /opt/homebrew/opt/sqlite/lib/libsqlite3.dylib /usr/local/opt/sqlite/lib/libsqlite3.dylib; do
-          if [ -f "$p" ]; then found="$p"; break; fi
-        done
-        if [ -z "$found" ]; then
-          echo "No full SQLite on the runner image; installing."
-          brew install sqlite || echo "::warning title=brew install sqlite failed::sqlite-vec will not load on this leg"
-          for p in /opt/homebrew/opt/sqlite/lib/libsqlite3.dylib /usr/local/opt/sqlite/lib/libsqlite3.dylib; do
-            if [ -f "$p" ]; then found="$p"; break; fi
-          done
+        set -euo pipefail
+        dir="$HOME/.cache/nimbus-sqlite"
+        lib="$dir/libsqlite3.dylib"
+        if [ -f "$lib" ]; then
+          echo "Reusing cached $lib"
         else
-          echo "Runner image already ships a full SQLite."
+          bun scripts/build-sqlite-darwin.ts --dest "$dir" --work "$dir"
         fi
-        if [ -z "$found" ]; then
-          echo "::warning title=No full SQLite available::db.loadExtension() cannot work on this leg; the sqlite-vec canary will fail the run"
-        else
-          echo "Full SQLite: $found"
-        fi
+        echo "NIMBUS_SQLITE_PATH=$lib" >> "$GITHUB_ENV"
+        echo "Full SQLite: $lib"
+        # No inline smoke check here on purpose: proving the library loads sqlite-vec, speaks FTS5
+        # and is the pinned version is `packages/gateway/test/integration/platform/bundled-sqlite.test.ts`,
+        # which runs in this same workflow and says what it checked when it fails.
 
     - name: Cache Bun package download cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/actions/setup-nimbus-ci/action.yml
+++ b/.github/actions/setup-nimbus-ci/action.yml
@@ -70,7 +70,10 @@ runs:
         if [ -f "$lib" ]; then
           echo "Reusing cached $lib"
         else
-          bun scripts/build-sqlite-darwin.ts --dest "$dir" --work "$dir"
+          # --work is OUTSIDE the cached directory on purpose: the amalgamation zip and the ~11 MB
+          # of C source it extracts to are build inputs, and caching them would store 14 MB to
+          # avoid re-fetching 3. Only the finished library is worth keeping between runs.
+          bun scripts/build-sqlite-darwin.ts --dest "$dir" --work "${RUNNER_TEMP}/sqlite-build"
         fi
         echo "NIMBUS_SQLITE_PATH=$lib" >> "$GITHUB_ENV"
         echo "Full SQLite: $lib"

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -507,6 +507,14 @@ jobs:
           fi
           cp "$VEC0_SRC" "$PAYLOAD/bin/$(basename "$VEC0_SRC")"
 
+          # The full SQLite that sidecar needs to load on macOS (#1505). Real macOS archives ship
+          # one; this job builds the same artifact so the assertion below proves install.sh's own
+          # copy loop ran, not that a file we placed by hand survived a tar round-trip.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            bun scripts/build-sqlite-darwin.ts --dest "$RUNNER_TEMP/sqlite" --work "$RUNNER_TEMP/sqlite"
+            cp "$RUNNER_TEMP/sqlite/libsqlite3.dylib" "$PAYLOAD/bin/libsqlite3.dylib"
+          fi
+
           # Names + layout MUST match scripts/install/lib/release-assets.ts's
           # assetNameFor() and the real release.yml packaging: the Linux
           # tarball is versioned and nests binaries under bin/; the macOS
@@ -583,6 +591,14 @@ jobs:
           if [ "$RUNNER_OS" = "Linux" ]; then VEC0_NAME="vec0.so"; else VEC0_NAME="vec0.dylib"; fi
           test -f "$HOME/.local/bin/$VEC0_NAME" || {
             echo "::error::remote install did not place the sqlite-vec sidecar ($VEC0_NAME) — the sidecar-copy path in install.sh did not run"; exit 1; }
+
+          # Same proof for the full SQLite build (#1505). On macOS the sidecar above is INERT
+          # without it, so an install that placed one and not the other is an install with no
+          # vector search — which is exactly the state this pair of files exists to end.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            test -f "$HOME/.local/bin/libsqlite3.dylib" || {
+              echo "::error::remote install did not place libsqlite3.dylib — the sqlite-copy path in install.sh did not run, and vec0.dylib cannot load without it"; exit 1; }
+          fi
 
           "$HOME/.local/bin/nimbus" --version
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -508,11 +508,13 @@ jobs:
           cp "$VEC0_SRC" "$PAYLOAD/bin/$(basename "$VEC0_SRC")"
 
           # The full SQLite that sidecar needs to load on macOS (#1505). Real macOS archives ship
-          # one; this job builds the same artifact so the assertion below proves install.sh's own
-          # copy loop ran, not that a file we placed by hand survived a tar round-trip.
+          # one, so the served fixture must too — otherwise the assertion below would prove nothing
+          # about install.sh's own copy loop. Taken from NIMBUS_SQLITE_PATH, which setup-nimbus-ci
+          # exported after building it, for release.yml's reason: one artifact per job, not two.
           if [ "$RUNNER_OS" = "macOS" ]; then
-            bun scripts/build-sqlite-darwin.ts --dest "$RUNNER_TEMP/sqlite" --work "$RUNNER_TEMP/sqlite"
-            cp "$RUNNER_TEMP/sqlite/libsqlite3.dylib" "$PAYLOAD/bin/libsqlite3.dylib"
+            test -n "${NIMBUS_SQLITE_PATH:-}" || {
+              echo "::error::NIMBUS_SQLITE_PATH unset — setup-nimbus-ci did not build the bundled SQLite"; exit 1; }
+            cp "$NIMBUS_SQLITE_PATH" "$PAYLOAD/bin/libsqlite3.dylib"
           fi
 
           # Names + layout MUST match scripts/install/lib/release-assets.ts's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,23 @@ jobs:
       #
       # It resolves from dirname(process.execPath), exactly like vec0.dylib, so it travels the same
       # three routes below: the .pkg payload and both tar.gz archives.
-      - name: Build bundled SQLite (macOS)
+      #
+      # COPIED, NOT REBUILT. `setup-nimbus-ci` already built (or restored from cache) exactly this
+      # library and exported NIMBUS_SQLITE_PATH to it. Compiling a second time here would ship bytes
+      # that no step in this job ever loaded, while the ones the action selected sat unused — two
+      # artifacts from one source, and the packaged one the less exercised of the pair. It is also
+      # ~25 s of a paid runner per macOS leg for a duplicate.
+      - name: Stage bundled SQLite (macOS)
         if: startsWith(matrix.target.os, 'macos')
-        run: bun scripts/build-sqlite-darwin.ts --dest dist --work "${RUNNER_TEMP}/sqlite-build"
+        run: |
+          set -euo pipefail
+          # Fail loudly rather than package a macOS archive with no SQLite in it: the setup step is
+          # fatal on macOS, so an unset variable here means the action changed, not that the build
+          # was skipped.
+          test -n "${NIMBUS_SQLITE_PATH:-}" || {
+            echo "::error::NIMBUS_SQLITE_PATH unset — setup-nimbus-ci did not build the bundled SQLite"; exit 1; }
+          cp "$NIMBUS_SQLITE_PATH" dist/libsqlite3.dylib
+          ls -l dist/libsqlite3.dylib
 
       # nimbus-sandbox-helper.exe (I15): the Windows AppContainer helper the sandbox runner
       # spawns through. helperPath() resolves it the same way tryLoadFromSidecar() resolves

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,20 @@ jobs:
       - name: Copy sqlite-vec sidecar
         run: bun scripts/copy-vec0-sidecar.ts --dest dist
 
+      # libsqlite3.dylib (macOS only, #1505): the sidecar above is INERT on macOS without it.
+      # Bun links Apple's system SQLite there, which has extension loading compiled out, so
+      # `loadExtension()` — and with it vector search, hybrid ranking and session-memory recall —
+      # cannot work until `setCustomSQLite()` points the process at a vanilla build. Until this
+      # step existed the only such build on a user's machine was Homebrew's, making `brew install
+      # sqlite` an undocumented prerequisite for a headline feature on one platform and nothing on
+      # the other two (non-negotiable #5).
+      #
+      # It resolves from dirname(process.execPath), exactly like vec0.dylib, so it travels the same
+      # three routes below: the .pkg payload and both tar.gz archives.
+      - name: Build bundled SQLite (macOS)
+        if: startsWith(matrix.target.os, 'macos')
+        run: bun scripts/build-sqlite-darwin.ts --dest dist --work "${RUNNER_TEMP}/sqlite-build"
+
       # nimbus-sandbox-helper.exe (I15): the Windows AppContainer helper the sandbox runner
       # spawns through. helperPath() resolves it the same way tryLoadFromSidecar() resolves
       # vec0.dll — dirname(process.execPath) — so it has to travel beside the gateway binary
@@ -192,16 +206,19 @@ jobs:
       # + <bin>.sig per target — without the sidecars, build-update-manifest.ts
       # fails with ENOENT and the v0.1.0 latest.json was never produced.
       #
-      # vec0.* and nimbus-sandbox-helper.exe are SECOND/THIRD path entries rather than part of the
-      # glob above, which is anchored on the binary's name. All live under dist/, so the
-      # least-common-ancestor stays dist/ and every file still lands at the artifact root. The
-      # downstream `Stage release assets`, `Compute SHA256SUMS` and `Flatten artifact dir` steps
-      # all glob on the nimbus-gateway-* prefix, so neither sidecar ever becomes a loose release
-      # asset — both ship inside the archives and installers, which is where a user's binary can
-      # actually find them. nimbus-sandbox-helper.exe only exists on the windows leg of this
-      # matrix; upload-artifact's `if-no-files-found: error` triggers only when NONE of the listed
-      # paths resolve to a file, so its absence on Linux/macOS is silently a no-op for that one
-      # line rather than a failure — the binary and vec0.* entries always match.
+      # vec0.*, libsqlite3.dylib and nimbus-sandbox-helper.exe are SECOND/THIRD/FOURTH path entries
+      # rather than part of the glob above, which is anchored on the binary's name. All live under
+      # dist/, so the least-common-ancestor stays dist/ and every file still lands at the artifact
+      # root. The downstream `Stage release assets`, `Compute SHA256SUMS` and `Flatten artifact dir`
+      # steps all glob on the nimbus-gateway-* prefix, so no sidecar ever becomes a loose release
+      # asset — they ship inside the archives and installers, which is where a user's binary can
+      # actually find them.
+      #
+      # Two of the three are per-platform: nimbus-sandbox-helper.exe exists only on the windows leg
+      # and libsqlite3.dylib only on the two macOS legs. upload-artifact's `if-no-files-found: error`
+      # triggers only when NONE of the listed paths resolve to a file, so each one's absence
+      # elsewhere is a silent no-op for that line rather than a failure — the binary and vec0.*
+      # entries always match.
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -209,6 +226,7 @@ jobs:
           path: |
             dist/${{ matrix.target.artifact }}${{ matrix.target.ext }}*
             dist/vec0.*
+            dist/libsqlite3.dylib
             dist/nimbus-sandbox-helper.exe
           if-no-files-found: error
           retention-days: 30
@@ -405,6 +423,7 @@ jobs:
             cp "dist/nimbus-gateway-macos-$arch/nimbus-gateway-macos-$arch" "$stage/nimbus-gateway"
             cp "dist/nimbus-cli-macos-$arch/nimbus-cli-macos-$arch"         "$stage/nimbus"
             cp "dist/nimbus-gateway-macos-$arch/vec0.dylib"                 "$stage/vec0.dylib"
+            cp "dist/nimbus-gateway-macos-$arch/libsqlite3.dylib"          "$stage/libsqlite3.dylib"
             chmod +x "$stage/nimbus" "$stage/nimbus-gateway"
             out="dist/installers/nimbus-headless-macos-$arch.pkg"
             bash scripts/package-macos-installer.sh --bin-dir "$stage" --version "$V" --out "$out"
@@ -535,6 +554,7 @@ jobs:
           cp dist/nimbus-gateway-macos-x64/nimbus-gateway-macos-x64 dist/stage-macos-x64/nimbus-gateway
           cp dist/nimbus-cli-macos-x64/nimbus-cli-macos-x64         dist/stage-macos-x64/nimbus
           cp dist/nimbus-gateway-macos-x64/vec0.dylib               dist/stage-macos-x64/vec0.dylib
+          cp dist/nimbus-gateway-macos-x64/libsqlite3.dylib        dist/stage-macos-x64/libsqlite3.dylib
           cp scripts/release/archive-contents/README-QUICKSTART.txt dist/stage-macos-x64/
           cp scripts/release/archive-contents/LICENSE-AGPL.txt      dist/stage-macos-x64/
           cp scripts/install/unix/install.sh                         dist/stage-macos-x64/
@@ -547,6 +567,7 @@ jobs:
           cp dist/nimbus-gateway-macos-arm64/nimbus-gateway-macos-arm64 dist/stage-macos-arm64/nimbus-gateway
           cp dist/nimbus-cli-macos-arm64/nimbus-cli-macos-arm64         dist/stage-macos-arm64/nimbus
           cp dist/nimbus-gateway-macos-arm64/vec0.dylib                 dist/stage-macos-arm64/vec0.dylib
+          cp dist/nimbus-gateway-macos-arm64/libsqlite3.dylib           dist/stage-macos-arm64/libsqlite3.dylib
           cp scripts/release/archive-contents/README-QUICKSTART.txt     dist/stage-macos-arm64/
           cp scripts/release/archive-contents/LICENSE-AGPL.txt          dist/stage-macos-arm64/
           cp scripts/install/unix/install.sh                             dist/stage-macos-arm64/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,59 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
 ## Post-Phase-6 deliveries
 
+- **2026-09-12 — macOS releases ship their own full SQLite, so semantic search no longer needs
+  Homebrew.** Closes #1505, the half of #1029 that #1503 deliberately left open. #1503 made
+  `sqlite-vec` load for **developers and CI** by calling `Database.setCustomSQLite()` against a
+  Homebrew build; it changed nothing for a macOS **end user** who installs the binary on a machine
+  with no `brew install sqlite`, because Apple's system SQLite has extension loading compiled out
+  and the packaged `vec0.dylib` sidecar goes through the same failing call. That user had no vector
+  search, no hybrid ranking and no session-memory recall — a break of **non-negotiable #5**, since
+  Linux and Windows get all three from Bun's own build with no prerequisite at all.
+
+  `scripts/build-sqlite-darwin.ts` now compiles a **pinned** SQLite amalgamation (3.53.4, verified
+  against the SHA3-256 sqlite.org itself publishes — size checked first, so a truncated download
+  reports as a size rather than as an unreadable hash mismatch) and the macOS `.pkg` and both
+  `tar.gz` archives carry the result beside the binaries, on the same rails `vec0.dylib` already
+  travelled. `platform/sqlite-runtime.ts` resolves it ahead of the Homebrew prefixes;
+  `NIMBUS_SQLITE_PATH` still outranks everything. ~1.5 MB per macOS artifact, no license obligation
+  (SQLite is public domain) and no change to signing — payload libraries are not individually
+  codesigned today, `vec0.dylib` included, and the `.pkg` they ride in is `productsign`ed and
+  notarized as a unit. **No migration, no new security invariant, no new egress coverage class, no
+  new HITL action type.**
+
+  **The compile flags are the part worth reviewing, not the plumbing.** `setCustomSQLite` repoints
+  the WHOLE process, and this library is now preferred over a user's own Homebrew build — so a
+  build missing FTS5 would take keyword search AWAY from every macOS user in the act of giving them
+  vector search, and every unit test in the tree would still pass. The flag set is therefore an
+  explicit superset of Homebrew's, asserted in `build-sqlite-darwin.test.ts` (including the ABSENCE
+  of `SQLITE_OMIT_LOAD_EXTENSION`, since extension loading has no positive flag to assert instead),
+  and proved end to end on the macOS leg by `test/integration/platform/bundled-sqlite.test.ts` —
+  which checks that the library loads sqlite-vec, answers an FTS5 `MATCH`, has the JSON functions
+  **and reports the pinned version**, that last assertion being what stops the other three from
+  passing just as well against Apple's build.
+
+  **CI now builds and tests the bytes the release ships.** `setup-nimbus-ci`'s `brew install sqlite`
+  is replaced by this same script, exporting `NIMBUS_SQLITE_PATH` to the result, so the 54
+  `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the shipped artifact instead of
+  a library that merely resembles it. That step also changed from deliberately non-fatal to fatal,
+  and both halves of the old reasoning are why: a brew hiccup used to be cosmetic, but the library
+  is now a PAYLOAD COMPONENT, so a release that cannot build it must not publish a package silently
+  missing it — and a tolerant failure would leave the variable unset, let the resolver fall through
+  to whatever the runner image happened to carry, and go green against something we do not ship.
+
+  **Two things stated rather than softened.** We now own the macOS SQLite version and feature set,
+  so the pin needs bumping deliberately (take a whole `PRODUCT` line; the zip name is asserted
+  against the version encoding, so a half-edit fails the tests). And `sqlite-runtime.ts`'s own
+  header notes Apple's build is a ~50% throughput win: Homebrew users already paid that, and a
+  no-brew user now pays it in exchange for having semantic search at all. **Not measured here** —
+  no escape hatch was added for a number nobody has produced yet.
+
+  Incidental, and found by this change rather than sought: `audit:platform-test-gaps` reported
+  "every test in them runs on win32" for a file containing five darwin-only tests, because its
+  matcher reads ONE line and the condition was hoisted (`const isDarwin = …` then
+  `skipIf(!isDarwin)`). It now resolves that alias — a false all-clear from the one tool whose job
+  is to deny exactly that.
+
 - **2026-09-12 — `nimbus standup`, the sixteenth built-in agent.** Third row of the v0.1.1 CLI
   batch, after `nimbus index health` and `nimbus changelog`. Your own activity over a window
   (default `24h`), assembled entirely from the local index and formatted as copy-pasteable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,7 +51,8 @@ Phase-level history before `v0.1.0` (Phases 1–4) lives in [`docs/roadmap.md` �
 
   **CI now builds and tests the bytes the release ships.** `setup-nimbus-ci`'s `brew install sqlite`
   is replaced by this same script, exporting `NIMBUS_SQLITE_PATH` to the result, so the 54
-  `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the shipped artifact instead of
+  `skipIf(!VEC_AVAILABLE)` sites (68 of them, re-derived rather than carried forward — the CI
+  comment this replaced said 54) and the sqlite-vec canary exercise the shipped artifact instead of
   a library that merely resembles it. That step also changed from deliberately non-fatal to fatal,
   and both halves of the old reasoning are why: a brew hiccup used to be cosmetic, but the library
   is now a PAYLOAD COMPONENT, so a release that cannot build it must not publish a package silently

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -3245,12 +3245,13 @@ nimbus doctor
 
 > **Exit code 2 when `sqlite-vec` is not loaded.** The vector-search check reports `[fail]`, not
 > `[warn]`, because semantic search, hybrid ranking and session-memory recall are all off when it
-> fires — the same severity the sibling `Embeddings: unavailable` line already carries. On **macOS
-> this is reachable on a normal install**: Bun links Apple's system SQLite, which has extension
-> loading compiled out, so a machine with no Homebrew SQLite (`brew install sqlite`, or
-> `NIMBUS_SQLITE_PATH`) makes `nimbus doctor` exit `2` where it previously exited `0` and said
-> nothing. Keyword search is unaffected. A gateway too old to report the field leaves the line out
-> entirely and the exit code unchanged.
+> fires — the same severity the sibling `Embeddings: unavailable` line already carries. On macOS
+> Bun links Apple's system SQLite, which has extension loading compiled out, so this needs a full
+> SQLite build to be present at all; **released macOS builds now ship one** beside the binaries, so
+> a normal install is unaffected. It remains reachable on a **dev checkout** on a machine with
+> neither that bundled library nor a Homebrew one (`brew install sqlite`, or `NIMBUS_SQLITE_PATH`),
+> where `nimbus doctor` exits `2`. Keyword search is unaffected either way. A gateway too old to
+> report the field leaves the line out entirely and the exit code unchanged.
 
 #### `nimbus doctor --fix-keyring`
 
@@ -4486,7 +4487,7 @@ nimbus lan remove abc123
 | `NIMBUS_MAX_TOOL_CALLS_PER_SESSION` | Hard cap on total tool calls per session (1–200; default 20) |
 | `NIMBUS_RUN_QUERY_BENCH` | Set to `1` to enable strict `< 100ms` p95 assertion in the query latency benchmark |
 | `NIMBUS_LOG_LEVEL` | `debug` / `info` / `warn` / `error` (default: `info`) |
-| `NIMBUS_SQLITE_PATH` | **macOS only.** Path to a full `libsqlite3.dylib`, checked before the Homebrew prefixes (`/opt/homebrew/opt/sqlite/lib/`, then `/usr/local/opt/sqlite/lib/`). Bun links Apple's system SQLite on macOS, which has extension loading compiled out, so sqlite-vec — and therefore vector search, hybrid ranking and session-memory recall — needs one of these present. Ignored on Linux and Windows, which use Bun's own full build. `nimbus doctor` reports the resolved state. |
+| `NIMBUS_SQLITE_PATH` | **macOS only.** Path to a full `libsqlite3.dylib`. Checked first, ahead of the `libsqlite3.dylib` released builds ship beside the binaries and then the Homebrew prefixes (`/opt/homebrew/opt/sqlite/lib/`, then `/usr/local/opt/sqlite/lib/`). Bun links Apple's system SQLite on macOS, which has extension loading compiled out, so sqlite-vec — and therefore vector search, hybrid ranking and session-memory recall — needs one of these present; on a released install the bundled one always is, and this variable is an override rather than a requirement. Mainly useful on a dev checkout, where `process.execPath` is `bun` and no library sits beside it. Ignored on Linux and Windows, which use Bun's own full build. `nimbus doctor` reports the resolved state. |
 | `NIMBUS_UPDATER_URL` | Override the update manifest URL (default: official endpoint) |
 | `NIMBUS_UPDATER_DISABLE` | Set to `true` to disable all auto-update checks |
 | `NIMBUS_EXTENSIONS_REGISTRY_URL` | Extension registry base URL; the auto-update polling daemon is only constructed when this is set |

--- a/packages/gateway/src/platform/sqlite-runtime.test.ts
+++ b/packages/gateway/src/platform/sqlite-runtime.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { load as loadSqliteVec } from "sqlite-vec";
 
 import {
+  bundledSqlitePath,
   DARWIN_SQLITE_CANDIDATES,
   DEFAULT_FULL_SQLITE_DEPS,
   type ExtensionProbeResult,
@@ -36,6 +37,15 @@ import {
  */
 type Calls = { warn: string[]; debug: string[]; set: string[]; probes: number };
 
+/**
+ * A stand-in for `process.execPath` inside a real install.
+ *
+ * POSIX-shaped on purpose and on every host: the candidate it produces is a macOS path, so a
+ * Windows dev box must not be allowed to assert against a backslash-joined one. `bundledSqlitePath`
+ * takes the platform for the same reason.
+ */
+const EXEC = "/Applications/nimbus/bin/nimbus-gateway";
+
 function makeDeps(
   over: Partial<FullSqliteDeps> & {
     existing?: readonly string[];
@@ -48,6 +58,7 @@ function makeDeps(
   const deps: FullSqliteDeps = {
     platform: over.platform ?? "darwin",
     env: over.env ?? ((): undefined => undefined),
+    execPath: over.execPath ?? EXEC,
     exists: over.exists ?? ((p: string): boolean => existing.has(p)),
     setCustomSQLite:
       over.setCustomSQLite ??
@@ -70,32 +81,72 @@ function makeDeps(
 describe("fullSqliteCandidates", () => {
   test("is empty off darwin, on every non-darwin platform", () => {
     for (const p of ["win32", "linux", "freebsd"] as const) {
-      expect(fullSqliteCandidates(p, () => "/anything")).toEqual([]);
+      expect(fullSqliteCandidates(p, () => "/anything", EXEC)).toEqual([]);
     }
   });
 
   test("on darwin, Apple Silicon before Intel", () => {
-    expect(fullSqliteCandidates("darwin", () => undefined)).toEqual([...DARWIN_SQLITE_CANDIDATES]);
+    const homebrew = fullSqliteCandidates("darwin", () => undefined, EXEC).slice(1);
+    expect(homebrew).toEqual([...DARWIN_SQLITE_CANDIDATES]);
     expect(DARWIN_SQLITE_CANDIDATES[0]).toContain("/opt/homebrew/");
     expect(DARWIN_SQLITE_CANDIDATES[1]).toContain("/usr/local/");
   });
 
   test(`${SQLITE_PATH_ENV} takes precedence over both Homebrew prefixes`, () => {
-    const got = fullSqliteCandidates("darwin", (n) =>
-      n === SQLITE_PATH_ENV ? "/custom/libsqlite3.dylib" : undefined,
+    const got = fullSqliteCandidates(
+      "darwin",
+      (n) => (n === SQLITE_PATH_ENV ? "/custom/libsqlite3.dylib" : undefined),
+      EXEC,
     );
     expect(got[0]).toBe("/custom/libsqlite3.dylib");
-    expect(got).toHaveLength(DARWIN_SQLITE_CANDIDATES.length + 1);
+    expect(got).toHaveLength(DARWIN_SQLITE_CANDIDATES.length + 2);
   });
 
   test("a blank or whitespace override is ignored, not treated as a path", () => {
     for (const v of ["", "   "]) {
-      expect(fullSqliteCandidates("darwin", () => v)).toEqual([...DARWIN_SQLITE_CANDIDATES]);
+      expect(fullSqliteCandidates("darwin", () => v, EXEC).slice(1)).toEqual([
+        ...DARWIN_SQLITE_CANDIDATES,
+      ]);
     }
   });
 
   test("a padded override is trimmed", () => {
-    expect(fullSqliteCandidates("darwin", () => "  /padded.dylib  ")[0]).toBe("/padded.dylib");
+    expect(fullSqliteCandidates("darwin", () => "  /padded.dylib  ", EXEC)[0]).toBe(
+      "/padded.dylib",
+    );
+  });
+
+  test("the library bundled beside the binary comes before both Homebrew prefixes", () => {
+    // The one we ship is the one CI tested. A stale or differently-configured Homebrew build must
+    // not shadow it — that is the whole reason this entry is ordered ahead of them rather than
+    // appended as a last resort.
+    const got = fullSqliteCandidates("darwin", () => undefined, EXEC);
+    expect(got[0]).toBe("/Applications/nimbus/bin/libsqlite3.dylib");
+    expect(got.slice(1)).toEqual([...DARWIN_SQLITE_CANDIDATES]);
+  });
+
+  test(`${SQLITE_PATH_ENV} still outranks the bundled library`, () => {
+    const got = fullSqliteCandidates(
+      "darwin",
+      (n) => (n === SQLITE_PATH_ENV ? "/custom/libsqlite3.dylib" : undefined),
+      EXEC,
+    );
+    expect(got[0]).toBe("/custom/libsqlite3.dylib");
+    expect(got[1]).toBe(bundledSqlitePath(EXEC, "darwin"));
+  });
+
+  test("off darwin the bundled entry is absent too, not merely the Homebrew ones", () => {
+    for (const p of ["win32", "linux"] as const) {
+      expect(fullSqliteCandidates(p, () => undefined, EXEC)).toEqual([]);
+    }
+  });
+});
+
+describe("bundledSqlitePath", () => {
+  test("sits beside the executable, exactly as the vec0 sidecar does", () => {
+    expect(bundledSqlitePath("/Applications/nimbus/bin/nimbus-gateway", "darwin")).toBe(
+      "/Applications/nimbus/bin/libsqlite3.dylib",
+    );
   });
 });
 

--- a/packages/gateway/src/platform/sqlite-runtime.ts
+++ b/packages/gateway/src/platform/sqlite-runtime.ts
@@ -41,11 +41,26 @@
  * `scripts/gen-agent-brief-fixtures.ts`. The helpers under `packages/gateway/test/` are unwired on
  * purpose: they only ever execute inside `bun test`, where the preload has already installed.
  *
- * OUT OF SCOPE, deliberately: what ships to a macOS end user who has no Homebrew SQLite. That
- * needs a decision about bundling a `libsqlite3.dylib` in the macOS package versus degrading
- * honestly (size, notarization and licensing consequences), and it is a separate change. What
- * this module guarantees is that such a user is TOLD — see `index/sqlite-vec-load.ts`, which now
- * surfaces the final failure at `warn` instead of `debug`.
+ * WHAT SHIPS TO A USER WITH NO HOMEBREW SQLITE. That was deliberately out of scope when this
+ * module landed, and is issue #1505; it is now answered by BUNDLING one. `scripts/build-sqlite-
+ * darwin.ts` compiles a pinned SQLite amalgamation with an explicit, tested flag set, and the
+ * macOS `.pkg` and both `tar.gz` archives carry it beside the binaries — so
+ * {@link bundledSqlitePath} resolves ahead of the Homebrew prefixes and `brew install sqlite`
+ * stops being an undocumented prerequisite for a headline feature on one platform out of three
+ * (non-negotiable #5). Of the three consequences that decision was waiting on: size is ~1.5 MB
+ * per macOS artifact, licensing is nil (SQLite is public domain), and notarization is unchanged —
+ * payload libraries are not codesigned individually today, `vec0.dylib` included, and the `.pkg`
+ * they travel in is `productsign`ed and notarized as a unit.
+ *
+ * THE BUNDLED LIBRARY IS PREFERRED OVER A USER'S OWN HOMEBREW BUILD, which is why its feature set
+ * is a superset rather than a minimum: it is the build CI tested, and a machine that has both must
+ * not get a worse SQLite than it had. `NIMBUS_SQLITE_PATH` still outranks both, for anyone who
+ * needs to override.
+ *
+ * A user who has NEITHER — a dev checkout on a machine with no Homebrew SQLite, where
+ * `process.execPath` is `bun` rather than an installed binary — is still TOLD rather than left to
+ * guess: see `index/sqlite-vec-load.ts`, which surfaces the final failure at `warn`, and the
+ * `nimbus doctor` line.
  */
 
 import { Database } from "bun:sqlite";
@@ -92,6 +107,27 @@ export function sidecarFilename(platform: NodeJS.Platform): string {
 export function sidecarPath(execPath: string, platform: NodeJS.Platform): string {
   const p = platform === "win32" ? winPath : posixPath;
   return p.join(p.dirname(execPath), sidecarFilename(platform));
+}
+
+/**
+ * The full SQLite build shipped beside the macOS binaries by `scripts/build-sqlite-darwin.ts`.
+ *
+ * Named for what it IS rather than where it came from, because `setCustomSQLite` takes any full
+ * build and the Homebrew candidates below are the same kind of thing from a different source.
+ */
+export const BUNDLED_SQLITE_FILENAME = "libsqlite3.dylib";
+
+/**
+ * Where the bundled full SQLite sits relative to an executable — the same relationship
+ * {@link sidecarPath} expresses for `vec0.dylib`, and travelling in the same archives and
+ * installer payload.
+ *
+ * Takes the platform for {@link sidecarPath}'s reason: so a Windows or Linux test can assert
+ * against the macOS path this produces without the host's separator leaking into it.
+ */
+export function bundledSqlitePath(execPath: string, platform: NodeJS.Platform): string {
+  const p = platform === "win32" ? winPath : posixPath;
+  return p.join(p.dirname(execPath), BUNDLED_SQLITE_FILENAME);
 }
 
 /** Environment override, checked before any built-in candidate. */
@@ -155,6 +191,13 @@ export interface FullSqliteStatus {
 export interface FullSqliteDeps {
   readonly platform: NodeJS.Platform;
   readonly env: (name: string) => string | undefined;
+  /**
+   * `process.execPath`, from which the bundled library's location is derived.
+   *
+   * Injected rather than read at the use site so the darwin resolution order is assertable from
+   * a Linux or Windows runner — the same reason every other host fact here arrives as a dep.
+   */
+  readonly execPath: string;
   readonly exists: (path: string) => boolean;
   /** `Database.setCustomSQLite`. Returns false, or throws, when the library is unusable. */
   readonly setCustomSQLite: (path: string) => boolean;
@@ -181,11 +224,12 @@ const REMEDY =
 export function fullSqliteCandidates(
   platform: NodeJS.Platform,
   env: (name: string) => string | undefined,
+  execPath: string,
 ): readonly string[] {
   if (platform !== "darwin") return [];
   const override = env(SQLITE_PATH_ENV);
   const overrides = override === undefined || override.trim() === "" ? [] : [override.trim()];
-  return [...overrides, ...DARWIN_SQLITE_CANDIDATES];
+  return [...overrides, bundledSqlitePath(execPath, platform), ...DARWIN_SQLITE_CANDIDATES];
 }
 
 /**
@@ -272,7 +316,7 @@ function discriminateRejection(
  * runs it without semantic search, and says so.
  */
 export function installFullSqlite(deps: FullSqliteDeps): FullSqliteStatus {
-  const candidates = fullSqliteCandidates(deps.platform, deps.env);
+  const candidates = fullSqliteCandidates(deps.platform, deps.env, deps.execPath);
   if (deps.platform !== "darwin") {
     return {
       state: "not-applicable",
@@ -393,6 +437,7 @@ function defaultExtensionProbe(): ExtensionProbeResult {
 export const DEFAULT_FULL_SQLITE_DEPS: FullSqliteDeps = {
   platform: process.platform,
   env: (name) => process.env[name],
+  execPath: process.execPath,
   exists: existsSync,
   setCustomSQLite: (path) => Database.setCustomSQLite(path),
   probeExtensionLoad: defaultExtensionProbe,

--- a/packages/gateway/test/integration/platform/bundled-sqlite.test.ts
+++ b/packages/gateway/test/integration/platform/bundled-sqlite.test.ts
@@ -1,0 +1,120 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { load as loadSqliteVec } from "sqlite-vec";
+
+import { buildBundledSqlite, SQLITE_PIN } from "../../../../../scripts/build-sqlite-darwin.ts";
+import { SQLITE_PATH_ENV } from "../../../src/platform/sqlite-runtime.ts";
+
+/**
+ * What the bundled macOS SQLite must actually be able to do.
+ *
+ * `build-sqlite-darwin.test.ts` proves the compile LINE is right on every platform. This proves the
+ * resulting LIBRARY is right, which only macOS can answer — and it is the check that matters,
+ * because `Database.setCustomSQLite()` repoints the whole process: a library that loads sqlite-vec
+ * but has no FTS5 would give this repo vector search and take keyword search away, and every unit
+ * test in the tree would still pass.
+ *
+ * IT DOES NOT SKIP ITSELF INTO VACUITY. On darwin, a missing library is a FAILURE with the command
+ * that produces it, never a skip — CI's `setup-nimbus-ci` action builds it and exports
+ * `NIMBUS_SQLITE_PATH`, so absence there means the wiring broke, which is exactly the thing worth
+ * failing on. Off darwin the one assertion that still means something — that the builder refuses to
+ * run at all — is asserted rather than skipped, so this file is never inert.
+ */
+
+const isDarwin = process.platform === "darwin";
+
+describe("the bundled macOS SQLite", () => {
+  test.skipIf(isDarwin)(
+    "refuses to build off darwin rather than emitting something unusable",
+    async () => {
+      await expect(buildBundledSqlite("dist", "dist/.sqlite-build")).rejects.toThrow(/darwin only/);
+    },
+  );
+
+  test.skipIf(!isDarwin)("is present where the build placed it", () => {
+    // Deliberately not `skipIf(!exists)`: on macOS this file's whole premise is that the artifact
+    // was built, so a missing one is a red test naming the fix, not a silent pass.
+    const path = process.env[SQLITE_PATH_ENV] ?? "";
+    if (path === "") {
+      throw new Error(
+        `${SQLITE_PATH_ENV} is unset on darwin — run ` +
+          "`bun scripts/build-sqlite-darwin.ts --dest dist` and point it at the result",
+      );
+    }
+    expect(existsSync(path)).toBe(true);
+  });
+
+  describe.skipIf(!isDarwin)("once installed into this process", () => {
+    // The bunfig preload (`scripts/test-preload/hermetic-credentials.ts`) already called
+    // `ensureFullSqlite()` before any test file loaded, so this process is ALREADY pointed at the
+    // library under test. Re-installing here would be a no-op at best; asserting through a plain
+    // `Database` is what proves the real, production install took.
+
+    test("loads the sqlite-vec extension, which is the whole reason it is bundled", () => {
+      const db = new Database(":memory:");
+      try {
+        loadSqliteVec(db);
+        const stmt = db.query<{ v: string }, []>("SELECT vec_version() AS v");
+        try {
+          expect(String(stmt.get()?.v ?? "")).not.toBe("");
+        } finally {
+          stmt.finalize();
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    test("speaks FTS5, so bundling it does not cost keyword search", () => {
+      const db = new Database(":memory:");
+      try {
+        db.run("CREATE VIRTUAL TABLE ft USING fts5(body)");
+        db.run("INSERT INTO ft(body) VALUES ('the quick brown fox')");
+        const stmt = db.query<{ n: number }, []>(
+          "SELECT count(*) AS n FROM ft WHERE ft MATCH 'brown'",
+        );
+        try {
+          expect(stmt.get()?.n).toBe(1);
+        } finally {
+          stmt.finalize();
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    test("has the JSON functions the index queries depend on", () => {
+      const db = new Database(":memory:");
+      try {
+        const stmt = db.query<{ v: number }, []>(
+          `SELECT json_extract('{"a":{"b":7}}', '$.a.b') AS v`,
+        );
+        try {
+          expect(stmt.get()?.v).toBe(7);
+        } finally {
+          stmt.finalize();
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    test("is the pinned release, not whatever the host happened to have", () => {
+      // The assertion that makes the three above mean something: without it they would pass just as
+      // well against Apple's build for FTS5/JSON, and this file would be proving the host rather
+      // than the artifact.
+      const db = new Database(":memory:");
+      try {
+        const stmt = db.query<{ v: string }, []>("SELECT sqlite_version() AS v");
+        try {
+          expect(stmt.get()?.v).toBe(SQLITE_PIN.version);
+        } finally {
+          stmt.finalize();
+        }
+      } finally {
+        db.close();
+      }
+    });
+  });
+});

--- a/scripts/build-sqlite-darwin.test.ts
+++ b/scripts/build-sqlite-darwin.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+import { BUNDLED_SQLITE_FILENAME } from "../packages/gateway/src/platform/sqlite-runtime.ts";
+import {
+  amalgamationNumericVersion,
+  amalgamationUrl,
+  assertDownloadMatchesPin,
+  clangArgs,
+  OUTPUT_FILENAME,
+  SQLITE_PIN,
+} from "./build-sqlite-darwin.ts";
+
+/**
+ * The compile itself is macOS-only; everything decided BEFORE the compile is not, and that is what
+ * these cover. The flag set and the download pin are the two places a mistake ships silently — a
+ * missing `SQLITE_ENABLE_FTS5` would break keyword search on every macOS install while vector
+ * search started working, and a wrong pin would compile whatever the mirror served.
+ *
+ * The end-to-end proof that the resulting library actually loads sqlite-vec and speaks FTS5 lives
+ * in `test/integration/platform/bundled-sqlite.test.ts`, which runs on the macOS leg only.
+ */
+
+describe("amalgamationNumericVersion", () => {
+  test("encodes major, minor, patch and a trailing build field, each zero-padded", () => {
+    expect(amalgamationNumericVersion("3.53.4")).toBe("3530400");
+    expect(amalgamationNumericVersion("3.50.0")).toBe("3500000");
+    expect(amalgamationNumericVersion("3.9.2")).toBe("3090200");
+  });
+
+  test("refuses a version that is not three dotted numbers", () => {
+    for (const bad of ["3.53", "3.53.4.1", "3.53.x", "", "353400"]) {
+      expect(() => amalgamationNumericVersion(bad)).toThrow(/version/i);
+    }
+  });
+
+  test("the pinned version encodes to the pinned zip name", () => {
+    expect(SQLITE_PIN.zip).toBe(
+      `sqlite-amalgamation-${amalgamationNumericVersion(SQLITE_PIN.version)}.zip`,
+    );
+  });
+});
+
+describe("OUTPUT_FILENAME", () => {
+  test("is the same name the gateway resolves beside its executable", () => {
+    // TWO definitions on purpose, pinned by this one assertion rather than merged. The build script
+    // runs in CI BEFORE `bun install`, so it cannot import the gateway module — that module's first
+    // line pulls in `bun:sqlite` and `sqlite-vec`, neither of which exists yet at that point. This
+    // test runs after install, where importing both is free, so the drift the duplication invites
+    // is caught here instead of in a release that packages a file nothing looks for.
+    expect(OUTPUT_FILENAME).toBe(BUNDLED_SQLITE_FILENAME);
+  });
+});
+
+describe("amalgamationUrl", () => {
+  test("is an https sqlite.org URL carrying the pinned year and zip", () => {
+    const url = amalgamationUrl(SQLITE_PIN);
+    expect(url).toBe(`https://sqlite.org/${SQLITE_PIN.year}/${SQLITE_PIN.zip}`);
+    expect(new URL(url).protocol).toBe("https:");
+  });
+});
+
+describe("assertDownloadMatchesPin", () => {
+  const pinFor = (bytes: Uint8Array) => ({
+    ...SQLITE_PIN,
+    sizeBytes: bytes.byteLength,
+    sha3_256: createHash("sha3-256").update(bytes).digest("hex"),
+  });
+
+  test("accepts bytes whose size and SHA3-256 both match", () => {
+    const bytes = new TextEncoder().encode("pretend amalgamation");
+    expect(() => assertDownloadMatchesPin(bytes, pinFor(bytes))).not.toThrow();
+  });
+
+  test("refuses a hash mismatch, naming both hashes so the reader can compare", () => {
+    const bytes = new TextEncoder().encode("tampered");
+    const pin = { ...pinFor(bytes), sha3_256: "0".repeat(64) };
+    expect(() => assertDownloadMatchesPin(bytes, pin)).toThrow(/0{64}/);
+    expect(() => assertDownloadMatchesPin(bytes, pin)).toThrow(
+      new RegExp(createHash("sha3-256").update(bytes).digest("hex")),
+    );
+  });
+
+  test("refuses a size mismatch before hashing, so a truncated download says so plainly", () => {
+    const bytes = new TextEncoder().encode("short");
+    expect(() => assertDownloadMatchesPin(bytes, { ...pinFor(bytes), sizeBytes: 999999 })).toThrow(
+      /999999/,
+    );
+  });
+});
+
+describe("clangArgs", () => {
+  const args = clangArgs({
+    sourceC: "/w/sqlite3.c",
+    outDylib: "/w/libsqlite3.dylib",
+    arch: "arm64",
+    minMacos: "11.0",
+  });
+
+  test("builds a dynamic library at the requested path from the requested source", () => {
+    expect(args).toContain("-dynamiclib");
+    expect(args).toContain("/w/sqlite3.c");
+    expect(args.join(" ")).toContain("-o /w/libsqlite3.dylib");
+  });
+
+  test("enables FTS5, which keyword search already depends on", () => {
+    // setCustomSQLite repoints the WHOLE process. A build without FTS5 would take away something
+    // that works on macOS today in the act of fixing something that does not.
+    expect(args).toContain("-DSQLITE_ENABLE_FTS5");
+  });
+
+  test("never compiles out extension loading, which is the entire point of the library", () => {
+    expect(args.join(" ")).not.toContain("SQLITE_OMIT_LOAD_EXTENSION");
+  });
+
+  test("enables the other features a Homebrew build would have had", () => {
+    // Our library is now preferred OVER Homebrew's, including for users who have one. It must not
+    // be less capable than the build it displaces.
+    for (const flag of [
+      "-DSQLITE_ENABLE_RTREE",
+      "-DSQLITE_ENABLE_GEOPOLY",
+      "-DSQLITE_ENABLE_DBSTAT_VTAB",
+      "-DSQLITE_ENABLE_COLUMN_METADATA",
+      "-DSQLITE_ENABLE_MATH_FUNCTIONS",
+      "-DSQLITE_MAX_VARIABLE_NUMBER=250000",
+    ]) {
+      expect(args).toContain(flag);
+    }
+  });
+
+  test("is threadsafe, because the gateway opens databases from several Worker realms", () => {
+    expect(args).toContain("-DSQLITE_THREADSAFE=1");
+  });
+
+  test("pins the architecture and the deployment target rather than inheriting the runner's", () => {
+    expect(args.join(" ")).toContain("-arch arm64");
+    expect(args).toContain("-mmacosx-version-min=11.0");
+    expect(
+      clangArgs({
+        sourceC: "/w/sqlite3.c",
+        outDylib: "/w/libsqlite3.dylib",
+        arch: "x64",
+        minMacos: "11.0",
+      }).join(" "),
+    ).toContain("-arch x86_64");
+  });
+
+  test("refuses an architecture it has no macOS name for", () => {
+    expect(() =>
+      clangArgs({
+        sourceC: "/w/sqlite3.c",
+        outDylib: "/w/libsqlite3.dylib",
+        arch: "riscv64",
+        minMacos: "11.0",
+      }),
+    ).toThrow(/riscv64/);
+  });
+});

--- a/scripts/build-sqlite-darwin.test.ts
+++ b/scripts/build-sqlite-darwin.test.ts
@@ -7,6 +7,8 @@ import {
   amalgamationUrl,
   assertDownloadMatchesPin,
   clangArgs,
+  type FetchLike,
+  fetchAmalgamation,
   OUTPUT_FILENAME,
   SQLITE_PIN,
 } from "./build-sqlite-darwin.ts";
@@ -86,6 +88,117 @@ describe("assertDownloadMatchesPin", () => {
     expect(() => assertDownloadMatchesPin(bytes, { ...pinFor(bytes), sizeBytes: 999999 })).toThrow(
       /999999/,
     );
+  });
+});
+
+describe("fetchAmalgamation", () => {
+  // Every case here injects `fetch`, so the retry and timeout policy is exercised on all three
+  // platforms even though the compile it feeds is macOS-only. Nothing here touches the network.
+  const bytes = new TextEncoder().encode("pretend amalgamation");
+  const pin = {
+    ...SQLITE_PIN,
+    sizeBytes: bytes.byteLength,
+    sha3_256: createHash("sha3-256").update(bytes).digest("hex"),
+  };
+  const ok = () => new Response(bytes, { status: 200 });
+  const deps = (fetchImpl: FetchLike) => ({
+    fetch: fetchImpl,
+    sleep: async (): Promise<void> => {},
+  });
+
+  test("returns the verified bytes when the first attempt succeeds", async () => {
+    let calls = 0;
+    const got = await fetchAmalgamation(
+      pin,
+      deps(async () => {
+        calls += 1;
+        return ok();
+      }),
+    );
+    expect(got.byteLength).toBe(bytes.byteLength);
+    expect(calls).toBe(1);
+  });
+
+  test("applies a per-attempt timeout, so a stalled mirror cannot hang the release job", async () => {
+    // Bun's fetch has no default timeout: without a signal, a half-open connection to sqlite.org
+    // blocks until the JOB timeout, which on the release workflow is 45 minutes of a paid runner.
+    let seen: AbortSignal | undefined;
+    await fetchAmalgamation(
+      pin,
+      deps(async (_url, init) => {
+        seen = (init as RequestInit | undefined)?.signal ?? undefined;
+        return ok();
+      }),
+    );
+    expect(seen).toBeInstanceOf(AbortSignal);
+  });
+
+  test("retries a 503 and succeeds on a later attempt", async () => {
+    let calls = 0;
+    const got = await fetchAmalgamation(
+      pin,
+      deps(async () => {
+        calls += 1;
+        return calls < 2 ? new Response("busy", { status: 503 }) : ok();
+      }),
+    );
+    expect(got.byteLength).toBe(bytes.byteLength);
+    expect(calls).toBe(2);
+  });
+
+  test("retries a thrown network error", async () => {
+    let calls = 0;
+    await fetchAmalgamation(
+      pin,
+      deps(async () => {
+        calls += 1;
+        if (calls < 3) throw new Error("ECONNRESET");
+        return ok();
+      }),
+    );
+    expect(calls).toBe(3);
+  });
+
+  test("does NOT retry a 404 — a wrong pin is permanent, and retrying hides it", async () => {
+    let calls = 0;
+    await expect(
+      fetchAmalgamation(
+        pin,
+        deps(async () => {
+          calls += 1;
+          return new Response("nope", { status: 404 });
+        }),
+      ),
+    ).rejects.toThrow(/404/);
+    expect(calls).toBe(1);
+  });
+
+  test("gives up after the attempt budget and says how many it made", async () => {
+    let calls = 0;
+    await expect(
+      fetchAmalgamation(
+        pin,
+        deps(async () => {
+          calls += 1;
+          throw new Error("ETIMEDOUT");
+        }),
+      ),
+    ).rejects.toThrow(/3 attempt/);
+    expect(calls).toBe(3);
+  });
+
+  test("does NOT retry a checksum mismatch — wrong bytes are not a transient failure", async () => {
+    let calls = 0;
+    await expect(
+      fetchAmalgamation(
+        { ...pin, sha3_256: "0".repeat(64) },
+        deps(async () => {
+          calls += 1;
+          return ok();
+        }),
+      ),
+    ).rejects.toThrow(/SHA3-256/);
+    expect(calls).toBe(1);
   });
 });
 

--- a/scripts/build-sqlite-darwin.ts
+++ b/scripts/build-sqlite-darwin.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env bun
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * Build the full SQLite that ships beside the macOS binaries.
+ *
+ * WHY THIS EXISTS. On macOS Bun links Apple's system SQLite, which has extension loading compiled
+ * out, so `db.loadExtension()` — and therefore sqlite-vec, vector search, hybrid ranking and
+ * session-memory recall — cannot work until `Database.setCustomSQLite()` has pointed the process at
+ * a vanilla build (`packages/gateway/src/platform/sqlite-runtime.ts` explains that half). Until
+ * this script existed the only vanilla build on a user's machine was Homebrew's, so a macOS user
+ * without `brew install sqlite` had no semantic search at all — issue #1505, and a break of
+ * non-negotiable #5 (platform equality), since Linux and Windows get it from Bun's own build with
+ * no prerequisite at all.
+ *
+ * WHY WE COMPILE RATHER THAN COPY THE RUNNER'S HOMEBREW BUILD. The point is that the library we
+ * SHIP is the library CI TESTED. `.github/actions/setup-nimbus-ci` builds this same artifact and
+ * exports `NIMBUS_SQLITE_PATH` to it, so the 54 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec
+ * canary exercise these exact bytes. Copying whatever `brew` had installed that morning would test
+ * one library and ship another.
+ *
+ * WHY THE FLAG SET IS EXPLICIT AND TESTED. `setCustomSQLite` repoints the WHOLE process, and this
+ * library is resolved ahead of Homebrew's even on machines that have one. A build missing FTS5
+ * would take keyword search AWAY from every macOS user in the act of giving them vector search, so
+ * the flags are asserted in `build-sqlite-darwin.test.ts` rather than left to review.
+ *
+ * SQLite is public domain, so bundling it carries no license obligation — the third of the three
+ * consequences (size, notarization, licensing) that `sqlite-runtime.ts` named as needing a decision.
+ */
+
+export interface SqlitePin {
+  /** Dotted release version, as sqlite.org names it. */
+  readonly version: string;
+  /** The year directory sqlite.org files that release under. */
+  readonly year: string;
+  /** Amalgamation zip filename. */
+  readonly zip: string;
+  readonly sizeBytes: number;
+  /** sqlite.org publishes SHA3-256, not SHA-256, in its download manifest. */
+  readonly sha3_256: string;
+}
+
+/**
+ * The pinned release.
+ *
+ * Every field is copied from the `PRODUCT` line on <https://sqlite.org/download.html>, which is why
+ * the hash is SHA3-256: it is the hash sqlite.org itself publishes, so a reader can compare this
+ * constant against the source rather than against a number we computed. Verified against that page
+ * and against the downloaded bytes on 2026-09-12.
+ *
+ *   PRODUCT,3.53.4,2026/sqlite-amalgamation-3530400.zip,2946650,628a44cf…
+ *
+ * To bump: take the new PRODUCT line wholesale — version, year, zip, size and hash move together,
+ * and `amalgamationNumericVersion` is asserted against the zip name, so a half-edit fails the tests
+ * rather than 404ing inside a release job.
+ */
+export const SQLITE_PIN: SqlitePin = {
+  version: "3.53.4",
+  year: "2026",
+  zip: "sqlite-amalgamation-3530400.zip",
+  sizeBytes: 2_946_650,
+  sha3_256: "628a44cfe82c66aed1ccbbe85a562d2e33ebe64b3288981ed76285612227934e",
+};
+
+/**
+ * sqlite.org's numeric version encoding: major, then minor, patch and a build field, each padded to
+ * two digits — `3.53.4` is `3530400`, not `35304`.
+ *
+ * Worth its own function and its own test because it is the part of the URL a human gets wrong, and
+ * getting it wrong means a 404 inside a release job rather than anywhere a test would see it.
+ */
+export function amalgamationNumericVersion(version: string): string {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (m === null) {
+    throw new Error(
+      `build-sqlite-darwin: version must be three dotted numbers (e.g. 3.53.4), got "${version}"`,
+    );
+  }
+  const [, major, minor, patch] = m as unknown as [string, string, string, string];
+  return `${major}${minor.padStart(2, "0")}${patch.padStart(2, "0")}00`;
+}
+
+export function amalgamationUrl(pin: SqlitePin): string {
+  return `https://sqlite.org/${pin.year}/${pin.zip}`;
+}
+
+/**
+ * Refuse anything but the pinned bytes.
+ *
+ * The checksum is the trust anchor, not the URL: this runs in CI and in the release job, both of
+ * which fetch over the network, and a mirror or redirect serving different bytes would otherwise be
+ * compiled and shipped. Size is checked first so the common failure — a truncated download or an
+ * error page — reports as a size, which is legible, rather than as a hash mismatch, which is not.
+ */
+export function assertDownloadMatchesPin(bytes: Uint8Array, pin: SqlitePin): void {
+  if (bytes.byteLength !== pin.sizeBytes) {
+    throw new Error(
+      `build-sqlite-darwin: ${pin.zip} is ${String(bytes.byteLength)} bytes, expected ` +
+        `${String(pin.sizeBytes)} — refusing to compile an unexpected download`,
+    );
+  }
+  const got = createHash("sha3-256").update(bytes).digest("hex");
+  if (got !== pin.sha3_256) {
+    throw new Error(
+      `build-sqlite-darwin: ${pin.zip} SHA3-256 is ${got}, expected ${pin.sha3_256} — ` +
+        "refusing to compile an unexpected download",
+    );
+  }
+}
+
+/** Node's `process.arch` spelling mapped to the one `clang -arch` wants. */
+const CLANG_ARCH: Readonly<Record<string, string>> = { arm64: "arm64", x64: "x86_64" };
+
+export interface ClangArgsOptions {
+  readonly sourceC: string;
+  readonly outDylib: string;
+  /** A `process.arch` value. */
+  readonly arch: string;
+  readonly minMacos: string;
+}
+
+/**
+ * Deployment target.
+ *
+ * Deliberately older than anything Bun itself supports, so this library is never the component that
+ * decides which macOS versions Nimbus runs on.
+ */
+export const MIN_MACOS = "11.0";
+
+/** The library filename — must match `platform/sqlite-runtime.ts`'s `BUNDLED_SQLITE_FILENAME`. */
+export const OUTPUT_FILENAME = "libsqlite3.dylib";
+
+/**
+ * The compile line.
+ *
+ * The feature flags are a superset of what a Homebrew `sqlite` build provides, because this library
+ * is resolved AHEAD of Homebrew's — a user who has one must not lose capability by upgrading
+ * Nimbus. `SQLITE_OMIT_LOAD_EXTENSION` is deliberately absent (extension loading is on unless
+ * omitted, and there is no positive flag to assert instead), which is why the test asserts its
+ * ABSENCE rather than some enabling flag's presence.
+ */
+export function clangArgs(opts: ClangArgsOptions): string[] {
+  const arch = CLANG_ARCH[opts.arch];
+  if (arch === undefined) {
+    throw new Error(
+      `build-sqlite-darwin: no macOS architecture name for "${opts.arch}" ` +
+        `(known: ${Object.keys(CLANG_ARCH).join(", ")})`,
+    );
+  }
+  return [
+    "-O2",
+    "-dynamiclib",
+    "-arch",
+    arch,
+    `-mmacosx-version-min=${opts.minMacos}`,
+    "-install_name",
+    "@rpath/libsqlite3.dylib",
+    "-DSQLITE_THREADSAFE=1",
+    "-DSQLITE_ENABLE_FTS5",
+    "-DSQLITE_ENABLE_FTS4",
+    "-DSQLITE_ENABLE_RTREE",
+    "-DSQLITE_ENABLE_GEOPOLY",
+    "-DSQLITE_ENABLE_DBSTAT_VTAB",
+    "-DSQLITE_ENABLE_COLUMN_METADATA",
+    "-DSQLITE_ENABLE_MATH_FUNCTIONS",
+    "-DSQLITE_ENABLE_DESERIALIZE",
+    "-DSQLITE_MAX_VARIABLE_NUMBER=250000",
+    opts.sourceC,
+    "-o",
+    opts.outDylib,
+  ];
+}
+
+async function run(cmd: string[]): Promise<void> {
+  const proc = Bun.spawn(cmd, { stdout: "inherit", stderr: "inherit" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`build-sqlite-darwin: ${cmd[0] ?? "?"} exited ${String(code)}`);
+  }
+}
+
+/**
+ * Download, verify, extract and compile. macOS only — it shells out to `clang`.
+ *
+ * The download is cached under the pinned zip name and re-verified on reuse, so a second invocation
+ * in the same job (the CI action builds before the tests; the release job builds before packaging)
+ * does not re-fetch, and a corrupted cache entry is refetched rather than compiled.
+ */
+export async function buildBundledSqlite(destDir: string, workDir: string): Promise<string> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      `build-sqlite-darwin: darwin only — ${process.platform} uses Bun's own full SQLite build`,
+    );
+  }
+  mkdirSync(workDir, { recursive: true });
+  mkdirSync(destDir, { recursive: true });
+
+  const zipPath = join(workDir, SQLITE_PIN.zip);
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(readFileSync(zipPath));
+    assertDownloadMatchesPin(bytes, SQLITE_PIN);
+  } catch {
+    const url = amalgamationUrl(SQLITE_PIN);
+    process.stdout.write(`build-sqlite-darwin: fetching ${url}\n`);
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`build-sqlite-darwin: GET ${url} -> ${String(res.status)}`);
+    }
+    bytes = new Uint8Array(await res.arrayBuffer());
+    assertDownloadMatchesPin(bytes, SQLITE_PIN);
+    writeFileSync(zipPath, bytes);
+  }
+
+  const srcDir = join(
+    workDir,
+    `sqlite-amalgamation-${amalgamationNumericVersion(SQLITE_PIN.version)}`,
+  );
+  rmSync(srcDir, { recursive: true, force: true });
+  await run(["unzip", "-q", "-o", zipPath, "-d", workDir]);
+
+  const out = join(destDir, OUTPUT_FILENAME);
+  await run([
+    "clang",
+    ...clangArgs({
+      sourceC: join(srcDir, "sqlite3.c"),
+      outDylib: out,
+      arch: process.arch,
+      minMacos: MIN_MACOS,
+    }),
+  ]);
+  return out;
+}
+
+if (import.meta.main) {
+  const arg = (flag: string): string | undefined => {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+  };
+  const destDir = resolve(arg("--dest") ?? "dist");
+  const workDir = resolve(arg("--work") ?? join(destDir, ".sqlite-build"));
+  const out = await buildBundledSqlite(destDir, workDir);
+  process.stdout.write(
+    `build-sqlite-darwin: → ${out} (${String(statSync(out).size)} bytes, ` +
+      `SQLite ${SQLITE_PIN.version})\n`,
+  );
+}

--- a/scripts/build-sqlite-darwin.ts
+++ b/scripts/build-sqlite-darwin.ts
@@ -17,7 +17,7 @@ import { join, resolve } from "node:path";
  *
  * WHY WE COMPILE RATHER THAN COPY THE RUNNER'S HOMEBREW BUILD. The point is that the library we
  * SHIP is the library CI TESTED. `.github/actions/setup-nimbus-ci` builds this same artifact and
- * exports `NIMBUS_SQLITE_PATH` to it, so the 54 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec
+ * exports `NIMBUS_SQLITE_PATH` to it, so the 68 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec
  * canary exercise these exact bytes. Copying whatever `brew` had installed that morning would test
  * one library and ship another.
  *
@@ -108,6 +108,88 @@ export function assertDownloadMatchesPin(bytes: Uint8Array, pin: SqlitePin): voi
         "refusing to compile an unexpected download",
     );
   }
+}
+
+/**
+ * Just enough of `fetch` to make the download policy testable.
+ *
+ * Narrower than `typeof fetch` deliberately: that type carries Bun's `preconnect` property, which a
+ * test double would have to fake for no reason. What this arm actually uses is a URL, a signal and
+ * a `Response`.
+ */
+export type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
+
+export interface FetchDeps {
+  readonly fetch: FetchLike;
+  readonly sleep: (ms: number) => Promise<void>;
+}
+
+export interface DownloadPolicy {
+  /** Total attempts, not retries after the first. */
+  readonly attempts: number;
+  /** Per-attempt deadline. Applies to the whole attempt, headers and body alike. */
+  readonly timeoutMs: number;
+  readonly backoffMs: number;
+}
+
+/**
+ * Bounded, because the alternative is unbounded.
+ *
+ * Bun's `fetch` has NO default timeout, so a half-open connection to sqlite.org would block until
+ * the JOB timeout — 45 minutes of a paid macOS runner on the release workflow, reported as a
+ * timeout with no indication of which step stalled. The retry exists for the same reason the step
+ * is fatal: this is now a payload component, so a transient mirror blip should cost 2 seconds
+ * rather than a release.
+ */
+export const DOWNLOAD_POLICY: DownloadPolicy = { attempts: 3, timeoutMs: 60_000, backoffMs: 2_000 };
+
+/** A status worth trying again: rate limiting and server-side faults, never a client error. */
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * Download the pinned amalgamation, verify it, and return the bytes.
+ *
+ * Retries only what can plausibly succeed on a second try — a thrown transport error (which
+ * includes the abort raised by the per-attempt timeout) and a retryable status. A 404 is NOT
+ * retried: it means the pin names something that does not exist, and three attempts would turn a
+ * clear error into a slow one. A CHECKSUM failure is not retried either — wrong bytes from a mirror
+ * are not a transient condition, and retrying into them would be asking a bad source twice.
+ */
+export async function fetchAmalgamation(
+  pin: SqlitePin,
+  deps: FetchDeps,
+  policy: DownloadPolicy = DOWNLOAD_POLICY,
+): Promise<Uint8Array> {
+  const url = amalgamationUrl(pin);
+  let last = "";
+  for (let attempt = 1; attempt <= policy.attempts; attempt++) {
+    try {
+      const res = await deps.fetch(url, { signal: AbortSignal.timeout(policy.timeoutMs) });
+      if (!res.ok) {
+        if (!isRetryableStatus(res.status)) {
+          throw new Error(
+            `build-sqlite-darwin: GET ${url} -> ${String(res.status)} (not retryable)`,
+          );
+        }
+        last = `HTTP ${String(res.status)}`;
+      } else {
+        const bytes = new Uint8Array(await res.arrayBuffer());
+        // Outside the retry decision on purpose: a mismatch throws straight out of the loop.
+        assertDownloadMatchesPin(bytes, pin);
+        return bytes;
+      }
+    } catch (e) {
+      if (e instanceof Error && /not retryable|SHA3-256|refusing to compile/.test(e.message))
+        throw e;
+      last = e instanceof Error ? e.message : String(e);
+    }
+    if (attempt < policy.attempts) await deps.sleep(policy.backoffMs * attempt);
+  }
+  throw new Error(
+    `build-sqlite-darwin: GET ${url} failed after ${String(policy.attempts)} attempts (${last})`,
+  );
 }
 
 /** Node's `process.arch` spelling mapped to the one `clang -arch` wants. */

--- a/scripts/ci/platform-test-gaps.test.ts
+++ b/scripts/ci/platform-test-gaps.test.ts
@@ -102,6 +102,32 @@ describe("scanSource", () => {
     expect(scanSource("a.test.ts", aliased, "darwin").map((s) => s.line)).toEqual([3]);
   });
 
+  it("expands the alias only in the condition, never in a test title", () => {
+    // The alias name is an ordinary word and can legitimately appear in the title or the body on
+    // the same line. Substituting it there put the comparison INSIDE the string, where
+    // `matchSkipSite` — which reads everything after `skipIf(` to end of line — then found it and
+    // reported a test that actually runs. An over-report from a tool whose entire value is that you
+    // can believe it.
+    //
+    // Scanned ON the named platform, which is where it actually goes wrong: substituting into the
+    // title on win32 yields a comparison that evaluates to NOT-skipped and is silently dropped, so
+    // the bug only surfaces on the platform the alias names. A regression test written against the
+    // wrong platform passes while the defect ships.
+    const source3 = [
+      'const isDarwin = process.platform === "darwin";',
+      'it.skipIf(false)("isDarwin", () => {});',
+    ].join("\n");
+    expect(scanSource("a.test.ts", source3, "darwin")).toHaveLength(0);
+
+    // The `!==` alias is the same defect wearing the other comparison, and it reports a DIFFERENT
+    // platform than the one being scanned — worth pinning separately.
+    const source4 = [
+      'const isWin = process.platform !== "win32";',
+      'it.skipIf(false)("isWin behaviour", () => {});',
+    ].join("\n");
+    expect(scanSource("a.test.ts", source4, "darwin")).toHaveLength(0);
+  });
+
   it("ignores an alias that is not a platform comparison at all", () => {
     const source2 = ["const ready = cache.size > 0;", 'it.skipIf(!ready)("x", () => {});'].join(
       "\n",

--- a/scripts/ci/platform-test-gaps.test.ts
+++ b/scripts/ci/platform-test-gaps.test.ts
@@ -81,6 +81,33 @@ describe("scanSource", () => {
       for (const s of scanSource("a.test.ts", source, p)) expect(s.skipped).toBe(true);
     }
   });
+
+  // A per-line matcher cannot see a condition hoisted to the top of the file, and that form is
+  // common enough to matter: a file with five darwin-only tests behind `skipIf(!isDarwin)` reported
+  // "every test in them runs on win32", which is the exact reassurance this audit exists to refuse.
+  const aliased = [
+    'const isDarwin = process.platform === "darwin";', // line 1
+    'it.skipIf(!isDarwin)("darwin only", () => {});', // line 2
+    'it.skipIf(isDarwin)("everywhere but darwin", () => {});', // line 3
+    'describe.skipIf(!isDarwin)("darwin only group", () => {});', // line 4
+  ].join("\n");
+
+  it("resolves a platform condition hoisted into a const, negated", () => {
+    const sites = scanSource("a.test.ts", aliased, "win32");
+    expect(sites.map((s) => s.line)).toEqual([2, 4]);
+    expect(sites[0]?.namedPlatform).toBe("darwin");
+  });
+
+  it("resolves the same alias un-negated, which skips on the named platform instead", () => {
+    expect(scanSource("a.test.ts", aliased, "darwin").map((s) => s.line)).toEqual([3]);
+  });
+
+  it("ignores an alias that is not a platform comparison at all", () => {
+    const source2 = ["const ready = cache.size > 0;", 'it.skipIf(!ready)("x", () => {});'].join(
+      "\n",
+    );
+    expect(scanSource("a.test.ts", source2, "win32")).toHaveLength(0);
+  });
 });
 
 describe("insideStringLiteral — the false-positive guard", () => {

--- a/scripts/ci/platform-test-gaps.ts
+++ b/scripts/ci/platform-test-gaps.ts
@@ -120,6 +120,12 @@ const PLATFORM_ALIAS =
  * `NAME` the comparison itself; anything more (a reassigned alias, a compound condition, an alias
  * for an alias) is left alone and simply not reported, which is the same silence as before rather
  * than a new wrong answer.
+ *
+ * It rewrites ONLY a `skipIf(NAME)` / `skipIf(!NAME)` condition, never the rest of the line. An
+ * alias name is an ordinary word that also appears in test titles and bodies, and a whole-line
+ * replace put the comparison inside the TITLE — where `matchSkipSite`, which reads to end of line,
+ * found it and reported a test that actually runs. That over-report only surfaces when scanning ON
+ * the platform the alias names, so it is easy to write a regression test that passes against it.
  */
 export function scanSource(file: string, source: string, onPlatform: string): SkipSite[] {
   const out: SkipSite[] = [];
@@ -138,15 +144,25 @@ export function scanSource(file: string, source: string, onPlatform: string): Sk
   return out;
 }
 
-/** Replace `!NAME` / `NAME` inside a `skipIf(...)` argument with the comparison the alias holds. */
+/**
+ * Rewrite `skipIf(NAME)` / `skipIf(!NAME)` to `skipIf(<comparison>)`, and nothing else on the line.
+ *
+ * The `\)` in the pattern is what keeps this scoped: only a condition that is EXACTLY the alias,
+ * closing the call immediately, is rewritten. A compound condition (`skipIf(!isDarwin && slow)`) is
+ * left alone and therefore not reported — under-reporting, which is this tool's stated safe
+ * direction.
+ */
 function expandAliases(text: string, aliases: ReadonlyMap<string, string>): string {
   if (aliases.size === 0 || !text.includes("skipIf(")) return text;
   let out = text;
   for (const [name, cmp] of aliases) {
-    // `!alias` first: inverting the comparison is what makes the negated form report the right
-    // platform, and replacing the bare name first would leave a stray `!` in front of it.
-    out = out.replace(new RegExp(`!\\s*\\b${name}\\b`, "g"), invertComparison(cmp));
-    out = out.replace(new RegExp(`\\b${name}\\b`, "g"), cmp);
+    // Negated first: inverting the comparison is what makes `!alias` report the right platform, and
+    // handling the bare form first would leave a stray `!` in front of the substituted text.
+    out = out.replace(
+      new RegExp(`skipIf\\(\\s*!\\s*${name}\\s*\\)`, "g"),
+      `skipIf(${invertComparison(cmp)})`,
+    );
+    out = out.replace(new RegExp(`skipIf\\(\\s*${name}\\s*\\)`, "g"), `skipIf(${cmp})`);
   }
   return out;
 }

--- a/scripts/ci/platform-test-gaps.ts
+++ b/scripts/ci/platform-test-gaps.ts
@@ -98,15 +98,61 @@ export function matchSkipSite(
   return null;
 }
 
-/** Scan one file's source for platform-gated sites that are skipped on `onPlatform`. */
+/**
+ * A `const NAME = <platform comparison>` hoisted to the top of a file.
+ *
+ * Only the comparison forms {@link matchSkipSite} already understands qualify, so an alias for
+ * anything else (`const ready = cache.size > 0`) stays invisible rather than being guessed at.
+ */
+const PLATFORM_ALIAS =
+  /^\s*const\s+(\w+)\s*=\s*((?:process\.)?platform(?:\(\))?\s*[!=]==\s*["']\w+["'])\s*;/;
+
+/**
+ * Scan one file's source for platform-gated sites that are skipped on `onPlatform`.
+ *
+ * Resolves hoisted aliases before matching, because {@link matchSkipSite} reads ONE line and the
+ * condition is routinely not on it. `const isDarwin = process.platform === "darwin"` followed by
+ * `skipIf(!isDarwin)` is the shape that motivated this: a file of five darwin-only tests written
+ * that way was reported as "every test in them runs on win32" — a false all-clear from the one tool
+ * whose job is to deny exactly that.
+ *
+ * Substitution is textual and deliberately shallow. `!NAME` becomes the inverted comparison and
+ * `NAME` the comparison itself; anything more (a reassigned alias, a compound condition, an alias
+ * for an alias) is left alone and simply not reported, which is the same silence as before rather
+ * than a new wrong answer.
+ */
 export function scanSource(file: string, source: string, onPlatform: string): SkipSite[] {
   const out: SkipSite[] = [];
   const lines = source.split("\n");
+
+  const aliases = new Map<string, string>();
+  for (const text of lines) {
+    const m = PLATFORM_ALIAS.exec(text);
+    if (m?.[1] !== undefined && m[2] !== undefined) aliases.set(m[1], m[2]);
+  }
+
   for (const [i, text] of lines.entries()) {
-    const site = matchSkipSite(file, i + 1, text, onPlatform);
-    if (site?.skipped === true) out.push(site);
+    const site = matchSkipSite(file, i + 1, expandAliases(text, aliases), onPlatform);
+    if (site?.skipped === true) out.push({ ...site, text: text.trim() });
   }
   return out;
+}
+
+/** Replace `!NAME` / `NAME` inside a `skipIf(...)` argument with the comparison the alias holds. */
+function expandAliases(text: string, aliases: ReadonlyMap<string, string>): string {
+  if (aliases.size === 0 || !text.includes("skipIf(")) return text;
+  let out = text;
+  for (const [name, cmp] of aliases) {
+    // `!alias` first: inverting the comparison is what makes the negated form report the right
+    // platform, and replacing the bare name first would leave a stray `!` in front of it.
+    out = out.replace(new RegExp(`!\\s*\\b${name}\\b`, "g"), invertComparison(cmp));
+    out = out.replace(new RegExp(`\\b${name}\\b`, "g"), cmp);
+  }
+  return out;
+}
+
+function invertComparison(cmp: string): string {
+  return cmp.includes("!==") ? cmp.replace("!==", "===") : cmp.replace("===", "!==");
 }
 
 /**

--- a/scripts/install/unix/install.sh
+++ b/scripts/install/unix/install.sh
@@ -427,6 +427,17 @@ for cand in "${SCRIPT_DIR}/vec0.so" "${SCRIPT_DIR}/vec0.dylib" \
   fi
 done
 
+# The full SQLite build that extension needs in order to load on macOS (#1505). Same rule, same
+# directory, same reason — the gateway resolves it beside its own executable — and the same
+# optionality: absent, the user keeps everything except semantic search, and `nimbus doctor` says
+# which. Present only in the macOS archives; the loop is a no-op elsewhere.
+for cand in "${SCRIPT_DIR}/libsqlite3.dylib" "${SCRIPT_DIR}/bin/libsqlite3.dylib"; do
+  if [ -f "$cand" ]; then
+    cp "$cand" "${INSTALL_DIR}/libsqlite3.dylib"
+    break
+  fi
+done
+
 # Append marker block to rc files (idempotent — strip first if present).
 BLOCK="${BEGIN_MARKER}
 export PATH=\"${INSTALL_DIR}:\$PATH\"

--- a/scripts/package-headless-bundle.ts
+++ b/scripts/package-headless-bundle.ts
@@ -2,6 +2,7 @@
 import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { OUTPUT_FILENAME as BUNDLED_SQLITE_FILENAME } from "./build-sqlite-darwin.ts";
 import { vec0Filename } from "./copy-vec0-sidecar.ts";
 
 const isWin = process.platform === "win32";
@@ -56,6 +57,16 @@ const vec0Name = vec0Filename(process.platform);
 const vec0Src = resolve(repoRoot, "dist", vec0Name);
 if (existsSync(vec0Src)) {
   copyFileSync(vec0Src, join(outDir, vec0Name));
+}
+
+// On macOS the extension above cannot load without a full SQLite build to point the process at
+// (#1505), so the bundle carries one too, resolved from the same directory. Optional for the same
+// reason as the sidecar, and absent by construction off darwin.
+if (process.platform === "darwin") {
+  const sqliteSrc = resolve(repoRoot, "dist", BUNDLED_SQLITE_FILENAME);
+  if (existsSync(sqliteSrc)) {
+    copyFileSync(sqliteSrc, join(outDir, BUNDLED_SQLITE_FILENAME));
+  }
 }
 
 async function materializeEmbeddingModelDefault(dest: string): Promise<void> {

--- a/scripts/package-macos-installer.sh
+++ b/scripts/package-macos-installer.sh
@@ -40,6 +40,18 @@ if [ -f "${BIN_DIR}/vec0.dylib" ]; then
   install -m 0644 "${BIN_DIR}/vec0.dylib" "${ROOT}/nimbus/bin/vec0.dylib"
 fi
 
+# The full SQLite build the extension above needs in order to load at all (#1505). Apple's system
+# SQLite has extension loading compiled out, so without this the sidecar is inert and the user has
+# no vector search, no hybrid ranking and no session-memory recall unless they happen to have run
+# `brew install sqlite`. Resolved from dirname(process.execPath) by
+# packages/gateway/src/platform/sqlite-runtime.ts, hence the same directory as the binaries.
+#
+# Guarded like the sidecar rather than required: a .pkg built from a staging dir that lacks it is
+# still a working Nimbus, minus semantic search — and `nimbus doctor` says so.
+if [ -f "${BIN_DIR}/libsqlite3.dylib" ]; then
+  install -m 0644 "${BIN_DIR}/libsqlite3.dylib" "${ROOT}/nimbus/bin/libsqlite3.dylib"
+fi
+
 # Channel-marked wrappers -> ~/.local/bin
 for t in nimbus nimbus-gateway; do
   cat > "${ROOT}/bin/${t}" <<EOF


### PR DESCRIPTION
Closes #1505.

#1503 made `sqlite-vec` load on macOS for **developers and CI**. It changed nothing for a macOS **end user** who installs the binary on a machine with no `brew install sqlite`: Apple's system SQLite has extension loading compiled out, and the packaged `vec0.dylib` sidecar bottoms out in the same failing `loadExtension()` call. That user has no vector search, no hybrid ranking and no session-memory recall — a break of **non-negotiable #5**, since Linux and Windows get all three from Bun's own build with no prerequisite at all.

`sqlite-runtime.ts`'s own header named the decision this PR makes: *"a decision about bundling a `libsqlite3.dylib` in the macOS package versus degrading honestly (size, notarization and licensing consequences)."* It bundles.

## What ships

`scripts/build-sqlite-darwin.ts` compiles a pinned SQLite amalgamation (3.53.4) and the macOS `.pkg` and both `tar.gz` archives carry the result beside the binaries, on the rails `vec0.dylib` already travelled. `platform/sqlite-runtime.ts` resolves it ahead of the Homebrew prefixes; `NIMBUS_SQLITE_PATH` still outranks everything.

The three consequences that decision was waiting on, answered: **size** ~1.5 MB per macOS artifact; **licensing** nil (SQLite is public domain); **notarization** unchanged — payload libraries are not individually codesigned today, `vec0.dylib` included, and the `.pkg` they ride in is `productsign`ed and notarized as a unit.

No migration, no new security invariant, no new egress coverage class, no new HITL action type.

## The compile flags are the part worth reviewing, not the plumbing

`setCustomSQLite` repoints the **whole process**, and this library is now preferred over a user's own Homebrew build. A build missing FTS5 would take keyword search **away** from every macOS user in the act of giving them vector search — and every unit test in the tree would still pass. So the flag set is an explicit superset of Homebrew's, asserted in `build-sqlite-darwin.test.ts`, including the **absence** of `SQLITE_OMIT_LOAD_EXTENSION` (extension loading has no positive flag to assert instead).

The pin is verified against the **SHA3-256 sqlite.org itself publishes**, so a reviewer can diff the constant against the download page rather than against a number I computed. Size is checked first, so a truncated download reports as a size rather than as an unreadable hash mismatch.

## CI now tests the bytes the release ships

`setup-nimbus-ci`'s `brew install sqlite` is replaced by this same script, exporting `NIMBUS_SQLITE_PATH` to its output — so the 54 `skipIf(!VEC_AVAILABLE)` sites and the sqlite-vec canary exercise the shipped artifact rather than a library that merely resembles it.

That step also goes from deliberately non-fatal to **fatal**, and both halves of the old reasoning are why it had to: a brew hiccup used to be cosmetic, but the library is now a payload component, so a release that cannot build it must not publish a package silently missing it — and a tolerant failure would leave the variable unset, let the resolver fall through to whatever the runner image carried, and go green against something we do not ship.

## Verification, stated honestly

- Whole suite in a clean worktree: **22,939 pass / 0 fail**.
- `preflight` (full) green; `typecheck:tests` checked **alone** (it prints a green tick inside preflight while being advisory on win32).
- `SQLITE_PIN` verified against the **real downloaded archive** — size, SHA3-256, the constructed URL, and the `sqlite-amalgamation-3530400/sqlite3.c` path the compile step assumes.
- **The macOS path has never executed.** I develop on Windows; the five darwin-gated tests in `bundled-sqlite.test.ts` have no local equivalent and **CI is their first execution**. `audit:platform-test-gaps` says so by name — after a fix in this PR, see below.

## Residuals, not softened

1. **We now own macOS users' SQLite version and feature set.** Bumping is deliberate: take a whole `PRODUCT` line; the zip name is asserted against the version encoding, so a half-edit fails the tests rather than 404ing in a release job.
2. **Throughput.** `sqlite-runtime.ts` notes Apple's build is a ~50% win. Homebrew users already paid that; a no-brew user now pays it in exchange for having semantic search at all. **Not measured** — I added no escape hatch for a number nobody has produced.
3. **Gatekeeper quarantine on the `tar.gz` path** is unverified. It is identical for `vec0.dylib` today, so pre-existing rather than introduced — but `vec0.dylib` has never actually loaded on macOS, so nothing has exercised it.

## Incidental, found rather than sought

`audit:platform-test-gaps` reported *"every test in them runs on win32"* for a file containing five darwin-only tests, because its matcher reads one line and the condition was hoisted (`const isDarwin = …` then `skipIf(!isDarwin)`). It now resolves that alias — a false all-clear from the one tool whose job is to deny exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TS9ZL23nsgXfHWQK6mpTj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS releases now bundle a full SQLite library supporting sqlite-vec, FTS5, JSON, and extension loading.
  * Installers and archives include the required SQLite runtime automatically.
  * `NIMBUS_SQLITE_PATH` can override the bundled library location.

* **Bug Fixes**
  * macOS SQLite loading now uses a reliable priority order and avoids runner-provided versions.

* **Documentation**
  * Updated macOS installation and troubleshooting guidance.

* **Tests**
  * Added validation for bundled libraries, supported features, versions, architectures, and installation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->